### PR TITLE
add: support --bundle flag for one-step register and assign

### DIFF
--- a/src/commands/add_cmd.zig
+++ b/src/commands/add_cmd.zig
@@ -20,6 +20,8 @@ const jsonEscapeAlloc = commands.jsonEscapeAlloc;
 const PromptRef = commands.PromptRef;
 const freePromptRefs = commands.freePromptRefs;
 const updatePromptsIndex = commands.updatePromptsIndex;
+const addPromptsToBundle = commands.addPromptsToBundle;
+const bundleExists = commands.bundleExists;
 
 pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const Q = 0;
@@ -27,12 +29,14 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     const C = 2;
     const META = 3;
     const S = 4;
+    const B = 5;
     const SPECS = [_]flag.FlagSpec{
         .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },
         .{ .short = 'd', .long = "desc", .kind = .value },
         .{ .short = 'g', .long = "group", .kind = .value },
         .{ .short = 'm', .long = "meta", .kind = .boolean },
         .{ .short = 's', .long = "sync", .kind = .boolean },
+        .{ .short = 'b', .long = "bundle", .kind = .value },
     };
     var err_ctx: flag.ErrorContext = .{};
     var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
@@ -56,6 +60,7 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
     const desc_flag = result.value(D);
     var group_flag = result.value(C);
     const sync = result.boolean(S);
+    const bundle_flag = result.value(B);
 
     if (result.boolean(META)) {
         group_flag = META_PROMPT_GROUP;
@@ -119,6 +124,14 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
+    // Validate bundle exists before registering (fail fast)
+    if (bundle_flag) |bname| {
+        if (!bundleExists(allocator, registry_path, bname)) {
+            try stderr.print("{s}{s}{s}Error:{s} Bundle not found: {s}\n", .{ P, Color.bold, Color.red, Color.reset, bname });
+            return;
+        }
+    }
+
     var refs: std.ArrayListUnmanaged(PromptRef) = .empty;
     defer freePromptRefs(allocator, &refs);
 
@@ -141,6 +154,20 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
 
     const registered = refs.items.len;
 
+    // Add to bundle if requested
+    var bundle_added: usize = 0;
+    if (bundle_flag) |bname| {
+        var hash_ptrs: std.ArrayListUnmanaged([]const u8) = .empty;
+        defer hash_ptrs.deinit(allocator);
+        for (refs.items) |ref| {
+            try hash_ptrs.append(allocator, ref.hash);
+        }
+        bundle_added = addPromptsToBundle(allocator, registry_path, bname, hash_ptrs.items) catch {
+            try stderr.print("{s}{s}{s}Error:{s} Failed to add prompts to bundle: {s}\n", .{ P, Color.bold, Color.red, Color.reset, bname });
+            return;
+        };
+    }
+
     // Commit and push
     var sp = spinner.init(stdout, "Registering prompt(s)");
     sp.start();
@@ -153,7 +180,10 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     };
 
-    const commit_msg = if (registered == 1) "Add prompt" else "Add prompts";
+    const commit_msg = if (bundle_flag != null)
+        (if (registered == 1) "Add prompt to bundle" else "Add prompts to bundle")
+    else
+        (if (registered == 1) "Add prompt" else "Add prompts");
     var commit_output: GitOutput = .{};
     defer commit_output.deinit(allocator);
     git.commit(allocator, registry_path, commit_msg, &commit_output) catch {};
@@ -174,6 +204,11 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         try stdout.print("{s}{s}{s}✓{s} Registered prompt in registry\n", .{ P, Color.bold, Color.green, Color.reset });
     } else {
         try stdout.print("{s}{s}{s}✓{s} Registered {d} prompts in registry\n", .{ P, Color.bold, Color.green, Color.reset, registered });
+    }
+    if (bundle_flag) |bname| {
+        if (bundle_added > 0) {
+            try stdout.print("{s}{s}{s}✓{s} Added {d} prompt{s} to bundle: {s}\n", .{ P, Color.bold, Color.green, Color.reset, bundle_added, if (bundle_added == 1) "" else "s", bname });
+        }
     }
 }
 
