### PR TITLE
hub: implement invite-only onboarding with bootstrap and CLI activate

### DIFF
--- a/src/commands/login_cmd.zig
+++ b/src/commands/login_cmd.zig
@@ -62,28 +62,68 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     const response = try client.post("/api/auth/login", body);
     defer response.deinit();
 
-    if (response.status != .ok) {
+    if (response.status == .ok) {
+        const parsed = std.json.parseFromSlice(LoginResponse, allocator, response.body, .{ .allocate = .alloc_always }) catch {
+            try stderr.print("{s}{s}{s}Error:{s} Failed to parse login response\n", .{ P, Color.bold, Color.red, Color.reset });
+            return;
+        };
+        defer parsed.deinit();
+        try auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token);
+        try stdout.print("{s}{s}{s}Logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
+        return;
+    }
+
+    if (response.status != .unauthorized) {
         try stderr.print("{s}{s}{s}Error:{s} Login failed (HTTP {d})\n", .{ P, Color.bold, Color.red, Color.reset, @intFromEnum(response.status) });
-        if (response.body.len > 0) {
-            try stderr.print("{s}{s}\n", .{ P, response.body });
+        return;
+    }
+
+    // 401: might be wrong password or invited user needing activation
+    try stderr.print("{s}Login failed. If you were invited, enter your invitation token to activate.\n", .{P});
+    try stderr.print("{s}Invitation token (or press Enter to abort): ", .{P});
+    try stderr.flush();
+    const invite_token = try readLine(allocator);
+    defer allocator.free(invite_token);
+
+    if (invite_token.len == 0) {
+        try stderr.print("{s}{s}{s}Error:{s} Login failed\n", .{ P, Color.bold, Color.red, Color.reset });
+        return;
+    }
+
+    // Collect new password for activation
+    try stderr.print("{s}Set password: ", .{P});
+    try stderr.flush();
+    const new_password = try readPassword(allocator);
+    defer allocator.free(new_password);
+    try stderr.print("\n", .{});
+
+    // Build activate body
+    const ActivateBody = struct { username: []const u8, invite_token: []const u8, credential: []const u8 };
+    const activate_body = std.json.Stringify.valueAlloc(allocator, ActivateBody{
+        .username = username,
+        .invite_token = invite_token,
+        .credential = new_password,
+    }, .{}) catch return error.OutOfMemory;
+    defer allocator.free(activate_body);
+
+    const activate_resp = try client.post("/api/auth/activate", activate_body);
+    defer activate_resp.deinit();
+
+    if (activate_resp.status != .ok) {
+        try stderr.print("{s}{s}{s}Error:{s} Activation failed (HTTP {d})\n", .{ P, Color.bold, Color.red, Color.reset, @intFromEnum(activate_resp.status) });
+        if (activate_resp.body.len > 0) {
+            try stderr.print("{s}{s}\n", .{ P, activate_resp.body });
         }
         return;
     }
 
-    // Parse response JSON for access_token and refresh_token
-    const parsed = std.json.parseFromSlice(LoginResponse, allocator, response.body, .{ .allocate = .alloc_always }) catch {
-        try stderr.print("{s}{s}{s}Error:{s} Failed to parse login response\n", .{ P, Color.bold, Color.red, Color.reset });
+    const parsed = std.json.parseFromSlice(LoginResponse, allocator, activate_resp.body, .{ .allocate = .alloc_always }) catch {
+        try stderr.print("{s}{s}{s}Error:{s} Failed to parse activation response\n", .{ P, Color.bold, Color.red, Color.reset });
         return;
     };
     defer parsed.deinit();
-
-    const access_token = parsed.value.access_token;
-    const refresh_token = parsed.value.refresh_token;
-
-    // Save auth
-    try auth_mod.saveAuth(allocator, hub_url, username, access_token, refresh_token);
-
-    try stdout.print("{s}{s}{s}Logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
+    try auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token);
+    try stdout.print("{s}{s}{s}Account activated and logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
 }
 
 fn readLine(allocator: std.mem.Allocator) ![]const u8 {

--- a/src/hub/auth.zig
+++ b/src/hub/auth.zig
@@ -14,8 +14,8 @@ pub const AuthUser = struct {
     scopes: []const u8,
 };
 
-const MEMBER_SCOPES = "library:read,workspace:read,workspace:write,trace:write,stats:read,members:read,pr:read,pr:write,team:read";
-const MAINTAINER_SCOPES = "library:read,library:write,bundle:write,workspace:read,workspace:write,trace:write,stats:read,members:read,members:write,pr:read,pr:write,pr:merge,team:read,team:write";
+const MEMBER_SCOPES = "library:read,workspace:read,workspace:write,trace:write,stats:read,members:read,pr:read,pr:write";
+const MAINTAINER_SCOPES = "library:read,library:write,bundle:write,workspace:read,workspace:write,trace:write,stats:read,members:read,members:write,pr:read,pr:write,pr:merge";
 
 pub fn requireScope(user: AuthUser, scope: []const u8, res: anytype) bool {
     if (std.mem.indexOf(u8, user.scopes, scope) != null) return true;
@@ -65,13 +65,20 @@ pub fn handleLogin(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     defer conn.release();
 
     var row = conn.row(
-        "SELECT user_id, org_id, username, role, password_hash FROM users WHERE username = $1",
+        "SELECT user_id, org_id, username, role, password_hash, status FROM users WHERE username = $1",
         .{login.username},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 401, "UNAUTHORIZED", "invalid credentials");
     };
+
+    // Reject invited users with the same 401 to avoid username enumeration
+    const status = try row.get([]const u8, 5);
+    if (std.mem.eql(u8, status, "invited")) {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invalid credentials");
+    }
 
     const stored_hash = try row.get([]const u8, 4);
     if (!verifyPassword(login.credential, stored_hash)) {
@@ -275,6 +282,18 @@ fn verifyPassword(input: []const u8, stored_hash: []const u8) bool {
     return std.mem.eql(u8, input, stored_hash);
 }
 
+fn generateInviteToken(buf: *[68]u8) []const u8 {
+    var rand_bytes: [32]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    @memcpy(buf[0..4], "inv_");
+    hexEncode(&rand_bytes, buf[4..68]);
+    return buf;
+}
+
+fn hashInviteToken(token: []const u8) [64]u8 {
+    return hashToken(token);
+}
+
 pub fn hashPassword(password: []const u8, out: []u8) ![]const u8 {
     return bcrypt.strHash(password, .{
         .params = .{ .rounds_log = 10, .silently_truncate_password = false },
@@ -330,6 +349,7 @@ const MemberInfo = struct {
     user_id: []const u8,
     username: []const u8,
     role: []const u8,
+    status: []const u8,
     joined_at: []const u8,
 };
 
@@ -348,7 +368,7 @@ pub fn handleListMembers(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     defer conn.release();
 
     var result = conn.query(
-        "SELECT user_id, username, role, created_at::text FROM users WHERE org_id = $1::uuid ORDER BY username",
+        "SELECT user_id, username, role, status, created_at::text FROM users WHERE org_id = $1::uuid ORDER BY username",
         .{user.org_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -361,7 +381,8 @@ pub fn handleListMembers(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
             .user_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
             .username = try req.arena.dupe(u8, try row.get([]const u8, 1)),
             .role = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-            .joined_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .status = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .joined_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
         });
     }
 
@@ -408,10 +429,16 @@ pub fn handleInviteMember(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         uid_buf[4 + i * 2 + 1] = hex[byte & 0x0f];
     }
 
+    // Generate invite token
+    var invite_buf: [68]u8 = undefined;
+    const invite_token = generateInviteToken(&invite_buf);
+    const invite_hash = hashInviteToken(invite_token);
+    const invite_hash_slice: []const u8 = &invite_hash;
+
     _ = conn.exec(
-        "INSERT INTO users (user_id, org_id, username, role, password_hash) VALUES ($1, $2::uuid, $3, $4, '!invited')",
-        .{ @as([]const u8, &uid_buf), user.org_id, body.username, body.role },
-    ) catch {
+        \\INSERT INTO users (user_id, org_id, username, role, status, invite_token_hash, invite_expires_at)
+        \\VALUES ($1, $2::uuid, $3, $4, 'invited', $5, now() + interval '7 days')
+    , .{ @as([]const u8, &uid_buf), user.org_id, body.username, body.role, invite_hash_slice }) catch {
         if (conn.err) |pg_err| {
             if (std.mem.indexOf(u8, pg_err.message, "unique") != null or
                 std.mem.indexOf(u8, pg_err.message, "duplicate") != null)
@@ -422,11 +449,25 @@ pub fn handleInviteMember(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         return apiError(res, 500, "INTERNAL_ERROR", "database insert failed");
     };
 
+    // Read back invite_expires_at for response
+    var exp_row = conn.row(
+        "SELECT invite_expires_at::text FROM users WHERE user_id = $1",
+        .{@as([]const u8, &uid_buf)},
+    ) catch null;
+    const expires_at = if (exp_row) |*er| blk: {
+        const val = req.arena.dupe(u8, er.get([]const u8, 0) catch "") catch "";
+        er.deinit() catch {};
+        break :blk val;
+    } else "";
+
     res.status = 201;
     try res.json(.{
         .user_id = @as([]const u8, &uid_buf),
         .username = body.username,
         .role = body.role,
+        .status = "invited",
+        .invite_token = invite_token,
+        .invite_expires_at = expires_at,
     }, .{});
 }
 
@@ -545,4 +586,173 @@ pub fn handleRemoveMember(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     };
 
     res.status = 204;
+}
+
+// Invite activation
+
+const ActivateRequest = struct {
+    username: []const u8,
+    invite_token: []const u8,
+    credential: []const u8,
+};
+
+pub fn handleActivate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+    const client_ip = req.header("x-forwarded-for") orelse "unknown";
+    if (!ctx.rate_limiter.check(client_ip)) {
+        return apiError(res, 429, "TOO_MANY_REQUESTS", "rate limit exceeded");
+    }
+
+    const body = req.json(ActivateRequest) catch {
+        return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
+    } orelse {
+        return apiError(res, 400, "BAD_REQUEST", "missing request body");
+    };
+
+    if (body.credential.len == 0) {
+        return apiError(res, 400, "BAD_REQUEST", "credential is required");
+    }
+
+    const conn = ctx.pool.acquire() catch {
+        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
+    };
+    defer conn.release();
+
+    var row = conn.row(
+        "SELECT user_id, org_id, role, status, invite_token_hash, invite_expires_at > now() as not_expired FROM users WHERE username = $1",
+        .{body.username},
+    ) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    } orelse {
+        return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
+    };
+
+    const status = row.get([]const u8, 3) catch {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
+    };
+    if (!std.mem.eql(u8, status, "invited")) {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
+    }
+
+    const stored_hash = row.get([]const u8, 4) catch {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
+    };
+    const not_expired = row.get(bool, 5) catch false;
+    if (!not_expired) {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invitation has expired");
+    }
+
+    // Verify invite token
+    const input_hash = hashInviteToken(body.invite_token);
+    const input_hash_slice: []const u8 = &input_hash;
+    if (!std.mem.eql(u8, input_hash_slice, stored_hash)) {
+        row.deinit() catch {};
+        return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
+    }
+
+    const user_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
+    const org_id = try req.arena.dupe(u8, try row.get([]const u8, 1));
+    const role = try req.arena.dupe(u8, try row.get([]const u8, 2));
+    row.deinit() catch {};
+
+    // Hash the new password and activate
+    var hash_buf: [128]u8 = undefined;
+    const password_hash = hashPassword(body.credential, &hash_buf) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "password hashing failed");
+    };
+
+    _ = conn.exec(
+        \\UPDATE users SET password_hash = $2, status = 'active',
+        \\  invite_token_hash = NULL, invite_expires_at = NULL
+        \\WHERE user_id = $1
+    , .{ user_id, password_hash }) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database update failed");
+    };
+
+    // Issue token pair (same as login)
+    const default_scopes = if (std.mem.eql(u8, role, "maintainer")) MAINTAINER_SCOPES else MEMBER_SCOPES;
+    const ttl = ctx.config.token_ttl_seconds;
+
+    const access_token = generateToken(req.arena, conn, user_id, "access", default_scopes, ttl) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "token generation failed");
+    };
+    const refresh_token = generateToken(req.arena, conn, user_id, "refresh", default_scopes, ttl * 24) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "token generation failed");
+    };
+
+    _ = org_id; // Used for token scope validation in future
+
+    try res.json(.{
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+        .expires_in = ttl,
+    }, .{});
+}
+
+pub fn handleReissueInvite(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+    const user = authenticate(ctx, req) catch {
+        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
+    };
+    if (!requireScope(user, "members:write", res)) return;
+    if (!std.mem.eql(u8, user.role, "maintainer")) {
+        return apiError(res, 403, "FORBIDDEN", "maintainer role required");
+    }
+
+    const target_id = req.param("user_id") orelse {
+        return apiError(res, 400, "BAD_REQUEST", "user_id is required");
+    };
+
+    const conn = ctx.pool.acquire() catch {
+        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
+    };
+    defer conn.release();
+
+    var row = conn.row(
+        "SELECT status FROM users WHERE user_id = $1 AND org_id = $2::uuid",
+        .{ target_id, user.org_id },
+    ) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    } orelse {
+        return apiError(res, 404, "NOT_FOUND", "user not found");
+    };
+
+    const status = try req.arena.dupe(u8, try row.get([]const u8, 0));
+    row.deinit() catch {};
+
+    if (!std.mem.eql(u8, status, "invited")) {
+        return apiError(res, 400, "BAD_REQUEST", "user is already active");
+    }
+
+    // Generate new invite token (old one is overwritten)
+    var invite_buf: [68]u8 = undefined;
+    const invite_token = generateInviteToken(&invite_buf);
+    const invite_hash = hashInviteToken(invite_token);
+    const invite_hash_slice: []const u8 = &invite_hash;
+
+    _ = conn.exec(
+        "UPDATE users SET invite_token_hash = $2, invite_expires_at = now() + interval '7 days' WHERE user_id = $1",
+        .{ target_id, invite_hash_slice },
+    ) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database update failed");
+    };
+
+    var exp_row = conn.row(
+        "SELECT invite_expires_at::text FROM users WHERE user_id = $1",
+        .{target_id},
+    ) catch null;
+    const expires_at = if (exp_row) |*er| blk: {
+        const val = req.arena.dupe(u8, er.get([]const u8, 0) catch "") catch "";
+        er.deinit() catch {};
+        break :blk val;
+    } else "";
+
+    try res.json(.{
+        .user_id = target_id,
+        .status = "invited",
+        .invite_token = invite_token,
+        .invite_expires_at = expires_at,
+    }, .{});
 }

