### PR TITLE
fix: capitalize badge labels for License and Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml)
 [![Tests](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml)
-[![License: MIT](https://img.shields.io/github/license/lilhammerfun/clumsies)](https://github.com/lilhammerfun/clumsies/blob/main/LICENSE)
-[![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies)](https://github.com/lilhammerfun/clumsies/releases/latest)
+[![License: MIT](https://img.shields.io/github/license/lilhammerfun/clumsies?label=License)](https://github.com/lilhammerfun/clumsies/blob/main/LICENSE)
+[![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies?label=Release)](https://github.com/lilhammerfun/clumsies/releases/latest)
 [![Zig](https://img.shields.io/badge/Zig-0.15%2B-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 
 User-level memory layer for AI agents.


### PR DESCRIPTION
## Summary
- Add `?label=License` and `?label=Release` to Shields.io badge URLs to capitalize labels