### PR TITLE
add install.ps1 for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ More on the design in [ARCHITECTURE.md](./ARCHITECTURE.md).
 curl -fsSL https://raw.githubusercontent.com/lilhammerfun/clumsies/main/install.sh | sh
 ```
 
+**Windows (PowerShell):**
+
+```powershell
+irm https://raw.githubusercontent.com/lilhammerfun/clumsies/main/install.ps1 | iex
+```
+
 <details>
 <summary>Manual install</summary>
 
@@ -144,7 +150,7 @@ mkdir -p ~/.clumsies/bin
 mv clumsies-darwin-arm64 ~/.clumsies/bin/clumsies
 ```
 
-Platforms: `darwin-arm64`, `darwin-x86_64`, `linux-arm64`, `linux-x86_64`
+Platforms: `darwin-arm64`, `darwin-x86_64`, `linux-arm64`, `linux-x86_64`, `windows-x86_64`
 </details>
 
 ## Quick start

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,61 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "lilhammerfun/clumsies"
+$InstallDir = Join-Path $env:USERPROFILE ".clumsies"
+$BinDir = Join-Path $InstallDir "bin"
+$BinaryName = "clumsies-windows-x86_64.exe"
+
+function Info($msg) { Write-Host "-> $msg" }
+function Success($msg) { Write-Host "OK $msg" -ForegroundColor Green }
+function Fail($msg) { Write-Host "Error: $msg" -ForegroundColor Red; exit 1 }
+
+Write-Host "Installing clumsies..." -ForegroundColor White
+
+# Create install directory
+Info "Creating $BinDir"
+New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+
+# Download checksums
+Info "Downloading checksums..."
+$ChecksumsUrl = "https://github.com/$Repo/releases/latest/download/checksums.txt"
+$ChecksumsFile = Join-Path ([System.IO.Path]::GetTempPath()) "clumsies-checksums.txt"
+Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $ChecksumsFile -UseBasicParsing
+
+$ExpectedLine = Get-Content $ChecksumsFile | Where-Object { $_ -match $BinaryName }
+Remove-Item $ChecksumsFile -ErrorAction SilentlyContinue
+if (-not $ExpectedLine) { Fail "Checksum not found for $BinaryName" }
+$ExpectedChecksum = ($ExpectedLine -split '\s+')[0]
+
+# Download binary
+Info "Downloading binary..."
+$DownloadUrl = "https://github.com/$Repo/releases/latest/download/$BinaryName"
+$TempBinary = Join-Path ([System.IO.Path]::GetTempPath()) "clumsies-download.exe"
+Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempBinary -UseBasicParsing
+
+# Verify checksum
+Info "Verifying checksum..."
+$ActualChecksum = (Get-FileHash -Path $TempBinary -Algorithm SHA256).Hash.ToLower()
+if ($ActualChecksum -ne $ExpectedChecksum) {
+    Remove-Item $TempBinary -ErrorAction SilentlyContinue
+    Fail "Checksum verification failed!"
+}
+Success "Checksum verified"
+
+# Install binary
+$DestPath = Join-Path $BinDir "clumsies.exe"
+Move-Item -Path $TempBinary -Destination $DestPath -Force
+
+# Add to PATH
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$BinDir*") {
+    Info "Adding $BinDir to user PATH"
+    [Environment]::SetEnvironmentVariable("Path", "$BinDir;$UserPath", "User")
+} else {
+    Info "PATH already configured"
+}
+
+Success "clumsies installed successfully!"
+Write-Host "Restart your terminal, then try:"
+Write-Host "    clumsies --help" -ForegroundColor Cyan
+Write-Host "    clumsies config set registry <git-url>" -ForegroundColor Cyan
+Write-Host "    clumsies ls" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

Add a PowerShell installer script for Windows users, mirroring install.sh. Downloads the binary, verifies SHA-256 checksum, installs to ~/.clumsies/bin/, and adds to user PATH.

README updated with the PowerShell install command and windows-x86_64 added to platform list.

## Test plan

- Untested on Windows — depends on community validation via #20
- install.sh behavior unchanged