### PR TITLE
hub: enrich stats, PR list, and org directory endpoints for TUI

### DIFF
--- a/src/hub/collab.zig
+++ b/src/hub/collab.zig
@@ -93,6 +93,7 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
         status: []const u8,
         description: []const u8,
         created_at: []const u8,
+        author: []const u8,
     };
 
     var list: std.ArrayList(PrMeta) = .empty;
@@ -101,9 +102,11 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
     if (status_filter) |sf| {
         if (prompt_filter) |pf| {
             var result = conn.query(
-                "SELECT pr_id, prompt_id, status, description, created_at::text FROM prompt_prs WHERE org_id = $1::uuid AND status = $2 AND prompt_id = $3 ORDER BY created_at DESC",
-                .{ user.org_id, sf, pf },
-            ) catch {
+                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
+                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+                \\WHERE pp.org_id = $1::uuid AND pp.status = $2 AND pp.prompt_id = $3
+                \\ORDER BY pp.created_at DESC
+            , .{ user.org_id, sf, pf }) catch {
                 return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
             };
             defer result.deinit();
@@ -114,13 +117,16 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                     .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                     .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                     .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
                 });
             }
         } else {
             var result = conn.query(
-                "SELECT pr_id, prompt_id, status, description, created_at::text FROM prompt_prs WHERE org_id = $1::uuid AND status = $2 ORDER BY created_at DESC",
-                .{ user.org_id, sf },
-            ) catch {
+                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
+                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+                \\WHERE pp.org_id = $1::uuid AND pp.status = $2
+                \\ORDER BY pp.created_at DESC
+            , .{ user.org_id, sf }) catch {
                 return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
             };
             defer result.deinit();
@@ -131,15 +137,18 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                     .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                     .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                     .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
                 });
             }
         }
     } else {
         if (prompt_filter) |pf| {
             var result = conn.query(
-                "SELECT pr_id, prompt_id, status, description, created_at::text FROM prompt_prs WHERE org_id = $1::uuid AND prompt_id = $2 ORDER BY created_at DESC",
-                .{ user.org_id, pf },
-            ) catch {
+                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
+                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+                \\WHERE pp.org_id = $1::uuid AND pp.prompt_id = $2
+                \\ORDER BY pp.created_at DESC
+            , .{ user.org_id, pf }) catch {
                 return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
             };
             defer result.deinit();
@@ -150,13 +159,16 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                     .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                     .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                     .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
                 });
             }
         } else {
             var result = conn.query(
-                "SELECT pr_id, prompt_id, status, description, created_at::text FROM prompt_prs WHERE org_id = $1::uuid ORDER BY created_at DESC",
-                .{user.org_id},
-            ) catch {
+                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
+                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+                \\WHERE pp.org_id = $1::uuid
+                \\ORDER BY pp.created_at DESC
+            , .{user.org_id}) catch {
                 return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
             };
             defer result.deinit();
@@ -167,6 +179,7 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                     .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                     .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                     .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
                 });
             }
         }

--- a/src/hub/server.zig
+++ b/src/hub/server.zig
@@ -57,6 +57,7 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.post("/api/org/members", auth.handleInviteMember, .{});
     router.patch("/api/org/members/:user_id", auth.handleChangeRole, .{});
     router.delete("/api/org/members/:user_id", auth.handleRemoveMember, .{});
+    router.get("/api/org/directory", team_handler.handleDirectory, .{});
 
     // Teams
     router.post("/api/org/teams", team_handler.handleCreateTeam, .{});

--- a/src/hub/team.zig
+++ b/src/hub/team.zig
@@ -270,6 +270,9 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
     if (!auth.requireScope(user, "members:read", res)) return;
+    if (!std.mem.eql(u8, user.role, "maintainer")) {
+        return apiError(res, 403, "FORBIDDEN", "maintainer role required");
+    }
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -281,13 +284,13 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         username: []const u8,
         role: []const u8,
         joined_at: []const u8,
-        team_ids: []const []const u8,
+        team_ids: []const []const u8 = &.{},
     };
 
     const DirectoryTeam = struct {
         team_id: []const u8,
         name: []const u8,
-        member_ids: []const []const u8,
+        member_ids: []const []const u8 = &.{},
     };
 
     // Members with team_ids as CSV via string_agg
@@ -304,15 +307,15 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
     defer member_result.deinit();
