### PR TITLE
bump version to 0.16.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa21731978d142f78,
     .name = .clumsies,
-    .version = "0.15.0",
+    .version = "0.16.0",
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
## Summary

Version bump for the v0.16.0 release (category → group rename, frontmatter removal).

## Test plan

- Version string only, no code changes