### PR TITLE
commands: eliminate duplication and simplify

### DIFF
--- a/src/commands/add_cmd.zig
+++ b/src/commands/add_cmd.zig
@@ -20,6 +20,9 @@ const stripFrontmatter = commands.stripFrontmatter;
 const parseFrontmatter = commands.parseFrontmatter;
 const appendPromptEntry = commands.appendPromptEntry;
 const jsonEscapeAlloc = commands.jsonEscapeAlloc;
+const PromptRef = commands.PromptRef;
+const freePromptRefs = commands.freePromptRefs;
+const updatePromptsIndex = commands.updatePromptsIndex;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const Q = 0;
@@ -119,15 +122,23 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    var registered: usize = 0;
+    var refs: std.ArrayListUnmanaged(PromptRef) = .empty;
+    defer freePromptRefs(allocator, &refs);
 
     for (expanded_paths.items) |file_path| {
-        if (try registerOne(stdout, stderr, allocator, registry_path, prompts_dir, cwd, file_path, desc_flag, cat_flag)) {
-            registered += 1;
+        if (try preparePrompt(stdout, stderr, allocator, prompts_dir, cwd, file_path, desc_flag, cat_flag)) |ref| {
+            try refs.append(allocator, ref);
         }
     }
 
-    if (registered == 0) return;
+    if (refs.items.len == 0) return;
+
+    updatePromptsIndex(allocator, registry_path, refs.items) catch {
+        try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        return;
+    };
+
+    const registered = refs.items.len;
 
     // Commit and push
     var sp = spinner.init(stdout, "Registering prompt(s)");
@@ -165,7 +176,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     }
 }
 
