### PR TITLE
registry: reject ambiguous short hashes and require prompt groups

### DIFF
--- a/src/commands/add_cmd.zig
+++ b/src/commands/add_cmd.zig
@@ -130,8 +130,12 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
 
     if (refs.items.len == 0) return;
 
-    updatePromptsIndex(allocator, registry_path, refs.items) catch {
-        try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+    updatePromptsIndex(allocator, registry_path, refs.items) catch |err| {
+        if (err == error.MissingGroup) {
+            try stderr.print("{s}{s}{s}Error:{s} Existing prompt metadata missing group in prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        } else {
+            try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        }
         return;
     };
 

--- a/src/commands/commands.zig
+++ b/src/commands/commands.zig
@@ -26,8 +26,12 @@ pub const jsonEscapeAlloc = encoding_mod.jsonEscapeAlloc;
 pub const isHexString = encoding_mod.isHexString;
 
 pub const RefKind = registry_mod.RefKind;
+pub const PromptMatch = registry_mod.PromptMatch;
+pub const PromptIndexEntry = registry_mod.PromptIndexEntry;
 pub const ensureRegistry = registry_mod.ensureRegistry;
 pub const resolveRef = registry_mod.resolveRef;
+pub const findPromptByHashPrefix = registry_mod.findPromptByHashPrefix;
+pub const printAmbiguousPromptHashError = registry_mod.printAmbiguousPromptHashError;
 pub const bundleExists = registry_mod.bundleExists;
 pub const printGitOutputRaw = registry_mod.printGitOutputRaw;
 pub const getBasePath = registry_mod.getBasePath;

--- a/src/commands/get_cmd.zig
+++ b/src/commands/get_cmd.zig
@@ -13,6 +13,8 @@ const findNextSequence = commands.findNextSequence;
 const MAX_FILE_SIZE = commands.MAX_FILE_SIZE;
 const ensureRegistry = commands.ensureRegistry;
 const resolveRef = commands.resolveRef;
+const findPromptByHashPrefix = commands.findPromptByHashPrefix;
+const printAmbiguousPromptHashError = commands.printAmbiguousPromptHashError;
 const importPrompt = commands.importPrompt;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
@@ -71,6 +73,10 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
                 return;
             },
             .prompt => {},
+            .ambiguous_prompt => {
+                try printAmbiguousPromptHashError(stderr, refs[0]);
+                return;
+            },
             .not_found => {
                 if (group_filters.len == 0) {
                     try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs[0] });
@@ -129,29 +135,27 @@ fn getPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem
 
     // Import by hash
     for (hash_args) |hash| {
-        var found_hash: ?[]const u8 = null;
-        var found_name: ?[]const u8 = null;
-        var found_format: []const u8 = "md";
-        var found_group: []const u8 = "conduct";
+        const entry = switch (findPromptByHashPrefix(prompts, hash)) {
+            .unique => |entry| entry,
+            .ambiguous => {
+                try printAmbiguousPromptHashError(stderr, hash);
+                fail_count += 1;
+                continue;
+            },
+            .not_found => {
+                try stderr.print("{s}{s}{s}✗{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+                fail_count += 1;
+                continue;
+            },
+        };
 
-        for (prompts.array.items) |item| {
-            const item_hash = if (item.object.get("hash")) |h| h.string else continue;
-            if (std.mem.startsWith(u8, item_hash, hash)) {
-                found_hash = item_hash;
-                found_name = if (item.object.get("name")) |n| n.string else null;
-                found_format = if (item.object.get("format")) |f| f.string else "md";
-                found_group = if (item.object.get("group")) |p| p.string else "conduct";
-                break;
-            }
-        }
-
-        if (found_hash == null) {
-            try stderr.print("{s}{s}{s}✗{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+        const group = entry.group orelse {
+            try stderr.print("{s}{s}{s}✗{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, entry.hash });
             fail_count += 1;
             continue;
-        }
+        };
 
-        switch (try importPrompt(stdout, stderr, allocator, registry_path, prompts_path, found_hash.?, found_name, found_format, found_group)) {
+        switch (try importPrompt(stdout, stderr, allocator, registry_path, prompts_path, entry.hash, entry.name, entry.format, group)) {
             .imported => success_count += 1,
             .skipped => {},
             .failed => fail_count += 1,
@@ -165,7 +169,11 @@ fn getPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem
             const item_hash = if (item.object.get("hash")) |h| h.string else continue;
             const item_name_opt: ?[]const u8 = if (item.object.get("name")) |n| n.string else null;
             const item_format = if (item.object.get("format")) |f| f.string else "md";
-            const item_group = if (item.object.get("group")) |p| p.string else "conduct";
+            const item_group = if (item.object.get("group")) |p| p.string else {
+                try stderr.print("{s}{s}{s}✗{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, item_hash });
+                fail_count += 1;
+                continue;
+            };
 
             var matches = false;
             for (group_filters) |grp| {
@@ -322,14 +330,14 @@ fn importBundlePrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator
     for (prompts_arr.array.items) |ref| {
         const hash = if (ref.object.get("hash")) |h| h.string else continue;
 
-        var group: []const u8 = "conduct";
+        var group: ?[]const u8 = null;
         var prompt_name: ?[]const u8 = null;
         var prompt_format: []const u8 = "md";
         if (prompts_list) |pl| {
             for (pl.array.items) |p| {
                 const p_hash = if (p.object.get("hash")) |ph| ph.string else continue;
                 if (std.mem.eql(u8, p_hash, hash)) {
-                    group = if (p.object.get("group")) |c| c.string else "conduct";
+                    group = if (p.object.get("group")) |c| c.string else null;
                     prompt_name = if (p.object.get("name")) |n| n.string else null;
                     prompt_format = if (p.object.get("format")) |f| f.string else "md";
                     break;
@@ -337,7 +345,13 @@ fn importBundlePrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator
             }
         }
 
-        if (try importPrompt(stdout, stderr, allocator, registry_path, prompts_path, hash, prompt_name, prompt_format, group) == .imported) {
+        const resolved_group = group orelse {
+            sp.fail();
+            try stderr.print("{s}{s}{s}Error:{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+            return error.MissingGroup;
+        };
+
+        if (try importPrompt(stdout, stderr, allocator, registry_path, prompts_path, hash, prompt_name, prompt_format, resolved_group) == .imported) {
             count += 1;
         }
     }

--- a/src/commands/index.zig
+++ b/src/commands/index.zig
@@ -117,7 +117,7 @@ pub fn appendPromptEntry(allocator: std.mem.Allocator, buf: *std.ArrayListUnmana
     const item_name = if (item.object.get("name")) |n| n.string else "-";
     const item_desc = if (item.object.get("description")) |d| d.string else "-";
     const item_format = if (item.object.get("format")) |f| f.string else "md";
-    const item_group = if (item.object.get("group")) |p| p.string else "conduct";
+    const item_group = if (item.object.get("group")) |p| p.string else return error.MissingGroup;
     const item_created = if (item.object.get("created_at")) |c| c.string else "0";
 
     const esc_name = try encoding.jsonEscapeAlloc(allocator, item_name);
@@ -285,4 +285,16 @@ test "updatePromptsIndex: escapes special chars in name" {
     const prompts = parsed.value.object.get("prompts").?;
     try testing.expectEqual(@as(usize, 1), prompts.array.items.len);
     try testing.expectEqualStrings("has\"quotes", prompts.array.items[0].object.get("name").?.string);
+}
+
+test "appendPromptEntry: missing group returns error" {
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator,
+        \\{"hash":"abc123","name":"TEST","description":"-","format":"md","created_at":"0"}
+    , .{});
+    defer parsed.deinit();
+
+    var buf: std.ArrayListUnmanaged(u8) = .{};
+    defer buf.deinit(testing.allocator);
+
+    try testing.expectError(error.MissingGroup, appendPromptEntry(testing.allocator, &buf, parsed.value));
 }

--- a/src/commands/ls.zig
+++ b/src/commands/ls.zig
@@ -123,10 +123,11 @@ fn listPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.me
         const hash = if (item.object.get("hash")) |h| h.string else continue;
         const name = if (item.object.get("name")) |n| n.string else "-";
         const desc = if (item.object.get("description")) |d| d.string else "-";
-        const group = if (item.object.get("group")) |c| c.string else "conduct";
+        const group = if (item.object.get("group")) |c| c.string else "<missing>";
 
         // Apply group filter
         if (group_filter) |filter| {
+            if (!item.object.contains("group")) continue;
             if (!std.mem.eql(u8, group, filter) and
                 !(std.mem.startsWith(u8, group, filter) and group.len > filter.len and group[filter.len] == '/'))
                 continue;

--- a/src/commands/pub_cmd.zig
+++ b/src/commands/pub_cmd.zig
@@ -21,6 +21,8 @@ const updatePromptsIndex = commands.updatePromptsIndex;
 const appendBundleEntry = commands.appendBundleEntry;
 const freePromptRefs = commands.freePromptRefs;
 const jsonEscapeAlloc = commands.jsonEscapeAlloc;
+const findPromptByHashPrefix = commands.findPromptByHashPrefix;
+const printAmbiguousPromptHashError = commands.printAmbiguousPromptHashError;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const N = 0;
@@ -144,7 +146,6 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         const pidx_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts/index.json" });
         defer allocator.free(pidx_path);
 
-        var resolved: ?[]const u8 = null;
         if (fs.openFileAbsolute(pidx_path, .{})) |pidx_file| {
             const pidx_content = pidx_file.readToEndAlloc(allocator, MAX_FILE_SIZE) catch {
                 pidx_file.close();
@@ -157,21 +158,22 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
             if (std.json.parseFromSlice(std.json.Value, allocator, pidx_content, .{})) |pidx_parsed| {
                 defer pidx_parsed.deinit();
                 if (pidx_parsed.value.object.get("prompts")) |pidx_prompts| {
-                    for (pidx_prompts.array.items) |pitem| {
-                        const pitem_hash = if (pitem.object.get("hash")) |h| h.string else continue;
-                        if (std.mem.startsWith(u8, pitem_hash, meta_prompt_arg)) {
-                            resolved = try allocator.dupe(u8, pitem_hash);
-                            break;
-                        }
+                    switch (findPromptByHashPrefix(pidx_prompts, meta_prompt_arg)) {
+                        .unique => |entry| {
+                            meta_prompt_hash = try allocator.dupe(u8, entry.hash);
+                            meta_hash_owned = true;
+                        },
+                        .ambiguous => {
+                            try printAmbiguousPromptHashError(stderr, meta_prompt_arg);
+                            return;
+                        },
+                        .not_found => {},
                     }
                 }
             } else |_| {}
         } else |_| {}
 
-        if (resolved) |full_hash| {
-            meta_prompt_hash = full_hash;
-            meta_hash_owned = true;
-        } else {
+        if (!meta_hash_owned) {
             try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, meta_prompt_arg });
             return;
         }
@@ -242,9 +244,13 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     // Update prompts/index.json (includes both regular prompts and MPF)
     var sp2 = spinner.init(stdout, "Updating prompts index");
     sp2.start();
-    updatePromptsIndex(allocator, registry_path, prompt_refs.items) catch {
+    updatePromptsIndex(allocator, registry_path, prompt_refs.items) catch |err| {
         sp2.fail();
-        try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        if (err == error.MissingGroup) {
+            try stderr.print("{s}{s}{s}Error:{s} Existing prompt metadata missing group in prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        } else {
+            try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+        }
         return;
     };
     sp2.succeed();

--- a/src/commands/registry.zig
+++ b/src/commands/registry.zig
@@ -13,7 +13,21 @@ const GitOutput = git.GitOutput;
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-pub const RefKind = enum { prompt, bundle, not_found };
+pub const PromptIndexEntry = struct {
+    hash: []const u8,
+    name: ?[]const u8 = null,
+    description: []const u8 = "-",
+    format: []const u8 = "md",
+    group: ?[]const u8 = null,
+};
+
+pub const PromptMatch = union(enum) {
+    unique: PromptIndexEntry,
+    ambiguous: void,
+    not_found: void,
+};
+
+pub const RefKind = enum { prompt, bundle, ambiguous_prompt, not_found };
 
 pub fn printGitOutputRaw(output: *const GitOutput, quiet: bool) void {
     if (quiet) return;
@@ -155,11 +169,11 @@ pub fn resolveRef(allocator: std.mem.Allocator, registry_path: []const u8, ref: 
         defer parsed.deinit();
 
         const prompts = parsed.value.object.get("prompts") orelse return .not_found;
-        for (prompts.array.items) |item| {
-            const item_hash = if (item.object.get("hash")) |h| h.string else continue;
-            if (std.mem.startsWith(u8, item_hash, ref)) return .prompt;
-        }
-        return .not_found;
+        return switch (findPromptByHashPrefix(prompts, ref)) {
+            .unique => .prompt,
+            .ambiguous => .ambiguous_prompt,
+            .not_found => .not_found,
+        };
     } else {
         const index_path = std.fs.path.join(allocator, &.{ registry_path, "bundles/index.json" }) catch return .not_found;
         defer allocator.free(index_path);
@@ -179,6 +193,33 @@ pub fn resolveRef(allocator: std.mem.Allocator, registry_path: []const u8, ref: 
         }
         return .not_found;
     }
+}
+
+pub fn findPromptByHashPrefix(prompts: std.json.Value, prefix: []const u8) PromptMatch {
+    var found: ?PromptIndexEntry = null;
+
+    for (prompts.array.items) |item| {
+        const item_hash = if (item.object.get("hash")) |h| h.string else continue;
+        if (!std.mem.startsWith(u8, item_hash, prefix)) continue;
+
+        if (found != null) return .ambiguous;
+
+        found = .{
+            .hash = item_hash,
+            .name = if (item.object.get("name")) |n| n.string else null,
+            .description = if (item.object.get("description")) |d| d.string else "-",
+            .format = if (item.object.get("format")) |f| f.string else "md",
+            .group = if (item.object.get("group")) |g| g.string else null,
+        };
+    }
+
+    if (found) |entry| return .{ .unique = entry };
+    return .not_found;
+}
+
+pub fn printAmbiguousPromptHashError(stderr: *std.io.Writer, ref: []const u8) !void {
+    try stderr.print("{s}{s}{s}Error:{s} Ambiguous prompt hash prefix: {s}\n", .{ P, Color.bold, Color.red, Color.reset, ref });
+    try stderr.print("{s}Use a longer prefix or the full hash\n", .{P});
 }
 
 /// Check if a bundle exists in the registry by name
@@ -226,6 +267,21 @@ test "resolveRef: hash prefix matches prompt" {
     try testing.expectEqual(RefKind.prompt, resolveRef(testing.allocator, path, "abcdef12"));
 }
 
+test "resolveRef: ambiguous hash prefix returns ambiguous_prompt" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("prompts");
+    try writeTestFile(tmp.dir, "prompts/index.json",
+        \\{"prompts":[
+        \\{"hash":"abcdef1234567890","name":"FOO","description":"-","format":"md","group":"rule","created_at":"0"},
+        \\{"hash":"abcdef99aaaa0000","name":"BAR","description":"-","format":"md","group":"rule","created_at":"0"}
+        \\]}
+    );
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpDirAbsolutePath(&tmp, &buf);
+    try testing.expectEqual(RefKind.ambiguous_prompt, resolveRef(testing.allocator, path, "abcdef"));
+}
+
 test "resolveRef: name matches bundle" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -249,6 +305,44 @@ test "resolveRef: no match returns not_found" {
     const path = tmpDirAbsolutePath(&tmp, &buf);
     try testing.expectEqual(RefKind.not_found, resolveRef(testing.allocator, path, "deadbeef"));
     try testing.expectEqual(RefKind.not_found, resolveRef(testing.allocator, path, "nonexistent"));
+}
+
+test "findPromptByHashPrefix: unique match returns metadata" {
+    const json =
+        \\{"prompts":[{"hash":"abcdef1234567890","name":"FOO","description":"desc","format":"md","group":"rule","created_at":"0"}]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const prompts = parsed.value.object.get("prompts").?;
+    const match = findPromptByHashPrefix(prompts, "abcdef12");
+    switch (match) {
+        .unique => |entry| {
+            try testing.expectEqualStrings("abcdef1234567890", entry.hash);
+            try testing.expectEqualStrings("FOO", entry.name.?);
+            try testing.expectEqualStrings("desc", entry.description);
+            try testing.expectEqualStrings("md", entry.format);
+            try testing.expectEqualStrings("rule", entry.group.?);
+        },
+        else => return error.UnexpectedResult,
+    }
+}
+
+test "findPromptByHashPrefix: ambiguous prefix returns ambiguous" {
+    const json =
+        \\{"prompts":[
+        \\{"hash":"abcdef1234567890","name":"FOO","description":"-","format":"md","group":"rule","created_at":"0"},
+        \\{"hash":"abcdef99aaaa0000","name":"BAR","description":"-","format":"md","group":"rule","created_at":"0"}
+        \\]}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const prompts = parsed.value.object.get("prompts").?;
+    switch (findPromptByHashPrefix(prompts, "abcdef")) {
+        .ambiguous => {},
+        else => return error.UnexpectedResult,
+    }
 }
 
 test "resolveRef: no index files returns not_found" {

--- a/src/commands/rm_cmd.zig
+++ b/src/commands/rm_cmd.zig
@@ -14,6 +14,8 @@ const ensureRegistry = commands.ensureRegistry;
 const resolveRef = commands.resolveRef;
 const appendBundleEntry = commands.appendBundleEntry;
 const appendPromptEntry = commands.appendPromptEntry;
+const findPromptByHashPrefix = commands.findPromptByHashPrefix;
+const printAmbiguousPromptHashError = commands.printAmbiguousPromptHashError;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const Q = 0;
@@ -58,6 +60,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     switch (kind) {
         .prompt => try rmPrompts(stdout, stderr, allocator, registry_path, refs, quiet_git),
         .bundle => try rmBundles(stdout, stderr, allocator, registry_path, refs, quiet_git),
+        .ambiguous_prompt => try printAmbiguousPromptHashError(stderr, refs[0]),
         .not_found => {
             try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, refs[0] });
         },
@@ -95,6 +98,29 @@ fn rmPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
     var removed_hashes: std.ArrayListUnmanaged([]const u8) = .{};
     defer removed_hashes.deinit(allocator);
 
+    for (hash_args) |hash| {
+        switch (findPromptByHashPrefix(prompts, hash)) {
+            .unique => |entry| {
+                var duplicate = false;
+                for (removed_hashes.items) |existing| {
+                    if (std.mem.eql(u8, existing, entry.hash)) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (!duplicate) try removed_hashes.append(allocator, entry.hash);
+            },
+            .ambiguous => {
+                try printAmbiguousPromptHashError(stderr, hash);
+                return;
+            },
+            .not_found => {
+                try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+                return;
+            },
+        }
+    }
+
     var new_prompts: std.ArrayListUnmanaged(u8) = .{};
     defer new_prompts.deinit(allocator);
 
@@ -105,10 +131,9 @@ fn rmPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
         const item_hash = if (item.object.get("hash")) |h| h.string else continue;
 
         var should_remove = false;
-        for (hash_args) |hash| {
-            if (std.mem.startsWith(u8, item_hash, hash)) {
+        for (removed_hashes.items) |hash| {
+            if (std.mem.eql(u8, item_hash, hash)) {
                 should_remove = true;
-                try removed_hashes.append(allocator, item_hash);
                 break;
             }
         }
@@ -117,7 +142,13 @@ fn rmPrompts(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
 
         if (!first) try new_prompts.appendSlice(allocator, ",");
         first = false;
-        try appendPromptEntry(allocator, &new_prompts, item);
+        appendPromptEntry(allocator, &new_prompts, item) catch |err| switch (err) {
+            error.MissingGroup => {
+                try stderr.print("{s}{s}{s}Error:{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, item_hash });
+                return;
+            },
+            else => return err,
+        };
     }
     try new_prompts.appendSlice(allocator, "\n  ]\n}\n");
 

--- a/src/commands/set_cmd.zig
+++ b/src/commands/set_cmd.zig
@@ -19,6 +19,8 @@ const PromptRef = commands.PromptRef;
 const collectAndUploadPrompts = commands.collectAndUploadPrompts;
 const updatePromptsIndex = commands.updatePromptsIndex;
 const freePromptRefs = commands.freePromptRefs;
+const findPromptByHashPrefix = commands.findPromptByHashPrefix;
+const printAmbiguousPromptHashError = commands.printAmbiguousPromptHashError;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const Q = 5;
@@ -74,6 +76,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     switch (kind) {
         .prompt => try setPrompt(stdout, stderr, allocator, registry_path, ref.?, args),
         .bundle => try setBundle(stdout, stderr, allocator, registry_path, ref.?, args),
+        .ambiguous_prompt => try printAmbiguousPromptHashError(stderr, ref.?),
         .not_found => {
             try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, ref.? });
         },
@@ -145,6 +148,24 @@ fn setPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
     }
 }
 
+fn existingPromptGroup(stderr: *std.io.Writer, item: std.json.Value, hash: []const u8) !?[]const u8 {
+    if (item.object.get("group")) |group| return group.string;
+    try stderr.print("{s}{s}{s}Error:{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+    return null;
+}
+
+fn appendPromptEntryOrReport(stderr: *std.io.Writer, allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8), item: std.json.Value) !bool {
+    const item_hash = if (item.object.get("hash")) |hash| hash.string else return true;
+    appendPromptEntry(allocator, buf, item) catch |err| switch (err) {
+        error.MissingGroup => {
+            try stderr.print("{s}{s}{s}Error:{s} Prompt metadata missing group: {s}\n", .{ P, Color.bold, Color.red, Color.reset, item_hash });
+            return false;
+        },
+        else => return err,
+    };
+    return true;
+}
+
 fn updatePromptMeta(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, registry_path: []const u8, hash: []const u8, name_flag: ?[]const u8, desc_flag: ?[]const u8, group_flag: ?[]const u8, quiet_git: bool) !void {
     const index_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts/index.json" });
     defer allocator.free(index_path);
@@ -190,7 +211,7 @@ fn updatePromptMeta(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: s
             found = true;
             const item_name = name_flag orelse (if (item.object.get("name")) |n| n.string else "-");
             const item_desc = desc_flag orelse (if (item.object.get("description")) |d| d.string else "-");
-            const item_group = group_flag orelse (if (item.object.get("group")) |p| p.string else "conduct");
+            const item_group = group_flag orelse ((try existingPromptGroup(stderr, item, item_hash)) orelse return);
             const item_format = if (item.object.get("format")) |f| f.string else "md";
             const item_created = if (item.object.get("created_at")) |c| c.string else "0";
 
@@ -198,7 +219,7 @@ fn updatePromptMeta(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: s
             defer allocator.free(entry);
             try new_index.appendSlice(allocator, entry);
         } else {
-            try appendPromptEntry(allocator, &new_index, item);
+            if (!(try appendPromptEntryOrReport(stderr, allocator, &new_index, item))) return;
         }
     }
     try new_index.appendSlice(allocator, "\n  ]\n}\n");
@@ -378,14 +399,14 @@ fn replacePrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.
             const item_name = if (item.object.get("name")) |n| n.string else "-";
             const item_desc = desc_flag orelse (if (item.object.get("description")) |d| d.string else "-");
             const item_format = if (hash_changed) new_format else (if (item.object.get("format")) |f| f.string else "md");
-            const item_group = group_flag orelse (if (item.object.get("group")) |p| p.string else "conduct");
+            const item_group = group_flag orelse ((try existingPromptGroup(stderr, item, item_hash)) orelse return);
             const item_created = if (item.object.get("created_at")) |c| c.string else "0";
 
             const entry = try std.fmt.allocPrint(allocator, "\n    {{\n      \"hash\": \"{s}\",\n      \"name\": \"{s}\",\n      \"description\": \"{s}\",\n      \"format\": \"{s}\",\n      \"group\": \"{s}\",\n      \"created_at\": \"{s}\"\n    }}", .{ use_hash, item_name, item_desc, item_format, item_group, item_created });
             defer allocator.free(entry);
             try new_index.appendSlice(allocator, entry);
         } else {
-            try appendPromptEntry(allocator, &new_index, item);
+            if (!(try appendPromptEntryOrReport(stderr, allocator, &new_index, item))) return;
         }
     }
     try new_index.appendSlice(allocator, "\n  ]\n}\n");
@@ -537,7 +558,7 @@ fn renameGroupFromRef(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator:
     for (prompts.array.items) |item| {
         const item_hash = if (item.object.get("hash")) |h| h.string else continue;
         if (std.mem.startsWith(u8, item_hash, hash)) {
-            old_group = if (item.object.get("group")) |c| c.string else "conduct";
+            old_group = (try existingPromptGroup(stderr, item, item_hash)) orelse return;
             break;
         }
     }
@@ -564,7 +585,7 @@ fn renameGroupFromRef(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator:
 
     for (prompts.array.items) |item| {
         const item_hash = if (item.object.get("hash")) |h| h.string else continue;
-        const item_group = if (item.object.get("group")) |p| p.string else "conduct";
+        const item_group = (try existingPromptGroup(stderr, item, item_hash)) orelse return;
 
         if (!first) try new_index.appendSlice(allocator, ",");
         first = false;
@@ -580,7 +601,7 @@ fn renameGroupFromRef(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator:
             defer allocator.free(entry);
             try new_index.appendSlice(allocator, entry);
         } else {
-            try appendPromptEntry(allocator, &new_index, item);
+            if (!(try appendPromptEntryOrReport(stderr, allocator, &new_index, item))) return;
         }
     }
     try new_index.appendSlice(allocator, "\n  ]\n}\n");
@@ -697,8 +718,6 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
             const prompts_index_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts/index.json" });
             defer allocator.free(prompts_index_path);
 
-            var resolved_hash: ?[]const u8 = null;
-
             if (fs.openFileAbsolute(prompts_index_path, .{})) |pidx_file| {
                 const pidx_content = pidx_file.readToEndAlloc(allocator, MAX_FILE_SIZE) catch {
                     pidx_file.close();
@@ -710,20 +729,19 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
                 if (std.json.parseFromSlice(std.json.Value, allocator, pidx_content, .{})) |pidx_parsed| {
                     defer pidx_parsed.deinit();
                     if (pidx_parsed.value.object.get("prompts")) |pidx_prompts| {
-                        for (pidx_prompts.array.items) |pitem| {
-                            const pitem_hash = if (pitem.object.get("hash")) |h| h.string else continue;
-                            if (std.mem.startsWith(u8, pitem_hash, meta_arg)) {
-                                resolved_hash = try allocator.dupe(u8, pitem_hash);
-                                break;
-                            }
+                        switch (findPromptByHashPrefix(pidx_prompts, meta_arg)) {
+                            .unique => |entry| new_meta_hash = try allocator.dupe(u8, entry.hash),
+                            .ambiguous => {
+                                try printAmbiguousPromptHashError(stderr, meta_arg);
+                                return;
+                            },
+                            .not_found => {},
                         }
                     }
                 } else |_| {}
             } else |_| {}
 
-            if (resolved_hash) |full_hash| {
-                new_meta_hash = full_hash;
-            } else {
+            if (new_meta_hash == null) {
                 try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, meta_arg });
                 return;
             }
@@ -805,9 +823,13 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
 
         var sp_idx = spinner.init(stdout, "Updating prompts index");
         sp_idx.start();
-        updatePromptsIndex(allocator, registry_path, new_refs.items) catch {
+        updatePromptsIndex(allocator, registry_path, new_refs.items) catch |err| {
             sp_idx.fail();
-            try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+            if (err == error.MissingGroup) {
+                try stderr.print("{s}{s}{s}Error:{s} Existing prompt metadata missing group in prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+            } else {
+                try stderr.print("{s}{s}{s}Error:{s} Failed to update prompts index\n", .{ P, Color.bold, Color.red, Color.reset });
+            }
             return;
         };
         sp_idx.succeed();
@@ -820,7 +842,13 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
         resolved_add_hashes.deinit(allocator);
     }
 
-    if (add_prompt_hashes.len > 0) {
+    var resolved_rm_hashes: std.ArrayListUnmanaged([]const u8) = .{};
+    defer {
+        for (resolved_rm_hashes.items) |h| allocator.free(h);
+        resolved_rm_hashes.deinit(allocator);
+    }
+
+    if (add_prompt_hashes.len > 0 or rm_prompt_hashes.len > 0) {
         const pidx_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts/index.json" });
         defer allocator.free(pidx_path);
 
@@ -843,20 +871,31 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
             return;
         };
 
-        for (add_prompt_hashes) |add_hash| {
-            var found_full: ?[]const u8 = null;
-            for (pidx_prompts.array.items) |pitem| {
-                const pitem_hash = if (pitem.object.get("hash")) |h| h.string else continue;
-                if (std.mem.startsWith(u8, pitem_hash, add_hash)) {
-                    found_full = pitem_hash;
-                    break;
-                }
+        for (rm_prompt_hashes) |rm_hash| {
+            switch (findPromptByHashPrefix(pidx_prompts, rm_hash)) {
+                .unique => |entry| try resolved_rm_hashes.append(allocator, try allocator.dupe(u8, entry.hash)),
+                .ambiguous => {
+                    try printAmbiguousPromptHashError(stderr, rm_hash);
+                    return;
+                },
+                .not_found => {
+                    try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, rm_hash });
+                    return;
+                },
             }
-            if (found_full) |full| {
-                try resolved_add_hashes.append(allocator, try allocator.dupe(u8, full));
-            } else {
-                try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, add_hash });
-                return;
+        }
+
+        for (add_prompt_hashes) |add_hash| {
+            switch (findPromptByHashPrefix(pidx_prompts, add_hash)) {
+                .unique => |entry| try resolved_add_hashes.append(allocator, try allocator.dupe(u8, entry.hash)),
+                .ambiguous => {
+                    try printAmbiguousPromptHashError(stderr, add_hash);
+                    return;
+                },
+                .not_found => {
+                    try stderr.print("{s}{s}{s}Error:{s} No prompt found matching hash: {s}\n", .{ P, Color.bold, Color.red, Color.reset, add_hash });
+                    return;
+                },
             }
         }
     }
@@ -926,8 +965,8 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
                     const ref_hash = if (ref.object.get("hash")) |h| h.string else continue;
 
                     var should_remove = false;
-                    for (rm_prompt_hashes) |rm_hash| {
-                        if (std.mem.startsWith(u8, ref_hash, rm_hash)) {
+                    for (resolved_rm_hashes.items) |rm_hash| {
+                        if (std.mem.eql(u8, ref_hash, rm_hash)) {
                             should_remove = true;
                             prompts_removed += 1;
                             break;

--- a/src/commands/show_cmd.zig
+++ b/src/commands/show_cmd.zig
@@ -8,6 +8,8 @@ const P = commands.P;
 const MAX_FILE_SIZE = commands.MAX_FILE_SIZE;
 const ensureRegistry = commands.ensureRegistry;
 const resolveRef = commands.resolveRef;
+const findPromptByHashPrefix = commands.findPromptByHashPrefix;
+const printAmbiguousPromptHashError = commands.printAmbiguousPromptHashError;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const Q = 0;
@@ -55,6 +57,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     switch (kind) {
         .prompt => try showPrompt(stdout, stderr, allocator, registry_path, ref.?),
         .bundle => try showBundle(stdout, stderr, allocator, registry_path, ref.?, show_meta),
+        .ambiguous_prompt => try printAmbiguousPromptHashError(stderr, ref.?),
         .not_found => {
             try stderr.print("{s}{s}{s}Error:{s} Not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, ref.? });
         },
@@ -88,24 +91,19 @@ fn showPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem
         return;
     };
 
-    var found_hash: ?[]const u8 = null;
-    var found_name: ?[]const u8 = null;
+    const entry = switch (findPromptByHashPrefix(prompts, hash)) {
+        .unique => |entry| entry,
+        .ambiguous => {
+            try printAmbiguousPromptHashError(stderr, hash);
+            return;
+        },
+        .not_found => {
+            try stderr.print("{s}{s}{s}Error:{s} Prompt not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
+            return;
+        },
+    };
 
-    for (prompts.array.items) |item| {
-        const item_hash = if (item.object.get("hash")) |h| h.string else continue;
-        if (std.mem.startsWith(u8, item_hash, hash)) {
-            found_hash = item_hash;
-            found_name = if (item.object.get("name")) |n| n.string else null;
-            break;
-        }
-    }
-
-    if (found_hash == null) {
-        try stderr.print("{s}{s}{s}Error:{s} Prompt not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, hash });
-        return;
-    }
-
-    const prompt_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts", found_hash.? });
+    const prompt_path = try std.fs.path.join(allocator, &.{ registry_path, "prompts", entry.hash });
     defer allocator.free(prompt_path);
 
     const prompt_file = fs.openFileAbsolute(prompt_path, .{}) catch {
@@ -120,10 +118,10 @@ fn showPrompt(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem
     };
     defer allocator.free(prompt_content);
 
-    if (found_name) |n| {
+    if (entry.name) |n| {
         try stdout.print("{s}{s}{s}Prompt:{s} {s}\n", .{ P, Color.bold, Color.orange, Color.reset, n });
     }
-    try stdout.print("{s}{s}Hash:{s} {s}\n", .{ P, Color.orange, Color.reset, found_hash.? });
+    try stdout.print("{s}{s}Hash:{s} {s}\n", .{ P, Color.orange, Color.reset, entry.hash });
     try stdout.print("{s}────────────────────────────────────────────────────────────────────────────\n", .{P});
     try stdout.print("{s}\n", .{prompt_content});
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -94,6 +94,9 @@ mkdir -p "$WORKSPACE/.prompts/rule/coding"
 printf "# Test Coding Rule\n\nAlways use snake_case.\n" > "$WORKSPACE/.prompts/rule/coding/00_SNAKE_CASE.md"
 mkdir -p "$WORKSPACE/.prompts/rule/testing"
 printf "# Test Testing Rule\n\nWrite tests first.\n" > "$WORKSPACE/.prompts/rule/testing/00_TDD.md"
+mkdir -p "$WORKSPACE/.prompts/rule/ambiguous"
+printf "# Prompt 264\n\ncontent 264\n" > "$WORKSPACE/.prompts/rule/ambiguous/00_ALPHA.md"
+printf "# Prompt 269\n\ncontent 269\n" > "$WORKSPACE/.prompts/rule/ambiguous/01_BETA.md"
 cd "$WORKSPACE"
 
 # 1. config set registry
@@ -117,6 +120,16 @@ assert_file_contains "index has TDD entry" "$PROMPTS_INDEX" "TDD"
 assert_file_contains "derived group uses forward slash" "$PROMPTS_INDEX" "rule/testing"
 assert_file_not_contains "no backslash in groups" "$PROMPTS_INDEX" 'rule\\testing'
 
+# 3b. add directory with colliding hash prefixes
+step "3b. add directory (ambiguous short hash setup)"
+"$CLUMSIES" add .prompts/rule/ambiguous/ -Q
+ALPHA_HASH=$(grep -B 5 '"name": "ALPHA"' "$PROMPTS_INDEX" | grep -o '"hash": "[a-f0-9]*"' | head -1 | cut -d'"' -f4)
+BETA_HASH=$(grep -B 5 '"name": "BETA"' "$PROMPTS_INDEX" | grep -o '"hash": "[a-f0-9]*"' | head -1 | cut -d'"' -f4)
+AMBIG_PREFIX="${ALPHA_HASH:0:4}"
+assert "alpha hash found" test -n "$ALPHA_HASH"
+assert "beta hash found" test -n "$BETA_HASH"
+assert "hash prefix is ambiguous" test "${BETA_HASH:0:4}" = "$AMBIG_PREFIX"
+
 # Extract a hash for later use
 HASH=$(grep -o '"hash": "[a-f0-9]*"' "$PROMPTS_INDEX" | head -1 | cut -d'"' -f4)
 SHORT_HASH="${HASH:0:8}"
@@ -136,6 +149,11 @@ assert_output "combined flags work" "SNAKE_CASE" "$LS_COMBINED"
 step "6. show <hash>"
 SHOW_OUTPUT=$("$CLUMSIES" show "$SHORT_HASH" -Q 2>&1 || true)
 assert_output "show contains prompt content" "snake_case" "$SHOW_OUTPUT"
+
+# 6b. show ambiguous <hash>
+step "6b. show ambiguous <hash>"
+SHOW_AMBIG=$("$CLUMSIES" show "$AMBIG_PREFIX" -Q 2>&1 || true)
+assert_output "ambiguous short hash rejected" "Ambiguous prompt hash prefix" "$SHOW_AMBIG"
 
 # 7. get <hash> (import prompt)
 step "7. get <hash>"
@@ -187,6 +205,13 @@ step "12. rm prompt"
 "$CLUMSIES" rm "$CONDUCT_SHORT" -Q
 assert_file_not_contains "prompt removed from index" "$PROMPTS_INDEX" "$CONDUCT_HASH"
 assert "prompt file deleted" test ! -f "$HOME_DIR/.clumsies/registry/prompts/$CONDUCT_HASH"
+
+# 13. rm ambiguous <hash>
+step "13. rm ambiguous <hash>"
+RM_AMBIG=$("$CLUMSIES" rm "$AMBIG_PREFIX" -Q 2>&1 || true)
+assert_output "ambiguous rm rejected" "Ambiguous prompt hash prefix" "$RM_AMBIG"
+assert_file_contains "alpha preserved after ambiguous rm" "$PROMPTS_INDEX" "$ALPHA_HASH"
+assert_file_contains "beta preserved after ambiguous rm" "$PROMPTS_INDEX" "$BETA_HASH"
 
 # Summary
 printf "\n=== Results: %d passed, %d failed ===\n" "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Prompt refs were resolved by simple prefix matching, so a short hash
could stop being safe as soon as another prompt shared the same prefix.
That made read paths brittle and could turn destructive commands like
`rm` into multi-delete operations when the user intended to target a
single prompt.

Resolve prompt refs through a shared matcher that distinguishes unique,
ambiguous, and missing prefixes, and use that result consistently across
`show`, `get`, `set`, `rm`, and `pub`. Commands now reject ambiguous
short hashes instead of guessing, and destructive paths only operate on
fully resolved prompt hashes.

This PR also removes the old implicit `"conduct"` fallback for prompt
groups in execution paths and index serialization. Commands that need a
real group now fail fast on corrupt prompt metadata, while `ls` still
surfaces those entries as `<missing>` so they can be repaired.

## Test plan

Run `zig fmt --check src/`.

Run `git diff --check`.

Run `zig build test`.

Run `zig build`.

Run `bash test/e2e.sh`, including the ambiguous short-hash regressions
for `show` and `rm` and the missing-group serialization test.
