### PR TITLE
mcp: make constraintId optional and fix skill cwd

### DIFF
--- a/cc-plugin/scripts/session-start.sh
+++ b/cc-plugin/scripts/session-start.sh
@@ -39,7 +39,7 @@ argument-hint: "[task description]"
 user-invocable: true
 allowed-tools: Bash
 ---
-!\`clumsies load workflow:$rel_path\`
+!\`cd "\${CLAUDE_PROJECT_DIR:-.}" && clumsies load workflow:$rel_path\`
 
 \$ARGUMENTS
 SKILL

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -295,8 +295,8 @@ fn handleRefer(
 
     const constraint_id = if (args_obj.get("constraintId")) |value| switch (value) {
         .string => |s| s,
-        else => return error.InvalidParams,
-    } else return error.InvalidParams;
+        else => null,
+    } else null;
 
     const reason = if (args_obj.get("reason")) |value| switch (value) {
         .string => |s| s,


### PR DESCRIPTION
## Summary

Two related fixes that prevented the constraint tracking loop from working end-to-end.

The `memory.refer` MCP handler required `constraintId` despite the JSON schema declaring it optional. Agents calling refer with only `taskId` and `promptId` always received error -32602. Aligned the handler with the schema so `constraintId` defaults to null when omitted.

Workflow skill templates generated by the SessionStart hook ran `clumsies load` without specifying a working directory. When the shell cwd differed from the project root, the CLI could not find `.prompts/` and crashed. The templates now cd into `$CLAUDE_PROJECT_DIR` before invoking the CLI.

## Test plan

- Build passes with the handler change
- Verify `memory.refer` accepts calls without `constraintId` after deploying the new binary
- Verify `/gen-commit-msg` and other workflow skills work when cwd is not the project root