-fn registerOne(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, _: []const u8, prompts_dir: []const u8, cwd: []const u8, file_path: []const u8, desc_flag: ?[]const u8, cat_flag: ?[]const u8) !bool {
+fn preparePrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, prompts_dir: []const u8, cwd: []const u8, file_path: []const u8, desc_flag: ?[]const u8, cat_flag: ?[]const u8) !?PromptRef {
     const abs_path = if (std.fs.path.isAbsolute(file_path))
         try allocator.dupe(u8, file_path)
     else
@@ -174,21 +185,20 @@ fn registerOne(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
 
     const file = fs.openFileAbsolute(abs_path, .{}) catch {
         try stderr.print("{s}{s}{s}Error:{s} Could not open file: {s}\n", .{ P, Color.bold, Color.red, Color.reset, file_path });
-        return false;
+        return null;
     };
     defer file.close();
 
     const raw_content = file.readToEndAlloc(allocator, MAX_FILE_SIZE) catch {
         try stderr.print("{s}{s}{s}Error:{s} Failed to read file: {s}\n", .{ P, Color.bold, Color.red, Color.reset, file_path });
-        return false;
+        return null;
     };
     defer allocator.free(raw_content);
 
     const fm = parseFrontmatter(raw_content);
     const is_meta = if (cat_flag) |c| std.mem.eql(u8, c, META_PROMPT_CATEGORY) else false;
 
-    // Meta-prompt files keep frontmatter for round-trip fidelity (pub → get → pub)
-    // Regular prompts strip frontmatter; metadata lives in index.json
+    // Meta-prompt files keep frontmatter for round-trip fidelity (pub -> get -> pub)
     const content = if (is_meta) raw_content else stripFrontmatter(raw_content);
     const had_frontmatter = if (!is_meta) hasFrontmatter(raw_content) else false;
 
@@ -196,13 +206,11 @@ fn registerOne(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
         try stdout.print("{s}{s}Stripped frontmatter from {s}{s}\n", .{ P, Color.dim, file_path, Color.reset });
     }
 
-    // Compute SHA-256 hash
     var hash: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(content, &hash, .{});
     var hash_hex: [64]u8 = undefined;
     hexEncode(&hash, &hash_hex);
 
-    // Extract file extension and name
     const basename = std.fs.path.basename(file_path);
     const ext_idx = std.mem.lastIndexOf(u8, basename, ".");
     const format = if (ext_idx) |idx| basename[idx + 1 ..] else "md";
@@ -213,9 +221,10 @@ fn registerOne(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
     const raw_category = cat_flag orelse deriveCategory(abs_path) orelse {
         try stderr.print("{s}{s}{s}Error:{s} Could not derive category from path: {s}\n", .{ P, Color.bold, Color.red, Color.reset, file_path });
         try stderr.print("{s}Use {s}--cat{s} to specify a category\n", .{ P, Color.cyan, Color.reset });
-        return false;
+        return null;
     };
-    // Normalize backslashes to forward slashes for cross-platform registry consistency
+
+    // Normalize backslashes for cross-platform registry consistency
     var category_owned: ?[]u8 = null;
     defer if (category_owned) |c| allocator.free(c);
     const prompt_category: []const u8 = if (std.mem.indexOfScalar(u8, raw_category, '\\') != null) blk: {
@@ -231,84 +240,28 @@ fn registerOne(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
     if (fs.openFileAbsolute(dest_path, .{})) |existing| {
         existing.close();
         try stdout.print("{s}{s}{s}!{s} Already exists: {s} ({s})\n", .{ P, Color.bold, Color.orange, Color.reset, name, hash_hex[0..8] });
-        return false;
+        return null;
     } else |_| {}
 
     const dest_file = fs.createFileAbsolute(dest_path, .{}) catch {
         try stderr.print("{s}{s}{s}Error:{s} Failed to create file in registry\n", .{ P, Color.bold, Color.red, Color.reset });
-        return false;
+        return null;
     };
     defer dest_file.close();
     dest_file.writeAll(content) catch {
         try stderr.print("{s}{s}{s}Error:{s} Failed to write file\n", .{ P, Color.bold, Color.red, Color.reset });
-        return false;
-    };
-
-    // Update index.json
-    const index_path = try std.fs.path.join(allocator, &.{ prompts_dir, "index.json" });
-    defer allocator.free(index_path);
-
-    var existing_prompts: std.ArrayListUnmanaged(u8) = .{};
-    defer existing_prompts.deinit(allocator);
-    var has_existing: bool = false;
-
-    if (fs.openFileAbsolute(index_path, .{})) |idx_file| {
-        const idx_content = idx_file.readToEndAlloc(allocator, MAX_FILE_SIZE) catch {
-            idx_file.close();
-            try stderr.print("{s}{s}{s}Error:{s} Failed to read index\n", .{ P, Color.bold, Color.red, Color.reset });
-            return false;
-        };
-        idx_file.close();
-        defer allocator.free(idx_content);
-
-        if (std.json.parseFromSlice(std.json.Value, allocator, idx_content, .{})) |parsed| {
-            defer parsed.deinit();
-            if (parsed.value.object.get("prompts")) |prompts| {
-                try existing_prompts.appendSlice(allocator, "{\n  \"prompts\": [");
-                for (prompts.array.items, 0..) |item, idx| {
-                    if (idx > 0) try existing_prompts.appendSlice(allocator, ",");
-                    try appendPromptEntry(allocator, &existing_prompts, item);
-                    has_existing = true;
-                }
-            }
-        } else |_| {}
-    } else |_| {
-        try existing_prompts.appendSlice(allocator, "{\n  \"prompts\": [");
-    }
-
-    const timestamp = std.time.timestamp();
-    const esc_name = try jsonEscapeAlloc(allocator, name);
-    defer allocator.free(esc_name);
-    const esc_desc = try jsonEscapeAlloc(allocator, description);
-    defer allocator.free(esc_desc);
-    const esc_format = try jsonEscapeAlloc(allocator, format);
-    defer allocator.free(esc_format);
-    const esc_category = try jsonEscapeAlloc(allocator, prompt_category);
-    defer allocator.free(esc_category);
-    const new_entry = try std.fmt.allocPrint(allocator, "{s}\n    {{\n      \"hash\": \"{s}\",\n      \"name\": \"{s}\",\n      \"description\": \"{s}\",\n      \"format\": \"{s}\",\n      \"category\": \"{s}\",\n      \"created_at\": \"{d}\"\n    }}\n  ]\n}}\n", .{
-        if (has_existing) "," else "",
-        hash_hex,
-        esc_name,
-        esc_desc,
-        esc_format,
-        esc_category,
-        timestamp,
-    });
-    defer allocator.free(new_entry);
-    try existing_prompts.appendSlice(allocator, new_entry);
-
-    const idx_out = fs.createFileAbsolute(index_path, .{}) catch {
-        try stderr.print("{s}{s}{s}Error:{s} Failed to write index\n", .{ P, Color.bold, Color.red, Color.reset });
-        return false;
-    };
-    defer idx_out.close();
-    idx_out.writeAll(existing_prompts.items) catch {
-        try stderr.print("{s}{s}{s}Error:{s} Failed to write index\n", .{ P, Color.bold, Color.red, Color.reset });
-        return false;
+        return null;
     };
 
     try stdout.print("{s}Hash: {s}{s}{s}  Name: {s}\n", .{ P, Color.cyan, hash_hex[0..8], Color.reset, name });
-    return true;
+
+    return .{
+        .hash = try allocator.dupe(u8, &hash_hex),
+        .category = try allocator.dupe(u8, prompt_category),
+        .name = try allocator.dupe(u8, name),
+        .description = try allocator.dupe(u8, description),
+        .format = try allocator.dupe(u8, format),
+    };
 }
 
 /// Derive category from file path by finding `.prompts/` segment.

--- a/src/commands/commands.zig
+++ b/src/commands/commands.zig
@@ -4,7 +4,6 @@ const testing = std.testing;
 const styles = @import("../styles.zig");
 const git = @import("../git.zig");
 
-// Sub-modules
 const frontmatter_mod = @import("frontmatter.zig");
 const sequence_mod = @import("sequence.zig");
 const encoding_mod = @import("encoding.zig");
@@ -12,44 +11,32 @@ const registry_mod = @import("registry.zig");
 const index_mod = @import("index.zig");
 const import_mod = @import("import.zig");
 
-// --- Re-exported types ---
-
 pub const Color = styles.Color;
 pub const P = styles.P;
 pub const GitOutput = git.GitOutput;
 
-// --- Shared constants ---
-
 pub const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 pub const MAX_SEQUENCE_NUMBER: u8 = sequence_mod.MAX_SEQUENCE_NUMBER;
 pub const META_PROMPT_CATEGORY = "../";
-
-// --- Re-exports: frontmatter ---
 
 pub const Frontmatter = frontmatter_mod.Frontmatter;
 pub const parseFrontmatter = frontmatter_mod.parseFrontmatter;
 pub const hasFrontmatter = frontmatter_mod.hasFrontmatter;
 pub const stripFrontmatter = frontmatter_mod.stripFrontmatter;
 
-// --- Re-exports: sequence ---
-
 pub const stripSequencePrefix = sequence_mod.stripSequencePrefix;
 pub const findNextSequence = sequence_mod.findNextSequence;
-
-// --- Re-exports: encoding ---
 
 pub const hexEncode = encoding_mod.hexEncode;
 pub const jsonEscapeAlloc = encoding_mod.jsonEscapeAlloc;
 pub const isHexString = encoding_mod.isHexString;
 
-// --- Re-exports: registry ---
-
 pub const RefKind = registry_mod.RefKind;
 pub const ensureRegistry = registry_mod.ensureRegistry;
 pub const resolveRef = registry_mod.resolveRef;
 pub const bundleExists = registry_mod.bundleExists;
-
-// --- Re-exports: index ---
+pub const printGitOutputRaw = registry_mod.printGitOutputRaw;
+pub const getBasePath = registry_mod.getBasePath;
 
 pub const PromptRef = index_mod.PromptRef;
 pub const freePromptRefs = index_mod.freePromptRefs;
@@ -57,30 +44,14 @@ pub const updatePromptsIndex = index_mod.updatePromptsIndex;
 pub const appendPromptEntry = index_mod.appendPromptEntry;
 pub const appendBundleEntry = index_mod.appendBundleEntry;
 
-// --- Re-exports: import ---
-
 pub const ImportResult = import_mod.ImportResult;
 pub const importPrompt = import_mod.importPrompt;
 pub const collectAndUploadPrompts = import_mod.collectAndUploadPrompts;
-
-// --- Path utilities ---
 
 pub fn getPromptsPath(allocator: std.mem.Allocator) ![]const u8 {
     const cwd = try std.process.getCwdAlloc(allocator);
     defer allocator.free(cwd);
     return try std.fs.path.join(allocator, &.{ cwd, ".prompts" });
-}
-
-pub fn getHomePath(allocator: std.mem.Allocator) ![]const u8 {
-    return std.process.getEnvVarOwned(allocator, "HOME") catch
-        std.process.getEnvVarOwned(allocator, "USERPROFILE") catch
-        return error.NoHome;
-}
-
-pub fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
-    const home = try getHomePath(allocator);
-    defer allocator.free(home);
-    return try std.fs.path.join(allocator, &.{ home, ".clumsies" });
 }
 
 pub fn promptsExist() bool {
@@ -95,44 +66,23 @@ pub fn promptsIsGitRepo() bool {
     return true;
 }
 
-// --- Date formatting ---
-
 /// Format timestamp to ISO date string (YYYY-MM-DD)
 pub fn formatDate(timestamp: i64, buf: *[10]u8) []const u8 {
-    const epoch_seconds: u64 = @intCast(if (timestamp < 0) 0 else timestamp);
-    const days_since_epoch = epoch_seconds / 86400;
+    const secs: u64 = @intCast(if (timestamp < 0) 0 else timestamp);
+    const epoch_secs = std.time.epoch.EpochSeconds{ .secs = secs };
+    const epoch_day = epoch_secs.getEpochDay();
+    const year_day = epoch_day.calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
 
-    var year: u32 = 1970;
-    var remaining_days = days_since_epoch;
-
-    while (true) {
-        const is_leap = (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0);
-        const days_in_year: u64 = if (is_leap) 366 else 365;
-        if (remaining_days < days_in_year) break;
-        remaining_days -= days_in_year;
-        year += 1;
-    }
-
-    const is_leap = (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0);
-    const days_in_months = [_]u8{ 31, if (is_leap) 29 else 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-
-    var month: u8 = 1;
-    for (days_in_months) |days| {
-        if (remaining_days < days) break;
-        remaining_days -= days;
-        month += 1;
-    }
-
-    const day: u8 = @intCast(remaining_days + 1);
-
-    _ = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}", .{ year, month, day }) catch return "0000-00-00";
+    _ = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}", .{
+        year_day.year,
+        @as(u8, @intFromEnum(month_day.month)) + 1,
+        month_day.day_index + 1,
+    }) catch return "0000-00-00";
     return buf[0..10];
 }
 
-// --- Git output formatting ---
-
-/// Print git output in unified format
-/// Shows both stdout and stderr with dim styling
+/// Print git output in unified format with dim styling
 pub fn printGitOutput(writer: *std.io.Writer, output: *const GitOutput) void {
     const has_stdout = output.stdout != null and output.stdout.?.len > 0;
     const has_stderr = output.stderr != null and output.stderr.?.len > 0;
@@ -157,42 +107,6 @@ pub fn printGitOutput(writer: *std.io.Writer, output: *const GitOutput) void {
         }
     }
 }
