### PR TITLE
flags: extract shared flag parsing module

### DIFF
--- a/src/commands/add_cmd.zig
+++ b/src/commands/add_cmd.zig
@@ -4,6 +4,7 @@ const testing = std.testing;
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -21,57 +22,46 @@ const appendPromptEntry = commands.appendPromptEntry;
 const jsonEscapeAlloc = commands.jsonEscapeAlloc;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var file_paths: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer file_paths.deinit(allocator);
-    var desc_flag: ?[]const u8 = null;
-    var cat_flag: ?[]const u8 = null;
-    var meta_flag: bool = false;
-    var sync: bool = false;
-    var quiet_git: bool = false;
-
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "--desc") or std.mem.eql(u8, arg, "-d")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                desc_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --desc requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "--cat") or std.mem.eql(u8, arg, "-c")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                cat_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --cat requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "-m") or std.mem.eql(u8, arg, "--meta")) {
-            meta_flag = true;
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const D = 1;
+    const C = 2;
+    const META = 3;
+    const S = 4;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 'd', .long = "desc", .kind = .value },
+        .{ .short = 'c', .long = "cat", .kind = .value },
+        .{ .short = 'm', .long = "meta", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        } else {
-            try file_paths.append(allocator, arg);
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const desc_flag = result.value(D);
+    var cat_flag = result.value(C);
+    const sync = result.boolean(S);
 
-    // --meta is sugar for --cat ../
-    if (meta_flag) {
+    if (result.boolean(META)) {
         cat_flag = META_PROMPT_CATEGORY;
     }
 
-    if (file_paths.items.len == 0) {
+    if (result.positionals.items.len == 0) {
         try stderr.print("{s}{s}{s}Error:{s} File(s) required\n", .{ P, Color.bold, Color.red, Color.reset });
         try printHelp(stderr);
         return;
@@ -97,7 +87,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         expanded_paths.deinit(allocator);
     }
 
-    for (file_paths.items) |raw_path| {
+    for (result.positionals.items) |raw_path| {
         const abs = if (std.fs.path.isAbsolute(raw_path))
             try allocator.dupe(u8, raw_path)
         else

--- a/src/commands/clone.zig
+++ b/src/commands/clone.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -15,20 +16,30 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    // Get remote URL from args
-    var remote_url: ?[]const u8 = null;
-    var quiet_git: bool = false;
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+    const Q = 0;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try stdout.print("{s}Usage: {s}clumsies clone <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try stderr.print("{s}Usage: {s}clumsies clone <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
             return;
-        } else if (remote_url == null) {
-            remote_url = arg;
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const remote_url: ?[]const u8 = if (result.positionals.items.len > 0) result.positionals.items[0] else null;
 
     if (remote_url == null) {
         try stderr.print("{s}{s}{s}Error:{s} Remote URL required\n", .{ P, Color.bold, Color.red, Color.reset });

--- a/src/commands/get_cmd.zig
+++ b/src/commands/get_cmd.zig
@@ -3,6 +3,7 @@ const fs = std.fs;
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -15,47 +16,41 @@ const resolveRef = commands.resolveRef;
 const importPrompt = commands.importPrompt;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var refs: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer refs.deinit(allocator);
-    var cat_filters: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer cat_filters.deinit(allocator);
-    var remote_url: ?[]const u8 = null;
-    var sync: bool = false;
-    var quiet_git: bool = false;
-
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "--cat") or std.mem.eql(u8, arg, "-c")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                try cat_filters.append(allocator, args[i]);
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --cat requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "--remote-url") or std.mem.eql(u8, arg, "-r")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                remote_url = args[i];
-            }
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const C = 1;
+    const R = 2;
+    const S = 3;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 'c', .long = "cat", .kind = .multi_value },
+        .{ .short = 'r', .long = "remote-url", .kind = .value },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        } else {
-            try refs.append(allocator, arg);
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const cat_filters = result.multiValues(C);
+    const remote_url = result.value(R);
+    const sync = result.boolean(S);
+    const refs = result.positionals.items;
 
-    if (refs.items.len == 0 and cat_filters.items.len == 0) {
+    if (refs.len == 0 and cat_filters.len == 0) {
         try stderr.print("{s}{s}{s}Error:{s} Reference or --cat required\n", .{ P, Color.bold, Color.red, Color.reset });
         try printHelp(stderr);
         return;
@@ -65,26 +60,24 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     defer allocator.free(registry_path);
 
     // If first ref resolves as bundle, do bundle import; otherwise prompt import
-    if (refs.items.len > 0) {
-        const kind = resolveRef(allocator, registry_path, refs.items[0]);
+    if (refs.len > 0) {
+        const kind = resolveRef(allocator, registry_path, refs[0]);
         switch (kind) {
             .bundle => {
-                try getBundle(stdout, stderr, allocator, registry_path, refs.items[0], remote_url, quiet_git);
+                try getBundle(stdout, stderr, allocator, registry_path, refs[0], remote_url, quiet_git);
                 return;
             },
             .prompt => {},
             .not_found => {
-                // Check --cat mode
-                if (cat_filters.items.len == 0) {
-                    try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs.items[0] });
+                if (cat_filters.len == 0) {
+                    try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs[0] });
                     return;
                 }
             },
         }
     }
 
-    // Prompt import mode
-    try getPrompts(stdout, stderr, allocator, registry_path, refs.items, cat_filters.items);
+    try getPrompts(stdout, stderr, allocator, registry_path, refs, cat_filters);
 }
 
 fn getPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, registry_path: []const u8, hash_args: []const []const u8, cat_filters: []const []const u8) !void {

--- a/src/commands/ls.zig
+++ b/src/commands/ls.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const fs = std.fs;
 const commands = @import("commands.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -9,40 +10,41 @@ const META_PROMPT_CATEGORY = commands.META_PROMPT_CATEGORY;
 const ensureRegistry = commands.ensureRegistry;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var show_prompts: bool = false;
-    var show_meta: bool = false;
-    var cat_filter: ?[]const u8 = null;
-    var sync: bool = false;
-    var quiet_git: bool = false;
-
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "-p") or std.mem.eql(u8, arg, "--prompts")) {
-            show_prompts = true;
-        } else if (std.mem.eql(u8, arg, "-m") or std.mem.eql(u8, arg, "--meta")) {
-            show_meta = true;
-        } else if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--cat")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                cat_filter = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --cat requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const P_ = 1;
+    const M = 2;
+    const C = 3;
+    const S = 4;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 'p', .long = "prompts", .kind = .boolean },
+        .{ .short = 'm', .long = "meta", .kind = .boolean },
+        .{ .short = 'c', .long = "cat", .kind = .value },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const show_prompts = result.boolean(P_);
+    const show_meta = result.boolean(M);
+    const cat_filter = result.value(C);
+    const sync = result.boolean(S);
 
     if (show_meta) {
         // --meta is sugar for --prompts --cat ../

--- a/src/commands/pub_cmd.zig
+++ b/src/commands/pub_cmd.zig
@@ -3,6 +3,7 @@ const fs = std.fs;
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -24,36 +25,41 @@ const freePromptRefs = commands.freePromptRefs;
 const jsonEscapeAlloc = commands.jsonEscapeAlloc;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var sync: bool = false;
-    var quiet_git: bool = false;
-    var positional: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer positional.deinit(allocator);
-
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const S = 1;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        } else {
-            try positional.append(allocator, arg);
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const sync = result.boolean(S);
 
-    if (positional.items.len < 2) {
+    if (result.positionals.items.len < 2) {
         try stderr.print("{s}{s}{s}Error:{s} Meta-prompt file and at least one directory required\n", .{ P, Color.bold, Color.red, Color.reset });
         try printHelp(stderr);
         return;
     }
 
-    const meta_prompt_path_arg = positional.items[0];
-    const dirs = positional.items[1..];
+    const meta_prompt_path_arg = result.positionals.items[0];
+    const dirs = result.positionals.items[1..];
 
     const cwd = std.process.getCwdAlloc(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Could not determine current directory\n", .{ P, Color.bold, Color.red, Color.reset });

--- a/src/commands/pull.zig
+++ b/src/commands/pull.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -15,12 +16,28 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    var quiet_git: bool = false;
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        }
-    }
+    const Q = 0;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try stdout.print("{s}Usage: {s}clumsies pull [-Q]{s}\n", .{ P, Color.cyan, Color.reset });
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
 
     const prompts_path = try commands.getPromptsPath(allocator);
     defer allocator.free(prompts_path);

--- a/src/commands/push.zig
+++ b/src/commands/push.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -15,22 +16,32 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    // Parse flags
-    var message: []const u8 = "Update prompts";
-    var quiet_git: bool = false;
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        if (std.mem.eql(u8, args[i], "-Q") or std.mem.eql(u8, args[i], "--quiet-git")) {
-            quiet_git = true;
-        } else if ((std.mem.eql(u8, args[i], "-m") or std.mem.eql(u8, args[i], "--message")) and i + 1 < args.len) {
-            message = args[i + 1];
-            i += 1;
-        } else if (std.mem.startsWith(u8, args[i], "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, args[i] });
+    const Q = 0;
+    const M = 1;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 'm', .long = "message", .kind = .value },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try stdout.print("{s}Usage: {s}clumsies push [-m <message>]{s}\n", .{ P, Color.cyan, Color.reset });
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try stderr.print("{s}Usage: {s}clumsies push [-m <message>]{s}\n", .{ P, Color.cyan, Color.reset });
             return;
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const message = result.value(M) orelse "Update prompts";
 
     const prompts_path = try commands.getPromptsPath(allocator);
     defer allocator.free(prompts_path);

--- a/src/commands/remote.zig
+++ b/src/commands/remote.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -8,21 +9,34 @@ const GitOutput = commands.GitOutput;
 const printGitOutputRaw = commands.printGitOutputRaw;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    if (args.len == 0) {
+    const Q = 0;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try stdout.print("{s}Usage: {s}clumsies remote <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            try stderr.print("{s}Usage: {s}clumsies remote <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
+            return;
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+
+    if (result.positionals.items.len == 0) {
         try stderr.print("{s}{s}{s}Error:{s} Remote URL required\n", .{ P, Color.bold, Color.red, Color.reset });
         try stderr.print("{s}Usage: {s}clumsies remote <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
         return;
-    }
-
-    var quiet_git: bool = false;
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
-            try stderr.print("{s}Usage: {s}clumsies remote <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
-            return;
-        }
     }
 
     if (!commands.promptsExist()) {
@@ -37,7 +51,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     };
     defer allocator.free(prompts_path);
 
-    const remote_url = args[0];
+    const remote_url = result.positionals.items[0];
 
     // Check if remote already exists
     var check_output: GitOutput = .{};

--- a/src/commands/rm_cmd.zig
+++ b/src/commands/rm_cmd.zig
@@ -3,6 +3,7 @@ const fs = std.fs;
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -15,45 +16,50 @@ const appendBundleEntry = commands.appendBundleEntry;
 const appendPromptEntry = commands.appendPromptEntry;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var refs: std.ArrayListUnmanaged([]const u8) = .empty;
-    defer refs.deinit(allocator);
-    var sync: bool = false;
-    var quiet_git: bool = false;
-
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const S = 1;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        } else {
-            try refs.append(allocator, arg);
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const sync = result.boolean(S);
 
-    if (refs.items.len == 0) {
+    if (result.positionals.items.len == 0) {
         try stderr.print("{s}{s}{s}Error:{s} Reference required\n", .{ P, Color.bold, Color.red, Color.reset });
         try printHelp(stderr);
         return;
     }
 
+    const refs = result.positionals.items;
     const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
     defer allocator.free(registry_path);
 
-    // Resolve first ref to determine type (all refs should be same type)
-    const kind = resolveRef(allocator, registry_path, refs.items[0]);
+    const kind = resolveRef(allocator, registry_path, refs[0]);
 
     switch (kind) {
-        .prompt => try rmPrompts(stdout, stderr, allocator, registry_path, refs.items, quiet_git),
-        .bundle => try rmBundles(stdout, stderr, allocator, registry_path, refs.items, quiet_git),
+        .prompt => try rmPrompts(stdout, stderr, allocator, registry_path, refs, quiet_git),
+        .bundle => try rmBundles(stdout, stderr, allocator, registry_path, refs, quiet_git),
         .not_found => {
-            try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs.items[0] });
+            try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs[0] });
         },
     }
 }