-    while (member_result.next() catch null) |row| {
-        const csv = row.get([]const u8, 4) catch "";
-        members.append(req.arena, .{
-            .user_id = req.arena.dupe(u8, row.get([]const u8, 0) catch continue) catch continue,
-            .username = req.arena.dupe(u8, row.get([]const u8, 1) catch continue) catch continue,
-            .role = req.arena.dupe(u8, row.get([]const u8, 2) catch continue) catch continue,
-            .joined_at = req.arena.dupe(u8, row.get([]const u8, 3) catch continue) catch continue,
-            .team_ids = splitCsv(req.arena, csv),
-        }) catch continue;
+    while (try member_result.next()) |row| {
+        const csv = try row.get([]const u8, 4);
+        try members.append(req.arena, .{
+            .user_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+            .username = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+            .role = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+            .joined_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .team_ids = try splitCsv(req.arena, csv),
+        });
     }
 
     // Teams with member_ids as CSV via string_agg
@@ -329,13 +332,13 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
     defer team_result.deinit();
-    while (team_result.next() catch null) |row| {
-        const csv = row.get([]const u8, 2) catch "";
-        teams.append(req.arena, .{
-            .team_id = req.arena.dupe(u8, row.get([]const u8, 0) catch continue) catch continue,
-            .name = req.arena.dupe(u8, row.get([]const u8, 1) catch continue) catch continue,
-            .member_ids = splitCsv(req.arena, csv),
-        }) catch continue;
+    while (try team_result.next()) |row| {
+        const csv = try row.get([]const u8, 2);
+        try teams.append(req.arena, .{
+            .team_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+            .name = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+            .member_ids = try splitCsv(req.arena, csv),
+        });
     }
 
     try res.json(.{
@@ -344,12 +347,12 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     }, .{});
 }
 
-fn splitCsv(arena: std.mem.Allocator, csv: []const u8) []const []const u8 {
+fn splitCsv(arena: std.mem.Allocator, csv: []const u8) ![]const []const u8 {
     if (csv.len == 0) return &.{};
     var list: std.ArrayList([]const u8) = .empty;
     var iter = std.mem.splitScalar(u8, csv, ',');
     while (iter.next()) |part| {
-        list.append(arena, arena.dupe(u8, part) catch continue) catch continue;
+        try list.append(arena, try arena.dupe(u8, part));
     }
     return list.items;
 }

--- a/src/hub/team.zig
+++ b/src/hub/team.zig
@@ -264,6 +264,96 @@ pub fn handleAddTeamMember(ctx: *Server.Context, req: *httpz.Request, res: *http
     try res.json(.{ .team_id = team_id, .user_id = body.user_id }, .{});
 }
 
+// GET /api/org/directory
+pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+    const user = auth.authenticate(ctx, req) catch {
+        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
+    };
+    if (!auth.requireScope(user, "members:read", res)) return;
+
+    const conn = ctx.pool.acquire() catch {
+        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
+    };
+    defer conn.release();
+
+    const DirectoryMember = struct {
+        user_id: []const u8,
+        username: []const u8,
+        role: []const u8,
+        joined_at: []const u8,
+        team_ids: []const []const u8,
+    };
+
+    const DirectoryTeam = struct {
+        team_id: []const u8,
+        name: []const u8,
+        member_ids: []const []const u8,
+    };
+
+    // Members with team_ids as CSV via string_agg
+    var members: std.ArrayList(DirectoryMember) = .empty;
+    const member_result = conn.query(
+        \\SELECT u.user_id, u.username, u.role, u.created_at::text,
+        \\  COALESCE(string_agg(tm.team_id, ',' ORDER BY tm.team_id), '')
+        \\FROM users u
+        \\LEFT JOIN team_members tm ON tm.user_id = u.user_id
+        \\WHERE u.org_id = $1::uuid
+        \\GROUP BY u.user_id, u.username, u.role, u.created_at
+        \\ORDER BY u.username
+    , .{user.org_id}) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    };
+    defer member_result.deinit();
+    while (member_result.next() catch null) |row| {
+        const csv = row.get([]const u8, 4) catch "";
+        members.append(req.arena, .{
+            .user_id = req.arena.dupe(u8, row.get([]const u8, 0) catch continue) catch continue,
+            .username = req.arena.dupe(u8, row.get([]const u8, 1) catch continue) catch continue,
+            .role = req.arena.dupe(u8, row.get([]const u8, 2) catch continue) catch continue,
+            .joined_at = req.arena.dupe(u8, row.get([]const u8, 3) catch continue) catch continue,
+            .team_ids = splitCsv(req.arena, csv),
+        }) catch continue;
+    }
+
+    // Teams with member_ids as CSV via string_agg
+    var teams: std.ArrayList(DirectoryTeam) = .empty;
+    const team_result = conn.query(
+        \\SELECT t.team_id, t.name,
+        \\  COALESCE(string_agg(tm.user_id, ',' ORDER BY tm.user_id), '')
+        \\FROM teams t
+        \\LEFT JOIN team_members tm ON tm.team_id = t.team_id
+        \\WHERE t.org_id = $1::uuid
+        \\GROUP BY t.team_id, t.name
+        \\ORDER BY t.name
+    , .{user.org_id}) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    };
+    defer team_result.deinit();
+    while (team_result.next() catch null) |row| {
+        const csv = row.get([]const u8, 2) catch "";
+        teams.append(req.arena, .{
+            .team_id = req.arena.dupe(u8, row.get([]const u8, 0) catch continue) catch continue,
+            .name = req.arena.dupe(u8, row.get([]const u8, 1) catch continue) catch continue,
+            .member_ids = splitCsv(req.arena, csv),
+        }) catch continue;
+    }
+
+    try res.json(.{
+        .members = members.items,
+        .teams = teams.items,
+    }, .{});
+}
+
+fn splitCsv(arena: std.mem.Allocator, csv: []const u8) []const []const u8 {
+    if (csv.len == 0) return &.{};
+    var list: std.ArrayList([]const u8) = .empty;
+    var iter = std.mem.splitScalar(u8, csv, ',');
+    while (iter.next()) |part| {
+        list.append(arena, arena.dupe(u8, part) catch continue) catch continue;
+    }
+    return list.items;
+}
+
 // DELETE /api/org/teams/:team_id/members/:user_id
 pub fn handleRemoveTeamMember(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {

--- a/src/hub/trace.zig
+++ b/src/hub/trace.zig
@@ -33,6 +33,15 @@ const TrendEntry = struct {
     refer_count: i64,
 };
 
+const OrgPromptStats = struct {
+    prompt_id: []const u8,
+    refer_count: i64,
+    active_constraint_count: i64,
+    workspace_count: i64,
+    bundle_count: i64,
+    open_pr_count: i64,
+};
+
 fn parsePeriod(period: []const u8) ?[]const u8 {
     if (std.mem.eql(u8, period, "daily")) return "day";
     if (std.mem.eql(u8, period, "weekly")) return "week";
@@ -46,13 +55,19 @@ fn queryTrend(
     sql_trunc: []const u8,
     where_clause: []const u8,
     bind: anytype,
+    max_days: ?u32,
 ) []const TrendEntry {
+    const days_filter = if (max_days) |d|
+        std.fmt.allocPrint(arena, " AND timestamp >= (extract(epoch from now()) * 1000 - {d} * 86400000)", .{d}) catch ""
+    else
+        "";
+
     const query = std.fmt.allocPrint(
         arena,
         "SELECT date_trunc('{s}', to_timestamp(timestamp/1000))::date::text as date, count(*) as refer_count" ++
-            " FROM trace_events WHERE {s} AND type = 'refer'" ++
+            " FROM trace_events WHERE {s} AND type = 'refer'{s}" ++
             " GROUP BY 1 ORDER BY 1",
-        .{ sql_trunc, where_clause },
+        .{ sql_trunc, where_clause, days_filter },
     ) catch return &.{};
 
     var result = conn.query(query, bind) catch return &.{};
@@ -157,6 +172,7 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
+    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -171,10 +187,62 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     , .{user.org_id}) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        try res.json(.{ .total_refer_count = @as(i64, 0), .workspace_count = @as(i64, 0), .prompt_count = @as(i64, 0), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
+        try res.json(.{ .total_refer_count = @as(i64, 0), .workspace_count = @as(i64, 0), .prompt_count = @as(i64, 0), .prompts = @as([]const OrgPromptStats, &.{}), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
         return;
     };
     defer row.deinit() catch {};
+
+    // Per-prompt aggregated stats via LEFT JOINs
+    var prompt_list: std.ArrayList(OrgPromptStats) = .empty;
+    const prompt_result = conn.query(
+        \\SELECT p.prompt_id,
+        \\  COALESCE(te_stats.refer_count, 0),
+        \\  COALESCE(te_stats.active_constraints, 0),
+        \\  COALESCE(ws_stats.workspace_count, 0),
+        \\  COALESCE(bp_stats.bundle_count, 0),
+        \\  COALESCE(pr_stats.open_pr_count, 0)
+        \\FROM prompts p
+        \\LEFT JOIN (
+        \\  SELECT te.prompt_id, count(*) as refer_count,
+        \\    count(DISTINCT te.constraint_id) as active_constraints
+        \\  FROM trace_events te JOIN workspaces w ON w.ws_id = te.ws_id
+        \\  WHERE w.org_id = $1::uuid AND te.type = 'refer' AND te.prompt_id IS NOT NULL
+        \\  GROUP BY te.prompt_id
+        \\) te_stats ON te_stats.prompt_id = p.prompt_id
+        \\LEFT JOIN (
+        \\  SELECT wp.prompt_id, count(DISTINCT wp.ws_id) as workspace_count
+        \\  FROM workspace_prompts wp JOIN workspaces w ON w.ws_id = wp.ws_id
+        \\  WHERE w.org_id = $1::uuid
+        \\  GROUP BY wp.prompt_id
+        \\) ws_stats ON ws_stats.prompt_id = p.prompt_id
+        \\LEFT JOIN (
+        \\  SELECT bp.prompt_id, count(*) as bundle_count
+        \\  FROM bundle_prompts bp JOIN bundles b ON b.bundle_id = bp.bundle_id
+        \\  WHERE b.org_id = $1::uuid
+        \\  GROUP BY bp.prompt_id
+        \\) bp_stats ON bp_stats.prompt_id = p.prompt_id
+        \\LEFT JOIN (
+        \\  SELECT pr.prompt_id, count(*) as open_pr_count
+        \\  FROM prompt_prs pr
+        \\  WHERE pr.org_id = $1::uuid AND pr.status = 'open'
+        \\  GROUP BY pr.prompt_id
+        \\) pr_stats ON pr_stats.prompt_id = p.prompt_id
+        \\WHERE p.org_id = $1::uuid
+        \\ORDER BY COALESCE(te_stats.refer_count, 0) DESC
+    , .{user.org_id}) catch null;
+    if (prompt_result) |pr| {
+        defer pr.deinit();
+        while (pr.next() catch null) |prow| {
+            prompt_list.append(req.arena, .{
+                .prompt_id = req.arena.dupe(u8, prow.get([]const u8, 0) catch continue) catch continue,
+                .refer_count = prow.get(i64, 1) catch continue,
+                .active_constraint_count = prow.get(i64, 2) catch continue,
+                .workspace_count = prow.get(i64, 3) catch continue,
+                .bundle_count = prow.get(i64, 4) catch continue,
+                .open_pr_count = prow.get(i64, 5) catch continue,
+            }) catch continue;
+        }
+    }
 
     const trend_data = queryTrend(
         conn,
@@ -182,12 +250,14 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         sql_trunc,
         "ws_id IN (SELECT ws_id FROM workspaces WHERE org_id = $1::uuid)",
         .{user.org_id},
+        max_days,
     );
 
     try res.json(.{
         .total_refer_count = try row.get(i64, 0),
         .workspace_count = try row.get(i64, 1),
         .prompt_count = try row.get(i64, 2),
+        .prompts = prompt_list.items,
         .trend = .{ .period = period, .data = trend_data },
     }, .{});
 }
@@ -209,6 +279,7 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
+    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -262,7 +333,7 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
         }
     }
 
-    const trend_data = queryTrend(conn, req.arena, sql_trunc, "ws_id = $1", .{ws_id});
+    const trend_data = queryTrend(conn, req.arena, sql_trunc, "ws_id = $1", .{ws_id}, max_days);
 
     try res.json(.{
         .ws_id = ws_id,
@@ -290,6 +361,7 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
+    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -326,7 +398,7 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         }) catch continue;
     }
 
-    const trend_data = queryTrend(conn, req.arena, sql_trunc, "prompt_id = $1", .{prompt_id});
+    const trend_data = queryTrend(conn, req.arena, sql_trunc, "prompt_id = $1", .{prompt_id}, max_days);
 
     try res.json(.{
         .prompt_id = prompt_id,

--- a/src/hub/trace.zig
+++ b/src/hub/trace.zig
@@ -49,18 +49,22 @@ fn parsePeriod(period: []const u8) ?[]const u8 {
     return null;
 }
 
+fn defaultDays(period: []const u8) u32 {
+    if (std.mem.eql(u8, period, "daily")) return 7;
+    if (std.mem.eql(u8, period, "weekly")) return 56; // 8 weeks
+    if (std.mem.eql(u8, period, "monthly")) return 365; // 12 months
+    return 30;
+}
+
 fn queryTrend(
     conn: anytype,
     arena: std.mem.Allocator,
     sql_trunc: []const u8,
     where_clause: []const u8,
     bind: anytype,
-    max_days: ?u32,
+    max_days: u32,
 ) []const TrendEntry {
-    const days_filter = if (max_days) |d|
-        std.fmt.allocPrint(arena, " AND timestamp >= (extract(epoch from now()) * 1000 - {d} * 86400000)", .{d}) catch ""
-    else
-        "";
+    const days_filter = std.fmt.allocPrint(arena, " AND timestamp >= (extract(epoch from now()) * 1000 - {d} * 86400000)", .{max_days}) catch "";
 
     const query = std.fmt.allocPrint(
         arena,
@@ -172,7 +176,7 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
+    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -279,7 +283,7 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
+    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -361,7 +365,7 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: ?u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch null else null;
+    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");

--- a/src/hub/trace.zig
+++ b/src/hub/trace.zig
@@ -64,7 +64,7 @@ fn queryTrend(
     bind: anytype,
     max_days: u32,
 ) []const TrendEntry {
-    const days_filter = std.fmt.allocPrint(arena, " AND timestamp >= (extract(epoch from now()) * 1000 - {d} * 86400000)", .{max_days}) catch "";
+    const days_filter = std.fmt.allocPrint(arena, " AND timestamp >= (extract(epoch from now()) * 1000 - {d}::bigint * 86400000)", .{max_days}) catch "";
 
     const query = std.fmt.allocPrint(
         arena,
@@ -176,7 +176,15 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
+    const max_days: u32 = if (qs.get("days")) |ds| blk: {
+        const d = std.fmt.parseInt(u32, ds, 10) catch {
+            return apiError(res, 400, "BAD_REQUEST", "invalid days parameter; must be a positive integer");
+        };
+        if (d == 0 or d > 3650) {
+            return apiError(res, 400, "BAD_REQUEST", "days must be between 1 and 3650");
+        }
+        break :blk d;
+    } else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -283,7 +291,15 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
+    const max_days: u32 = if (qs.get("days")) |ds| blk: {
+        const d = std.fmt.parseInt(u32, ds, 10) catch {
+            return apiError(res, 400, "BAD_REQUEST", "invalid days parameter; must be a positive integer");
+        };
+        if (d == 0 or d > 3650) {
+            return apiError(res, 400, "BAD_REQUEST", "days must be between 1 and 3650");
+        }
+        break :blk d;
+    } else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -365,7 +381,15 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     const sql_trunc = parsePeriod(period) orelse {
         return apiError(res, 400, "BAD_REQUEST", "invalid period; use daily, weekly, or monthly");
     };
-    const max_days: u32 = if (qs.get("days")) |ds| std.fmt.parseInt(u32, ds, 10) catch defaultDays(period) else defaultDays(period);
+    const max_days: u32 = if (qs.get("days")) |ds| blk: {
+        const d = std.fmt.parseInt(u32, ds, 10) catch {
+            return apiError(res, 400, "BAD_REQUEST", "invalid days parameter; must be a positive integer");
+        };
+        if (d == 0 or d > 3650) {
+            return apiError(res, 400, "BAD_REQUEST", "days must be between 1 and 3650");
+        }
+        break :blk d;
+    } else defaultDays(period);
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");


### PR DESCRIPTION
## Summary

The TUI dashboard migration from mock data to real API calls revealed
systematic field gaps across multiple endpoints. Rather than patching
fields individually, the gaps were grouped into three coherent changes.

Stats endpoints became the single source for aggregated data. Org-level
/api/stats now returns a prompts[] array with per-prompt refer_count,
active_constraint_count, workspace_count, bundle_count, and
open_pr_count, computed via LEFT JOIN subqueries. All three stats
endpoints accept an optional ?days=N parameter to limit trend data,
with spec-defined defaults when omitted (daily=7, weekly=56,
monthly=365).

The prompt PR list was missing the author field. All four query
variants now JOIN users to return the author username alongside
each PR.

A new GET /api/org/directory endpoint returns the complete org
structure (members with team_ids, teams with member_ids) in a
single request, replacing the N+1 pattern of fetching members,
teams, then per-team details separately.

## Test plan

- `zig build && zig build test` pass
- `zig fmt --check` clean on all changed files
- Manual verification with `clumsies-seed --reset` test data:
  - `GET /api/stats?period=daily` returns prompts[] with aggregates
  - `GET /api/stats?period=daily&days=30` returns 30-day trend window
  - `GET /api/org/prompt-prs` includes author on each PR
  - `GET /api/org/directory` returns bidirectional member-team refs