### PR TITLE
ci: add zig fmt lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           version: 0.15.1
 
+      - name: Lint (zig fmt)
+        run: zig fmt --check src/
+
       - name: Build (native)
         run: zig build
 


### PR DESCRIPTION
Add zig fmt --check step to CI workflow before build.