--- a/src/commands/set_cmd.zig
+++ b/src/commands/set_cmd.zig
@@ -3,6 +3,7 @@ const fs = std.fs;
 const git = @import("../git.zig");
 const commands = @import("commands.zig");
 const spinner = @import("../spinner.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -77,51 +78,46 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
 }
 
 fn setPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, registry_path: []const u8, hash: []const u8, args: []const []const u8, quiet_git: bool) !void {
-    var name_flag: ?[]const u8 = null;
-    var desc_flag: ?[]const u8 = null;
-    var cat_flag: ?[]const u8 = null;
-    var file_flag: ?[]const u8 = null;
-    var all_flag: bool = false;
-
-    var i: usize = 0;
-    while (i < args.len) : (i += 1) {
-        const arg = args[i];
-        if (std.mem.eql(u8, arg, "-n") or std.mem.eql(u8, arg, "--name")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                name_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --name requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "-d") or std.mem.eql(u8, arg, "--desc")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                desc_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --desc requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--cat")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                cat_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --cat requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "-f") or std.mem.eql(u8, arg, "--file")) {
-            if (i + 1 < args.len) {
-                i += 1;
-                file_flag = args[i];
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} --file requires a value\n", .{ P, Color.bold, Color.red, Color.reset });
-                return;
-            }
-        } else if (std.mem.eql(u8, arg, "--all")) {
-            all_flag = true;
-        }
-    }
+    _ = quiet_git;
+    const N = 0;
+    const D = 1;
+    const C = 2;
+    const F = 3;
+    const ALL = 4;
+    const Q = 5;
+    const PROMPT_SPECS = [_]flag.FlagSpec{
+        .{ .short = 'n', .long = "name", .kind = .value },
+        .{ .short = 'd', .long = "desc", .kind = .value },
+        .{ .short = 'c', .long = "cat", .kind = .value },
+        .{ .short = 'f', .long = "file", .kind = .value },
+        .{ .short = null, .long = "all", .kind = .boolean },
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var parsed = flag.parse(&PROMPT_SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try printHelp(stdout);
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            try printHelp(stderr);
+            return;
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer parsed.deinit(allocator);
+    const name_flag = parsed.value(N);
+    const desc_flag = parsed.value(D);
+    const cat_flag = parsed.value(C);
+    const file_flag = parsed.value(F);
+    const all_flag = parsed.boolean(ALL);
+    const p_quiet_git = parsed.boolean(Q);
 
     // --all requires --cat
     if (all_flag and cat_flag == null) {
@@ -131,21 +127,19 @@ fn setPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
 
     // --all with --cat: batch rename category (like old rename-cat)
     if (all_flag and cat_flag != null) {
-        try renameCatFromRef(stdout, stderr, allocator, registry_path, hash, cat_flag.?, quiet_git);
+        try renameCatFromRef(stdout, stderr, allocator, registry_path, hash, cat_flag.?, p_quiet_git);
         return;
     }
 
     if (file_flag != null) {
-        // Replace content (produces new hash)
-        try replacePrompt(stdout, stderr, allocator, registry_path, hash, file_flag.?, desc_flag, cat_flag, quiet_git);
+        try replacePrompt(stdout, stderr, allocator, registry_path, hash, file_flag.?, desc_flag, cat_flag, p_quiet_git);
     } else {
-        // Update metadata only
         if (name_flag == null and desc_flag == null and cat_flag == null) {
             try stderr.print("{s}{s}{s}Error:{s} At least one of -n, -d, -c, or -f required\n", .{ P, Color.bold, Color.red, Color.reset });
             try stderr.print("{s}Usage: {s}clumsies set <hash> [-n name] [-d desc] [-c cat] [-f file] [--all]{s}\n", .{ P, Color.cyan, Color.reset });
             return;
         }
-        try updatePromptMeta(stdout, stderr, allocator, registry_path, hash, name_flag, desc_flag, cat_flag, quiet_git);
+        try updatePromptMeta(stdout, stderr, allocator, registry_path, hash, name_flag, desc_flag, cat_flag, p_quiet_git);
     }
 }
 

--- a/src/commands/show_cmd.zig
+++ b/src/commands/show_cmd.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const fs = std.fs;
 const commands = @import("commands.zig");
+const flag = @import("../flags.zig");
 
 const Color = commands.Color;
 const P = commands.P;
@@ -9,29 +10,36 @@ const ensureRegistry = commands.ensureRegistry;
 const resolveRef = commands.resolveRef;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
-    var ref: ?[]const u8 = null;
-    var show_meta: bool = false;
-    var sync: bool = false;
-    var quiet_git: bool = false;
-
-    for (args) |arg| {
-        if (std.mem.eql(u8, arg, "-Q") or std.mem.eql(u8, arg, "--quiet-git")) {
-            quiet_git = true;
-        } else if (std.mem.eql(u8, arg, "--meta")) {
-            show_meta = true;
-        } else if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--sync")) {
-            sync = true;
-        } else if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+    const Q = 0;
+    const META = 1;
+    const S = 2;
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+        .{ .short = null, .long = "meta", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
             try printHelp(stdout);
             return;
-        } else if (std.mem.startsWith(u8, arg, "-")) {
-            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, arg });
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
             try printHelp(stderr);
             return;
-        } else if (ref == null) {
-            ref = arg;
-        }
-    }
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+    const quiet_git = result.boolean(Q);
+    const show_meta = result.boolean(META);
+    const sync = result.boolean(S);
+    const ref: ?[]const u8 = if (result.positionals.items.len > 0) result.positionals.items[0] else null;
 
     if (ref == null) {
         try stderr.print("{s}{s}{s}Error:{s} Reference required\n", .{ P, Color.bold, Color.red, Color.reset });

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -1,0 +1,344 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const FlagKind = enum { boolean, value, multi_value };
+
+pub const FlagSpec = struct {
+    short: ?u8,
+    long: ?[]const u8,
+    kind: FlagKind,
+};
+
+pub const ErrorContext = struct {
+    flag: ?[]const u8 = null,
+    short_buf: [2]u8 = undefined,
+};
+
+const MAX_FLAGS = 16;
+
+const FlagState = struct {
+    set: bool = false,
+    val: ?[]const u8 = null,
+    multi: std.ArrayListUnmanaged([]const u8) = .empty,
+};
+
+pub const ParseResult = struct {
+    flags: [MAX_FLAGS]FlagState = [_]FlagState{.{}} ** MAX_FLAGS,
+    positionals: std.ArrayListUnmanaged([]const u8) = .empty,
+
+    pub fn boolean(self: *const ParseResult, comptime idx: usize) bool {
+        return self.flags[idx].set;
+    }
+
+    pub fn value(self: *const ParseResult, comptime idx: usize) ?[]const u8 {
+        return self.flags[idx].val;
+    }
+
+    pub fn multiValues(self: *const ParseResult, comptime idx: usize) []const []const u8 {
+        return self.flags[idx].multi.items;
+    }
+
+    pub fn deinit(self: *ParseResult, allocator: std.mem.Allocator) void {
+        for (&self.flags) |*f| {
+            f.multi.deinit(allocator);
+        }
+        self.positionals.deinit(allocator);
+    }
+};
+
+pub fn parse(specs: []const FlagSpec, allocator: std.mem.Allocator, args: []const []const u8, err_ctx: *ErrorContext) !ParseResult {
+    var result: ParseResult = .{};
+    errdefer result.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+
+        if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+            return error.HelpRequested;
+        }
+
+        if (arg.len >= 2 and arg[0] == '-') {
+            if (arg[1] == '-') {
+                if (arg.len == 2) {
+                    err_ctx.flag = arg;
+                    return error.UnknownFlag;
+                }
+                const name = arg[2..];
+                const spec_idx = findLong(specs, name) orelse {
+                    err_ctx.flag = arg;
+                    return error.UnknownFlag;
+                };
+                try consumeValue(&result, specs, spec_idx, args, &i, err_ctx, allocator);
+            } else {
+                if (arg.len == 2) {
+                    const ch = arg[1];
+                    if (ch == 'h') return error.HelpRequested;
+                    const spec_idx = findShort(specs, ch) orelse {
+                        err_ctx.flag = arg;
+                        return error.UnknownFlag;
+                    };
+                    try consumeValue(&result, specs, spec_idx, args, &i, err_ctx, allocator);
+                } else {
+                    const chars = arg[1..];
+                    for (chars, 0..) |ch, j| {
+                        if (ch == 'h') return error.HelpRequested;
+                        const spec_idx = findShort(specs, ch) orelse {
+                            err_ctx.flag = arg;
+                            return error.UnknownFlag;
+                        };
+                        const is_last = j == chars.len - 1;
+                        if (specs[spec_idx].kind == .boolean) {
+                            result.flags[spec_idx].set = true;
+                        } else {
+                            if (!is_last) {
+                                err_ctx.short_buf = .{ '-', ch };
+                                err_ctx.flag = &err_ctx.short_buf;
+                                return error.MissingValue;
+                            }
+                            if (i + 1 >= args.len) {
+                                err_ctx.short_buf = .{ '-', ch };
+                                err_ctx.flag = &err_ctx.short_buf;
+                                return error.MissingValue;
+                            }
+                            i += 1;
+                            try applyValue(&result, spec_idx, specs[spec_idx].kind, args[i], allocator);
+                        }
+                    }
+                }
+            }
+        } else {
+            try result.positionals.append(allocator, arg);
+        }
+    }
+
+    return result;
+}
+
+fn consumeValue(result: *ParseResult, specs: []const FlagSpec, spec_idx: usize, args: []const []const u8, i: *usize, err_ctx: *ErrorContext, allocator: std.mem.Allocator) !void {
+    switch (specs[spec_idx].kind) {
+        .boolean => result.flags[spec_idx].set = true,
+        .value, .multi_value => {
+            if (i.* + 1 >= args.len) {
+                err_ctx.flag = args[i.*];
+                return error.MissingValue;
+            }
+            i.* += 1;
+            try applyValue(result, spec_idx, specs[spec_idx].kind, args[i.*], allocator);
+        },
+    }
+}
+
+fn applyValue(result: *ParseResult, spec_idx: usize, kind: FlagKind, val: []const u8, allocator: std.mem.Allocator) !void {
+    switch (kind) {
+        .boolean => unreachable,
+        .value => result.flags[spec_idx].val = val,
+        .multi_value => {
+            var iter = std.mem.splitScalar(u8, val, ',');
+            while (iter.next()) |part| {
+                try result.flags[spec_idx].multi.append(allocator, part);
+            }
+        },
+    }
+}
+
+fn findLong(specs: []const FlagSpec, name: []const u8) ?usize {
+    for (specs, 0..) |spec, idx| {
+        if (spec.long) |long| {
+            if (std.mem.eql(u8, long, name)) return idx;
+        }
+    }
+    return null;
+}
+
+fn findShort(specs: []const FlagSpec, ch: u8) ?usize {
+    for (specs, 0..) |spec, idx| {
+        if (spec.short) |short| {
+            if (short == ch) return idx;
+        }
+    }
+    return null;
+}
+
+// Tests
+
+test "single boolean short flag" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{"-Q"}, &err_ctx);
+    defer result.deinit(testing.allocator);
+    try testing.expect(result.boolean(0));
+}
+
+test "single boolean long flag" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{"--quiet-git"}, &err_ctx);
+    defer result.deinit(testing.allocator);
+    try testing.expect(result.boolean(0));
+}
+
+test "combined short boolean flags -psQ" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'p', .long = "prompts", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{"-psQ"}, &err_ctx);
+    defer result.deinit(testing.allocator);
+    try testing.expect(result.boolean(0));
+    try testing.expect(result.boolean(1));
+    try testing.expect(result.boolean(2));
+}
+
+test "combined short flag + tail value -psc foo" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'p', .long = "prompts", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+        .{ .short = 'c', .long = "cat", .kind = .value },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{ "-psc", "conduct" }, &err_ctx);
+    defer result.deinit(testing.allocator);
+    try testing.expect(result.boolean(0));
+    try testing.expect(result.boolean(1));
+    try testing.expectEqualStrings("conduct", result.value(2).?);
+}
+
+test "value flag in middle of combined group errors" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .value },
+        .{ .short = 'p', .long = "prompts", .kind = .boolean },
+        .{ .short = 's', .long = "sync", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"-cps"}, &err_ctx);
+    try testing.expectError(error.MissingValue, result);
+    try testing.expectEqualStrings("-c", err_ctx.flag.?);
+}
+
+test "unknown flag errors" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"--foo"}, &err_ctx);
+    try testing.expectError(error.UnknownFlag, result);
+    try testing.expectEqualStrings("--foo", err_ctx.flag.?);
+}
+
+test "unknown short flag errors" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"-x"}, &err_ctx);
+    try testing.expectError(error.UnknownFlag, result);
+    try testing.expectEqualStrings("-x", err_ctx.flag.?);
+}
+
+test "multi_value comma separated -c A,B,C" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .multi_value },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{ "-c", "A,B,C" }, &err_ctx);
+    defer result.deinit(testing.allocator);
+    const vals = result.multiValues(0);
+    try testing.expectEqual(@as(usize, 3), vals.len);
+    try testing.expectEqualStrings("A", vals[0]);
+    try testing.expectEqualStrings("B", vals[1]);
+    try testing.expectEqualStrings("C", vals[2]);
+}
+
+test "multi_value repeated flag -c A -c B" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .multi_value },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{ "-c", "A", "-c", "B" }, &err_ctx);
+    defer result.deinit(testing.allocator);
+    const vals = result.multiValues(0);
+    try testing.expectEqual(@as(usize, 2), vals.len);
+    try testing.expectEqualStrings("A", vals[0]);
+    try testing.expectEqualStrings("B", vals[1]);
+}
+
+test "multi_value combo: -c A,B -c C" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .multi_value },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{ "-c", "A,B", "-c", "C" }, &err_ctx);
+    defer result.deinit(testing.allocator);
+    const vals = result.multiValues(0);
+    try testing.expectEqual(@as(usize, 3), vals.len);
+    try testing.expectEqualStrings("A", vals[0]);
+    try testing.expectEqualStrings("B", vals[1]);
+    try testing.expectEqualStrings("C", vals[2]);
+}
+
+test "positional args collected" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    var result = try parse(&specs, testing.allocator, &.{ "foo", "-Q", "bar" }, &err_ctx);
+    defer result.deinit(testing.allocator);
+    try testing.expect(result.boolean(0));
+    try testing.expectEqual(@as(usize, 2), result.positionals.items.len);
+    try testing.expectEqualStrings("foo", result.positionals.items[0]);
+    try testing.expectEqualStrings("bar", result.positionals.items[1]);
+}
+
+test "MissingValue: flag at end without value" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .value },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"-c"}, &err_ctx);
+    try testing.expectError(error.MissingValue, result);
+    try testing.expectEqualStrings("-c", err_ctx.flag.?);
+}
+
+test "MissingValue: long flag at end without value" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'c', .long = "cat", .kind = .value },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"--cat"}, &err_ctx);
+    try testing.expectError(error.MissingValue, result);
+    try testing.expectEqualStrings("--cat", err_ctx.flag.?);
+}
+
+test "-h returns HelpRequested" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"-h"}, &err_ctx);
+    try testing.expectError(error.HelpRequested, result);
+}
+
+test "--help returns HelpRequested" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"--help"}, &err_ctx);
+    try testing.expectError(error.HelpRequested, result);
+}
+
+test "combined flags with -h returns HelpRequested" {
+    const specs = [_]FlagSpec{
+        .{ .short = 'p', .long = "prompts", .kind = .boolean },
+    };
+    var err_ctx: ErrorContext = .{};
+    const result = parse(&specs, testing.allocator, &.{"-ph"}, &err_ctx);
+    try testing.expectError(error.HelpRequested, result);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -20,6 +20,8 @@ const cmd_get = @import("commands/get_cmd.zig");
 const cmd_pub = @import("commands/pub_cmd.zig");
 const cmd_help = @import("commands/help.zig");
 
+const flags = @import("flags.zig");
+
 const Color = styles.Color;
 const P = styles.P;
 


### PR DESCRIPTION
## Summary

The CLI parsed flags with per-command std.mem.eql loops, which made it
impossible to support combined short flags (-psQ) or comma-separated
multi-value flags (-c A,B,C). Both are expected POSIX conventions.

This PR adds src/flags.zig with a declarative FlagSpec table and a
single parse() function that handles boolean, value, and multi_value
flags with combined short flag expansion and comma splitting. All 11
applicable commands are migrated; setBundle() and config remain manual
due to their multi-arg consumption patterns.

Also fixes a latent bug in remote.zig where args[0] was used as the
URL regardless of flag ordering, and adds -h/--help plus unknown-flag
rejection to pull, clone, remote, and push.

## Test plan

- `zig build test` passes (17 new unit tests in flags.zig)
- Manual: `clumsies ls -ps`, `clumsies ls -psc conduct`,
  `clumsies get -c rule,coding`, `clumsies ls --foo` (error)