@@ -276,13 +311,14 @@ fn expandDirectory(allocator: std.mem.Allocator, abs_path: []const u8, expanded_
 }
 
 fn printHelp(out: *std.io.Writer) !void {
-    try out.print("{s}Usage: {s}clumsies add <file|dir>... [-g <group>] [-m] [-d <desc>] [-s]{s}\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}Usage: {s}clumsies add <file|dir>... [-g <group>] [-b <bundle>] [-m] [-d <desc>] [-s]{s}\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}Register prompt(s) to registry. Directories are expanded to their files.\n", .{P});
     try out.print("{s}Options:\n", .{P});
-    try out.print("{s}  {s}-g, --group{s} <group> Group (derived from .prompts/ path)\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}  {s}-m, --meta{s}          Register as meta-prompt file (shorthand for -g ../)\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}  {s}-d, --desc{s} <desc>  Description\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}  {s}-s, --sync{s}         Sync registry before command\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}  {s}-Q, --quiet-git{s}    Suppress git output\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}  {s}-h, --help{s}         Show this help\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-g, --group{s} <group>   Group (derived from .prompts/ path)\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-b, --bundle{s} <name>  Add to bundle after registering\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-m, --meta{s}            Register as meta-prompt file (shorthand for -g ../)\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-d, --desc{s} <desc>    Description\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-s, --sync{s}           Sync registry before command\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-Q, --quiet-git{s}      Suppress git output\n", .{ P, Color.cyan, Color.reset });
+    try out.print("{s}  {s}-h, --help{s}           Show this help\n", .{ P, Color.cyan, Color.reset });
 }

--- a/src/commands/commands.zig
+++ b/src/commands/commands.zig
@@ -41,6 +41,8 @@ pub const freePromptRefs = index_mod.freePromptRefs;
 pub const updatePromptsIndex = index_mod.updatePromptsIndex;
 pub const appendPromptEntry = index_mod.appendPromptEntry;
 pub const appendBundleEntry = index_mod.appendBundleEntry;
+pub const appendBundlePromptRef = index_mod.appendBundlePromptRef;
+pub const addPromptsToBundle = index_mod.addPromptsToBundle;
 
 pub const ImportResult = import_mod.ImportResult;
 pub const importPrompt = import_mod.importPrompt;

--- a/src/commands/index.zig
+++ b/src/commands/index.zig
@@ -167,6 +167,112 @@ pub fn appendBundleEntry(allocator: std.mem.Allocator, buf: *std.ArrayListUnmana
     try buf.appendSlice(allocator, "]\n    }");
 }
 
