### PR TITLE
workspace: guard git commands against non-repo .prompts/

### DIFF
--- a/src/commands/log.zig
+++ b/src/commands/log.zig
@@ -14,6 +14,12 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
+    if (!commands.promptsIsGitRepo()) {
+        try stderr.print("{s}{s}{s}Error:{s} .prompts/ is not a git repository\n", .{ P, Color.bold, Color.red, Color.reset });
+        try stderr.print("{s}Run {s}clumsies clone <url>{s} first\n", .{ P, Color.cyan, Color.reset });
+        return;
+    }
+
     const prompts_path = try commands.getPromptsPath(allocator);
     defer allocator.free(prompts_path);
 

--- a/src/commands/pull.zig
+++ b/src/commands/pull.zig
@@ -16,6 +16,12 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
+    if (!commands.promptsIsGitRepo()) {
+        try stderr.print("{s}{s}{s}Error:{s} .prompts/ is not a git repository\n", .{ P, Color.bold, Color.red, Color.reset });
+        try stderr.print("{s}Run {s}clumsies clone <url>{s} first\n", .{ P, Color.cyan, Color.reset });
+        return;
+    }
+
     const Q = 0;
     const SPECS = [_]flag.FlagSpec{
         .{ .short = 'Q', .long = "quiet-git", .kind = .boolean },

--- a/src/commands/push.zig
+++ b/src/commands/push.zig
@@ -16,6 +16,12 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
+    if (!commands.promptsIsGitRepo()) {
+        try stderr.print("{s}{s}{s}Error:{s} .prompts/ is not a git repository\n", .{ P, Color.bold, Color.red, Color.reset });
+        try stderr.print("{s}Run {s}clumsies clone <url>{s} first\n", .{ P, Color.cyan, Color.reset });
+        return;
+    }
+
     const Q = 0;
     const M = 1;
     const SPECS = [_]flag.FlagSpec{

--- a/src/commands/remote.zig
+++ b/src/commands/remote.zig
@@ -45,6 +45,12 @@ pub fn run(stdout: *std.io.Writer, stderr: *std.io.Writer, allocator: std.mem.Al
         return;
     }
 
+    if (!commands.promptsIsGitRepo()) {
+        try stderr.print("{s}{s}{s}Error:{s} .prompts/ is not a git repository\n", .{ P, Color.bold, Color.red, Color.reset });
+        try stderr.print("{s}Run {s}clumsies clone <url>{s} first\n", .{ P, Color.cyan, Color.reset });
+        return;
+    }
+
     const prompts_path = commands.getPromptsPath(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Could not determine .prompts/ path\n", .{ P, Color.bold, Color.red, Color.reset });
         return;


### PR DESCRIPTION
## Summary
When `.prompts/` exists as a plain directory without `.git`, git operations in `remote`, `push`, `pull` and `log` walked up to the parent workspace repository. This caused `push` to upload the entire workspace to a prompts remote URL.

Add the same `promptsIsGitRepo()` guard that `status` already uses so these commands fail early with a clear error message.

## Test plan
- [ ] `clumsies remote <url>` on non-git `.prompts/` returns error
- [ ] `clumsies push` on non-git `.prompts/` returns error
- [ ] `clumsies pull` on non-git `.prompts/` returns error
- [ ] `clumsies log` on non-git `.prompts/` returns error
- [ ] `clumsies status` still works as before