### PR TITLE
ci: split tests into separate workflow, add test badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           version: 0.15.1
 
-      - name: Run tests
-        run: zig build test
-
       - name: Build (native)
         run: zig build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+
+      - name: Run tests
+        run: zig build test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # clumsies
 
 [![CI](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml)
+[![Tests](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/github/license/lilhammerfun/clumsies)](https://github.com/lilhammerfun/clumsies/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies)](https://github.com/lilhammerfun/clumsies/releases/latest)
 [![Zig](https://img.shields.io/badge/Zig-0.15%2B-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)


### PR DESCRIPTION
## Summary
- Split test step from CI workflow into its own `test.yml` for a separate Tests badge
- Add Tests badge to README
- Both `build` and `test` jobs are required status checks for merging to main

## Test plan
- [x] CI workflow still builds all 4 platforms
- [x] Test workflow runs `zig build test` independently
- [x] Both badges render on README