### PR TITLE
bump version to 0.17.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ zig build -Doptimize=ReleaseFast
 
 | Component | Status |
 |-----------|--------|
-| CLI + Registry | Stable — prompt management, bundles, import/export, task lifecycle |
+| CLI + Registry | Working — prompt management, bundles, import/export, task lifecycle |
 | MCP Server | Working — `clumsies mcp serve`, 9 tools |
 | Stats engine | Working — workspace/prompt/diff/timebucket scopes |
 | Claude Code plugin | Alpha — hooks, skills, auto-skill generation |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,7 @@
 .{
     .fingerprint = 0xa21731978d142f78,
     .name = .clumsies,
-    .version = "0.16.3",
+    .version = "0.17.0-alpha",
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/cc-plugin/.claude-plugin/plugin.json
+++ b/cc-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clumsies",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
   "description": "User-level memory for AI agents. Protocol bootstrapping, task tracking, and constraint tracing via hooks and skills.",
   "author": {
     "name": "lilhammerfun",


### PR DESCRIPTION
## Summary

Version bump for the first alpha release. This release includes MCP server, stats engine, CLI task commands (setup, begin, complete, search, load, refer, validate), Claude Code plugin with hooks and skills, and the prompt template format with reserved headings.

The install script is unaffected — GitHub's `latest` tag excludes pre-releases, so existing users stay on 0.16.3. After merging, tag `v0.17.0-alpha` and create a GitHub Release marked as Pre-release.

## Test plan

- [x] `zig build test` passes
- [x] `clumsies --version` shows `0.17.0-alpha`
- [x] CC plugin version shows `0.1.0-alpha`
- [ ] After merge: `git tag v0.17.0-alpha && git push --tags`
- [ ] After merge: create GitHub Release as Pre-release