-
-/// Print git output using raw stdout (for use after spinner)
-/// If quiet=true, output is suppressed.
-pub fn printGitOutputRaw(output: *const GitOutput, quiet: bool) void {
-    if (quiet) return;
-    const has_stdout = output.stdout != null and output.stdout.?.len > 0;
-    const has_stderr = output.stderr != null and output.stderr.?.len > 0;
-
-    if (!has_stdout and !has_stderr) return;
-
-    const raw_stdout = std.fs.File.stdout();
-    var buf: [4096]u8 = undefined;
-
-    const header = std.fmt.bufPrint(&buf, "{s}{s}git:{s}\n", .{ P, Color.dim, Color.reset }) catch return;
-    _ = raw_stdout.write(header) catch return;
-
-    if (has_stdout) {
-        const stdout_content = std.mem.trim(u8, output.stdout.?, "\n\r ");
-        var lines = std.mem.splitScalar(u8, stdout_content, '\n');
-        while (lines.next()) |line| {
-            const formatted = std.fmt.bufPrint(&buf, "{s}  {s}{s}{s}\n", .{ P, Color.dim, line, Color.reset }) catch continue;
-            _ = raw_stdout.write(formatted) catch continue;
-        }
-    }
-
-    if (has_stderr) {
-        const stderr_content = std.mem.trim(u8, output.stderr.?, "\n\r ");
-        var lines = std.mem.splitScalar(u8, stderr_content, '\n');
-        while (lines.next()) |line| {
-            const formatted = std.fmt.bufPrint(&buf, "{s}  {s}{s}{s}\n", .{ P, Color.dim, line, Color.reset }) catch continue;
-            _ = raw_stdout.write(formatted) catch continue;
-        }
-    }
-}
-
-// --- Tests for functions that remain in this file ---
 
 test "formatDate: unix epoch" {
     var buf: [10]u8 = undefined;

--- a/src/commands/registry.zig
+++ b/src/commands/registry.zig
@@ -15,9 +15,7 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
 pub const RefKind = enum { prompt, bundle, not_found };
 
-/// Print git output using raw stdout (for use after spinner)
-/// If quiet=true, output is suppressed.
-fn printGitOutputRaw(output: *const GitOutput, quiet: bool) void {
+pub fn printGitOutputRaw(output: *const GitOutput, quiet: bool) void {
     if (quiet) return;
     const has_stdout = output.stdout != null and output.stdout.?.len > 0;
     const has_stderr = output.stderr != null and output.stderr.?.len > 0;
@@ -49,7 +47,7 @@ fn printGitOutputRaw(output: *const GitOutput, quiet: bool) void {
     }
 }
 
-fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
+pub fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
     const home = std.process.getEnvVarOwned(allocator, "HOME") catch
         std.process.getEnvVarOwned(allocator, "USERPROFILE") catch
         return error.NoHome;

--- a/src/commands/set_cmd.zig
+++ b/src/commands/set_cmd.zig
@@ -69,7 +69,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     const kind = resolveRef(allocator, registry_path, ref.?);
 
     switch (kind) {
-        .prompt => try setPrompt(stdout, stderr, allocator, registry_path, ref.?, args, quiet_git),
+        .prompt => try setPrompt(stdout, stderr, allocator, registry_path, ref.?, args),
         .bundle => try setBundle(stdout, stderr, allocator, registry_path, ref.?, args, quiet_git),
         .not_found => {
             try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, ref.? });
@@ -77,8 +77,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     }
 }
 
