### PR TITLE
get: add --registry flag for ad-hoc registry access

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,19 +115,48 @@ Platforms: `darwin-arm64`, `darwin-x86_64`, `linux-arm64`, `linux-x86_64`
 
 ## Quick start
 
+Get a working prompt setup in 30 seconds, no configuration needed.
+
+```bash
+mkdir clumsies-demo && cd clumsies-demo
+
+clumsies get opus-coding --registry https://github.com/lilhammerfun/clumsies-registry.git
+```
+
+This creates `.prompts/` with coding rules, reusable commands, and a four-layer architecture workflow (Architecture → ADR → Research → Spec). It also drops a `CLAUDE.md` at the project root that tells your agent where everything is.
+
+Now give your agent a task. Here's an example, or replace it with any project you're interested in:
+
+```
+Follow the arch rules to design a local-first AI agent orchestration
+framework. It should support multiple LLM backends, tool calling,
+streaming output, and conversation memory persistence.
+```
+
+The agent reads `CLAUDE.md`, discovers `.prompts/`, and finds the arch rules. You don't need to point it to specific files. That's the whole point of the MPF: it tells the agent where things are so you can talk in natural language.
+
+> The demo prompts are written in Chinese. The agent follows them regardless and responds in whatever language you write your task in. Add "用中文回复" or "Respond in English" if you want to be explicit.
+
+Check if it worked. The agent should have created files following the architecture workflow:
+
+```bash
+ls .prompts/context/
+# Expected: 01_ARCHITECTURE.md, and possibly adr/, research/, spec/
+```
+
+If you see an Architecture document that identifies modules, references ADRs for cross-cutting decisions, and links to Specs, the prompts are working. That structure came from the rules in `.prompts/rule/arch/`, not from the agent's defaults.
+
+### Build your own registry
+
 ```bash
 # Point to your registry
 clumsies config set registry git@github.com:you/prompt-registry.git
 
-# Register a prompt
+# Register prompts you've refined
 clumsies add .prompts/rule/coding/
 
-# Import a bundle into a new project
+# Import them into another project
 clumsies get my-coding-bundle
-
-# List what's in the registry
-clumsies ls        # bundles
-clumsies ls -p     # prompts
 ```
 
 ## Registry