+/// Append a prompt hash reference to a bundle JSON buffer, deduplicating by hash.
+/// Returns true if the hash was actually added (not a duplicate).
+pub fn appendBundlePromptRef(allocator: std.mem.Allocator, buf: *std.ArrayListUnmanaged(u8), seen_hashes: *std.ArrayListUnmanaged([]const u8), prompt_first: *bool, hash: []const u8) !bool {
+    for (seen_hashes.items) |seen_hash| {
+        if (std.mem.eql(u8, seen_hash, hash)) return false;
+    }
+
+    try seen_hashes.append(allocator, hash);
+
+    const ref_entry = try std.fmt.allocPrint(allocator, "{s}\n        {{ \"hash\": \"{s}\" }}", .{
+        if (prompt_first.*) "" else ",",
+        hash,
+    });
+    defer allocator.free(ref_entry);
+    try buf.appendSlice(allocator, ref_entry);
+    prompt_first.* = false;
+    return true;
+}
+
+/// Add prompt hashes to an existing bundle in bundles/index.json.
+/// Returns the number of prompts actually added (excluding duplicates).
+pub fn addPromptsToBundle(allocator: std.mem.Allocator, registry_path: []const u8, bundle_name: []const u8, hashes: []const []const u8) !usize {
+    const index_path = try std.fs.path.join(allocator, &.{ registry_path, "bundles/index.json" });
+    defer allocator.free(index_path);
+
+    const idx_file = fs.openFileAbsolute(index_path, .{}) catch return error.BundleIndexNotFound;
+    const idx_content = idx_file.readToEndAlloc(allocator, MAX_FILE_SIZE) catch {
+        idx_file.close();
+        return error.BundleIndexNotFound;
+    };
+    idx_file.close();
+    defer allocator.free(idx_content);
+
+    const idx_parsed = std.json.parseFromSlice(std.json.Value, allocator, idx_content, .{}) catch
+        return error.BundleIndexNotFound;
+    defer idx_parsed.deinit();
+
+    const bundles = idx_parsed.value.object.get("bundles") orelse return error.BundleNotFound;
+
+    var new_index: std.ArrayListUnmanaged(u8) = .empty;
+    defer new_index.deinit(allocator);
+    try new_index.appendSlice(allocator, "{\n  \"bundles\": [");
+
+    var b_first = true;
+    var prompts_added: usize = 0;
+    var found_bundle = false;
+
+    for (bundles.array.items) |item| {
+        const item_name = if (item.object.get("name")) |n| n.string else continue;
+
+        if (!b_first) try new_index.appendSlice(allocator, ",");
+        b_first = false;
+
+        if (std.mem.eql(u8, item_name, bundle_name)) {
+            found_bundle = true;
+            const item_task = if (item.object.get("task")) |t| t.string else "-";
+            const item_desc = if (item.object.get("description")) |d| d.string else "-";
+            const item_created = if (item.object.get("created_at")) |c| c.string else "0";
+            const item_meta = if (item.object.get("meta_prompt")) |m| m.string else "";
+
+            const esc_name = try encoding.jsonEscapeAlloc(allocator, item_name);
+            defer allocator.free(esc_name);
+            const esc_task = try encoding.jsonEscapeAlloc(allocator, item_task);
+            defer allocator.free(esc_task);
+            const esc_desc = try encoding.jsonEscapeAlloc(allocator, item_desc);
+            defer allocator.free(esc_desc);
+
+            const entry_start = try std.fmt.allocPrint(allocator, "\n    {{\n      \"name\": \"{s}\",\n      \"task\": \"{s}\",\n      \"description\": \"{s}\",\n      \"created_at\": \"{s}\",\n      \"meta_prompt\": \"{s}\",\n      \"prompts\": [", .{ esc_name, esc_task, esc_desc, item_created, item_meta });
+            defer allocator.free(entry_start);
+            try new_index.appendSlice(allocator, entry_start);
+
+            var prompt_first = true;
+            var seen_hashes: std.ArrayListUnmanaged([]const u8) = .empty;
+            defer seen_hashes.deinit(allocator);
+
+            // Keep existing prompts
+            if (item.object.get("prompts")) |existing_prompts| {
+                for (existing_prompts.array.items) |ref| {
+                    const ref_hash = if (ref.object.get("hash")) |h| h.string else continue;
+                    _ = try appendBundlePromptRef(allocator, &new_index, &seen_hashes, &prompt_first, ref_hash);
+                }
+            }
+
+            // Add new prompt hashes
+            for (hashes) |hash| {
+                if (try appendBundlePromptRef(allocator, &new_index, &seen_hashes, &prompt_first, hash)) {
+                    prompts_added += 1;
+                }
+            }
+
+            try new_index.appendSlice(allocator, "]\n    }");
+        } else {
+            try appendBundleEntry(allocator, &new_index, item);
+        }
+    }
+    try new_index.appendSlice(allocator, "\n  ]\n}\n");
+
+    if (!found_bundle) return error.BundleNotFound;
+
+    const idx_out = fs.createFileAbsolute(index_path, .{}) catch return error.BundleIndexNotFound;
+    defer idx_out.close();
+    idx_out.writeAll(new_index.items) catch return error.BundleIndexNotFound;
+
+    return prompts_added;
+}
+
 fn writeTestFile(dir: std.fs.Dir, sub_path: []const u8, content: []const u8) !void {
     const file = try dir.createFile(sub_path, .{});
     defer file.close();
@@ -285,6 +391,61 @@ test "updatePromptsIndex: escapes special chars in name" {
     const prompts = parsed.value.object.get("prompts").?;
     try testing.expectEqual(@as(usize, 1), prompts.array.items.len);
     try testing.expectEqualStrings("has\"quotes", prompts.array.items[0].object.get("name").?.string);
+}
+
+test "addPromptsToBundle: adds prompts to existing bundle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("bundles");
+    try writeTestFile(tmp.dir, "bundles/index.json",
+        \\{"bundles":[{"name":"test-bundle","task":"-","description":"test","created_at":"0","meta_prompt":"","prompts":[{"hash":"existing1"}]}]}
+    );
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpDirAbsolutePath(&tmp, &buf);
+
+    const hashes = [_][]const u8{"newhash2"};
+    const added = try addPromptsToBundle(testing.allocator, path, "test-bundle", &hashes);
+    try testing.expectEqual(@as(usize, 1), added);
+
+    const content = try readTmpFile(testing.allocator, tmp.dir, "bundles/index.json");
+    defer testing.allocator.free(content);
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, content, .{});
+    defer parsed.deinit();
+    const bundles = parsed.value.object.get("bundles").?;
+    const bundle = bundles.array.items[0];
+    const prompts = bundle.object.get("prompts").?;
+    try testing.expectEqual(@as(usize, 2), prompts.array.items.len);
+    try testing.expectEqualStrings("existing1", prompts.array.items[0].object.get("hash").?.string);
+    try testing.expectEqualStrings("newhash2", prompts.array.items[1].object.get("hash").?.string);
+}
+
+test "addPromptsToBundle: skips duplicate hashes" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("bundles");
+    try writeTestFile(tmp.dir, "bundles/index.json",
+        \\{"bundles":[{"name":"test-bundle","task":"-","description":"test","created_at":"0","meta_prompt":"","prompts":[{"hash":"existing1"}]}]}
+    );
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpDirAbsolutePath(&tmp, &buf);
+
+    const hashes = [_][]const u8{"existing1"};
+    const added = try addPromptsToBundle(testing.allocator, path, "test-bundle", &hashes);
+    try testing.expectEqual(@as(usize, 0), added);
+}
+
+test "addPromptsToBundle: returns error for nonexistent bundle" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("bundles");
+    try writeTestFile(tmp.dir, "bundles/index.json",
+        \\{"bundles":[{"name":"other","task":"-","description":"test","created_at":"0","meta_prompt":"","prompts":[]}]}
+    );
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const path = tmpDirAbsolutePath(&tmp, &buf);
+
+    const hashes = [_][]const u8{"abc123"};
+    try testing.expectError(error.BundleNotFound, addPromptsToBundle(testing.allocator, path, "nonexistent", &hashes));
 }
 
 test "appendPromptEntry: missing group returns error" {

--- a/src/commands/set_cmd.zig
+++ b/src/commands/set_cmd.zig
@@ -14,6 +14,7 @@ const MAX_FILE_SIZE = commands.MAX_FILE_SIZE;
 const ensureRegistry = commands.ensureRegistry;
 const resolveRef = commands.resolveRef;
 const appendBundleEntry = commands.appendBundleEntry;
+const appendBundlePromptRef = commands.appendBundlePromptRef;
 const appendPromptEntry = commands.appendPromptEntry;
 const PromptRef = commands.PromptRef;
 const collectAndUploadPrompts = commands.collectAndUploadPrompts;
@@ -1043,23 +1044,6 @@ fn setBundle(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.
     if (new_meta_hash != null) try stdout.print("{s}    Meta-prompt updated\n", .{P});
     if (prompts_added > 0) try stdout.print("{s}    Prompts added: {d}\n", .{ P, prompts_added });
     if (prompts_removed > 0) try stdout.print("{s}    Prompts removed: {d}\n", .{ P, prompts_removed });
-}
-
-fn appendBundlePromptRef(allocator: std.mem.Allocator, new_index: *std.ArrayListUnmanaged(u8), seen_hashes: *std.ArrayListUnmanaged([]const u8), prompt_first: *bool, hash: []const u8) !bool {
-    for (seen_hashes.items) |seen_hash| {
-        if (std.mem.eql(u8, seen_hash, hash)) return false;
-    }
-
-    try seen_hashes.append(allocator, hash);
-
-    const ref_entry = try std.fmt.allocPrint(allocator, "{s}\n        {{ \"hash\": \"{s}\" }}", .{
-        if (prompt_first.*) "" else ",",
-        hash,
-    });
-    defer allocator.free(ref_entry);
-    try new_index.appendSlice(allocator, ref_entry);
-    prompt_first.* = false;
-    return true;
 }
 
 fn printHelp(out: *std.io.Writer) !void {


### PR DESCRIPTION
## Summary
Add `-b, --bundle <name>` flag to `clumsies add` so users can register prompts and add them to a bundle in one command instead of requiring a separate `clumsies set --add-prompt` call.

`appendBundlePromptRef` is extracted from `set_cmd` into `index` as a shared helper, and a new `addPromptsToBundle` function encapsulates the bundle-index update logic for reuse. Bundle existence is validated before registration for fast failure.

## Notes
Initially closed this PR — was unsure whether to land it before or after #36 (`feat/mcp-workspace-core`). Decided to keep it: #36 can rebase on top of this once merged, conflicts are minimal and mechanical (shared files like `set_cmd.zig`, `commands.zig`, `index.zig`).

## Test plan
- [x] `zig build test` passes (3 new unit tests for `addPromptsToBundle`)
- [x] `clumsies add <file> -b <bundle>` registers and adds to bundle
- [x] `clumsies add <file> -b nonexistent` fails early
- [x] `clumsies set <bundle> --add-prompt <hash>` still works