### PR TITLE
ci: fetch all tags in release workflow for correct changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
@@ -55,6 +58,13 @@ jobs:
           TAG=${{ steps.version.outputs.tag }}
           CHECKSUMS=$(cat dist/checksums.txt)
 
+          PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
+
+          NOTES_FLAG=""
+          if [ -n "$PREV_TAG" ]; then
+            NOTES_FLAG="--notes-start-tag $PREV_TAG"
+          fi
+
           gh release create "$TAG" \
             dist/clumsies-darwin-arm64 \
             dist/clumsies-darwin-x86_64 \
@@ -63,5 +73,5 @@ jobs:
             dist/checksums.txt \
             --title "$TAG" \
             --generate-notes \
-            --notes-start-tag "$(git tag --sort=-v:refname | head -2 | tail -1)" \
+            $NOTES_FLAG \
             --verify-tag


### PR DESCRIPTION
## Summary

The release workflow did a shallow checkout without tags, so
git tag only saw the current tag. The previous-tag lookup
returned the same tag, producing a self-comparing changelog
link (v0.12.1...v0.12.1).

Add fetch-depth: 0 and fetch-tags: true to the checkout step,
and guard the --notes-start-tag flag for first-ever releases.

## Test plan

Will be verified on next release by checking the Full Changelog
link in the release notes.