--- a/src/commands/add_cmd.zig
+++ b/src/commands/add_cmd.zig
@@ -70,7 +70,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const cwd = std.process.getCwdAlloc(allocator) catch {

--- a/src/commands/get_cmd.zig
+++ b/src/commands/get_cmd.zig
@@ -20,11 +20,13 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     const C = 1;
     const R = 2;
     const S = 3;
+    const REG = 4;
     const SPECS = [_]flag.FlagSpec{
         .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
         .{ .short = 'c', .long = "cat", .kind = .multi_value },
         .{ .short = 'r', .long = "remote-url", .kind = .value },
         .{ .short = 's', .long = "sync", .kind = .boolean },
+        .{ .short = null, .long = "registry", .kind = .value },
     };
     var err_ctx: flag.ErrorContext = .{};
     var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
@@ -48,6 +50,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     const cat_filters = result.multiValues(C);
     const remote_url = result.value(R);
     const sync = result.boolean(S);
+    const registry_override = result.value(REG);
     const refs = result.positionals.items;
 
     if (refs.len == 0 and cat_filters.len == 0) {
@@ -56,7 +59,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, registry_override) catch return;
     defer allocator.free(registry_path);
 
     // If first ref resolves as bundle, do bundle import; otherwise prompt import
@@ -349,6 +352,7 @@ fn printHelp(out: *std.io.Writer) !void {
     try out.print("{s}Options:\n", .{P});
     try out.print("{s}  {s}-c, --cat{s} <cat>        Import all prompts in category (prefix match)\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}--remote-url{s} <url>      Add git remote after bundle import\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}--registry{s} <url>         Use a different registry (read-only)\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}-s, --sync{s}             Sync registry before command\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}-Q, --quiet-git{s}        Suppress git output\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}-h, --help{s}             Show this help\n", .{ P, Color.cyan, Color.reset });

--- a/src/commands/ls.zig
+++ b/src/commands/ls.zig
@@ -68,7 +68,7 @@ fn printHelp(out: *std.io.Writer) !void {
 }
 
 fn listPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, cat_filter: ?[]const u8, sync: bool, quiet_git: bool) !void {
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const index_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts/index.json" });
@@ -138,7 +138,7 @@ fn listPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
 }
 
 fn listBundles(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, sync: bool, quiet_git: bool) !void {
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const index_path = try std.fs.path.join(allocator, &.{ registry_path, "bundles/index.json" });

--- a/src/commands/pub_cmd.zig
+++ b/src/commands/pub_cmd.zig
@@ -107,7 +107,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     if (bundleExists(allocator, registry_path, bundle_name)) {

--- a/src/commands/registry.zig
+++ b/src/commands/registry.zig
@@ -55,17 +55,19 @@ pub fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
     return try std.fs.path.join(allocator, &.{ home, ".clumsies" });
 }
 
-/// Ensure registry exists, optionally sync with remote
-/// Caller must free the returned path
-/// If sync=false and registry exists locally, skip network operations (fast path)
-/// If registry doesn't exist, always clones regardless of sync flag
-pub fn ensureRegistry(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, sync: bool, quiet_git: bool) ![]const u8 {
-    const registry_info = config.getRegistryInfo(allocator) catch {
-        try stderr.print("{s}{s}{s}Error:{s} Registry not configured\n", .{ P, Color.bold, Color.red, Color.reset });
-        try stderr.print("{s}Run: {s}clumsies config set registry <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
-        try stderr.print("{s}Tip: Use {s}<git-url>#<branch>{s} to specify a branch\n", .{ P, Color.cyan, Color.reset });
-        return error.NoRegistry;
-    };
+/// Ensure registry exists, optionally sync with remote.
+/// If registry_url is provided, use it instead of the configured registry
+/// and cache in ~/.clumsies/cache/<hash>/.
+pub fn ensureRegistry(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, sync: bool, quiet_git: bool, registry_url: ?[]const u8) ![]const u8 {
+    const registry_info = if (registry_url) |url|
+        try config.parseRegistryUrl(allocator, url)
+    else
+        config.getRegistryInfo(allocator) catch {
+            try stderr.print("{s}{s}{s}Error:{s} Registry not configured\n", .{ P, Color.bold, Color.red, Color.reset });
+            try stderr.print("{s}Run: {s}clumsies config set registry <git-url>{s}\n", .{ P, Color.cyan, Color.reset });
+            try stderr.print("{s}Tip: Use {s}<git-url>#<branch>{s} to specify a branch\n", .{ P, Color.cyan, Color.reset });
+            return error.NoRegistry;
+        };
     defer registry_info.deinit(allocator);
 
     const base_path = getBasePath(allocator) catch {
@@ -74,7 +76,14 @@ pub fn ensureRegistry(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator:
     };
     defer allocator.free(base_path);
 
-    const registry_path = try std.fs.path.join(allocator, &.{ base_path, "registry" });
+    // Override: cache in ~/.clumsies/cache/<hash>/ to avoid conflicts
+    const registry_path = if (registry_url != null) blk: {
+        var hash: [32]u8 = undefined;
+        std.crypto.hash.sha2.Sha256.hash(registry_info.url, &hash, .{});
+        var hex: [64]u8 = undefined;
+        encoding.hexEncode(&hash, &hex);
+        break :blk try std.fs.path.join(allocator, &.{ base_path, "cache", hex[0..16] });
+    } else try std.fs.path.join(allocator, &.{ base_path, "registry" });
     errdefer allocator.free(registry_path);
 
     const registry_exists = blk: {

--- a/src/commands/rm_cmd.zig
+++ b/src/commands/rm_cmd.zig
@@ -50,7 +50,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     }
 
     const refs = result.positionals.items;
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const kind = resolveRef(allocator, registry_path, refs[0]);

--- a/src/commands/set_cmd.zig
+++ b/src/commands/set_cmd.zig
@@ -63,7 +63,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const kind = resolveRef(allocator, registry_path, ref.?);

--- a/src/commands/show_cmd.zig
+++ b/src/commands/show_cmd.zig
@@ -47,7 +47,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git) catch return;
+    const registry_path = ensureRegistry(stdout, stderr, allocator, sync, quiet_git, null) catch return;
     defer allocator.free(registry_path);
 
     const kind = resolveRef(allocator, registry_path, ref.?);


### PR DESCRIPTION
## Summary

Allow specifying a registry URL inline with `--registry` so users can
import from public registries without running `config set` first. The
registry is cloned to `~/.clumsies/cache/<hash>/` to avoid conflicts
with the user's own configured registry.

Only `get` supports `--registry` for now. `ls` and `show` also call
`ensureRegistry` and can benefit from the same flag in a follow-up.

The README quick start is rewritten to demonstrate one-command
onboarding: create a directory, run `clumsies get opus-coding --registry <url>`,
and immediately use the architecture workflow with an AI agent.

## Test plan

- `zig build test` passes
- `test/e2e.sh` passes locally (22 assertions)
- Manual: `clumsies get opus-coding --registry https://github.com/lilhammerfun/clumsies-registry.git` clones to cache and imports 14 prompts