-fn setPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, registry_path: []const u8, hash: []const u8, args: []const []const u8, quiet_git: bool) !void {
-    _ = quiet_git;
+fn setPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, registry_path: []const u8, hash: []const u8, args: []const []const u8) !void {
     const N = 0;
     const D = 1;
     const C = 2;

--- a/src/flags.zig
+++ b/src/flags.zig
@@ -47,6 +47,8 @@ pub const ParseResult = struct {
 };
 
 pub fn parse(specs: []const FlagSpec, allocator: std.mem.Allocator, args: []const []const u8, err_ctx: *ErrorContext) !ParseResult {
+    if (specs.len > MAX_FLAGS) @panic("specs exceeds MAX_FLAGS");
+
     var result: ParseResult = .{};
     errdefer result.deinit(allocator);
 
@@ -159,8 +161,6 @@ fn findShort(specs: []const FlagSpec, ch: u8) ?usize {
     }
     return null;
 }
-
-// Tests
 
 test "single boolean short flag" {
     const specs = [_]FlagSpec{


### PR DESCRIPTION
## Summary

Code review cleanup addressing 8 issues found across the codebase.

`getBasePath` and `printGitOutputRaw` were duplicated between
commands.zig and registry.zig, left over from an earlier module split.
Both now live in registry.zig (pub) and are re-exported through
commands.zig.

`registerOne` in add_cmd.zig hand-built JSON strings for index.json,
duplicating the same logic already in index.zig's `updatePromptsIndex`.
Refactored to `preparePrompt` (returns a PromptRef) with a single
`updatePromptsIndex` call at the end, also eliminating per-file
index.json read/write cycles.

`formatDate` replaced hand-rolled leap year calculation with
`std.time.epoch.EpochSeconds`. `flags.parse` now checks specs length
against MAX_FLAGS. Removed the unused `quiet_git` parameter from
`setPrompt` and decorative comment lines.

Net: -136 lines.

## Test plan

- `zig build test` passes (all existing tests including formatDate)
- `test/e2e.sh` passes locally (22 assertions)
- CI runs E2E on all three platforms