### PR TITLE
docs: rewrite README and rename prompt kind data to context

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,82 +6,51 @@
 [![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies?label=Release)](https://github.com/lilhammerfun/clumsies/releases/latest)
 [![Zig](https://img.shields.io/badge/Zig-0.15%2B-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 
-AI agents manage their own memory. Users should too. As agent memory systems get more sophisticated, we believe users deserve a parallel layer they fully control — one that persists what they decide matters, not what the agent decides to keep.
+> **Work in progress.** clumsies is an experimental project. The paradigm is clear; the tooling is still catching up.
 
-clumsies is our attempt at this: a user-level memory layer for AI agents.
+## The paradigm
 
-## The problem
+AI agents have memory systems — Claude Code writes to `~/.claude/memory/`, Windsurf stores memories per workspace, Copilot keeps them server-side. The agent decides what to remember, what to surface, and what to compress away when context runs low.
 
-AI coding agents all have memory systems — Claude Code writes to `~/.claude/memory/`, Windsurf stores memories per workspace, Copilot keeps them server-side, Gemini CLI appends to `GEMINI.md`. You can view them, and some tools let you manually add entries.
+We think users should have a parallel memory layer they fully control. One where you decide what matters, where it lives, and how it gets used — not one managed by the agent on your behalf.
 
-But unless you actively check and intervene, memory is agent-managed by default. The agent decides what to remember and what to surface. As Andrej Karpathy [put it](https://www.youtube.com/watch?v=LGo4VNfH228), LLMs are like a coworker with anterograde amnesia — all they have is short-term memory. When a conversation exceeds the context window, every major agent compresses or summarizes automatically: Claude Code at ~80% capacity, Cline at ~80%, Amazon Q at ~80%. You can influence the process, but you cannot decide precisely what gets kept and what gets forgotten.
+That layer is a directory of markdown files (`.prompts/`) sitting in your project. Inside it, a `META_PROMPT.md` file defines how the agent should interact with the constraints — when to search, when to load, when to declare what it used. The MCP server reads this file on `memory.setup` and bootstraps the entire protocol from it.
 
-There's also a portability problem. Every tool's memory is project-scoped. At best you get a single global config file. You refine prompts through real work — a commit format that catches edge cases, testing rules that reflect lessons learned — but each prompt stays trapped in the project where it was written.
+Today, most agents still need an external meta-prompt file (CLAUDE.md, .cursorrules, etc.) to learn about `.prompts/` in the first place. The planned Claude Code plugin eliminates this gap — a startup hook calls `memory.setup` automatically, loading `META_PROMPT.md` and injecting it into context. The meta-prompt lives inside `.prompts/` and syncs with the rest of your constraints.
 
-## What clumsies does
+The idea itself is simple. The hard part is making it actually work — making agents reliably discover, follow, and report on constraints. That's what clumsies is building tools for.
 
-Two things, both simple:
+## What we're building
 
-**A user-level memory layer.** You write prompts as markdown files in `.prompts/`, organized however you want. A meta-prompt file, or MPF (CLAUDE.md, AGENTS.md, etc.), tells the agent where things are. This sits alongside the agent's built-in memory, not replacing it — giving you a layer you fully control.
+clumsies is a set of tools layered on top of this paradigm:
 
-**Cross-project portability.** A central registry (a git repo) lets you register prompts, refine them over time, and import them into any project. Your prompt library grows with your practice — update once, pull everywhere.
+**CLI + Registry.** A command-line tool for managing a personal prompt library. Register prompts you've refined through real use, store them in a git-based registry, and import them into any project. Your prompt library grows with your practice.
+
+```bash
+clumsies add .prompts/rule/coding/     # register refined prompts
+clumsies get my-coding-bundle           # import into a new project
+clumsies stats                          # see which constraints get used
+```
+
+**MCP Server.** A protocol layer that gives agents structured access to your `.prompts/` space. Instead of the agent blindly reading files, it discovers available constraints (`memory.search`), loads what it needs (`memory.load`), and declares which constraints it referenced (`memory.refer`). Every interaction produces a trace log. Over time, you can see which constraints actually get used and which are dead weight.
+
+**Stats engine.** Aggregates trace data into views: which prompts are hot, which constraints are cold, how coverage changes across versions. Available via CLI (`clumsies stats`) and the MCP `memory.stats` tool.
+
+**Claude Code plugin.** (Planned.) Hooks and slash commands that solve MCP's biggest weakness — agents forgetting to call tools. A startup hook loads your meta-prompt automatically. A `/complete-task` command puts task completion in your hands instead of the agent's. A stop hook reminds the agent to declare which constraints it used.
+
+## The `.prompts/` layout
 
 ```
 workspace/
-├── CLAUDE.md              # MPF — tells the agent where things are
 └── .prompts/
-    ├── PIN.md             # Pinned rules (highest priority, optional)
-    ├── rule/              # Reusable rules (from registry)
-    ├── house-rule/        # Project-specific rules
-    ├── cmd/               # Procedures (invoke by name)
-    ├── context/           # Project knowledge (stays local)
-    ├── journal/           # Problem logs (stays local)
-    └── ...                # Whatever else you need
+    ├── META_PROMPT.md     # protocol bootstrap — loaded by memory.setup
+    ├── rule/              # constraints — coding rules, project context, etc.
+    ├── workflow/           # ordered procedures — commit messages, reviews, etc.
+    ├── context/           # reference material — research, specs, etc.
+    └── ...                # whatever else you need
 ```
 
-The MPF (CLAUDE.md, AGENTS.md, COPILOT.md — whatever your tool reads) describes the `.prompts/` layout in natural language. No special syntax, no tool integration. The agent reads the file, understands the structure, and knows where to find what it needs.
-
-<details>
-<summary>Example CLAUDE.md</summary>
-
-```markdown
-Principle 1: This project uses the .prompts/ directory for all rules, context,
-and commands. Read relevant files before starting work. (User-level memory)
-
-Principle 2: Priority from high to low: .prompts/PIN.md > .prompts/ managed
-memory > system prompt and model defaults. Higher priority wins on conflict.
-(Memory priority)
-
-Principle 3: Principles and memory must never be compressed or forgotten.
-(Persistence)
-
-Directory structure. Files use NN_UPPER_SNAKE_CASE.md naming. Numbers enable
-quick invocation ("run cmd 0" maps to .prompts/cmd/00_*.md).
-
-.prompts/
-├── PIN.md             # Highest priority rules (read before every task)
-├── context/           # Project context (read before starting work)
-├── rule/              # Universal rules (always active, reusable)
-├── house-rule/        # Project-specific rules (always active, local only)
-├── cmd/               # Commands (invoked on demand)
-├── journal/           # Checkpoint logs (consult when hitting problems)
-└── ...                # Other directories as needed (todo, plan, etc.)
-```
-
-This is one approach. Your MPF can be as simple or detailed as you want —
-the only requirement is that the agent can read it and find what it needs.
-
-</details>
-
-The full picture — user-level memory alongside agent-managed memory, connected through a registry:
-
-![System overview](docs/overview.drawio.png)
-
-Prompts get better through real use. You tell the agent "fix this code following coding rule ZIG_STYLE", review the output, find the prompt wasn't specific enough, refine it, try again. Once it reliably produces what you want, register it to the registry and reuse it across projects.
-
-Borrow from others freely — skills marketplaces, GitHub repos, developer communities. But a prompt written for someone else's workflow rarely works perfectly in yours. clumsies is a personal registry, not a marketplace.
-
-More on the design and registry internals in [ARCHITECTURE.md](./ARCHITECTURE.md).
+`META_PROMPT.md` is the entry point. It tells the agent what the `.prompts/` system is, how to use the MCP tools, and what the priority model looks like. The MCP server reads it on `memory.setup` and returns its content to the agent. Everything else — rules, workflows, data — is discovered through `memory.search` and loaded on demand.
 
 ## Install
 
@@ -93,11 +62,9 @@ curl -fsSL https://raw.githubusercontent.com/lilhammerfun/clumsies/main/install.
 <summary>Manual install</summary>
 
 ```bash
-# Download binary and checksums
 curl -LO https://github.com/lilhammerfun/clumsies/releases/latest/download/clumsies-darwin-arm64
 curl -LO https://github.com/lilhammerfun/clumsies/releases/latest/download/checksums.txt
 
-# Verify and install
 shasum -a 256 -c checksums.txt --ignore-missing
 chmod +x clumsies-darwin-arm64
 mkdir -p ~/.clumsies/bin
@@ -106,7 +73,7 @@ mv clumsies-darwin-arm64 ~/.clumsies/bin/clumsies
 
 Platforms: `darwin-arm64`, `darwin-x86_64`, `linux-arm64`, `linux-x86_64`, `windows-x86_64`
 
-Windows binaries are available but not yet validated in real-world use. If you're on Windows and willing to help test, see [#20](https://github.com/lilhammerfun/clumsies/issues/20).
+Windows binaries are available but not yet validated. If you're on Windows and willing to help test, see [#20](https://github.com/lilhammerfun/clumsies/issues/20).
 </details>
 
 <details>
@@ -124,47 +91,28 @@ zig build -Doptimize=ReleaseFast
 
 ## Quick start
 
-Get a working prompt setup in 30 seconds, no configuration needed.
-
 ```bash
-mkdir clumsies-demo && cd clumsies-demo
+mkdir demo && cd demo
 
 clumsies get opus-coding --registry https://github.com/lilhammerfun/clumsies-registry.git
 ```
 
-This creates `.prompts/` with coding rules, reusable commands, and a four-layer architecture workflow (Architecture → ADR → Research → Spec). It also drops a `CLAUDE.md` at the project root that tells your agent where everything is.
+This creates `.prompts/` with coding rules and a meta-prompt file. Give your agent a task and see if it follows the constraints.
 
-Now give your agent a task. Here's an example, or replace it with any project you're interested in:
-
-```
-Follow the arch rules to design a local-first AI agent orchestration
-framework. It should support multiple LLM backends, tool calling,
-streaming output, and conversation memory persistence.
-```
-
-The agent reads `CLAUDE.md`, discovers `.prompts/`, and finds the arch rules. You don't need to point it to specific files. That's the whole point of the MPF: it tells the agent where things are so you can talk in natural language.
-
-> The demo prompts are written in Chinese. The agent follows them regardless and responds in whatever language you write your task in. Add "用中文回复" or "Respond in English" if you want to be explicit.
-
-Check if it worked. The agent should have created files following the architecture workflow:
+Once you've refined prompts through real use, set up your own registry:
 
 ```bash
-ls .prompts/context/
-# Expected: 01_ARCHITECTURE.md, and possibly adr/, research/, spec/
-```
-
-If you see an Architecture document that identifies modules, references ADRs for cross-cutting decisions, and links to Specs, the prompts are working. That structure came from the rules in `.prompts/rule/arch/`, not from the agent's defaults.
-
-Once you've refined prompts through real use, set up your own registry to reuse them across projects:
-
-```bash
-# Point to your registry
 clumsies config set registry git@github.com:you/prompt-registry.git
-
-# Register prompts you've refined
 clumsies add .prompts/rule/coding/
-
-# Import them into another project
-clumsies get my-coding-bundle
 ```
 
+## Status
+
+| Component | Status |
+|-----------|--------|
+| CLI + Registry | Stable — prompt management, bundles, import/export |
+| MCP Server | Working — `clumsies mcp serve`, 9 tools implemented |
+| Stats engine | Working — workspace/prompt/diff/timebucket scopes |
+| Claude Code plugin | Planned — hooks, slash commands, startup bootstrap |
+
+The MCP server and stats engine are functional but haven't been tested with real agent workflows at scale. Trace data quality depends on agent compliance — which is exactly the problem the planned Claude Code plugin aims to address.

--- a/src/lib/workspace_prompt.zig
+++ b/src/lib/workspace_prompt.zig
@@ -6,7 +6,7 @@ const prompt = @import("prompt.zig");
 pub const PromptKind = enum {
     rule,
     workflow,
-    data,
+    context,
 };
 
 pub const SetupPriority = enum(u8) {
@@ -61,12 +61,12 @@ pub const LoadResult = struct {
 const kind_dirs = [_]struct { dir: []const u8, kind: PromptKind }{
     .{ .dir = "rule", .kind = .rule },
     .{ .dir = "workflow", .kind = .workflow },
-    .{ .dir = "data", .kind = .data },
+    .{ .dir = "context", .kind = .context },
 };
 
 fn priorityForKind(kind: PromptKind) SetupPriority {
     return switch (kind) {
-        .rule, .workflow, .data => .normal,
+        .rule, .workflow, .context => .normal,
     };
 }
 
@@ -74,7 +74,7 @@ pub fn kindToString(kind: PromptKind) []const u8 {
     return switch (kind) {
         .rule => "rule",
         .workflow => "workflow",
-        .data => "data",
+        .context => "context",
     };
 }
 
@@ -153,7 +153,7 @@ pub fn discoverSearchable(allocator: std.mem.Allocator, workspace_root: []const 
     const searchable_kinds = [_]struct { dir: []const u8, kind: PromptKind }{
         .{ .dir = "rule", .kind = .rule },
         .{ .dir = "workflow", .kind = .workflow },
-        .{ .dir = "data", .kind = .data },
+        .{ .dir = "context", .kind = .context },
     };
 
     for (searchable_kinds) |kd| {
@@ -525,7 +525,7 @@ pub fn validatePrompt(allocator: std.mem.Allocator, workspace_root: []const u8, 
         };
     };
 
-    if (item.kind == .data) {
+    if (item.kind == .context) {
         // Just check readable
         const content = readWorkspaceFileAlloc(allocator, workspace_root, item.path) catch {
             var issues: std.ArrayList([]const u8) = .empty;
@@ -566,11 +566,11 @@ test "discoverAll: finds rules workflows and data by kind directory" {
 
     try tmp.dir.makePath(".prompts/rule/coding");
     try tmp.dir.makePath(".prompts/workflow");
-    try tmp.dir.makePath(".prompts/data/research");
+    try tmp.dir.makePath(".prompts/context/research");
 
     try writeFile(tmp.dir, ".prompts/rule/coding/00_COMPAT.md", "compat rule");
     try writeFile(tmp.dir, ".prompts/workflow/00_GEN_COMMIT.md", "commit workflow");
-    try writeFile(tmp.dir, ".prompts/data/research/R1-0.md", "research data");
+    try writeFile(tmp.dir, ".prompts/context/research/R1-0.md", "research data");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
@@ -592,7 +592,7 @@ test "discoverAll: finds rules workflows and data by kind directory" {
             found_workflow = true;
             try testing.expect(item.group == null);
         }
-        if (std.mem.eql(u8, item.id, "data:research/R1-0.md")) {
+        if (std.mem.eql(u8, item.id, "context:research/R1-0.md")) {
             found_data = true;
             try testing.expectEqualStrings("research", item.group.?);
         }

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -49,8 +49,8 @@ const tool_begin =
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"goalSummary\":{\"type\":\"string\"}},\"required\":[\"goalSummary\"],\"additionalProperties\":false}}";
 
 const tool_search =
-    "{\"name\":\"memory.search\",\"title\":\"Search\",\"description\":\"Discover available rules, workflows, and data. Returns fresh metadata from the workspace.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\",\"data\"]},\"group\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
+    "{\"name\":\"memory.search\",\"title\":\"Search\",\"description\":\"Discover available rules, workflows, and context. Returns fresh metadata from the workspace.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\",\"context\"]},\"group\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const tool_load =
     "{\"name\":\"memory.load\",\"title\":\"Load\",\"description\":\"Load prompt content by ids. Returns delta based on knownHashes. Rule/Workflow content includes a refer reminder.\"," ++
@@ -794,7 +794,7 @@ fn parsePromptKind(value: std.json.Value) !?workspace_prompt.PromptKind {
 
     if (std.mem.eql(u8, str, "rule")) return .rule;
     if (std.mem.eql(u8, str, "workflow")) return .workflow;
-    if (std.mem.eql(u8, str, "data")) return .data;
+    if (std.mem.eql(u8, str, "context")) return .context;
     return error.InvalidParams;
 }
 


### PR DESCRIPTION
## Summary
- Rewrite README to reflect current architecture: WIP framing, paradigm advocacy, layered tooling introduction (CLI + MCP + Stats + planned CC plugin), setup loads META_PROMPT.md not CLAUDE.md
- Rename prompt kind `data` to `context` across code, specs, and research docs — "context" better describes files that provide project background and reference material

## Test plan
- [x] `zig build test` passes
- [x] `zig fmt --check src/` passes
- [x] e2e tests pass (39/39)