--- a/src/hub/auth.zig
+++ b/src/hub/auth.zig
@@ -578,8 +578,8 @@ pub fn handleRemoveMember(ctx: *Server.Context, req: *httpz.Request, res: *httpz
 
     // Cascade: remove from all workspaces
     _ = conn.exec("DELETE FROM workspace_members WHERE user_id = $1", .{target_id}) catch {};
-    // Revoke tokens
-    _ = conn.exec("UPDATE tokens SET revoked = true WHERE user_id = $1", .{target_id}) catch {};
+    // Delete tokens (FK on users has no CASCADE, must remove before user)
+    _ = conn.exec("DELETE FROM tokens WHERE user_id = $1", .{target_id}) catch {};
     // Remove user
     _ = conn.exec("DELETE FROM users WHERE user_id = $1 AND org_id = $2::uuid", .{ target_id, user.org_id }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database delete failed");
@@ -598,7 +598,7 @@ const ActivateRequest = struct {
 
 pub fn handleActivate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const client_ip = req.header("x-forwarded-for") orelse "unknown";
-    if (!ctx.rate_limiter.check(client_ip)) {
+    if (!ctx.auth_rate_limiter.check(client_ip)) {
         return apiError(res, 429, "TOO_MANY_REQUESTS", "rate limit exceeded");
     }
 
@@ -645,10 +645,16 @@ pub fn handleActivate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 401, "UNAUTHORIZED", "invitation has expired");
     }
 
-    // Verify invite token
+    // Verify invite token (constant-time comparison to prevent timing side-channel)
     const input_hash = hashInviteToken(body.invite_token);
-    const input_hash_slice: []const u8 = &input_hash;
-    if (!std.mem.eql(u8, input_hash_slice, stored_hash)) {
+    const match = if (stored_hash.len == input_hash.len) blk: {
+        var diff: u8 = 0;
+        for (&input_hash, stored_hash[0..input_hash.len]) |a, b| {
+            diff |= a ^ b;
+        }
+        break :blk diff == 0;
+    } else false;
+    if (!match) {
         row.deinit() catch {};
         return apiError(res, 401, "UNAUTHORIZED", "invalid activation credentials");
     }

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -38,9 +38,10 @@ pub fn migrate(pool: *Pool) !void {
 }
 
 pub fn bootstrap(pool: *Pool) !void {
-    const username = std.posix.getenv("HUB_BOOTSTRAP_USERNAME") orelse return;
-    const password = std.posix.getenv("HUB_BOOTSTRAP_PASSWORD") orelse return;
-    const org_name = std.posix.getenv("HUB_BOOTSTRAP_ORG") orelse "default";
+    const alloc = std.heap.page_allocator;
+    const username = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_USERNAME") catch return;
+    const password = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_PASSWORD") catch return;
+    const org_name = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_ORG") catch "default";
 
     const conn = try pool.acquire();
     defer conn.release();
@@ -64,12 +65,18 @@ pub fn bootstrap(pool: *Pool) !void {
         return;
     };
 
-    // Get org_id
+    // Get org_id — copy into stable buffer before row deinit
     var org_row = conn.row("SELECT org_id::text FROM orgs WHERE name = $1", .{org_name}) catch return;
-    const org_id = if (org_row) |*or_| blk: {
-        const val = or_.get([]const u8, 0) catch return;
-        defer or_.deinit() catch {};
-        break :blk val;
+    var org_id_buf: [64]u8 = undefined;
+    const org_id: []const u8 = if (org_row) |*or_| blk: {
+        const val = or_.get([]const u8, 0) catch {
+            or_.deinit() catch {};
+            return;
+        };
+        const len = @min(val.len, org_id_buf.len);
+        @memcpy(org_id_buf[0..len], val[0..len]);
+        or_.deinit() catch {};
+        break :blk org_id_buf[0..len];
     } else return;
 
     // Hash password

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const pg = @import("pg");
 const Config = @import("config.zig");
+const bcrypt = std.crypto.pwhash.bcrypt;
 
 pub const Pool = pg.Pool;
 
@@ -36,6 +37,79 @@ pub fn migrate(pool: *Pool) !void {
     };
 }
 
+pub fn bootstrap(pool: *Pool) !void {
+    const username = std.posix.getenv("HUB_BOOTSTRAP_USERNAME") orelse return;
+    const password = std.posix.getenv("HUB_BOOTSTRAP_PASSWORD") orelse return;
+    const org_name = std.posix.getenv("HUB_BOOTSTRAP_ORG") orelse "default";
+
+    const conn = try pool.acquire();
+    defer conn.release();
+
+    // Only bootstrap if no users exist
+    var count_row = conn.row("SELECT count(*) FROM users", .{}) catch return;
+    if (count_row) |*cr| {
+        const count = cr.get(i64, 0) catch 0;
+        cr.deinit() catch {};
+        if (count > 0) return;
+    }
+
+    const log = std.log.scoped(.bootstrap);
+
+    // Create org
+    _ = conn.exec(
+        "INSERT INTO orgs (name) VALUES ($1) ON CONFLICT DO NOTHING",
+        .{org_name},
+    ) catch |err| {
+        log.err("bootstrap org failed: {}", .{err});
+        return;
+    };
+
+    // Get org_id
+    var org_row = conn.row("SELECT org_id::text FROM orgs WHERE name = $1", .{org_name}) catch return;
+    const org_id = if (org_row) |*or_| blk: {
+        const val = or_.get([]const u8, 0) catch return;
+        defer or_.deinit() catch {};
+        break :blk val;
+    } else return;
+
+    // Hash password
+    var hash_buf: [128]u8 = undefined;
+    const password_hash = bcrypt.strHash(password, .{
+        .params = .{ .rounds_log = 10, .silently_truncate_password = false },
+        .encoding = .phc,
+    }, &hash_buf) catch {
+        log.err("bootstrap password hash failed", .{});
+        return;
+    };
+
+    // Generate user_id
+    var rand_bytes: [16]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    var uid_buf: [36]u8 = undefined;
+    @memcpy(uid_buf[0..4], "usr-");
+    const hex = "0123456789abcdef";
+    for (rand_bytes, 0..) |byte, i| {
+        uid_buf[4 + i * 2] = hex[byte >> 4];
+        uid_buf[4 + i * 2 + 1] = hex[byte & 0x0f];
+    }
+
+    _ = conn.exec(
+        \\INSERT INTO users (user_id, org_id, username, password_hash, role, status)
+        \\VALUES ($1, $2::uuid, $3, $4, 'maintainer', 'active')
+    , .{ @as([]const u8, &uid_buf), org_id, username, password_hash }) catch |err| {
+        log.err("bootstrap user failed: {}", .{err});
+        return;
+    };
+
+    // Create library manifest
+    _ = conn.exec(
+        "INSERT INTO library_manifest (org_id, revision) VALUES ($1::uuid, 0) ON CONFLICT DO NOTHING",
+        .{org_id},
+    ) catch {};
+
+    log.info("bootstrapped org '{s}' with maintainer '{s}'", .{ org_name, username });
+}
+
 const migration_sql =
     \\CREATE TABLE IF NOT EXISTS orgs (
     \\    org_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -48,8 +122,11 @@ const migration_sql =
     \\    user_id TEXT PRIMARY KEY,
     \\    org_id UUID NOT NULL REFERENCES orgs(org_id),
     \\    username TEXT NOT NULL,
-    \\    password_hash TEXT NOT NULL,
+    \\    password_hash TEXT NOT NULL DEFAULT '',
     \\    role TEXT NOT NULL CHECK (role IN ('member', 'maintainer')),
+    \\    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('invited', 'active')),
+    \\    invite_token_hash TEXT,
+    \\    invite_expires_at TIMESTAMPTZ,
     \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     \\    UNIQUE(org_id, username),
     \\    UNIQUE(username)

--- a/src/hub/server.zig
+++ b/src/hub/server.zig
@@ -48,6 +48,7 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
 
     // Auth
     router.post("/api/auth/login", auth.handleLogin, .{});
+    router.post("/api/auth/activate", auth.handleActivate, .{});
     router.post("/api/auth/refresh", auth.handleRefresh, .{});
     router.get("/api/auth/me", auth.handleMe, .{});
     router.delete("/api/auth/token", auth.handleRevokeToken, .{});
@@ -57,6 +58,7 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.post("/api/org/members", auth.handleInviteMember, .{});
     router.patch("/api/org/members/:user_id", auth.handleChangeRole, .{});
     router.delete("/api/org/members/:user_id", auth.handleRemoveMember, .{});
+    router.post("/api/org/members/:user_id/reissue-invite", auth.handleReissueInvite, .{});
     router.get("/api/org/directory", team_handler.handleDirectory, .{});
 
     // Workspaces

--- a/src/hub/team.zig
+++ b/src/hub/team.zig
@@ -23,12 +23,13 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         user_id: []const u8,
         username: []const u8,
         role: []const u8,
+        status: []const u8,
         joined_at: []const u8,
     };
 
     var members: std.ArrayList(DirectoryMember) = .empty;
     var result = conn.query(
-        "SELECT user_id, username, role, created_at::text FROM users WHERE org_id = $1::uuid ORDER BY username",
+        "SELECT user_id, username, role, status, created_at::text FROM users WHERE org_id = $1::uuid ORDER BY username",
         .{user.org_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -40,7 +41,8 @@ pub fn handleDirectory(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
             .user_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
             .username = try req.arena.dupe(u8, try row.get([]const u8, 1)),
             .role = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-            .joined_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .status = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .joined_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
         });
     }
 

--- a/src/hub_main.zig
+++ b/src/hub_main.zig
@@ -22,6 +22,8 @@ pub fn main() !void {
     try hub.db.migrate(pool);
     try log.print("database migrations applied\n", .{});
 
+    try hub.db.bootstrap(pool);
+
     var server = try hub.Server.init(allocator, config, pool);
     defer server.deinit();
 

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -111,17 +111,19 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
         used_count += 1;
 
         const id = faker.hexId(&state.user_ids[i], "usr-");
-        // First 2 users are maintainers, rest are members, last one is invited
+        // First 2 users are maintainers, rest are members; last 2 are invited
         const role: []const u8 = if (i < 2) "maintainer" else "member";
-        const password: []const u8 = if (i == data.USER_COUNT - 1) "!invited" else "testpass";
+        const is_invited = i >= data.USER_COUNT - 2;
+        const status: []const u8 = if (is_invited) "invited" else "active";
+        const password: []const u8 = if (is_invited) "" else "testpass";
 
         state.user_names[i] = name;
         state.user_roles[i] = role;
         state.user_count = i + 1;
 
         _ = try conn.exec(
-            "INSERT INTO users (user_id, org_id, username, password_hash, role) VALUES ($1, $2::uuid, $3, $4, $5)",
-            .{ id, data.ORG_ID, name, password, role },
+            "INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUES ($1, $2::uuid, $3, $4, $5, $6)",
+            .{ id, data.ORG_ID, name, password, role, status },
         );
     }
 }

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -42,11 +42,11 @@ seed_db() {
     PGPASSWORD=clumsies psql -h 127.0.0.1 -U clumsies -d clumsies -q <<'SQL'
 INSERT INTO orgs (org_id, name) VALUES ('a0000000-0000-0000-0000-000000000001', 'acme')
   ON CONFLICT DO NOTHING;
-INSERT INTO users (user_id, org_id, username, password_hash, role) VALUES
-  ('usr-maintainer-001', 'a0000000-0000-0000-0000-000000000001', 'alice', 'testpass', 'maintainer')
+INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUES
+  ('usr-maintainer-001', 'a0000000-0000-0000-0000-000000000001', 'alice', 'testpass', 'maintainer', 'active')
   ON CONFLICT DO NOTHING;
-INSERT INTO users (user_id, org_id, username, password_hash, role) VALUES
-  ('usr-member-001', 'a0000000-0000-0000-0000-000000000001', 'bob', 'testpass', 'member')
+INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUES
+  ('usr-member-001', 'a0000000-0000-0000-0000-000000000001', 'bob', 'testpass', 'member', 'active')
   ON CONFLICT DO NOTHING;
 INSERT INTO library_manifest (org_id, revision) VALUES ('a0000000-0000-0000-0000-000000000001', 0)
   ON CONFLICT DO NOTHING;
@@ -134,7 +134,37 @@ RAW=$(call POST "/api/org/members" '{"username":"carol","role":"member"}')
 parse_response "$RAW"
 assert_status "invite member" "201" "$STATUS"
 assert_json "returns carol" "carol" "$BODY"
+assert_json "returns invite_token" "invite_token" "$BODY"
+assert_json "status is invited" "invited" "$BODY"
 CAROL_ID=$(echo "$BODY" | grep -o '"user_id":"[^"]*"' | cut -d'"' -f4)
+INVITE_TOKEN=$(echo "$BODY" | grep -o '"invite_token":"[^"]*"' | cut -d'"' -f4)
+
+step "Invite: login as invited user fails"
+RAW=$(call POST "/api/auth/login" '{"username":"carol","credential":"anypass"}')
+parse_response "$RAW"
+assert_status "invited user cannot login" "401" "$STATUS"
+
+step "Invite: activate with token"
+RAW=$(call POST "/api/auth/activate" "{\"username\":\"carol\",\"invite_token\":\"$INVITE_TOKEN\",\"credential\":\"carolpass\"}")
+parse_response "$RAW"
+assert_status "activate succeeds" "200" "$STATUS"
+assert_json "returns access_token" "access_token" "$BODY"
+
+step "Invite: login after activation"
+RAW=$(call POST "/api/auth/login" '{"username":"carol","credential":"carolpass"}')
+parse_response "$RAW"
+assert_status "activated user can login" "200" "$STATUS"
+
+step "Invite: reissue fails for active user"
+RAW=$(call POST "/api/org/members/$CAROL_ID/reissue-invite" '{}')
+parse_response "$RAW"
+assert_status "reissue fails for active" "400" "$STATUS"
+
+step "Org Members: list shows status"
+RAW=$(call GET "/api/org/members")
+parse_response "$RAW"
+assert_status "list members with status" "200" "$STATUS"
+assert_json "contains status field" "status" "$BODY"
 
 step "Org Members: change role"
 RAW=$(call PATCH "/api/org/members/$CAROL_ID" '{"role":"maintainer"}')


### PR DESCRIPTION
## Summary

The previous invite flow used a placeholder password hash to represent
invited users. This made it impossible to distinguish "never set a
password" from "bad hash" at the data level, and there was no mechanism
for the first user to exist in an invite-only system.

This PR introduces explicit invited/active user status, one-time
invite tokens with SHA-256 hashing and expiry, and a complete
activation flow. Maintainers invite users via POST /api/org/members
which returns an invite token. The invited user activates through
POST /api/auth/activate, setting their credential and receiving a
token pair. A reissue endpoint handles expired or lost tokens.

Hub server bootstrap solves the first-user problem: when the users
table is empty and HUB_BOOTSTRAP_USERNAME/PASSWORD environment
variables are set, the server creates the initial maintainer on
startup.

CLI login absorbs the activation flow inline. On a 401 response it
offers to collect an invitation token and new password, then calls
the activate endpoint. No separate CLI command is needed.

This is a breaking schema change — existing databases must be
re-initialized.

## Test plan

- `zig build && zig build test` pass
- `zig fmt --check` clean on all changed files
- E2E tests cover the full invite lifecycle: invite, login rejection,
  activate, post-activation login, reissue rejection for active users
- Manual verification with bootstrap: start hub with
  HUB_BOOTSTRAP_USERNAME=admin HUB_BOOTSTRAP_PASSWORD=secret, confirm
  first maintainer is created and can login