### PR TITLE
fix: import META_PROMPT to .prompts/ root instead of project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,39 +3,52 @@
 [![CI](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml)
 [![Tests](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/github/license/lilhammerfun/clumsies?label=License)](https://github.com/lilhammerfun/clumsies/blob/main/LICENSE)
-[![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies?label=Release)](https://github.com/lilhammerfun/clumsies/releases/latest)
+[![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies?include_prereleases&label=Release)](https://github.com/lilhammerfun/clumsies/releases/tag/v0.17.0-alpha)
 [![Zig](https://img.shields.io/badge/Zig-0.15%2B-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)
 
-> **Work in progress.** clumsies is an experimental project. The paradigm is clear; the tooling is still catching up.
+User-controlled constraints that survive agent memory compression.
 
-## The paradigm
+> **v0.17.0-alpha** — functional but not battle-tested. The stable release (v0.16.3) does not include MCP, stats, or the Claude Code plugin.
 
-AI agents have memory systems — Claude Code writes to `~/.claude/memory/`, Windsurf stores memories per workspace, Copilot keeps them server-side. The agent decides what to remember, what to surface, and what to compress away when context runs low.
+## The problem
 
-We think users should have a parallel memory layer they fully control. One where you decide what matters, where it lives, and how it gets used — not one managed by the agent on your behalf.
+Every AI agent compresses memory when context runs low. Claude Code at ~80% capacity, Cline at ~80%, Amazon Q at ~80%. The agent decides what matters and what gets dropped. This works for generic knowledge — common patterns, standard library usage, widely known conventions.
 
-That layer is a directory of markdown files (`.prompts/`) sitting in your project. Inside it, a `META_PROMPT.md` file defines how the agent should interact with the constraints — when to search, when to load, when to declare what it used. The MCP server reads this file on `memory.setup` and bootstraps the entire protocol from it.
+But your project has rules that are specific to you. "All Zig code must use explicit allocators, never GeneralPurposeAllocator." "Commit messages follow this exact subsystem:subject format." "External API calls must go through the retry wrapper." These rules matter to your project, but from the compression algorithm's perspective, they are edge cases — not frequent enough to be prioritized, not generic enough to be preserved. They get silently dropped, and the agent keeps working confidently with outputs that look correct but violate constraints you thought were non-negotiable.
 
-The idea itself is simple. The hard part is making it actually work — making agents reliably discover, follow, and report on constraints. That's what clumsies is building tools for.
+You have no way to know what was compressed away. The agent does not tell you.
+
+## The approach
+
+clumsies puts your critical constraints in a place the agent's compression algorithm cannot touch: a `.prompts/` directory in your project that the agent queries but never manages.
+
+You decide what goes in `.prompts/`. You write rules, workflows, and context as markdown files. The agent discovers them through a structured protocol (`memory.search`, `memory.load`), follows them, and declares which ones it actually used (`memory.refer`). Over time, the trace data tells you which constraints are effective and which are dead weight — so you can refine what you wrote.
+
+The agent has no authority to compress, summarize, or delete anything in `.prompts/`. It can only read.
 
 ## What we're building
 
-clumsies is a set of tools layered on top of this paradigm:
+**CLI + Registry.** Manage a personal prompt library. Register constraints refined through real use, store them in a git-based registry, import them into any project.
 
-**CLI + Registry.** A command-line tool for managing a personal prompt library. Register prompts you've refined through real use, store them in a git-based registry, and import them into any project. Task lifecycle commands (`setup`, `begin`, `complete`, `search`, `load`, `refer`, `validate`, `stats`) mirror the MCP protocol for use by hooks and scripts.
+**MCP Server.** Structured protocol for agents to discover constraints (`memory.search`), load them (`memory.load`), and declare references (`memory.refer`). Every interaction produces a trace log.
 
-**MCP Server.** A protocol layer that gives agents structured access to your `.prompts/` space. Instead of the agent blindly reading files, it discovers available constraints (`memory.search`), loads what it needs (`memory.load`), and declares which constraints it referenced (`memory.refer`). Every interaction produces a trace log.
+**Stats engine.** Aggregates trace data: which constraints are hot, which are cold, how coverage changes across versions.
 
-**Stats engine.** Aggregates trace data into views: which prompts are hot, which constraints are cold, how coverage changes across versions. Available via CLI (`clumsies stats`) and the MCP `memory.stats` tool.
-
-**Claude Code plugin.** Hooks and skills that solve MCP's biggest weakness — agents forgetting to call tools. A startup hook loads your meta-prompt and creates a task automatically. A stop hook reminds the agent to declare constraint references. Slash commands (`/complete-task`, `/stats`, `/search`) put control in your hands. Workflow files are auto-generated as skills on session start.
+**Claude Code plugin.** Hooks and skills that solve MCP's passive nature. Startup hook loads your meta-prompt automatically. Stop hook reminds the agent to declare constraint references. `/complete-task` puts task completion in your hands.
 
 ## Quick start with Claude Code
 
-Install the CLI:
+Install the CLI (v0.17.0-alpha — the install script pulls the stable release; for alpha, download manually from [releases](https://github.com/lilhammerfun/clumsies/releases/tag/v0.17.0-alpha)):
 
 ```bash
+# stable (v0.16.3, no MCP/plugin support)
 curl -fsSL https://raw.githubusercontent.com/lilhammerfun/clumsies/main/install.sh | sh
+
+# alpha (v0.17.0-alpha, recommended for full experience)
+curl -LO https://github.com/lilhammerfun/clumsies/releases/download/v0.17.0-alpha/clumsies-darwin-arm64
+chmod +x clumsies-darwin-arm64
+mkdir -p ~/.clumsies/bin
+mv clumsies-darwin-arm64 ~/.clumsies/bin/clumsies
 ```
 
 Import a starter bundle into your project:
@@ -45,13 +58,13 @@ cd your-project
 clumsies get opus-coding --registry https://github.com/lilhammerfun/clumsies-registry.git
 ```
 
-This creates `.prompts/` with coding rules and workflows. Launch Claude Code with the plugin (local development — marketplace distribution coming once stable):
+This creates `.prompts/` with coding rules, workflows, and a `META_PROMPT.md`. Launch Claude Code with the plugin (marketplace distribution planned):
 
 ```bash
 claude --plugin-dir /path/to/clumsies/cc-plugin
 ```
 
-On session start, the plugin loads `META_PROMPT.md`, creates a task, and generates slash commands for your workflows. Give the agent a task — it will discover and follow constraints from `.prompts/`. When you're done, type `/complete-task`.
+On session start, the plugin loads `META_PROMPT.md`, creates a task, and generates slash commands for your workflows. Give the agent a task — it will search and load constraints from `.prompts/`. When you're done, type `/complete-task`.
 
 Check what happened:
 
@@ -59,26 +72,18 @@ Check what happened:
 clumsies stats
 ```
 
-Once you've refined prompts through real use, set up your own registry:
-
-```bash
-clumsies config set registry git@github.com:you/prompt-registry.git
-clumsies add .prompts/rule/coding/
-```
-
 ## The `.prompts/` layout
 
 ```
-workspace/
-└── .prompts/
-    ├── META_PROMPT.md     # protocol bootstrap — loaded on session start
-    ├── rule/              # constraints — coding rules, project context, etc.
-    ├── workflow/           # ordered procedures — commit messages, reviews, etc.
-    ├── context/           # reference material — research, specs, etc.
-    └── ...                # whatever else you need
+.prompts/
+├── META_PROMPT.md     # protocol bootstrap — loaded on session start
+├── rule/              # constraints — coding rules, project context, etc.
+├── workflow/           # ordered procedures — commit messages, architecture, etc.
+├── context/           # reference material — research, specs, documentation
+└── ...                # whatever else you need
 ```
 
-`META_PROMPT.md` is the entry point. The plugin loads it on session start and injects its content into the agent's context. Everything else — rules, workflows, context — is discovered through `memory.search` and loaded on demand.
+`META_PROMPT.md` tells the agent what clumsies is, how to use the protocol, and what the priority model looks like. Everything else is discovered through `memory.search` and loaded on demand.
 
 ## Install
 
@@ -86,23 +91,7 @@ workspace/
 curl -fsSL https://raw.githubusercontent.com/lilhammerfun/clumsies/main/install.sh | sh
 ```
 
-<details>
-<summary>Manual install</summary>
-
-```bash
-curl -LO https://github.com/lilhammerfun/clumsies/releases/latest/download/clumsies-darwin-arm64
-curl -LO https://github.com/lilhammerfun/clumsies/releases/latest/download/checksums.txt
-
-shasum -a 256 -c checksums.txt --ignore-missing
-chmod +x clumsies-darwin-arm64
-mkdir -p ~/.clumsies/bin
-mv clumsies-darwin-arm64 ~/.clumsies/bin/clumsies
-```
-
-Platforms: `darwin-arm64`, `darwin-x86_64`, `linux-arm64`, `linux-x86_64`, `windows-x86_64`
-
-Windows binaries are available but not yet validated. If you're on Windows and willing to help test, see [#20](https://github.com/lilhammerfun/clumsies/issues/20).
-</details>
+This installs the stable release. For the alpha release with MCP and plugin support, see [Quick start](#quick-start-with-claude-code) above.
 
 <details>
 <summary>Build from source</summary>
@@ -119,6 +108,8 @@ zig build -Doptimize=ReleaseFast
 
 ## Status
 
+**Current version: v0.17.0-alpha**
+
 | Component | Status |
 |-----------|--------|
 | CLI + Registry | Working — prompt management, bundles, import/export, task lifecycle |
@@ -126,4 +117,4 @@ zig build -Doptimize=ReleaseFast
 | Stats engine | Working — workspace/prompt/diff/timebucket scopes |
 | Claude Code plugin | Alpha — hooks, skills, auto-skill generation |
 
-The MCP server and stats engine are functional but haven't been battle-tested at scale. Trace data quality depends on agent compliance — which is what the Claude Code plugin is designed to improve.
+The MCP server and stats engine are functional but not yet tested at scale. Trace data quality depends on agent compliance — which is what the Claude Code plugin is designed to improve.

--- a/src/commands/commands.zig
+++ b/src/commands/commands.zig
@@ -19,7 +19,7 @@ pub const GitOutput = git.GitOutput;
 
 pub const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 pub const MAX_SEQUENCE_NUMBER: u8 = sequence_mod.MAX_SEQUENCE_NUMBER;
-pub const META_PROMPT_GROUP = "../";
+pub const META_PROMPT_GROUP = ".";
 
 pub const stripSequencePrefix = sequence_mod.stripSequencePrefix;
 pub const findNextSequence = sequence_mod.findNextSequence;

--- a/src/commands/import.zig
+++ b/src/commands/import.zig
@@ -11,7 +11,7 @@ const Color = styles.Color;
 const P = styles.P;
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
-const META_PROMPT_GROUP = "../";
+const META_PROMPT_GROUP = ".";
 
 pub const PromptRef = index.PromptRef;
 
@@ -24,18 +24,12 @@ pub fn importPrompt(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: s
 
     const name_part = name_opt orelse hash[0..8];
 
-    // Meta-prompt files (group "../") go to project root without sequence prefix
+    // Meta-prompt files (group ".") go to .prompts/ root without sequence prefix
     if (std.mem.eql(u8, group, META_PROMPT_GROUP)) {
-        const cwd = std.process.getCwdAlloc(allocator) catch {
-            try stderr.print("{s}{s}{s}✗{s} Failed to determine project root\n", .{ P, Color.bold, Color.red, Color.reset });
-            return .failed;
-        };
-        defer allocator.free(cwd);
-
         const dest_filename = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ name_part, format });
         defer allocator.free(dest_filename);
 
-        const dest_path = try std.fs.path.join(allocator, &.{ cwd, dest_filename });
+        const dest_path = try std.fs.path.join(allocator, &.{ prompts_path, dest_filename });
         defer allocator.free(dest_path);
 
         // Check if already exists
@@ -50,7 +44,7 @@ pub fn importPrompt(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: s
             return .failed;
         };
 
-        try stdout.print("{s}{s}{s}✓{s} {s} → ./{s}\n", .{ P, Color.bold, Color.green, Color.reset, name_part, dest_filename });
+        try stdout.print("{s}{s}{s}✓{s} {s} → .prompts/{s}\n", .{ P, Color.bold, Color.green, Color.reset, name_part, dest_filename });
         return .imported;
     }
 


### PR DESCRIPTION
## Summary

META_PROMPT_GROUP was `"../"` which placed meta-prompt files at the project root during `clumsies get`. Changed to `"."` so they land in `.prompts/` where `memory.setup` reads them. Registry META_PROMPT group also updated from `../` to `.`.

## Test plan

- [x] `zig build test` passes
- [x] `clumsies get opus-coding` places META_PROMPT at `.prompts/META_PROMPT.md`