### PR TITLE
cc-plugin: strengthen hook prompts to enforce protocol compliance

### DIFF
--- a/cc-plugin/scripts/session-start.sh
+++ b/cc-plugin/scripts/session-start.sh
@@ -44,8 +44,10 @@ SKILL
 fi
 
 # 3. Output: instruct agent to bootstrap protocol via MCP
-echo "Call memory.setup to bootstrap the clumsies protocol and load META_PROMPT.md."
-echo ""
+cat <<'INST'
+MANDATORY — HIGHEST PRIORITY — EXECUTE BEFORE ANY OTHER ACTION:
+You MUST call the `memory.setup` MCP tool immediately as your FIRST action in this session. Do NOT read files, do NOT respond to the user, do NOT call any other tool until memory.setup has been called and completed. This is a non-negotiable protocol requirement. If memory.setup is a deferred tool, call ToolSearch first to fetch its schema, then call it immediately.
+INST
 
 # List available workflow skills
 if [ -d "$SKILLS_DIR" ] && [ "$(ls -A "$SKILLS_DIR" 2>/dev/null)" ]; then

--- a/cc-plugin/scripts/user-prompt-begin.sh
+++ b/cc-plugin/scripts/user-prompt-begin.sh
@@ -12,4 +12,8 @@ INPUT=$(cat)
 # Extract user prompt as goal summary (first 200 chars, single line)
 GOAL=$(echo "$INPUT" | grep -o '"prompt"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/"prompt"[[:space:]]*:[[:space:]]*"//; s/"$//' | cut -c1-200)
 
-echo "Call memory.begin to start or resume a task${GOAL:+ with goal: $GOAL}."
+cat <<INST
+MANDATORY — HIGHEST PRIORITY — EXECUTE BEFORE ANY OTHER ACTION:
+You MUST call the \`memory.begin\` MCP tool immediately as your FIRST action before responding to this prompt. Do NOT read files, do NOT respond to the user, do NOT call any other tool until memory.begin has been called. If memory.begin is a deferred tool, call ToolSearch first to fetch its schema, then call it immediately.${GOAL:+
+Goal: $GOAL}
+INST


### PR DESCRIPTION
## Summary

SessionStart and UserPromptSubmit hooks produce advisory text that
agents routinely ignore, while the Stop hook (which uses blocking
JSON) achieves near-perfect compliance. The root cause is that
advisory stdout is injected as a system-reminder the agent treats
as optional context.

Rewrite both hook outputs with mandatory/highest-priority framing
and ToolSearch guidance for deferred tools, so agents treat protocol
bootstrap (memory.setup) and task creation (memory.begin) as
non-negotiable first actions.

## Test plan

- Start a new Claude Code session with the plugin and verify
  memory.setup is called on startup
- Submit a prompt and verify memory.begin is called before other tools