### PR TITLE
refactor: path-based library identity and server-aligned MCP trace

### DIFF
--- a/src/commands/sync_cmd.zig
+++ b/src/commands/sync_cmd.zig
@@ -93,25 +93,23 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     ensureDir(ws_dir);
     ensureDir(cache_dir);
 
-    // Sync prompts — write to rule/ and workflow/ subdirectories
-    // Manifest prompts are keyed by prompt_id, but canonical_name determines the path
+    // Sync prompts — write to paths mirroring the Library.
+    // Manifest prompts are keyed by prompt_id; we look up each prompt's path via the library API.
     var prompt_count: usize = 0;
     if (manifest.object.get("prompts")) |prompts_val| {
         if (prompts_val == .object) {
             var iter = prompts_val.object.iterator();
             while (iter.next()) |entry| {
                 const prompt_id = entry.key_ptr.*;
-                // Fetch prompt content by ID
                 const encoded_prompt_id = try percentEncode(allocator, prompt_id);
                 defer allocator.free(encoded_prompt_id);
-                const api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt?name={s}", .{encoded_prompt_id});
+                const api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt?prompt_id={s}", .{encoded_prompt_id});
                 defer allocator.free(api_path);
 
                 const response = client.get(api_path) catch continue;
                 defer response.deinit();
                 if (response.status != .ok) continue;
 
-                // Parse to get canonical_name and kind for directory placement
                 const prompt_parsed = std.json.parseFromSlice(std.json.Value, allocator, response.body, .{}) catch continue;
                 defer prompt_parsed.deinit();
 
@@ -119,26 +117,19 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
                     .object => |obj| obj,
                     else => continue,
                 };
-                const canonical_name = if (prompt_obj.get("canonical_name")) |v| switch (v) {
+                const prompt_path = if (prompt_obj.get("path")) |v| switch (v) {
                     .string => |s| s,
                     else => continue,
                 } else continue;
 
-                // Fetch actual content
-                const encoded_canonical = try percentEncode(allocator, canonical_name);
-                defer allocator.free(encoded_canonical);
-                const content_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt/content?name={s}", .{encoded_canonical});
-                defer allocator.free(content_path);
+                const content_api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt/content?prompt_id={s}", .{encoded_prompt_id});
+                defer allocator.free(content_api_path);
 
-                const content_response = client.get(content_path) catch continue;
+                const content_response = client.get(content_api_path) catch continue;
                 defer content_response.deinit();
                 if (content_response.status != .ok) continue;
 
-                // canonical_name is like "rule/coding/STYLE" or "workflow/cmd/COMMIT"
-                // Write directly to cache using canonical_name as the path
-                const file_name = try std.fmt.allocPrint(allocator, "{s}.md", .{canonical_name});
-                defer allocator.free(file_name);
-                writeToCache(allocator, cache_dir, "", file_name, content_response.body) catch continue;
+                writeToCache(allocator, cache_dir, "", prompt_path, content_response.body) catch continue;
                 prompt_count += 1;
             }
         }

--- a/src/hub/collab.zig
+++ b/src/hub/collab.zig
@@ -4,11 +4,18 @@ const Server = @import("server.zig");
 const auth = @import("auth.zig");
 const apiError = @import("../protocol/api_error.zig").send;
 
+const Operation = struct {
+    type: []const u8,
+    prompt_id: ?[]const u8 = null,
+    base_hash: ?[]const u8 = null,
+    content: ?[]const u8 = null,
+    path: ?[]const u8 = null,
+    new_path: ?[]const u8 = null,
+};
+
 const CreatePrRequest = struct {
-    prompt_id: []const u8,
-    base_hash: []const u8,
-    content: []const u8,
     description: []const u8,
+    operations: []const Operation,
 };
 
 pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -23,29 +30,24 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
     };
 
+    if (body.operations.len == 0) {
+        return apiError(res, 400, "BAD_REQUEST", "operations array must not be empty");
+    }
+
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
     defer conn.release();
 
-    // Verify prompt exists and base_hash matches
-    var prompt_row = conn.row(
-        "SELECT content_hash FROM prompts WHERE prompt_id = $1 AND org_id = $2::uuid",
-        .{ body.prompt_id, user.org_id },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt not found");
-    };
-
-    const current_hash = try req.arena.dupe(u8, try prompt_row.get([]const u8, 0));
-    prompt_row.deinit() catch {};
-
-    if (!std.mem.eql(u8, current_hash, body.base_hash)) {
-        return apiError(res, 409, "CONFLICT", "base_hash does not match current Library version");
+    for (body.operations) |op| {
+        if (!isValidType(op.type)) {
+            return apiError(res, 400, "BAD_REQUEST", "operation type must be modify, rename, create, or delete");
+        }
+        if (!try validateOperation(conn, user.org_id, op, res)) return;
     }
 
-    // Generate pr_id
+    if (!try validateNoIntraPrPathConflict(req.arena, body.operations, res)) return;
+
     var rand_bytes: [8]u8 = undefined;
     std.crypto.random.bytes(&rand_bytes);
     var id_buf: [20]u8 = undefined;
@@ -55,19 +57,174 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         id_buf[4 + i * 2] = hex_chars[byte >> 4];
         id_buf[4 + i * 2 + 1] = hex_chars[byte & 0x0f];
     }
+    const pr_id: []const u8 = &id_buf;
 
     _ = conn.exec(
-        \\INSERT INTO prompt_prs (pr_id, org_id, prompt_id, author_id, base_hash, content, description)
-        \\VALUES ($1, $2::uuid, $3, $4, $5, $6, $7)
-    , .{ &id_buf, user.org_id, body.prompt_id, user.user_id, body.base_hash, body.content, body.description }) catch {
+        \\INSERT INTO prompt_prs (pr_id, org_id, author_id, description)
+        \\VALUES ($1, $2::uuid, $3, $4)
+    , .{ pr_id, user.org_id, user.user_id, body.description }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "failed to create prompt PR");
     };
 
+    for (body.operations, 0..) |op, idx| {
+        const target_path: ?[]const u8 = if (std.mem.eql(u8, op.type, "rename"))
+            op.new_path
+        else if (std.mem.eql(u8, op.type, "create"))
+            op.path
+        else
+            null;
+
+        _ = conn.exec(
+            \\INSERT INTO prompt_pr_operations (pr_id, op_index, type, prompt_id, base_hash, content, path)
+            \\VALUES ($1, $2, $3, $4, $5, $6, $7)
+        , .{ pr_id, @as(i32, @intCast(idx)), op.type, op.prompt_id, op.base_hash, op.content, target_path }) catch {
+            _ = conn.exec("DELETE FROM prompt_prs WHERE pr_id = $1", .{pr_id}) catch {};
+            return apiError(res, 500, "INTERNAL_ERROR", "failed to store operation");
+        };
+    }
+
     res.status = 201;
     try res.json(.{
-        .pr_id = &id_buf,
+        .proposal_id = pr_id,
         .status = "open",
     }, .{});
+}
+
+fn isValidType(t: []const u8) bool {
+    return std.mem.eql(u8, t, "modify") or
+        std.mem.eql(u8, t, "rename") or
+        std.mem.eql(u8, t, "create") or
+        std.mem.eql(u8, t, "delete");
+}
+
+fn validateOperation(conn: anytype, org_id: []const u8, op: Operation, res: *httpz.Response) !bool {
+    if (std.mem.eql(u8, op.type, "modify")) {
+        const pid = op.prompt_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires prompt_id");
+            return false;
+        };
+        const base_hash = op.base_hash orelse {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires base_hash");
+            return false;
+        };
+        if (op.content == null) {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires content");
+            return false;
+        }
+        return try verifyPromptBaseHash(conn, org_id, pid, base_hash, res);
+    } else if (std.mem.eql(u8, op.type, "rename")) {
+        const pid = op.prompt_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires prompt_id");
+            return false;
+        };
+        const base_hash = op.base_hash orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires base_hash");
+            return false;
+        };
+        const new_path = op.new_path orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires new_path");
+            return false;
+        };
+        if (!try verifyPromptBaseHash(conn, org_id, pid, base_hash, res)) return false;
+        return try verifyPathAvailable(conn, org_id, new_path, pid, res);
+    } else if (std.mem.eql(u8, op.type, "create")) {
+        const path = op.path orelse {
+            try apiError(res, 400, "BAD_REQUEST", "create requires path");
+            return false;
+        };
+        if (op.content == null) {
+            try apiError(res, 400, "BAD_REQUEST", "create requires content");
+            return false;
+        }
+        return try verifyPathAvailable(conn, org_id, path, null, res);
+    } else if (std.mem.eql(u8, op.type, "delete")) {
+        const pid = op.prompt_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "delete requires prompt_id");
+            return false;
+        };
+        var row = conn.row(
+            "SELECT 1 FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+            .{ org_id, pid },
+        ) catch {
+            try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+            return false;
+        };
+        if (row) |*r| {
+            r.deinit() catch {};
+            return true;
+        }
+        try apiError(res, 404, "NOT_FOUND", "prompt not found");
+        return false;
+    }
+    return false;
+}
+
+fn verifyPromptBaseHash(conn: anytype, org_id: []const u8, prompt_id: []const u8, base_hash: []const u8, res: *httpz.Response) !bool {
+    var row = conn.row(
+        "SELECT content_hash FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+        .{ org_id, prompt_id },
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    } orelse {
+        try apiError(res, 404, "NOT_FOUND", "prompt not found");
+        return false;
+    };
+    const current_hash_raw = row.get([]const u8, 0) catch {
+        row.deinit() catch {};
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to read prompt hash");
+        return false;
+    };
+    var buf: [96]u8 = undefined;
+    const len = @min(current_hash_raw.len, buf.len);
+    @memcpy(buf[0..len], current_hash_raw[0..len]);
+    row.deinit() catch {};
+    if (!std.mem.eql(u8, buf[0..len], base_hash)) {
+        try apiError(res, 409, "CONFLICT", "base_hash does not match current Library version");
+        return false;
+    }
+    return true;
+}
+
+fn verifyPathAvailable(conn: anytype, org_id: []const u8, path: []const u8, allow_prompt_id: ?[]const u8, res: *httpz.Response) !bool {
+    var row = conn.row(
+        "SELECT prompt_id FROM prompts WHERE org_id = $1::uuid AND path = $2",
+        .{ org_id, path },
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    };
+    if (row) |*r| {
+        defer r.deinit() catch {};
+        const existing_pid = r.get([]const u8, 0) catch "";
+        if (allow_prompt_id) |allowed| {
+            if (std.mem.eql(u8, existing_pid, allowed)) return true;
+        }
+        try apiError(res, 409, "CONFLICT", "target path already exists in Library");
+        return false;
+    }
+    return true;
+}
+
+fn validateNoIntraPrPathConflict(arena: std.mem.Allocator, ops: []const Operation, res: *httpz.Response) !bool {
+    var seen: std.ArrayList([]const u8) = .empty;
+    for (ops) |op| {
+        const p: ?[]const u8 = if (std.mem.eql(u8, op.type, "create"))
+            op.path
+        else if (std.mem.eql(u8, op.type, "rename"))
+            op.new_path
+        else
+            null;
+        const path = p orelse continue;
+        for (seen.items) |prev| {
+            if (std.mem.eql(u8, prev, path)) {
+                try apiError(res, 400, "BAD_REQUEST", "two operations target the same path in one PR");
+                return false;
+            }
+        }
+        try seen.append(arena, path);
+    }
+    return true;
 }
 
 pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -88,105 +245,111 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
     defer conn.release();
 
     const PrMeta = struct {
-        pr_id: []const u8,
-        prompt_id: []const u8,
+        proposal_id: []const u8,
         status: []const u8,
         description: []const u8,
         created_at: []const u8,
         author: []const u8,
+        operation_count: i64,
     };
 
     var list: std.ArrayList(PrMeta) = .empty;
 
-    // Use separate query calls for each filter combination
-    if (status_filter) |sf| {
-        if (prompt_filter) |pf| {
-            var result = conn.query(
-                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
-                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
-                \\WHERE pp.org_id = $1::uuid AND pp.status = $2 AND pp.prompt_id = $3
-                \\ORDER BY pp.created_at DESC
-            , .{ user.org_id, sf, pf }) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            defer result.deinit();
-            while (try result.next()) |row| {
-                try list.append(req.arena, .{
-                    .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-                    .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-                    .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-                    .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-                    .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
-                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
-                });
-            }
-        } else {
-            var result = conn.query(
-                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
-                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
-                \\WHERE pp.org_id = $1::uuid AND pp.status = $2
-                \\ORDER BY pp.created_at DESC
-            , .{ user.org_id, sf }) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            defer result.deinit();
-            while (try result.next()) |row| {
-                try list.append(req.arena, .{
-                    .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-                    .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-                    .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-                    .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-                    .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
-                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
-                });
-            }
+    const base_sql =
+        \\SELECT pp.pr_id, pp.status, pp.description, pp.created_at::text, u.username,
+        \\  (SELECT count(*) FROM prompt_pr_operations op WHERE op.pr_id = pp.pr_id) as op_count
+        \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+    ;
+
+    if (status_filter != null and prompt_filter != null) {
+        var result = conn.query(base_sql ++
+            \\ WHERE pp.org_id = $1::uuid AND pp.status = $2
+            \\ AND pp.pr_id IN (SELECT pr_id FROM prompt_pr_operations WHERE prompt_id = $3)
+            \\ ORDER BY pp.created_at DESC
+        , .{ user.org_id, status_filter.?, prompt_filter.? }) catch {
+            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        };
+        defer result.deinit();
+        while (try result.next()) |row| {
+            try list.append(req.arena, .{
+                .proposal_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+                .status = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+                .description = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+                .created_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+                .author = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
+            });
+        }
+    } else if (status_filter) |sf| {
+        var result = conn.query(base_sql ++
+            \\ WHERE pp.org_id = $1::uuid AND pp.status = $2
+            \\ ORDER BY pp.created_at DESC
+        , .{ user.org_id, sf }) catch {
+            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        };
+        defer result.deinit();
+        while (try result.next()) |row| {
+            try list.append(req.arena, .{
+                .proposal_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+                .status = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+                .description = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+                .created_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+                .author = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
+            });
+        }
+    } else if (prompt_filter) |pf| {
+        var result = conn.query(base_sql ++
+            \\ WHERE pp.org_id = $1::uuid
+            \\ AND pp.pr_id IN (SELECT pr_id FROM prompt_pr_operations WHERE prompt_id = $2)
+            \\ ORDER BY pp.created_at DESC
+        , .{ user.org_id, pf }) catch {
+            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        };
+        defer result.deinit();
+        while (try result.next()) |row| {
+            try list.append(req.arena, .{
+                .proposal_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+                .status = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+                .description = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+                .created_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+                .author = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
+            });
         }
     } else {
-        if (prompt_filter) |pf| {
-            var result = conn.query(
-                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
-                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
-                \\WHERE pp.org_id = $1::uuid AND pp.prompt_id = $2
-                \\ORDER BY pp.created_at DESC
-            , .{ user.org_id, pf }) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            defer result.deinit();
-            while (try result.next()) |row| {
-                try list.append(req.arena, .{
-                    .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-                    .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-                    .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-                    .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-                    .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
-                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
-                });
-            }
-        } else {
-            var result = conn.query(
-                \\SELECT pp.pr_id, pp.prompt_id, pp.status, pp.description, pp.created_at::text, u.username
-                \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
-                \\WHERE pp.org_id = $1::uuid
-                \\ORDER BY pp.created_at DESC
-            , .{user.org_id}) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            defer result.deinit();
-            while (try result.next()) |row| {
-                try list.append(req.arena, .{
-                    .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-                    .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-                    .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-                    .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-                    .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
-                    .author = try req.arena.dupe(u8, try row.get([]const u8, 5)),
-                });
-            }
+        var result = conn.query(base_sql ++
+            \\ WHERE pp.org_id = $1::uuid
+            \\ ORDER BY pp.created_at DESC
+        , .{user.org_id}) catch {
+            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        };
+        defer result.deinit();
+        while (try result.next()) |row| {
+            try list.append(req.arena, .{
+                .proposal_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+                .status = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+                .description = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+                .created_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+                .author = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
+            });
         }
     }
 
     try res.json(.{ .prs = list.items }, .{});
 }
+
+const OperationView = struct {
+    op_index: i32,
+    type: []const u8,
+    prompt_id: ?[]const u8,
+    base_hash: ?[]const u8,
+    content: ?[]const u8,
+    path: ?[]const u8,
+    base_content: ?[]const u8,
+    current_path: ?[]const u8,
+};
 
 pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
@@ -204,7 +367,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     defer conn.release();
 
     var row = conn.row(
-        "SELECT pr_id, prompt_id, base_hash, status, content, description, created_at::text FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
+        "SELECT pr_id, status, description, created_at::text FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
         .{ id, user.org_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -213,15 +376,79 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     };
 
     const pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
-    const prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 1));
-    const base_hash = try req.arena.dupe(u8, try row.get([]const u8, 2));
-    const status = try req.arena.dupe(u8, try row.get([]const u8, 3));
-    const pr_content = try req.arena.dupe(u8, try row.get([]const u8, 4));
-    const description = try req.arena.dupe(u8, try row.get([]const u8, 5));
-    const created_at = try req.arena.dupe(u8, try row.get([]const u8, 6));
+    const status = try req.arena.dupe(u8, try row.get([]const u8, 1));
+    const description = try req.arena.dupe(u8, try row.get([]const u8, 2));
+    const created_at = try req.arena.dupe(u8, try row.get([]const u8, 3));
     row.deinit() catch {};
 
-    // Compute trace_summary from trace_events
+    var ops: std.ArrayList(OperationView) = .empty;
+    var op_result = conn.query(
+        "SELECT op_index, type, prompt_id, base_hash, content, path FROM prompt_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        .{pr_id},
+    ) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    };
+    defer op_result.deinit();
+
+    while (try op_result.next()) |orow| {
+        const op_index = try orow.get(i32, 0);
+        const op_type = try req.arena.dupe(u8, try orow.get([]const u8, 1));
+        const op_prompt_id: ?[]const u8 = if (orow.get([]const u8, 2)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_base_hash: ?[]const u8 = if (orow.get([]const u8, 3)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_content: ?[]const u8 = if (orow.get([]const u8, 4)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_path: ?[]const u8 = if (orow.get([]const u8, 5)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+
+        var base_content: ?[]const u8 = null;
+        var current_path: ?[]const u8 = null;
+        if (op_prompt_id) |pid| {
+            var pr = conn.row(
+                "SELECT content, path FROM prompts WHERE prompt_id = $1",
+                .{pid},
+            ) catch null;
+            if (pr) |*br| {
+                base_content = req.arena.dupe(u8, br.get([]const u8, 0) catch "") catch null;
+                current_path = req.arena.dupe(u8, br.get([]const u8, 1) catch "") catch null;
+                br.deinit() catch {};
+            }
+            if (base_content == null) {
+                if (op_base_hash) |bh| {
+                    var hr = conn.row(
+                        "SELECT content, path FROM prompt_history WHERE prompt_id = $1 AND content_hash = $2",
+                        .{ pid, bh },
+                    ) catch null;
+                    if (hr) |*h| {
+                        base_content = req.arena.dupe(u8, h.get([]const u8, 0) catch "") catch null;
+                        current_path = req.arena.dupe(u8, h.get([]const u8, 1) catch "") catch null;
+                        h.deinit() catch {};
+                    }
+                }
+            }
+        }
+
+        try ops.append(req.arena, .{
+            .op_index = op_index,
+            .type = op_type,
+            .prompt_id = op_prompt_id,
+            .base_hash = op_base_hash,
+            .content = op_content,
+            .path = op_path,
+            .base_content = base_content,
+            .current_path = current_path,
+        });
+    }
+
     const TraceSummary = struct {
         refer_count: i64 = 0,
         sessions_used: i64 = 0,
@@ -230,9 +457,11 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     var trace_summary = TraceSummary{};
 
     var trace_row = conn.row(
-        "SELECT count(*), count(DISTINCT session_id), max(to_timestamp(timestamp/1000))::text FROM trace_events WHERE prompt_id = $1 AND type = 'refer'",
-        .{prompt_id},
-    ) catch null;
+        \\SELECT count(*), count(DISTINCT session_id), max(to_timestamp(timestamp/1000))::text
+        \\FROM trace_events
+        \\WHERE prompt_id IN (SELECT prompt_id FROM prompt_pr_operations WHERE pr_id = $1 AND prompt_id IS NOT NULL)
+        \\  AND type = 'refer'
+    , .{pr_id}) catch null;
     if (trace_row) |*tr| {
         trace_summary.refer_count = tr.get(i64, 0) catch 0;
         trace_summary.sessions_used = tr.get(i64, 1) catch 0;
@@ -242,46 +471,13 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
         tr.deinit() catch {};
     }
 
-    // Fetch base content for diff: try current prompt content first, fall back to prompt_history
-    var base_content: ?[]const u8 = null;
-    var base_row = conn.row(
-        "SELECT content, content_hash FROM prompts WHERE prompt_id = $1",
-        .{prompt_id},
-    ) catch null;
-    if (base_row) |*br| {
-        const current_hash = br.get([]const u8, 1) catch "";
-        if (std.mem.eql(u8, current_hash, base_hash)) {
-            base_content = req.arena.dupe(u8, br.get([]const u8, 0) catch "") catch null;
-        }
-        br.deinit() catch {};
-    }
-
-    // If hash doesn't match current, try prompt_history
-    if (base_content == null) {
-        var hist_row = conn.row(
-            "SELECT content FROM prompt_history WHERE prompt_id = $1 AND content_hash = $2",
-            .{ prompt_id, base_hash },
-        ) catch null;
-        if (hist_row) |*hr| {
-            base_content = req.arena.dupe(u8, hr.get([]const u8, 0) catch "") catch null;
-            hr.deinit() catch {};
-        }
-    }
-
     try res.json(.{
-        .pr_id = pr_id,
-        .prompt_id = prompt_id,
-        .base_hash = base_hash,
+        .proposal_id = pr_id,
         .status = status,
-        .content = pr_content,
         .description = description,
         .created_at = created_at,
+        .operations = ops.items,
         .trace_summary = trace_summary,
-        .diff = .{
-            .base = base_content,
-            .proposed = pr_content,
-            .summary = computeDiffSummary(req.arena, base_content orelse "", pr_content),
-        },
     }, .{});
 }
 
@@ -319,87 +515,268 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     };
     defer conn.release();
 
-    var prop_row = conn.row(
-        "SELECT prompt_id, base_hash, content, status FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
+    var header = conn.row(
+        "SELECT status FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
         .{ id, user.org_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 404, "NOT_FOUND", "prompt PR not found");
     };
-
-    const prompt_id = try req.arena.dupe(u8, try prop_row.get([]const u8, 0));
-    const base_hash = try req.arena.dupe(u8, try prop_row.get([]const u8, 1));
-    const new_content = try req.arena.dupe(u8, try prop_row.get([]const u8, 2));
-    const status = try req.arena.dupe(u8, try prop_row.get([]const u8, 3));
-    prop_row.deinit() catch {};
-
-    if (!std.mem.eql(u8, status, "open")) {
+    const status_raw = header.get([]const u8, 0) catch "";
+    var status_buf: [32]u8 = undefined;
+    const status_len = @min(status_raw.len, status_buf.len);
+    @memcpy(status_buf[0..status_len], status_raw[0..status_len]);
+    header.deinit() catch {};
+    if (!std.mem.eql(u8, status_buf[0..status_len], "open")) {
         return apiError(res, 400, "BAD_REQUEST", "prompt PR is not open");
     }
 
-    if (std.mem.eql(u8, body.action, "accept")) {
-        // Verify base_hash still matches Library
-        var check_row = conn.row(
-            "SELECT content_hash FROM prompts WHERE prompt_id = $1",
-            .{prompt_id},
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-        } orelse {
-            return apiError(res, 404, "NOT_FOUND", "target prompt no longer exists");
-        };
+    const is_accept = std.mem.eql(u8, body.action, "accept");
 
-        const current_hash = try req.arena.dupe(u8, try check_row.get([]const u8, 0));
-        check_row.deinit() catch {};
-
-        if (!std.mem.eql(u8, current_hash, base_hash)) {
-            return apiError(res, 409, "CONFLICT", "Library has changed since prompt PR was created");
-        }
-
-        // Compute new hash and update prompt
-        const new_hash = @import("../protocol/hash.zig").ContentHash.compute(new_content);
-        const hash_slice: []const u8 = try req.arena.dupe(u8, &new_hash);
-
-        _ = conn.exec(
-            "UPDATE prompts SET content = $1, content_hash = $2, updated_at = now() WHERE prompt_id = $3",
-            .{ new_content, hash_slice, prompt_id },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
-        };
-
-        // Bump revision for all workspaces containing this prompt
-        _ = conn.exec(
-            "UPDATE workspaces SET revision = revision + 1 WHERE ws_id IN (SELECT ws_id FROM workspace_prompts WHERE prompt_id = $1)",
-            .{prompt_id},
-        ) catch {};
-
-        // Record in prompt history
-        _ = conn.exec(
-            "INSERT INTO prompt_history (prompt_id, content_hash, content, pr_id) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
-            .{ prompt_id, hash_slice, new_content, id },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "failed to record prompt history");
-        };
-
-        // Bump library manifest revision
-        _ = conn.exec(
-            "UPDATE library_manifest SET revision = revision + 1 WHERE org_id = $1::uuid",
-            .{user.org_id},
-        ) catch {};
+    if (is_accept) {
+        if (!try applyPr(conn, req.arena, user.org_id, id, res)) return;
     }
 
-    // Update prompt PR status
     _ = conn.exec(
         "UPDATE prompt_prs SET status = $1, updated_at = now() WHERE pr_id = $2",
-        .{ if (std.mem.eql(u8, body.action, "accept")) @as([]const u8, "accepted") else @as([]const u8, "rejected"), id },
+        .{ if (is_accept) @as([]const u8, "accepted") else @as([]const u8, "rejected"), id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt PR");
     };
 
     try res.json(.{
-        .pr_id = id,
-        .status = if (std.mem.eql(u8, body.action, "accept")) @as([]const u8, "accepted") else @as([]const u8, "rejected"),
+        .proposal_id = id,
+        .status = if (is_accept) @as([]const u8, "accepted") else @as([]const u8, "rejected"),
     }, .{});
+}
+
+const LoadedOp = struct {
+    op_index: i32,
+    type: []const u8,
+    prompt_id: ?[]const u8,
+    base_hash: ?[]const u8,
+    content: ?[]const u8,
+    path: ?[]const u8,
+};
+
+fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: []const u8, res: *httpz.Response) !bool {
+    var ops: std.ArrayList(LoadedOp) = .empty;
+    var op_result = conn.query(
+        "SELECT op_index, type, prompt_id, base_hash, content, path FROM prompt_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        .{pr_id},
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    };
+    defer op_result.deinit();
+    while (try op_result.next()) |r| {
+        const op_index = r.get(i32, 0) catch continue;
+        const t = arena.dupe(u8, r.get([]const u8, 1) catch "") catch continue;
+        const pid: ?[]const u8 = if (r.get([]const u8, 2)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const bh: ?[]const u8 = if (r.get([]const u8, 3)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const c: ?[]const u8 = if (r.get([]const u8, 4)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const p: ?[]const u8 = if (r.get([]const u8, 5)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        try ops.append(arena, .{
+            .op_index = op_index,
+            .type = t,
+            .prompt_id = pid,
+            .base_hash = bh,
+            .content = c,
+            .path = p,
+        });
+    }
+
+    conn.begin() catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to begin transaction");
+        return false;
+    };
+
+    for (ops.items) |op| {
+        if (std.mem.eql(u8, op.type, "modify")) {
+            const pid = op.prompt_id.?;
+            const bh = op.base_hash.?;
+            const new_content = op.content.?;
+            var row = conn.row(
+                "SELECT content_hash, path FROM prompts WHERE prompt_id = $1",
+                .{pid},
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+                return false;
+            } orelse {
+                conn.rollback() catch {};
+                try apiError(res, 404, "NOT_FOUND", "target prompt no longer exists");
+                return false;
+            };
+            const current_hash = row.get([]const u8, 0) catch {
+                row.deinit() catch {};
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to read prompt hash");
+                return false;
+            };
+            const matches = std.mem.eql(u8, current_hash, bh);
+            const current_path_raw = row.get([]const u8, 1) catch "";
+            var path_buf: [512]u8 = undefined;
+            const plen = @min(current_path_raw.len, path_buf.len);
+            @memcpy(path_buf[0..plen], current_path_raw[0..plen]);
+            row.deinit() catch {};
+            if (!matches) {
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "Library has changed since PR was created");
+                return false;
+            }
+            const new_hash = @import("../protocol/hash.zig").ContentHash.compute(new_content);
+            const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            _ = conn.exec(
+                "UPDATE prompts SET content = $1, content_hash = $2, updated_at = now() WHERE prompt_id = $3",
+                .{ new_content, hash_slice, pid },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                return false;
+            };
+            _ = conn.exec(
+                "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                .{ pid, hash_slice, path_buf[0..plen], new_content, pr_id },
+            ) catch {};
+            bumpWorkspaceRevisions(conn, pid);
+        } else if (std.mem.eql(u8, op.type, "rename")) {
+            const pid = op.prompt_id.?;
+            const bh = op.base_hash.?;
+            const new_path = op.path.?;
+            var row = conn.row(
+                "SELECT content_hash FROM prompts WHERE prompt_id = $1",
+                .{pid},
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+                return false;
+            } orelse {
+                conn.rollback() catch {};
+                try apiError(res, 404, "NOT_FOUND", "target prompt no longer exists");
+                return false;
+            };
+            const current_hash = row.get([]const u8, 0) catch "";
+            const matches = std.mem.eql(u8, current_hash, bh);
+            row.deinit() catch {};
+            if (!matches) {
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "Library has changed since PR was created");
+                return false;
+            }
+            if (op.content) |new_content| {
+                const new_hash = @import("../protocol/hash.zig").ContentHash.compute(new_content);
+                const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                    return false;
+                };
+                _ = conn.exec(
+                    "UPDATE prompts SET path = $1, content = $2, content_hash = $3, updated_at = now() WHERE prompt_id = $4",
+                    .{ new_path, new_content, hash_slice, pid },
+                ) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                    return false;
+                };
+                _ = conn.exec(
+                    "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                    .{ pid, hash_slice, new_path, new_content, pr_id },
+                ) catch {};
+            } else {
+                _ = conn.exec(
+                    "UPDATE prompts SET path = $1, updated_at = now() WHERE prompt_id = $2",
+                    .{ new_path, pid },
+                ) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                    return false;
+                };
+            }
+            bumpWorkspaceRevisions(conn, pid);
+        } else if (std.mem.eql(u8, op.type, "create")) {
+            const path = op.path.?;
+            const new_content = op.content.?;
+            var rand_bytes: [16]u8 = undefined;
+            std.crypto.random.bytes(&rand_bytes);
+            var new_pid_buf: [36]u8 = undefined;
+            @memcpy(new_pid_buf[0..2], "p-");
+            const hex = "0123456789abcdef";
+            for (rand_bytes, 0..) |byte, i| {
+                new_pid_buf[2 + i * 2] = hex[byte >> 4];
+                new_pid_buf[2 + i * 2 + 1] = hex[byte & 0x0f];
+            }
+            const new_pid: []const u8 = arena.dupe(u8, new_pid_buf[0..34]) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            const new_hash = @import("../protocol/hash.zig").ContentHash.compute(new_content);
+            const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            _ = conn.exec(
+                "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5)",
+                .{ new_pid, org_id, path, new_content, hash_slice },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "target path conflict on create");
+                return false;
+            };
+            _ = conn.exec(
+                "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                .{ new_pid, hash_slice, path, new_content, pr_id },
+            ) catch {};
+        } else if (std.mem.eql(u8, op.type, "delete")) {
+            const pid = op.prompt_id.?;
+            _ = conn.exec("DELETE FROM workspace_prompts WHERE prompt_id = $1", .{pid}) catch {};
+            _ = conn.exec("DELETE FROM bundle_prompts WHERE prompt_id = $1", .{pid}) catch {};
+            _ = conn.exec("DELETE FROM prompts WHERE prompt_id = $1", .{pid}) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to delete prompt");
+                return false;
+            };
+        }
+    }
+
+    _ = conn.exec(
+        "UPDATE library_manifest SET revision = revision + 1 WHERE org_id = $1::uuid",
+        .{org_id},
+    ) catch {};
+
+    conn.commit() catch {
+        conn.rollback() catch {};
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to commit transaction");
+        return false;
+    };
+
+    return true;
+}
+
+fn bumpWorkspaceRevisions(conn: anytype, prompt_id: []const u8) void {
+    _ = conn.exec(
+        "UPDATE workspaces SET revision = revision + 1 WHERE ws_id IN (SELECT ws_id FROM workspace_prompts WHERE prompt_id = $1)",
+        .{prompt_id},
+    ) catch {};
 }
 
 const CommentRequest = struct {
@@ -427,7 +804,6 @@ pub fn handleAddComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz.R
     };
     defer conn.release();
 
-    // Verify prompt PR exists and belongs to user's org
     var pr_row = conn.row("SELECT pr_id FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
@@ -455,7 +831,7 @@ pub fn handleAddComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz.R
     res.status = 201;
     try res.json(.{
         .comment_id = &cmt_id_buf,
-        .pr_id = id,
+        .proposal_id = id,
         .author = user.username,
         .body = comment.body,
     }, .{});
@@ -483,7 +859,6 @@ pub fn handleListComments(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         created_at: []const u8,
     };
 
-    // Verify prompt PR belongs to user's org
     var pr_check = conn.row("SELECT pr_id FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
@@ -510,30 +885,4 @@ pub fn handleListComments(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     }
 
     try res.json(.{ .comments = list.items }, .{});
-}
-
-fn computeDiffSummary(arena: std.mem.Allocator, base: []const u8, proposed: []const u8) []const u8 {
-    var added: usize = 0;
-    var removed: usize = 0;
-
-    var base_lines: usize = 0;
-    var proposed_lines: usize = 0;
-
-    for (base) |c| {
-        if (c == '\n') base_lines += 1;
-    }
-    if (base.len > 0 and base[base.len - 1] != '\n') base_lines += 1;
-
-    for (proposed) |c| {
-        if (c == '\n') proposed_lines += 1;
-    }
-    if (proposed.len > 0 and proposed[proposed.len - 1] != '\n') proposed_lines += 1;
-
-    if (proposed_lines > base_lines) {
-        added = proposed_lines - base_lines;
-    } else {
-        removed = base_lines - proposed_lines;
-    }
-
-    return std.fmt.allocPrint(arena, "+{d} -{d} lines", .{ added, removed }) catch "diff unavailable";
 }

--- a/src/hub/context.zig
+++ b/src/hub/context.zig
@@ -5,70 +5,6 @@ const auth = @import("auth.zig");
 const apiError = @import("../protocol/api_error.zig").send;
 const ContentHash = @import("../protocol/hash.zig").ContentHash;
 
-// GET /api/workspaces/:ws_id/context/branches
-pub fn handleListBranches(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
-    const user = auth.authenticate(ctx, req) catch {
-        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
-    };
-    if (!auth.requireScope(user, "workspace:read", res)) return;
-
-    const ws_id = req.param("ws_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
-    };
-
-    const conn = ctx.pool.acquire() catch {
-        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
-    };
-    defer conn.release();
-
-    if (!auth.checkWorkspaceMember(conn, ws_id, user.user_id)) {
-        return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
-    }
-
-    const BranchInfo = struct {
-        name: []const u8,
-        revision: i32,
-        file_count: i64,
-        ahead: ?i64 = null,
-        behind: ?i64 = null,
-    };
-
-    var result = conn.query(
-        \\SELECT cb.branch_name, cb.revision,
-        \\    (SELECT count(*) FROM context_files cf WHERE cf.ws_id = cb.ws_id AND cf.branch_name = cb.branch_name),
-        \\    CASE WHEN cb.branch_name != 'main' THEN
-        \\        (SELECT count(*) FROM context_files cf WHERE cf.ws_id = cb.ws_id AND cf.branch_name = cb.branch_name
-        \\         AND (cf.path NOT IN (SELECT mf.path FROM context_files mf WHERE mf.ws_id = cb.ws_id AND mf.branch_name = 'main')
-        \\              OR cf.content_hash != (SELECT mf.content_hash FROM context_files mf WHERE mf.ws_id = cb.ws_id AND mf.branch_name = 'main' AND mf.path = cf.path)))
-        \\    END,
-        \\    CASE WHEN cb.branch_name != 'main' THEN
-        \\        (SELECT count(*) FROM context_files mf WHERE mf.ws_id = cb.ws_id AND mf.branch_name = 'main'
-        \\         AND mf.updated_at > (SELECT COALESCE(MAX(cf2.updated_at), '1970-01-01') FROM context_files cf2 WHERE cf2.ws_id = cb.ws_id AND cf2.branch_name = cb.branch_name AND cf2.path = mf.path)
-        \\         AND mf.path IN (SELECT cf3.path FROM context_files cf3 WHERE cf3.ws_id = cb.ws_id AND cf3.branch_name = cb.branch_name))
-        \\    END
-        \\FROM context_branches cb WHERE cb.ws_id = $1 ORDER BY cb.branch_name
-    ,
-        .{ws_id},
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    };
-    defer result.deinit();
-
-    var list: std.ArrayList(BranchInfo) = .empty;
-    while (try result.next()) |row| {
-        try list.append(req.arena, .{
-            .name = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-            .revision = try row.get(i32, 1),
-            .file_count = try row.get(i64, 2),
-            .ahead = row.get(i64, 3) catch null,
-            .behind = row.get(i64, 4) catch null,
-        });
-    }
-
-    try res.json(.{ .branches = list.items }, .{});
-}
-
-// GET /api/workspaces/:ws_id/context/files
 pub fn handleListFiles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -88,22 +24,18 @@ pub fn handleListFiles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
     }
 
-    const qs = req.query() catch {
-        return apiError(res, 400, "BAD_REQUEST", "invalid query string");
-    };
-    const branch = qs.get("branch") orelse "main";
-
     const FileMeta = struct {
+        context_id: []const u8,
         path: []const u8,
-        hash: []const u8,
+        content_hash: []const u8,
         size: i64,
         author: []const u8,
         updated_at: []const u8,
     };
 
     var result = conn.query(
-        "SELECT path, content_hash, length(content)::bigint, author, updated_at::text FROM context_files WHERE ws_id = $1 AND branch_name = $2 ORDER BY path",
-        .{ ws_id, branch },
+        "SELECT context_id, path, content_hash, length(content)::bigint, author, updated_at::text FROM context_files WHERE ws_id = $1 ORDER BY path",
+        .{ws_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
@@ -112,18 +44,18 @@ pub fn handleListFiles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     var list: std.ArrayList(FileMeta) = .empty;
     while (try result.next()) |row| {
         try list.append(req.arena, .{
-            .path = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-            .hash = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-            .size = try row.get(i64, 2),
-            .author = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-            .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+            .context_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+            .path = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+            .content_hash = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+            .size = try row.get(i64, 3),
+            .author = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+            .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 5)),
         });
     }
 
-    try res.json(.{ .branch = branch, .files = list.items }, .{});
+    try res.json(.{ .files = list.items }, .{});
 }
 
-// GET /api/workspaces/:ws_id/context/file/content?path=...&branch=...
 pub fn handleGetFileContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -137,10 +69,11 @@ pub fn handleGetFileContent(ctx: *Server.Context, req: *httpz.Request, res: *htt
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const path = qs.get("path") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "path query parameter is required");
-    };
-    const branch = qs.get("branch") orelse "main";
+    const context_id_q = qs.get("context_id");
+    const path_q = qs.get("path");
+    if (context_id_q == null and path_q == null) {
+        return apiError(res, 400, "BAD_REQUEST", "context_id or path query parameter is required");
+    }
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
@@ -151,10 +84,13 @@ pub fn handleGetFileContent(ctx: *Server.Context, req: *httpz.Request, res: *htt
         return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
     }
 
-    var row = conn.row(
-        "SELECT content FROM context_files WHERE ws_id = $1 AND branch_name = $2 AND path = $3",
-        .{ ws_id, branch, path },
-    ) catch {
+    var row = (if (context_id_q) |cid| conn.row(
+        "SELECT content FROM context_files WHERE ws_id = $1 AND context_id = $2",
+        .{ ws_id, cid },
+    ) else conn.row(
+        "SELECT content FROM context_files WHERE ws_id = $1 AND path = $2",
+        .{ ws_id, path_q.? },
+    )) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 404, "NOT_FOUND", "file not found");
@@ -167,136 +103,20 @@ pub fn handleGetFileContent(ctx: *Server.Context, req: *httpz.Request, res: *htt
     res.body = content;
 }
 
-// PUT /api/workspaces/:ws_id/context/file?path=...
-pub fn handlePutFile(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
-    const user = auth.authenticate(ctx, req) catch {
-        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
-    };
-    if (!auth.requireScope(user, "workspace:write", res)) return;
-
-    const ws_id = req.param("ws_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
-    };
-
-    const qs = req.query() catch {
-        return apiError(res, 400, "BAD_REQUEST", "invalid query string");
-    };
-    const path = qs.get("path") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "path query parameter is required");
-    };
-
-    const body = req.body() orelse {
-        return apiError(res, 400, "BAD_REQUEST", "missing request body");
-    };
-
-    const max_file_size = 10 * 1024 * 1024;
-    if (body.len > max_file_size) {
-        return apiError(res, 413, "PAYLOAD_TOO_LARGE", "file exceeds 10MB limit");
-    }
-
-    const hash = ContentHash.compute(body);
-    const hash_slice: []const u8 = &hash;
-
-    const conn = ctx.pool.acquire() catch {
-        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
-    };
-    defer conn.release();
-
-    if (!auth.checkWorkspaceMember(conn, ws_id, user.user_id)) {
-        return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
-    }
-
-    const branch = user.username;
-
-    // Ensure member branch exists (create from main HEAD if not)
-    ensureMemberBranch(conn, ws_id, branch);
-
-    // Write file to member branch
-    _ = conn.exec(
-        \\INSERT INTO context_files (ws_id, branch_name, path, content, content_hash, author, updated_at)
-        \\VALUES ($1, $2, $3, $4, $5, $6, now())
-        \\ON CONFLICT (ws_id, branch_name, path) DO UPDATE SET content = $4, content_hash = $5, author = $6, updated_at = now()
-    ,
-        .{ ws_id, branch, path, body, hash_slice, user.username },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "failed to write file");
-    };
-
-    // Increment branch revision
-    _ = conn.exec(
-        "UPDATE context_branches SET revision = revision + 1 WHERE ws_id = $1 AND branch_name = $2",
-        .{ ws_id, branch },
-    ) catch {};
-
-    var rev_row = conn.row(
-        "SELECT revision FROM context_branches WHERE ws_id = $1 AND branch_name = $2",
-        .{ ws_id, branch },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    } orelse {
-        return apiError(res, 500, "INTERNAL_ERROR", "branch not found after write");
-    };
-    const branch_rev = try rev_row.get(i32, 0);
-    rev_row.deinit() catch {};
-
-    res.status = 200;
-    try res.json(.{
-        .branch = branch,
-        .path = path,
-        .hash = hash_slice,
-        .branch_revision = branch_rev,
-    }, .{});
-}
-
-// DELETE /api/workspaces/:ws_id/context/file?path=...
-pub fn handleDeleteFile(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
-    const user = auth.authenticate(ctx, req) catch {
-        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
-    };
-    if (!auth.requireScope(user, "workspace:write", res)) return;
-
-    const ws_id = req.param("ws_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
-    };
-
-    const qs = req.query() catch {
-        return apiError(res, 400, "BAD_REQUEST", "invalid query string");
-    };
-    const path = qs.get("path") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "path query parameter is required");
-    };
-
-    const conn = ctx.pool.acquire() catch {
-        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
-    };
-    defer conn.release();
-
-    if (!auth.checkWorkspaceMember(conn, ws_id, user.user_id)) {
-        return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
-    }
-
-    const branch = user.username;
-
-    const deleted = conn.exec(
-        "DELETE FROM context_files WHERE ws_id = $1 AND branch_name = $2 AND path = $3",
-        .{ ws_id, branch, path },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    };
-
-    if (deleted == null or deleted.? == 0) {
-        return apiError(res, 404, "NOT_FOUND", "file not found");
-    }
-
-    try res.json(.{ .status = "deleted" }, .{});
-}
-
-const CreatePrRequest = struct {
-    description: ?[]const u8 = null,
-    file_paths: ?[]const []const u8 = null,
+const Operation = struct {
+    type: []const u8,
+    context_id: ?[]const u8 = null,
+    base_hash: ?[]const u8 = null,
+    content: ?[]const u8 = null,
+    path: ?[]const u8 = null,
+    new_path: ?[]const u8 = null,
 };
 
-// POST /api/workspaces/:ws_id/context/prs
+const CreatePrRequest = struct {
+    description: []const u8,
+    operations: []const Operation,
+};
+
 pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -313,6 +133,10 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
     };
 
+    if (body.operations.len == 0) {
+        return apiError(res, 400, "BAD_REQUEST", "operations array must not be empty");
+    }
+
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
@@ -322,73 +146,14 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
     }
 
-    const branch = user.username;
-
-    // Check branch exists
-    var branch_row = conn.row(
-        "SELECT 1 FROM context_branches WHERE ws_id = $1 AND branch_name = $2",
-        .{ ws_id, branch },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    } orelse {
-        return apiError(res, 400, "BAD_REQUEST", "no branch found, make changes first");
-    };
-    branch_row.deinit() catch {};
-
-    // Conflict detection: check if any of the PR files were modified on main since branch fork
-    if (body.file_paths) |paths| {
-        for (paths) |p| {
-            var conflict_row = conn.row(
-                "SELECT 1 FROM context_files WHERE ws_id = $1 AND branch_name = 'main' AND path = $2 AND updated_at > (SELECT created_at FROM context_branches WHERE ws_id = $1 AND branch_name = $3)",
-                .{ ws_id, p, branch },
-            ) catch continue;
-            if (conflict_row) |*r| {
-                r.deinit() catch {};
-                return apiError(res, 409, "CONFLICT", "files conflict with main, rebase first");
-            }
+    for (body.operations) |op| {
+        if (!isValidType(op.type)) {
+            return apiError(res, 400, "BAD_REQUEST", "operation type must be modify, rename, create, or delete");
         }
+        if (!try validateOperation(conn, ws_id, op, res)) return;
     }
+    if (!try validateNoIntraPrPathConflict(req.arena, body.operations, res)) return;
 
-    // Determine which files to include in the PR
-    // If file_paths specified, use those; otherwise use all branch files
-    var file_count: i64 = 0;
-    if (body.file_paths) |paths| {
-        file_count = @intCast(paths.len);
-        if (file_count == 0) {
-            return apiError(res, 400, "BAD_REQUEST", "no changes to submit");
-        }
-        // Verify all specified paths exist on the branch
-        for (paths) |p| {
-            var exists = conn.row(
-                "SELECT 1 FROM context_files WHERE ws_id = $1 AND branch_name = $2 AND path = $3",
-                .{ ws_id, branch, p },
-            ) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            if (exists) |*r| {
-                r.deinit() catch {};
-            } else {
-                return apiError(res, 400, "BAD_REQUEST", "file_path not found on branch");
-            }
-        }
-    } else {
-        var count_row = conn.row(
-            "SELECT count(*) FROM context_files WHERE ws_id = $1 AND branch_name = $2",
-            .{ ws_id, branch },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-        } orelse {
-            return apiError(res, 400, "BAD_REQUEST", "no changes to submit");
-        };
-        file_count = try count_row.get(i64, 0);
-        count_row.deinit() catch {};
-
-        if (file_count == 0) {
-            return apiError(res, 400, "BAD_REQUEST", "no changes to submit");
-        }
-    }
-
-    // Generate PR ID
     var rand_bytes: [8]u8 = undefined;
     std.crypto.random.bytes(&rand_bytes);
     var pr_id_buf: [20]u8 = undefined;
@@ -398,42 +163,178 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         pr_id_buf[4 + i * 2] = hex_chars[byte >> 4];
         pr_id_buf[4 + i * 2 + 1] = hex_chars[byte & 0x0f];
     }
-
-    const description = body.description orelse "";
+    const pr_id: []const u8 = &pr_id_buf;
 
     _ = conn.exec(
-        "INSERT INTO context_prs (pr_id, ws_id, author, branch_name, description) VALUES ($1, $2, $3, $4, $5)",
-        .{ &pr_id_buf, ws_id, user.username, branch, description },
+        "INSERT INTO context_prs (pr_id, ws_id, author, description) VALUES ($1, $2, $3, $4)",
+        .{ pr_id, ws_id, user.username, body.description },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "failed to create PR");
     };
 
-    // Record which files are included in this PR
-    if (body.file_paths) |paths| {
-        for (paths) |p| {
-            _ = conn.exec(
-                "INSERT INTO context_pr_files (pr_id, path) VALUES ($1, $2)",
-                .{ &pr_id_buf, p },
-            ) catch {};
-        }
-    } else {
-        // All branch files
+    for (body.operations, 0..) |op, idx| {
+        const target_path: ?[]const u8 = if (std.mem.eql(u8, op.type, "rename"))
+            op.new_path
+        else if (std.mem.eql(u8, op.type, "create"))
+            op.path
+        else
+            null;
+
         _ = conn.exec(
-            "INSERT INTO context_pr_files (pr_id, path) SELECT $1, path FROM context_files WHERE ws_id = $2 AND branch_name = $3",
-            .{ &pr_id_buf, ws_id, branch },
-        ) catch {};
+            \\INSERT INTO context_pr_operations (pr_id, op_index, type, context_id, base_hash, content, path)
+            \\VALUES ($1, $2, $3, $4, $5, $6, $7)
+        , .{ pr_id, @as(i32, @intCast(idx)), op.type, op.context_id, op.base_hash, op.content, target_path }) catch {
+            _ = conn.exec("DELETE FROM context_prs WHERE pr_id = $1", .{pr_id}) catch {};
+            return apiError(res, 500, "INTERNAL_ERROR", "failed to store operation");
+        };
     }
 
     res.status = 201;
     try res.json(.{
-        .pr_id = &pr_id_buf,
+        .pr_id = pr_id,
         .status = "open",
         .author = user.username,
-        .files_changed = file_count,
+        .operation_count = @as(i64, @intCast(body.operations.len)),
     }, .{});
 }
 
-// GET /api/workspaces/:ws_id/context/prs
+fn isValidType(t: []const u8) bool {
+    return std.mem.eql(u8, t, "modify") or
+        std.mem.eql(u8, t, "rename") or
+        std.mem.eql(u8, t, "create") or
+        std.mem.eql(u8, t, "delete");
+}
+
+fn validateOperation(conn: anytype, ws_id: []const u8, op: Operation, res: *httpz.Response) !bool {
+    if (std.mem.eql(u8, op.type, "modify")) {
+        const cid = op.context_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires context_id");
+            return false;
+        };
+        const base_hash = op.base_hash orelse {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires base_hash");
+            return false;
+        };
+        if (op.content == null) {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires content");
+            return false;
+        }
+        return try verifyContextBaseHash(conn, ws_id, cid, base_hash, res);
+    } else if (std.mem.eql(u8, op.type, "rename")) {
+        const cid = op.context_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires context_id");
+            return false;
+        };
+        const base_hash = op.base_hash orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires base_hash");
+            return false;
+        };
+        const new_path = op.new_path orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires new_path");
+            return false;
+        };
+        if (!try verifyContextBaseHash(conn, ws_id, cid, base_hash, res)) return false;
+        return try verifyPathAvailable(conn, ws_id, new_path, cid, res);
+    } else if (std.mem.eql(u8, op.type, "create")) {
+        const path = op.path orelse {
+            try apiError(res, 400, "BAD_REQUEST", "create requires path");
+            return false;
+        };
+        if (op.content == null) {
+            try apiError(res, 400, "BAD_REQUEST", "create requires content");
+            return false;
+        }
+        return try verifyPathAvailable(conn, ws_id, path, null, res);
+    } else if (std.mem.eql(u8, op.type, "delete")) {
+        const cid = op.context_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "delete requires context_id");
+            return false;
+        };
+        var row = conn.row(
+            "SELECT 1 FROM context_files WHERE ws_id = $1 AND context_id = $2",
+            .{ ws_id, cid },
+        ) catch {
+            try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+            return false;
+        };
+        if (row) |*r| {
+            r.deinit() catch {};
+            return true;
+        }
+        try apiError(res, 404, "NOT_FOUND", "context file not found");
+        return false;
+    }
+    return false;
+}
+
+fn verifyContextBaseHash(conn: anytype, ws_id: []const u8, context_id: []const u8, base_hash: []const u8, res: *httpz.Response) !bool {
+    var row = conn.row(
+        "SELECT content_hash FROM context_files WHERE ws_id = $1 AND context_id = $2",
+        .{ ws_id, context_id },
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    } orelse {
+        try apiError(res, 404, "NOT_FOUND", "context file not found");
+        return false;
+    };
+    const current_raw = row.get([]const u8, 0) catch {
+        row.deinit() catch {};
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to read hash");
+        return false;
+    };
+    var buf: [96]u8 = undefined;
+    const len = @min(current_raw.len, buf.len);
+    @memcpy(buf[0..len], current_raw[0..len]);
+    row.deinit() catch {};
+    if (!std.mem.eql(u8, buf[0..len], base_hash)) {
+        try apiError(res, 409, "CONFLICT", "base_hash does not match current file version");
+        return false;
+    }
+    return true;
+}
+
+fn verifyPathAvailable(conn: anytype, ws_id: []const u8, path: []const u8, allow_context_id: ?[]const u8, res: *httpz.Response) !bool {
+    var row = conn.row(
+        "SELECT context_id FROM context_files WHERE ws_id = $1 AND path = $2",
+        .{ ws_id, path },
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    };
+    if (row) |*r| {
+        defer r.deinit() catch {};
+        const existing = r.get([]const u8, 0) catch "";
+        if (allow_context_id) |allowed| {
+            if (std.mem.eql(u8, existing, allowed)) return true;
+        }
+        try apiError(res, 409, "CONFLICT", "target path already exists");
+        return false;
+    }
+    return true;
+}
+
+fn validateNoIntraPrPathConflict(arena: std.mem.Allocator, ops: []const Operation, res: *httpz.Response) !bool {
+    var seen: std.ArrayList([]const u8) = .empty;
+    for (ops) |op| {
+        const p: ?[]const u8 = if (std.mem.eql(u8, op.type, "create"))
+            op.path
+        else if (std.mem.eql(u8, op.type, "rename"))
+            op.new_path
+        else
+            null;
+        const path = p orelse continue;
+        for (seen.items) |prev| {
+            if (std.mem.eql(u8, prev, path)) {
+                try apiError(res, 400, "BAD_REQUEST", "two operations target the same path in one PR");
+                return false;
+            }
+        }
+        try seen.append(arena, path);
+    }
+    return true;
+}
+
 pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -464,19 +365,24 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
         status: []const u8,
         description: []const u8,
         created_at: []const u8,
+        operation_count: i64,
     };
+
+    const base_sql =
+        \\SELECT pr_id, author, status, description, created_at::text,
+        \\  (SELECT count(*) FROM context_pr_operations op WHERE op.pr_id = context_prs.pr_id)
+        \\FROM context_prs
+    ;
 
     var list: std.ArrayList(PrInfo) = .empty;
 
     if (status_filter) |sf| {
-        var result = conn.query(
-            "SELECT pr_id, author, status, description, created_at::text FROM context_prs WHERE ws_id = $1 AND status = $2 ORDER BY created_at DESC",
-            .{ ws_id, sf },
-        ) catch {
+        var result = conn.query(base_sql ++
+            \\ WHERE ws_id = $1 AND status = $2 ORDER BY created_at DESC
+        , .{ ws_id, sf }) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         };
         defer result.deinit();
-
         while (try result.next()) |row| {
             try list.append(req.arena, .{
                 .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
@@ -484,17 +390,16 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                 .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                 .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                 .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
             });
         }
     } else {
-        var result = conn.query(
-            "SELECT pr_id, author, status, description, created_at::text FROM context_prs WHERE ws_id = $1 ORDER BY created_at DESC",
-            .{ws_id},
-        ) catch {
+        var result = conn.query(base_sql ++
+            \\ WHERE ws_id = $1 ORDER BY created_at DESC
+        , .{ws_id}) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         };
         defer result.deinit();
-
         while (try result.next()) |row| {
             try list.append(req.arena, .{
                 .pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
@@ -502,6 +407,7 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                 .status = try req.arena.dupe(u8, try row.get([]const u8, 2)),
                 .description = try req.arena.dupe(u8, try row.get([]const u8, 3)),
                 .created_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
+                .operation_count = try row.get(i64, 5),
             });
         }
     }
@@ -509,7 +415,17 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
     try res.json(.{ .prs = list.items }, .{});
 }
 
-// GET /api/workspaces/:ws_id/context/prs/:pr_id
+const OperationView = struct {
+    op_index: i32,
+    type: []const u8,
+    context_id: ?[]const u8,
+    base_hash: ?[]const u8,
+    content: ?[]const u8,
+    path: ?[]const u8,
+    base_content: ?[]const u8,
+    current_path: ?[]const u8,
+};
+
 pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -533,7 +449,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     }
 
     var row = conn.row(
-        "SELECT pr_id, author, status, branch_name, description, created_at::text FROM context_prs WHERE pr_id = $1 AND ws_id = $2",
+        "SELECT pr_id, author, status, description, created_at::text FROM context_prs WHERE pr_id = $1 AND ws_id = $2",
         .{ pr_id, ws_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -544,30 +460,62 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     const pr_id_val = try req.arena.dupe(u8, try row.get([]const u8, 0));
     const author = try req.arena.dupe(u8, try row.get([]const u8, 1));
     const status = try req.arena.dupe(u8, try row.get([]const u8, 2));
-    const branch_name = try req.arena.dupe(u8, try row.get([]const u8, 3));
-    const description = try req.arena.dupe(u8, try row.get([]const u8, 4));
-    const created_at = try req.arena.dupe(u8, try row.get([]const u8, 5));
+    const description = try req.arena.dupe(u8, try row.get([]const u8, 3));
+    const created_at = try req.arena.dupe(u8, try row.get([]const u8, 4));
     row.deinit() catch {};
 
-    // Get files on the branch
-    const FileInfo = struct {
-        path: []const u8,
-        content_hash: []const u8,
-    };
-
-    var file_result = conn.query(
-        "SELECT path, content_hash FROM context_files WHERE ws_id = $1 AND branch_name = $2 ORDER BY path",
-        .{ ws_id, branch_name },
+    var ops: std.ArrayList(OperationView) = .empty;
+    var op_result = conn.query(
+        "SELECT op_index, type, context_id, base_hash, content, path FROM context_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        .{pr_id_val},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
-    defer file_result.deinit();
+    defer op_result.deinit();
 
-    var files: std.ArrayList(FileInfo) = .empty;
-    while (try file_result.next()) |frow| {
-        try files.append(req.arena, .{
-            .path = try req.arena.dupe(u8, try frow.get([]const u8, 0)),
-            .content_hash = try req.arena.dupe(u8, try frow.get([]const u8, 1)),
+    while (try op_result.next()) |orow| {
+        const op_index = try orow.get(i32, 0);
+        const op_type = try req.arena.dupe(u8, try orow.get([]const u8, 1));
+        const op_context_id: ?[]const u8 = if (orow.get([]const u8, 2)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_base_hash: ?[]const u8 = if (orow.get([]const u8, 3)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_content: ?[]const u8 = if (orow.get([]const u8, 4)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+        const op_path: ?[]const u8 = if (orow.get([]const u8, 5)) |v|
+            try req.arena.dupe(u8, v)
+        else |_|
+            null;
+
+        var base_content: ?[]const u8 = null;
+        var current_path: ?[]const u8 = null;
+        if (op_context_id) |cid| {
+            var cr = conn.row(
+                "SELECT content, path FROM context_files WHERE ws_id = $1 AND context_id = $2",
+                .{ ws_id, cid },
+            ) catch null;
+            if (cr) |*br| {
+                base_content = req.arena.dupe(u8, br.get([]const u8, 0) catch "") catch null;
+                current_path = req.arena.dupe(u8, br.get([]const u8, 1) catch "") catch null;
+                br.deinit() catch {};
+            }
+        }
+
+        try ops.append(req.arena, .{
+            .op_index = op_index,
+            .type = op_type,
+            .context_id = op_context_id,
+            .base_hash = op_base_hash,
+            .content = op_content,
+            .path = op_path,
+            .base_content = base_content,
+            .current_path = current_path,
         });
     }
 
@@ -576,16 +524,16 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
         .author = author,
         .status = status,
         .description = description,
-        .files = files.items,
+        .operations = ops.items,
         .created_at = created_at,
     }, .{});
 }
 
 const PrActionRequest = struct {
     action: []const u8,
+    reason: ?[]const u8 = null,
 };
 
-// PUT /api/workspaces/:ws_id/context/prs/:pr_id
 pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -605,6 +553,10 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
     };
 
+    if (!std.mem.eql(u8, body.action, "merge") and !std.mem.eql(u8, body.action, "reject")) {
+        return apiError(res, 400, "BAD_REQUEST", "action must be 'merge' or 'reject'");
+    }
+
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
@@ -614,140 +566,250 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
     }
 
-    // Get PR info
     var pr_row = conn.row(
-        "SELECT branch_name, status FROM context_prs WHERE pr_id = $1 AND ws_id = $2",
+        "SELECT status FROM context_prs WHERE pr_id = $1 AND ws_id = $2",
         .{ pr_id, ws_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 404, "NOT_FOUND", "PR not found");
     };
-
-    const branch_name = try req.arena.dupe(u8, try pr_row.get([]const u8, 0));
-    const current_status = try req.arena.dupe(u8, try pr_row.get([]const u8, 1));
+    const current_status_raw = pr_row.get([]const u8, 0) catch "";
+    var status_buf: [32]u8 = undefined;
+    const status_len = @min(current_status_raw.len, status_buf.len);
+    @memcpy(status_buf[0..status_len], current_status_raw[0..status_len]);
     pr_row.deinit() catch {};
 
-    if (!std.mem.eql(u8, current_status, "open")) {
+    if (!std.mem.eql(u8, status_buf[0..status_len], "open")) {
         return apiError(res, 400, "BAD_REQUEST", "PR is not open");
     }
 
     if (std.mem.eql(u8, body.action, "merge")) {
-        // Only maintainer or ws:admin can merge
         if (!std.mem.eql(u8, user.role, "maintainer") and !auth.checkWorkspaceAdmin(conn, ws_id, user.user_id)) {
             return apiError(res, 403, "FORBIDDEN", "only maintainers or ws admins can merge");
         }
+        if (!try applyPr(conn, req.arena, ws_id, pr_id, user.username, res)) return;
 
-        // Ensure main branch exists
         _ = conn.exec(
-            "INSERT INTO context_branches (ws_id, branch_name, base_revision, revision) VALUES ($1, 'main', 0, 0) ON CONFLICT DO NOTHING",
-            .{ws_id},
-        ) catch {};
-
-        // File-level conflict detection: reject if main diverged since branch fork
-        var branch_info = conn.row(
-            "SELECT base_revision FROM context_branches WHERE ws_id = $1 AND branch_name = $2",
-            .{ ws_id, branch_name },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-        } orelse {
-            return apiError(res, 500, "INTERNAL_ERROR", "branch not found");
-        };
-        const base_revision = try branch_info.get(i32, 0);
-        branch_info.deinit() catch {};
-
-        var main_rev_row = conn.row(
-            "SELECT revision FROM context_branches WHERE ws_id = $1 AND branch_name = 'main'",
-            .{ws_id},
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-        };
-        const main_revision = if (main_rev_row) |*r| blk: {
-            const v = try r.get(i32, 0);
-            r.deinit() catch {};
-            break :blk v;
-        } else 0;
-
-        if (main_revision > base_revision) {
-            // Check for overlapping file paths
-            var conflict_check = conn.row(
-                \\SELECT count(*) FROM context_files bf
-                \\JOIN context_files mf ON mf.ws_id = bf.ws_id AND mf.path = bf.path AND mf.branch_name = 'main'
-                \\WHERE bf.ws_id = $1 AND bf.branch_name = $2
-                \\AND mf.updated_at > bf.updated_at
-            ,
-                .{ ws_id, branch_name },
-            ) catch {
-                return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-            };
-            if (conflict_check) |*cc| {
-                const cnt = try cc.get(i64, 0);
-                cc.deinit() catch {};
-                if (cnt > 0) {
-                    _ = conn.exec(
-                        "UPDATE context_prs SET status = 'conflict' WHERE pr_id = $1",
-                        .{pr_id},
-                    ) catch {};
-                    return apiError(res, 409, "CONFLICT", "files conflict with main, rebase first");
-                }
-            }
-        }
-
-        // Copy only PR-specified files from branch to main (upsert)
-        _ = conn.exec(
-            \\INSERT INTO context_files (ws_id, branch_name, path, content, content_hash, author, updated_at)
-            \\SELECT ws_id, 'main', path, content, content_hash, author, now()
-            \\FROM context_files WHERE ws_id = $1 AND branch_name = $2
-            \\AND path IN (SELECT path FROM context_pr_files WHERE pr_id = $3)
-            \\ON CONFLICT (ws_id, branch_name, path) DO UPDATE SET content = EXCLUDED.content, content_hash = EXCLUDED.content_hash, author = EXCLUDED.author, updated_at = now()
-        ,
-            .{ ws_id, branch_name, pr_id },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "failed to merge files to main");
-        };
-
-        // Increment main branch revision and workspace revision
-        _ = conn.exec(
-            "UPDATE context_branches SET revision = revision + 1 WHERE ws_id = $1 AND branch_name = 'main'",
-            .{ws_id},
+            "UPDATE context_prs SET status = 'merged' WHERE pr_id = $1",
+            .{pr_id},
         ) catch {};
         _ = conn.exec(
             "UPDATE workspaces SET revision = revision + 1 WHERE ws_id = $1",
             .{ws_id},
         ) catch {};
 
-        // Update member branch base_revision to main's new revision
+        try res.json(.{ .pr_id = pr_id, .status = "merged" }, .{});
+    } else {
         _ = conn.exec(
-            "UPDATE context_branches SET base_revision = (SELECT revision FROM context_branches WHERE ws_id = $1 AND branch_name = 'main') WHERE ws_id = $1 AND branch_name = $2",
-            .{ ws_id, branch_name },
-        ) catch {};
-
-        // Mark PR as merged
-        _ = conn.exec(
-            "UPDATE context_prs SET status = 'merged' WHERE pr_id = $1",
-            .{pr_id},
-        ) catch {};
-
-        try res.json(.{ .merged = true }, .{});
-    } else if (std.mem.eql(u8, body.action, "close")) {
-        _ = conn.exec(
-            "UPDATE context_prs SET status = 'closed' WHERE pr_id = $1",
+            "UPDATE context_prs SET status = 'rejected' WHERE pr_id = $1",
             .{pr_id},
         ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "failed to close PR");
+            return apiError(res, 500, "INTERNAL_ERROR", "failed to reject PR");
         };
-
-        try res.json(.{ .closed = true }, .{});
-    } else {
-        return apiError(res, 400, "BAD_REQUEST", "action must be 'merge' or 'close'");
+        try res.json(.{ .pr_id = pr_id, .status = "rejected" }, .{});
     }
+}
+
+const LoadedOp = struct {
+    op_index: i32,
+    type: []const u8,
+    context_id: ?[]const u8,
+    base_hash: ?[]const u8,
+    content: ?[]const u8,
+    path: ?[]const u8,
+};
+
+fn applyPr(conn: anytype, arena: std.mem.Allocator, ws_id: []const u8, pr_id: []const u8, author: []const u8, res: *httpz.Response) !bool {
+    var ops: std.ArrayList(LoadedOp) = .empty;
+    var op_result = conn.query(
+        "SELECT op_index, type, context_id, base_hash, content, path FROM context_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        .{pr_id},
+    ) catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+        return false;
+    };
+    defer op_result.deinit();
+    while (try op_result.next()) |r| {
+        const op_index = r.get(i32, 0) catch continue;
+        const t = arena.dupe(u8, r.get([]const u8, 1) catch "") catch continue;
+        const cid: ?[]const u8 = if (r.get([]const u8, 2)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const bh: ?[]const u8 = if (r.get([]const u8, 3)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const c: ?[]const u8 = if (r.get([]const u8, 4)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        const p: ?[]const u8 = if (r.get([]const u8, 5)) |v|
+            arena.dupe(u8, v) catch null
+        else |_|
+            null;
+        try ops.append(arena, .{
+            .op_index = op_index,
+            .type = t,
+            .context_id = cid,
+            .base_hash = bh,
+            .content = c,
+            .path = p,
+        });
+    }
+
+    conn.begin() catch {
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to begin transaction");
+        return false;
+    };
+
+    for (ops.items) |op| {
+        if (std.mem.eql(u8, op.type, "modify")) {
+            const cid = op.context_id.?;
+            const bh = op.base_hash.?;
+            const new_content = op.content.?;
+            var row = conn.row(
+                "SELECT content_hash FROM context_files WHERE ws_id = $1 AND context_id = $2",
+                .{ ws_id, cid },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+                return false;
+            } orelse {
+                conn.rollback() catch {};
+                try apiError(res, 404, "NOT_FOUND", "target file no longer exists");
+                return false;
+            };
+            const current_hash = row.get([]const u8, 0) catch "";
+            const matches = std.mem.eql(u8, current_hash, bh);
+            row.deinit() catch {};
+            if (!matches) {
+                _ = conn.exec("UPDATE context_prs SET status = 'conflicted' WHERE pr_id = $1", .{pr_id}) catch {};
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "file has changed since PR was created");
+                return false;
+            }
+            const new_hash = ContentHash.compute(new_content);
+            const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            _ = conn.exec(
+                "UPDATE context_files SET content = $1, content_hash = $2, author = $3, updated_at = now() WHERE ws_id = $4 AND context_id = $5",
+                .{ new_content, hash_slice, author, ws_id, cid },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to update file");
+                return false;
+            };
+        } else if (std.mem.eql(u8, op.type, "rename")) {
+            const cid = op.context_id.?;
+            const bh = op.base_hash.?;
+            const new_path = op.path.?;
+            var row = conn.row(
+                "SELECT content_hash FROM context_files WHERE ws_id = $1 AND context_id = $2",
+                .{ ws_id, cid },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+                return false;
+            } orelse {
+                conn.rollback() catch {};
+                try apiError(res, 404, "NOT_FOUND", "target file no longer exists");
+                return false;
+            };
+            const current_hash = row.get([]const u8, 0) catch "";
+            const matches = std.mem.eql(u8, current_hash, bh);
+            row.deinit() catch {};
+            if (!matches) {
+                _ = conn.exec("UPDATE context_prs SET status = 'conflicted' WHERE pr_id = $1", .{pr_id}) catch {};
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "file has changed since PR was created");
+                return false;
+            }
+            if (op.content) |new_content| {
+                const new_hash = ContentHash.compute(new_content);
+                const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                    return false;
+                };
+                _ = conn.exec(
+                    "UPDATE context_files SET path = $1, content = $2, content_hash = $3, author = $4, updated_at = now() WHERE ws_id = $5 AND context_id = $6",
+                    .{ new_path, new_content, hash_slice, author, ws_id, cid },
+                ) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update file");
+                    return false;
+                };
+            } else {
+                _ = conn.exec(
+                    "UPDATE context_files SET path = $1, author = $2, updated_at = now() WHERE ws_id = $3 AND context_id = $4",
+                    .{ new_path, author, ws_id, cid },
+                ) catch {
+                    conn.rollback() catch {};
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update file");
+                    return false;
+                };
+            }
+        } else if (std.mem.eql(u8, op.type, "create")) {
+            const path = op.path.?;
+            const new_content = op.content.?;
+            var rand_bytes: [16]u8 = undefined;
+            std.crypto.random.bytes(&rand_bytes);
+            var cid_buf: [36]u8 = undefined;
+            @memcpy(cid_buf[0..4], "ctx-");
+            const hex = "0123456789abcdef";
+            for (rand_bytes, 0..) |byte, i| {
+                cid_buf[4 + i * 2] = hex[byte >> 4];
+                cid_buf[4 + i * 2 + 1] = hex[byte & 0x0f];
+            }
+            const new_cid: []const u8 = arena.dupe(u8, cid_buf[0..36]) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            const new_hash = ContentHash.compute(new_content);
+            const hash_slice: []const u8 = arena.dupe(u8, &new_hash) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "alloc failed");
+                return false;
+            };
+            _ = conn.exec(
+                "INSERT INTO context_files (context_id, ws_id, path, content, content_hash, author) VALUES ($1, $2, $3, $4, $5, $6)",
+                .{ new_cid, ws_id, path, new_content, hash_slice, author },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 409, "CONFLICT", "target path conflict on create");
+                return false;
+            };
+        } else if (std.mem.eql(u8, op.type, "delete")) {
+            const cid = op.context_id.?;
+            _ = conn.exec(
+                "DELETE FROM context_files WHERE ws_id = $1 AND context_id = $2",
+                .{ ws_id, cid },
+            ) catch {
+                conn.rollback() catch {};
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to delete file");
+                return false;
+            };
+        }
+    }
+
+    conn.commit() catch {
+        conn.rollback() catch {};
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to commit transaction");
+        return false;
+    };
+    return true;
 }
 
 const CommentRequest = struct {
     body: []const u8,
 };
 
-// POST /api/workspaces/:ws_id/context/prs/:pr_id/comments
 pub fn handleAddPrComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
@@ -776,7 +838,6 @@ pub fn handleAddPrComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
     }
 
-    // Verify PR exists in this workspace
     var pr_check = conn.row(
         "SELECT 1 FROM context_prs WHERE pr_id = $1 AND ws_id = $2",
         .{ pr_id, ws_id },
@@ -809,151 +870,4 @@ pub fn handleAddPrComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         .comment_id = &comment_id_buf,
         .author = user.username,
     }, .{});
-}
-
-// POST /api/workspaces/:ws_id/context/branches/:branch/rebase
-pub fn handleRebase(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
-    const user = auth.authenticate(ctx, req) catch {
-        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
-    };
-    if (!auth.requireScope(user, "workspace:write", res)) return;
-
-    const ws_id = req.param("ws_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
-    };
-    const branch = req.param("branch") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "branch is required");
-    };
-
-    if (std.mem.eql(u8, branch, "main")) {
-        return apiError(res, 400, "BAD_REQUEST", "cannot rebase main");
-    }
-
-    const conn = ctx.pool.acquire() catch {
-        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
-    };
-    defer conn.release();
-
-    if (!auth.checkWorkspaceMember(conn, ws_id, user.user_id)) {
-        return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
-    }
-
-    // Get branch base_revision
-    var branch_row = conn.row(
-        "SELECT base_revision FROM context_branches WHERE ws_id = $1 AND branch_name = $2",
-        .{ ws_id, branch },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    } orelse {
-        return apiError(res, 404, "NOT_FOUND", "branch not found");
-    };
-    _ = try branch_row.get(i32, 0);
-    branch_row.deinit() catch {};
-
-    // Get main revision
-    var main_row = conn.row(
-        "SELECT revision FROM context_branches WHERE ws_id = $1 AND branch_name = 'main'",
-        .{ws_id},
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    } orelse {
-        // No main branch, nothing to rebase from
-        try res.json(.{ .branch = branch, .status = "rebased", .new_base_revision = @as(i32, 0) }, .{});
-        return;
-    };
-    const main_rev = try main_row.get(i32, 0);
-    main_row.deinit() catch {};
-
-    // Check for conflicts: files changed on both branch and main
-    var conflict_result = conn.query(
-        \\SELECT bf.path FROM context_files bf
-        \\JOIN context_files mf ON mf.ws_id = bf.ws_id AND mf.path = bf.path AND mf.branch_name = 'main'
-        \\WHERE bf.ws_id = $1 AND bf.branch_name = $2
-        \\AND bf.content_hash != mf.content_hash
-        \\AND mf.updated_at > bf.updated_at
-    ,
-        .{ ws_id, branch },
-    ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-    };
-    defer conflict_result.deinit();
-
-    const ConflictPath = struct { path: []const u8 };
-    var conflicts: std.ArrayList(ConflictPath) = .empty;
-    while (try conflict_result.next()) |crow| {
-        try conflicts.append(req.arena, .{
-            .path = try req.arena.dupe(u8, try crow.get([]const u8, 0)),
-        });
-    }
-
-    if (conflicts.items.len > 0) {
-        // Extract just the path strings for JSON
-        var paths: std.ArrayList([]const u8) = .empty;
-        for (conflicts.items) |c| {
-            try paths.append(req.arena, c.path);
-        }
-        res.status = 409;
-        try res.json(.{
-            .branch = branch,
-            .status = "conflict",
-            .conflicting_files = paths.items,
-        }, .{});
-        return;
-    }
-
-    // No conflicts: apply main changes to branch
-    // 1. Add files that exist on main but not on branch
-    _ = conn.exec(
-        \\INSERT INTO context_files (ws_id, branch_name, path, content, content_hash, author, updated_at)
-        \\SELECT ws_id, $2, path, content, content_hash, author, updated_at
-        \\FROM context_files WHERE ws_id = $1 AND branch_name = 'main'
-        \\AND path NOT IN (SELECT path FROM context_files WHERE ws_id = $1 AND branch_name = $2)
-    ,
-        .{ ws_id, branch },
-    ) catch {};
-
-    // 2. Update branch files where only main changed (branch file unchanged since fork)
-    _ = conn.exec(
-        \\UPDATE context_files bf SET
-        \\    content = mf.content, content_hash = mf.content_hash,
-        \\    author = mf.author, updated_at = mf.updated_at
-        \\FROM context_files mf
-        \\WHERE mf.ws_id = bf.ws_id AND mf.branch_name = 'main' AND mf.path = bf.path
-        \\AND bf.ws_id = $1 AND bf.branch_name = $2
-        \\AND mf.content_hash != bf.content_hash
-        \\AND mf.updated_at > bf.updated_at
-    ,
-        .{ ws_id, branch },
-    ) catch {};
-
-    // Update base_revision
-    _ = conn.exec(
-        "UPDATE context_branches SET base_revision = $1 WHERE ws_id = $2 AND branch_name = $3",
-        .{ main_rev, ws_id, branch },
-    ) catch {};
-
-    try res.json(.{
-        .branch = branch,
-        .status = "rebased",
-        .new_base_revision = main_rev,
-    }, .{});
-}
-
-fn ensureMemberBranch(conn: anytype, ws_id: []const u8, branch: []const u8) void {
-    // Get current main revision as base
-    var main_row = conn.row(
-        "SELECT revision FROM context_branches WHERE ws_id = $1 AND branch_name = 'main'",
-        .{ws_id},
-    ) catch null;
-
-    var main_rev: i32 = 0;
-    if (main_row) |*r| {
-        main_rev = r.get(i32, 0) catch 0;
-        r.deinit() catch {};
-    }
-
-    _ = conn.exec(
-        "INSERT INTO context_branches (ws_id, branch_name, base_revision, revision) VALUES ($1, $2, $3, 0) ON CONFLICT DO NOTHING",
-        .{ ws_id, branch, main_rev },
-    ) catch {};
 }

--- a/src/hub/context.zig
+++ b/src/hub/context.zig
@@ -685,7 +685,6 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, ws_id: []const u8, pr_id: []
             const matches = std.mem.eql(u8, current_hash, bh);
             row.deinit() catch {};
             if (!matches) {
-                _ = conn.exec("UPDATE context_prs SET status = 'conflicted' WHERE pr_id = $1", .{pr_id}) catch {};
                 conn.rollback() catch {};
                 try apiError(res, 409, "CONFLICT", "file has changed since PR was created");
                 return false;
@@ -724,7 +723,6 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, ws_id: []const u8, pr_id: []
             const matches = std.mem.eql(u8, current_hash, bh);
             row.deinit() catch {};
             if (!matches) {
-                _ = conn.exec("UPDATE context_prs SET status = 'conflicted' WHERE pr_id = $1", .{pr_id}) catch {};
                 conn.rollback() catch {};
                 try apiError(res, 409, "CONFLICT", "file has changed since PR was created");
                 return false;

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -184,43 +184,41 @@ const migration_sql =
     \\    PRIMARY KEY (ws_id, prompt_id)
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS context_branches (
-    \\    ws_id TEXT NOT NULL REFERENCES workspaces(ws_id) ON DELETE CASCADE,
-    \\    branch_name TEXT NOT NULL,
-    \\    base_revision INTEGER NOT NULL DEFAULT 0,
-    \\    revision INTEGER NOT NULL DEFAULT 0,
-    \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    \\    PRIMARY KEY (ws_id, branch_name)
-    \\);
-    \\
     \\CREATE TABLE IF NOT EXISTS context_files (
-    \\    ws_id TEXT NOT NULL,
-    \\    branch_name TEXT NOT NULL,
+    \\    context_id TEXT PRIMARY KEY,
+    \\    ws_id TEXT NOT NULL REFERENCES workspaces(ws_id) ON DELETE CASCADE,
     \\    path TEXT NOT NULL,
     \\    content TEXT NOT NULL,
     \\    content_hash TEXT NOT NULL,
     \\    author TEXT NOT NULL,
     \\    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    \\    PRIMARY KEY (ws_id, branch_name, path),
-    \\    FOREIGN KEY (ws_id, branch_name) REFERENCES context_branches(ws_id, branch_name) ON DELETE CASCADE
+    \\    UNIQUE(ws_id, path)
     \\);
+    \\CREATE INDEX IF NOT EXISTS context_files_ws_idx
+    \\    ON context_files(ws_id);
     \\
     \\CREATE TABLE IF NOT EXISTS context_prs (
     \\    pr_id TEXT PRIMARY KEY,
     \\    ws_id TEXT NOT NULL REFERENCES workspaces(ws_id) ON DELETE CASCADE,
     \\    author TEXT NOT NULL,
-    \\    branch_name TEXT NOT NULL,
     \\    description TEXT NOT NULL DEFAULT '',
     \\    status TEXT NOT NULL DEFAULT 'open'
-    \\        CHECK (status IN ('open', 'merged', 'closed', 'conflict')),
+    \\        CHECK (status IN ('open', 'merged', 'rejected', 'conflicted')),
     \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS context_pr_files (
+    \\CREATE TABLE IF NOT EXISTS context_pr_operations (
     \\    pr_id TEXT NOT NULL REFERENCES context_prs(pr_id) ON DELETE CASCADE,
-    \\    path TEXT NOT NULL,
-    \\    PRIMARY KEY (pr_id, path)
+    \\    op_index INTEGER NOT NULL,
+    \\    type TEXT NOT NULL CHECK (type IN ('modify', 'rename', 'create', 'delete')),
+    \\    context_id TEXT,
+    \\    base_hash TEXT,
+    \\    content TEXT,
+    \\    path TEXT,
+    \\    PRIMARY KEY (pr_id, op_index)
     \\);
+    \\CREATE INDEX IF NOT EXISTS context_pr_operations_context_id_idx
+    \\    ON context_pr_operations(context_id);
     \\
     \\CREATE TABLE IF NOT EXISTS context_pr_comments (
     \\    comment_id TEXT PRIMARY KEY,

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -203,7 +203,7 @@ const migration_sql =
     \\    author TEXT NOT NULL,
     \\    description TEXT NOT NULL DEFAULT '',
     \\    status TEXT NOT NULL DEFAULT 'open'
-    \\        CHECK (status IN ('open', 'merged', 'rejected', 'conflicted')),
+    \\        CHECK (status IN ('open', 'merged', 'rejected')),
     \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     \\);
     \\

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -171,12 +171,11 @@ const migration_sql =
     \\CREATE TABLE IF NOT EXISTS prompts (
     \\    prompt_id TEXT PRIMARY KEY,
     \\    org_id UUID NOT NULL REFERENCES orgs(org_id),
-    \\    canonical_name TEXT NOT NULL,
-    \\    kind TEXT NOT NULL CHECK (kind IN ('rule', 'workflow')),
+    \\    path TEXT NOT NULL,
     \\    content TEXT NOT NULL DEFAULT '',
     \\    content_hash TEXT NOT NULL DEFAULT '',
     \\    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    \\    UNIQUE(org_id, canonical_name)
+    \\    UNIQUE(org_id, path)
     \\);
     \\
     \\CREATE TABLE IF NOT EXISTS workspace_prompts (
@@ -250,15 +249,25 @@ const migration_sql =
     \\CREATE TABLE IF NOT EXISTS prompt_prs (
     \\    pr_id TEXT PRIMARY KEY,
     \\    org_id UUID NOT NULL REFERENCES orgs(org_id),
-    \\    prompt_id TEXT NOT NULL REFERENCES prompts(prompt_id),
     \\    author_id TEXT NOT NULL REFERENCES users(user_id),
-    \\    base_hash TEXT NOT NULL,
-    \\    content TEXT NOT NULL,
     \\    description TEXT NOT NULL DEFAULT '',
     \\    status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'accepted', 'rejected')),
     \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     \\    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
     \\);
+    \\
+    \\CREATE TABLE IF NOT EXISTS prompt_pr_operations (
+    \\    pr_id TEXT NOT NULL REFERENCES prompt_prs(pr_id) ON DELETE CASCADE,
+    \\    op_index INTEGER NOT NULL,
+    \\    type TEXT NOT NULL CHECK (type IN ('modify', 'rename', 'create', 'delete')),
+    \\    prompt_id TEXT,
+    \\    base_hash TEXT,
+    \\    content TEXT,
+    \\    path TEXT,
+    \\    PRIMARY KEY (pr_id, op_index)
+    \\);
+    \\CREATE INDEX IF NOT EXISTS prompt_pr_operations_prompt_id_idx
+    \\    ON prompt_pr_operations(prompt_id);
     \\
     \\CREATE TABLE IF NOT EXISTS prompt_pr_comments (
     \\    comment_id TEXT PRIMARY KEY,
@@ -292,6 +301,7 @@ const migration_sql =
     \\CREATE TABLE IF NOT EXISTS prompt_history (
     \\    prompt_id TEXT NOT NULL REFERENCES prompts(prompt_id),
     \\    content_hash TEXT NOT NULL,
+    \\    path TEXT NOT NULL DEFAULT '',
     \\    content TEXT NOT NULL DEFAULT '',
     \\    merged_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     \\    pr_id TEXT,

--- a/src/hub/library.zig
+++ b/src/hub/library.zig
@@ -70,8 +70,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
 
 const PromptMeta = struct {
     prompt_id: []const u8,
-    kind: []const u8,
-    canonical_name: []const u8,
+    path: []const u8,
     content_hash: []const u8,
     updated_at: []const u8,
     source: []const u8,
@@ -86,38 +85,37 @@ pub fn handleListPrompts(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const kind_filter = qs.get("kind");
+    const path_prefix = qs.get("path_prefix");
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
     defer conn.release();
 
-    var result = if (kind_filter) |kind|
-        conn.query(
-            "SELECT p.prompt_id, p.kind, p.canonical_name, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.kind = $2 ORDER BY p.canonical_name",
-            .{ user.org_id, kind },
-        ) catch {
-            return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
-        }
-    else
-        conn.query(
-            "SELECT p.prompt_id, p.kind, p.canonical_name, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid ORDER BY p.canonical_name",
-            .{user.org_id},
+    var result = if (path_prefix) |prefix| blk: {
+        const like_arg = try std.fmt.allocPrint(req.arena, "{s}%", .{prefix});
+        break :blk conn.query(
+            "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path LIKE $2 ORDER BY p.path",
+            .{ user.org_id, like_arg },
         ) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         };
+    } else conn.query(
+        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid ORDER BY p.path",
+        .{user.org_id},
+    ) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
+    };
     defer result.deinit();
 
     var list: std.ArrayList(PromptMeta) = .empty;
     while (try result.next()) |row| {
         try list.append(req.arena, .{
             .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-            .kind = try req.arena.dupe(u8, try row.get([]const u8, 1)),
-            .canonical_name = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-            .content_hash = try req.arena.dupe(u8, try row.get([]const u8, 3)),
-            .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 4)),
-            .source = try req.arena.dupe(u8, try row.get([]const u8, 5)),
+            .path = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+            .content_hash = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+            .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
+            .source = try req.arena.dupe(u8, try row.get([]const u8, 4)),
         });
     }
 
@@ -126,6 +124,7 @@ pub fn handleListPrompts(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
 
 const HistoryEntry = struct {
     content_hash: []const u8,
+    path: []const u8,
     merged_at: []const u8,
     pr_id: ?[]const u8,
 };
@@ -139,34 +138,38 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const name = qs.get("name") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "name query parameter is required");
-    };
+    const prompt_id_q = qs.get("prompt_id");
+    const path_q = qs.get("path");
+    if (prompt_id_q == null and path_q == null) {
+        return apiError(res, 400, "BAD_REQUEST", "prompt_id or path query parameter is required");
+    }
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
     defer conn.release();
 
-    var row = conn.row(
-        "SELECT p.prompt_id, p.kind, p.canonical_name, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.canonical_name = $2",
-        .{ user.org_id, name },
-    ) catch {
+    var row = (if (prompt_id_q) |pid| conn.row(
+        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.prompt_id = $2",
+        .{ user.org_id, pid },
+    ) else conn.row(
+        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path = $2",
+        .{ user.org_id, path_q.? },
+    )) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 404, "NOT_FOUND", "prompt not found");
     };
 
     const prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
-    const kind = try req.arena.dupe(u8, try row.get([]const u8, 1));
-    const canonical_name = try req.arena.dupe(u8, try row.get([]const u8, 2));
-    const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 3));
-    const updated_at = try req.arena.dupe(u8, try row.get([]const u8, 4));
-    const source = try req.arena.dupe(u8, try row.get([]const u8, 5));
+    const path = try req.arena.dupe(u8, try row.get([]const u8, 1));
+    const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 2));
+    const updated_at = try req.arena.dupe(u8, try row.get([]const u8, 3));
+    const source = try req.arena.dupe(u8, try row.get([]const u8, 4));
     row.deinit() catch {};
 
     var history_result = conn.query(
-        "SELECT content_hash, merged_at::text, pr_id FROM prompt_history WHERE prompt_id = $1 ORDER BY merged_at DESC",
+        "SELECT content_hash, path, merged_at::text, pr_id FROM prompt_history WHERE prompt_id = $1 ORDER BY merged_at DESC",
         .{prompt_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -176,13 +179,15 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     var history: std.ArrayList(HistoryEntry) = .empty;
     while (try history_result.next()) |hrow| {
         const h_hash = try req.arena.dupe(u8, try hrow.get([]const u8, 0));
-        const h_merged = try req.arena.dupe(u8, try hrow.get([]const u8, 1));
-        const h_pr_id: ?[]const u8 = if (hrow.get([]const u8, 2)) |v|
+        const h_path = try req.arena.dupe(u8, try hrow.get([]const u8, 1));
+        const h_merged = try req.arena.dupe(u8, try hrow.get([]const u8, 2));
+        const h_pr_id: ?[]const u8 = if (hrow.get([]const u8, 3)) |v|
             try req.arena.dupe(u8, v)
         else |_|
             null;
         try history.append(req.arena, .{
             .content_hash = h_hash,
+            .path = h_path,
             .merged_at = h_merged,
             .pr_id = h_pr_id,
         });
@@ -190,8 +195,7 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
 
     try res.json(.{
         .prompt_id = prompt_id,
-        .kind = kind,
-        .canonical_name = canonical_name,
+        .path = path,
         .content_hash = content_hash,
         .updated_at = updated_at,
         .source = source,
@@ -208,19 +212,24 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const name = qs.get("name") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "name query parameter is required");
-    };
+    const prompt_id_q = qs.get("prompt_id");
+    const path_q = qs.get("path");
+    if (prompt_id_q == null and path_q == null) {
+        return apiError(res, 400, "BAD_REQUEST", "prompt_id or path query parameter is required");
+    }
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
     defer conn.release();
 
-    var row = conn.row(
-        "SELECT prompt_id, content_hash, content FROM prompts WHERE org_id = $1::uuid AND canonical_name = $2",
-        .{ user.org_id, name },
-    ) catch {
+    var row = (if (prompt_id_q) |pid| conn.row(
+        "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+        .{ user.org_id, pid },
+    ) else conn.row(
+        "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND path = $2",
+        .{ user.org_id, path_q.? },
+    )) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         return apiError(res, 404, "NOT_FOUND", "prompt not found");
@@ -238,11 +247,13 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
 
     const prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
     const body = try req.arena.dupe(u8, try row.get([]const u8, 2));
+    const path = try req.arena.dupe(u8, try row.get([]const u8, 3));
     row.deinit() catch {};
 
     res.header("ETag", content_hash);
     try res.json(.{
         .prompt_id = prompt_id,
+        .path = path,
         .content_hash = content_hash,
         .body = body,
     }, .{});

--- a/src/hub/server.zig
+++ b/src/hub/server.zig
@@ -70,17 +70,13 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.post("/api/workspaces/:ws_id/prompts", workspace_handler.handleAddPrompt, .{});
     router.delete("/api/workspaces/:ws_id/prompts/:prompt_id", workspace_handler.handleRemovePrompt, .{});
     // Context
-    router.get("/api/workspaces/:ws_id/context/branches", context_handler.handleListBranches, .{});
     router.get("/api/workspaces/:ws_id/context/files", context_handler.handleListFiles, .{});
     router.get("/api/workspaces/:ws_id/context/file/content", context_handler.handleGetFileContent, .{});
-    router.put("/api/workspaces/:ws_id/context/file", context_handler.handlePutFile, .{});
-    router.delete("/api/workspaces/:ws_id/context/file", context_handler.handleDeleteFile, .{});
     router.post("/api/workspaces/:ws_id/context/prs", context_handler.handleCreatePr, .{});
     router.get("/api/workspaces/:ws_id/context/prs", context_handler.handleListPrs, .{});
     router.get("/api/workspaces/:ws_id/context/prs/:pr_id", context_handler.handleGetPr, .{});
     router.put("/api/workspaces/:ws_id/context/prs/:pr_id", context_handler.handleUpdatePr, .{});
     router.post("/api/workspaces/:ws_id/context/prs/:pr_id/comments", context_handler.handleAddPrComment, .{});
-    router.post("/api/workspaces/:ws_id/context/branches/:branch/rebase", context_handler.handleRebase, .{});
 
     // Workspace Members
     router.get("/api/workspaces/:ws_id/members", workspace_handler.handleListMembers, .{});

--- a/src/hub/trace.zig
+++ b/src/hub/trace.zig
@@ -234,10 +234,11 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         \\  GROUP BY bp.prompt_id
         \\) bp_stats ON bp_stats.prompt_id = p.prompt_id
         \\LEFT JOIN (
-        \\  SELECT pr.prompt_id, count(*) as open_pr_count
-        \\  FROM prompt_prs pr
-        \\  WHERE pr.org_id = $1::uuid AND pr.status = 'open'
-        \\  GROUP BY pr.prompt_id
+        \\  SELECT op.prompt_id, count(DISTINCT op.pr_id) as open_pr_count
+        \\  FROM prompt_pr_operations op
+        \\  JOIN prompt_prs pr ON pr.pr_id = op.pr_id
+        \\  WHERE pr.org_id = $1::uuid AND pr.status = 'open' AND op.prompt_id IS NOT NULL
+        \\  GROUP BY op.prompt_id
         \\) pr_stats ON pr_stats.prompt_id = p.prompt_id
         \\WHERE p.org_id = $1::uuid
         \\ORDER BY COALESCE(te_stats.refer_count, 0) DESC

--- a/src/lib/trace.zig
+++ b/src/lib/trace.zig
@@ -2,8 +2,6 @@ const std = @import("std");
 const testing = std.testing;
 const encoding = @import("encoding.zig");
 
-pub const LOG_DIR = "log";
-
 fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
     const home = std.process.getEnvVarOwned(allocator, "HOME") catch
         std.process.getEnvVarOwned(allocator, "USERPROFILE") catch
@@ -12,53 +10,36 @@ fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
     return std.fs.path.join(allocator, &.{ home, ".clumsies" });
 }
 
-pub const EventType = enum {
-    setup,
-    search,
-    load,
-    refer,
-};
-
 pub const TraceEvent = struct {
-    event_type: EventType,
-
-    // setup fields
-    mpf_hash: ?[]const u8 = null,
-
-    // load fields
+    ws_id: []const u8,
+    session_id: []const u8,
+    event_id: i64,
+    type: []const u8,
+    timestamp: i64,
     prompt_id: ?[]const u8 = null,
     prompt_hash: ?[]const u8 = null,
-
-    // refer fields
     constraint_id: ?[]const u8 = null,
+    override_base_hash: ?[]const u8 = null,
     reason: ?[]const u8 = null,
+    content: ?[]const u8 = null,
+    content_hash: ?[]const u8 = null,
 };
 
-/// Generate a workspace_id from workspace root path.
-pub fn workspaceId(allocator: std.mem.Allocator, workspace_root: []const u8) ![]const u8 {
-    var hasher = std.crypto.hash.sha2.Sha256.init(.{});
-    hasher.update(workspace_root);
-    var hash: [32]u8 = undefined;
-    hasher.final(&hash);
-
-    var hex: [64]u8 = undefined;
-    encoding.hexEncode(&hash, &hex);
-    return try std.fmt.allocPrint(allocator, "ws-{s}", .{hex[0..16]});
-}
-
-/// Get the trace file path: ~/.clumsies/log/{workspace_id}.jsonl
-pub fn traceFilePath(allocator: std.mem.Allocator, workspace_root: []const u8) ![]const u8 {
+/// Get the trace file path: ~/.clumsies/workspaces/{ws_id}/trace.jsonl
+pub fn traceFilePath(allocator: std.mem.Allocator, ws_id: []const u8) ![]const u8 {
     const base = try getBasePath(allocator);
     defer allocator.free(base);
-    const ws_id = try workspaceId(allocator, workspace_root);
-    defer allocator.free(ws_id);
-    const filename = try std.fmt.allocPrint(allocator, "{s}.jsonl", .{ws_id});
-    defer allocator.free(filename);
-    return try std.fs.path.join(allocator, &.{ base, LOG_DIR, filename });
+    return try std.fs.path.join(allocator, &.{ base, "workspaces", ws_id, "trace.jsonl" });
 }
 
-/// Ensure ~/.clumsies/log/ directory exists.
-pub fn ensureLogDir(allocator: std.mem.Allocator) !void {
+/// Get the trace cursor file path: ~/.clumsies/workspaces/{ws_id}/trace.cursor
+pub fn cursorFilePath(allocator: std.mem.Allocator, ws_id: []const u8) ![]const u8 {
+    const base = try getBasePath(allocator);
+    defer allocator.free(base);
+    return try std.fs.path.join(allocator, &.{ base, "workspaces", ws_id, "trace.cursor" });
+}
+
+fn ensureWorkspaceDir(allocator: std.mem.Allocator, ws_id: []const u8) !void {
     const base = try getBasePath(allocator);
     defer allocator.free(base);
 
@@ -67,20 +48,47 @@ pub fn ensureLogDir(allocator: std.mem.Allocator) !void {
         else => return err,
     };
 
-    const log_path = try std.fs.path.join(allocator, &.{ base, LOG_DIR });
-    defer allocator.free(log_path);
+    const ws_parent = try std.fs.path.join(allocator, &.{ base, "workspaces" });
+    defer allocator.free(ws_parent);
+    std.fs.makeDirAbsolute(ws_parent) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
 
-    std.fs.makeDirAbsolute(log_path) catch |err| switch (err) {
+    const ws_dir = try std.fs.path.join(allocator, &.{ ws_parent, ws_id });
+    defer allocator.free(ws_dir);
+    std.fs.makeDirAbsolute(ws_dir) catch |err| switch (err) {
         error.PathAlreadyExists => {},
         else => return err,
     };
 }
 
-/// Append a trace event to trace.jsonl.
-pub fn appendTraceEvent(allocator: std.mem.Allocator, workspace_root: []const u8, event: TraceEvent) !void {
-    try ensureLogDir(allocator);
+fn ensureCursorFile(allocator: std.mem.Allocator, ws_id: []const u8) !void {
+    const cursor_path = try cursorFilePath(allocator, ws_id);
+    defer allocator.free(cursor_path);
 
-    const trace_path = try traceFilePath(allocator, workspace_root);
+    const existing = std.fs.openFileAbsolute(cursor_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            const file = try std.fs.createFileAbsolute(cursor_path, .{});
+            defer file.close();
+            var buf: [32]u8 = undefined;
+            var w = std.fs.File.Writer.init(file, &buf);
+            defer w.interface.flush() catch {};
+            try w.interface.writeAll("0\n");
+            return;
+        },
+        else => return err,
+    };
+    existing.close();
+}
+
+/// Append a trace event to ~/.clumsies/workspaces/{ws_id}/trace.jsonl.
+/// The JSON format matches the server `POST /api/traces` TraceEventInput shape.
+pub fn appendTraceEvent(allocator: std.mem.Allocator, event: TraceEvent) !void {
+    try ensureWorkspaceDir(allocator, event.ws_id);
+    try ensureCursorFile(allocator, event.ws_id);
+
+    const trace_path = try traceFilePath(allocator, event.ws_id);
     defer allocator.free(trace_path);
 
     var file = try std.fs.createFileAbsolute(trace_path, .{ .truncate = false });
@@ -100,508 +108,77 @@ fn serializeTraceEvent(allocator: std.mem.Allocator, event: TraceEvent) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
 
-    const ts = std.time.milliTimestamp();
-    const type_str = @tagName(event.event_type);
+    const esc_ws = try encoding.jsonEscapeAlloc(allocator, event.ws_id);
+    defer allocator.free(esc_ws);
+    const esc_session = try encoding.jsonEscapeAlloc(allocator, event.session_id);
+    defer allocator.free(esc_session);
+    const esc_type = try encoding.jsonEscapeAlloc(allocator, event.type);
+    defer allocator.free(esc_type);
 
-    try buf.writer(allocator).print("{{\"type\":\"{s}\",\"ts\":{d}", .{ type_str, ts });
+    try buf.writer(allocator).print(
+        "{{\"ws_id\":\"{s}\",\"session_id\":\"{s}\",\"event_id\":{d},\"type\":\"{s}\",\"timestamp\":{d}",
+        .{ esc_ws, esc_session, event.event_id, esc_type, event.timestamp },
+    );
 
-    // Type-specific fields
-    switch (event.event_type) {
-        .setup => {
-            if (event.mpf_hash) |h| {
-                const esc = try encoding.jsonEscapeAlloc(allocator, h);
-                defer allocator.free(esc);
-                try buf.writer(allocator).print(",\"mpf_hash\":\"{s}\"", .{esc});
-            }
-        },
-        .load => {
-            if (event.prompt_id) |pid| {
-                const esc = try encoding.jsonEscapeAlloc(allocator, pid);
-                defer allocator.free(esc);
-                try buf.writer(allocator).print(",\"prompt_id\":\"{s}\"", .{esc});
-            }
-            if (event.prompt_hash) |ph| {
-                try buf.writer(allocator).print(",\"prompt_hash\":\"{s}\"", .{ph});
-            }
-        },
-        .refer => {
-            if (event.prompt_id) |pid| {
-                const esc = try encoding.jsonEscapeAlloc(allocator, pid);
-                defer allocator.free(esc);
-                try buf.writer(allocator).print(",\"prompt_id\":\"{s}\"", .{esc});
-            }
-            if (event.prompt_hash) |ph| {
-                try buf.writer(allocator).print(",\"prompt_hash\":\"{s}\"", .{ph});
-            }
-            if (event.constraint_id) |cid| {
-                const esc = try encoding.jsonEscapeAlloc(allocator, cid);
-                defer allocator.free(esc);
-                try buf.writer(allocator).print(",\"constraint_id\":\"{s}\"", .{esc});
-            }
-            if (event.reason) |r| {
-                const esc = try encoding.jsonEscapeAlloc(allocator, r);
-                defer allocator.free(esc);
-                try buf.writer(allocator).print(",\"reason\":\"{s}\"", .{esc});
-            }
-        },
-        .search => {},
-    }
+    try writeOptionalString(allocator, &buf, "prompt_id", event.prompt_id);
+    try writeOptionalString(allocator, &buf, "prompt_hash", event.prompt_hash);
+    try writeOptionalString(allocator, &buf, "constraint_id", event.constraint_id);
+    try writeOptionalString(allocator, &buf, "override_base_hash", event.override_base_hash);
+    try writeOptionalString(allocator, &buf, "reason", event.reason);
+    try writeOptionalString(allocator, &buf, "content", event.content);
+    try writeOptionalString(allocator, &buf, "content_hash", event.content_hash);
 
     try buf.appendSlice(allocator, "}\n");
     return try buf.toOwnedSlice(allocator);
 }
 
-// Stats: read and aggregate trace
-
-pub const PromptStats = struct {
-    id: []const u8,
-    refer_count: usize = 0,
-};
-
-pub const WorkspaceStats = struct {
-    prompts: std.StringArrayHashMap(PromptStats),
-
-    pub fn deinit(self: *WorkspaceStats, allocator: std.mem.Allocator) void {
-        var iter = self.prompts.iterator();
-        while (iter.next()) |entry| {
-            allocator.free(entry.value_ptr.id);
-        }
-        self.prompts.deinit();
-    }
-};
-
-pub fn computeWorkspaceStats(allocator: std.mem.Allocator, workspace_root: []const u8) !WorkspaceStats {
-    var stats: WorkspaceStats = .{ .prompts = .init(allocator) };
-    errdefer stats.deinit(allocator);
-
-    const trace_path = try traceFilePath(allocator, workspace_root);
-    defer allocator.free(trace_path);
-
-    const file = std.fs.openFileAbsolute(trace_path, .{}) catch return stats;
-    defer file.close();
-
-    var read_buf: [4096]u8 = undefined;
-    var fr = std.fs.File.Reader.init(file, &read_buf);
-    const content = try fr.interface.allocRemaining(allocator, std.io.Limit.limited(64 * 1024 * 1024));
-    defer allocator.free(content);
-
-    // Aggregate refer events
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
-        defer parsed.deinit();
-
-        const obj = switch (parsed.value) {
-            .object => |o| o,
-            else => continue,
-        };
-
-        const evt_type = getStr(obj, "type") orelse continue;
-        if (!std.mem.eql(u8, evt_type, "refer")) continue;
-
-        const pid = getStr(obj, "prompt_id") orelse continue;
-
-        const gop = try stats.prompts.getOrPut(pid);
-        if (!gop.found_existing) {
-            const owned_key = try allocator.dupe(u8, pid);
-            gop.key_ptr.* = owned_key;
-            gop.value_ptr.* = .{
-                .id = owned_key,
-            };
-        }
-        gop.value_ptr.refer_count += 1;
-    }
-
-    return stats;
+fn writeOptionalString(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), key: []const u8, value: ?[]const u8) !void {
+    const v = value orelse return;
+    const esc = try encoding.jsonEscapeAlloc(allocator, v);
+    defer allocator.free(esc);
+    try buf.writer(allocator).print(",\"{s}\":\"{s}\"", .{ key, esc });
 }
 
-// Per-constraint stats for prompt scope
+test "traceFilePath is under ~/.clumsies/workspaces/{ws_id}/" {
+    const p = try traceFilePath(testing.allocator, "ws-test123");
+    defer testing.allocator.free(p);
+    try testing.expect(std.mem.indexOf(u8, p, "/.clumsies/workspaces/ws-test123/trace.jsonl") != null);
+}
 
-pub const ConstraintStats = struct {
-    constraint_id: []const u8,
-    refer_count: usize = 0,
-    last_referred_at: ?i64 = null,
-};
-
-pub const PromptDetailStats = struct {
-    prompt_id: []const u8,
-    prompt_hash: ?[]const u8,
-    constraints: std.StringArrayHashMap(ConstraintStats),
-
-    pub fn deinit(self: *PromptDetailStats, allocator: std.mem.Allocator) void {
-        allocator.free(self.prompt_id);
-        if (self.prompt_hash) |h| allocator.free(h);
-        var iter = self.constraints.iterator();
-        while (iter.next()) |entry| {
-            allocator.free(entry.value_ptr.constraint_id);
-        }
-        self.constraints.deinit();
-    }
-};
-
-pub fn computePromptStats(
-    allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    prompt_id: []const u8,
-) !PromptDetailStats {
-    var stats: PromptDetailStats = .{
-        .prompt_id = try allocator.dupe(u8, prompt_id),
-        .prompt_hash = null,
-        .constraints = .init(allocator),
+test "serializeTraceEvent produces server-ready JSON" {
+    const event: TraceEvent = .{
+        .ws_id = "ws-abc",
+        .session_id = "sess-xyz",
+        .event_id = 3,
+        .type = "refer",
+        .timestamp = 1743753000000,
+        .prompt_id = "p-550e8400",
+        .constraint_id = "c-2",
+        .reason = "applying style",
     };
-    errdefer stats.deinit(allocator);
-
-    const trace_path = try traceFilePath(allocator, workspace_root);
-    defer allocator.free(trace_path);
-
-    const file = std.fs.openFileAbsolute(trace_path, .{}) catch return stats;
-    defer file.close();
-
-    var read_buf: [4096]u8 = undefined;
-    var fr = std.fs.File.Reader.init(file, &read_buf);
-    const content = try fr.interface.allocRemaining(allocator, std.io.Limit.limited(64 * 1024 * 1024));
-    defer allocator.free(content);
-
-    // Aggregate refer events for this prompt
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
-        defer parsed.deinit();
-        const obj = switch (parsed.value) {
-            .object => |o| o,
-            else => continue,
-        };
-
-        const evt_type = getStr(obj, "type") orelse continue;
-        if (!std.mem.eql(u8, evt_type, "refer")) continue;
-
-        const pid = getStr(obj, "prompt_id") orelse continue;
-        if (!std.mem.eql(u8, pid, prompt_id)) continue;
-
-        const cid = getStr(obj, "constraint_id") orelse continue;
-        const ph = getStr(obj, "prompt_hash");
-
-        // Capture prompt_hash from first event
-        if (stats.prompt_hash == null and ph != null) {
-            stats.prompt_hash = try allocator.dupe(u8, ph.?);
-        }
-
-        const ts_val: ?i64 = if (obj.get("ts")) |ts_json| switch (ts_json) {
-            .integer => |i| i,
-            else => null,
-        } else null;
-
-        // Update constraint stats
-        const gop = try stats.constraints.getOrPut(cid);
-        if (!gop.found_existing) {
-            const owned_cid = try allocator.dupe(u8, cid);
-            gop.key_ptr.* = owned_cid;
-            gop.value_ptr.* = .{
-                .constraint_id = owned_cid,
-            };
-        }
-        gop.value_ptr.refer_count += 1;
-
-        if (ts_val) |ts| {
-            if (gop.value_ptr.last_referred_at == null or ts > gop.value_ptr.last_referred_at.?) {
-                gop.value_ptr.last_referred_at = ts;
-            }
-        }
-    }
-
-    return stats;
+    const line = try serializeTraceEvent(testing.allocator, event);
+    defer testing.allocator.free(line);
+    try testing.expect(std.mem.indexOf(u8, line, "\"ws_id\":\"ws-abc\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"session_id\":\"sess-xyz\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"event_id\":3") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"type\":\"refer\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"timestamp\":1743753000000") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"prompt_id\":\"p-550e8400\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"constraint_id\":\"c-2\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"reason\":\"applying style\"") != null);
+    try testing.expect(std.mem.endsWith(u8, line, "}\n"));
 }
 
-// Diff scope stats
-
-pub const DiffConstraintStats = struct {
-    constraint_id: []const u8,
-    text_hash: []const u8,
-    refer_count: usize,
-    task_count: usize,
-};
-
-pub const DiffMatchedStats = struct {
-    old_constraint_id: []const u8,
-    new_constraint_id: []const u8,
-    text_hash: []const u8,
-    old_refer_count: usize,
-    old_task_count: usize,
-    new_refer_count: usize,
-    new_task_count: usize,
-};
-
-pub const PromptDiffStats = struct {
-    prompt_id: []const u8,
-    old_hash: []const u8,
-    new_hash: []const u8,
-    old_only: std.ArrayList(DiffConstraintStats),
-    new_only: std.ArrayList(DiffConstraintStats),
-    matched: std.ArrayList(DiffMatchedStats),
-
-    pub fn deinit(self: *PromptDiffStats, allocator: std.mem.Allocator) void {
-        allocator.free(self.prompt_id);
-        allocator.free(self.old_hash);
-        allocator.free(self.new_hash);
-        for (self.old_only.items) |item| {
-            allocator.free(item.constraint_id);
-            allocator.free(item.text_hash);
-        }
-        self.old_only.deinit(allocator);
-        for (self.new_only.items) |item| {
-            allocator.free(item.constraint_id);
-            allocator.free(item.text_hash);
-        }
-        self.new_only.deinit(allocator);
-        for (self.matched.items) |item| {
-            allocator.free(item.old_constraint_id);
-            allocator.free(item.new_constraint_id);
-            allocator.free(item.text_hash);
-        }
-        self.matched.deinit(allocator);
-    }
-};
-
-/// Aggregate refer counts for a specific prompt_id + prompt_hash, grouped by constraint_id.
-pub fn computeReferCountsByConstraint(
-    allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    prompt_id: []const u8,
-    prompt_hash: []const u8,
-) !std.StringHashMap(ConstraintReferAgg) {
-    var result = std.StringHashMap(ConstraintReferAgg).init(allocator);
-    errdefer {
-        var iter = result.iterator();
-        while (iter.next()) |entry| {
-            allocator.free(@constCast(entry.key_ptr.*));
-        }
-        result.deinit();
-    }
-
-    const trace_path = try traceFilePath(allocator, workspace_root);
-    defer allocator.free(trace_path);
-
-    const file = std.fs.openFileAbsolute(trace_path, .{}) catch return result;
-    defer file.close();
-
-    var read_buf: [4096]u8 = undefined;
-    var fr = std.fs.File.Reader.init(file, &read_buf);
-    const content = try fr.interface.allocRemaining(allocator, std.io.Limit.limited(64 * 1024 * 1024));
-    defer allocator.free(content);
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
-        defer parsed.deinit();
-        const obj = switch (parsed.value) {
-            .object => |o| o,
-            else => continue,
-        };
-
-        const evt_type = getStr(obj, "type") orelse continue;
-        if (!std.mem.eql(u8, evt_type, "refer")) continue;
-
-        const pid = getStr(obj, "prompt_id") orelse continue;
-        if (!std.mem.eql(u8, pid, prompt_id)) continue;
-
-        const ph = getStr(obj, "prompt_hash") orelse continue;
-        if (!std.mem.eql(u8, ph, prompt_hash)) continue;
-
-        const cid = getStr(obj, "constraint_id") orelse continue;
-
-        const gop = try result.getOrPut(cid);
-        if (!gop.found_existing) {
-            const owned_key = try allocator.dupe(u8, cid);
-            gop.key_ptr.* = owned_key;
-            gop.value_ptr.* = .{
-                .refer_count = 0,
-            };
-        }
-        gop.value_ptr.refer_count += 1;
-    }
-
-    return result;
-}
-
-pub const ConstraintReferAgg = struct {
-    refer_count: usize,
-};
-
-// TimeBuckets stats
-
-pub const TimeBucket = struct {
-    date: []const u8, // "YYYY-MM-DD" or "YYYY-Www"
-    coverage_ratio: f64,
-    tasks: usize,
-};
-
-pub const TimeBucketResult = struct {
-    prompt_id: []const u8,
-    prompt_hash: ?[]const u8,
-    buckets: std.ArrayList(TimeBucket),
-
-    pub fn deinit(self: *TimeBucketResult, allocator: std.mem.Allocator) void {
-        allocator.free(self.prompt_id);
-        if (self.prompt_hash) |h| allocator.free(h);
-        for (self.buckets.items) |b| allocator.free(b.date);
-        self.buckets.deinit(allocator);
-    }
-};
-
-pub const TimeBucketMode = enum {
-    daily,
-    weekly,
-};
-
-pub const ReferEvent = struct {
-    timestamp: i64,
-    constraint_id: []const u8,
-};
-
-/// Collect all refer events for a specific prompt.
-pub fn collectReferEvents(
-    allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    prompt_id: []const u8,
-) !std.ArrayList(ReferEvent) {
-    var events: std.ArrayList(ReferEvent) = .empty;
-    errdefer {
-        for (events.items) |e| {
-            allocator.free(e.constraint_id);
-        }
-        events.deinit(allocator);
-    }
-
-    const trace_path = try traceFilePath(allocator, workspace_root);
-    defer allocator.free(trace_path);
-
-    const file = std.fs.openFileAbsolute(trace_path, .{}) catch return events;
-    defer file.close();
-
-    var read_buf: [4096]u8 = undefined;
-    var fr = std.fs.File.Reader.init(file, &read_buf);
-    const content = try fr.interface.allocRemaining(allocator, std.io.Limit.limited(64 * 1024 * 1024));
-    defer allocator.free(content);
-
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |line| {
-        if (line.len == 0) continue;
-        const parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch continue;
-        defer parsed.deinit();
-        const obj = switch (parsed.value) {
-            .object => |o| o,
-            else => continue,
-        };
-
-        const evt_type = getStr(obj, "type") orelse continue;
-        if (!std.mem.eql(u8, evt_type, "refer")) continue;
-
-        const pid = getStr(obj, "prompt_id") orelse continue;
-        if (!std.mem.eql(u8, pid, prompt_id)) continue;
-
-        const cid = getStr(obj, "constraint_id") orelse continue;
-        const ts: i64 = if (obj.get("ts")) |ts_json| switch (ts_json) {
-            .integer => |i| i,
-            else => continue,
-        } else continue;
-
-        try events.append(allocator, .{
-            .timestamp = ts,
-            .constraint_id = try allocator.dupe(u8, cid),
-        });
-    }
-
-    return events;
-}
-
-/// Format a millisecond timestamp to "YYYY-MM-DD" date string.
-pub fn msToDateStr(allocator: std.mem.Allocator, ms: i64) ![]const u8 {
-    const epoch_secs: i64 = @divTrunc(ms, 1000);
-    const es = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(0, epoch_secs)) };
-    const day = es.getEpochDay();
-    const yd = day.calculateYearDay();
-    const md = yd.calculateMonthDay();
-    return try std.fmt.allocPrint(allocator, "{d:0>4}-{d:0>2}-{d:0>2}", .{
-        yd.year,
-        @intFromEnum(md.month),
-        md.day_index + 1,
-    });
-}
-
-/// Format a millisecond timestamp to "YYYY-Www" week string.
-pub fn msToWeekStr(allocator: std.mem.Allocator, ms: i64) ![]const u8 {
-    const epoch_secs: i64 = @divTrunc(ms, 1000);
-    const es = std.time.epoch.EpochSeconds{ .secs = @intCast(@max(0, epoch_secs)) };
-    const day = es.getEpochDay();
-    const yd = day.calculateYearDay();
-    // ISO week: approximate by day of year / 7
-    const week = @divTrunc(yd.day, 7) + 1;
-    return try std.fmt.allocPrint(allocator, "{d:0>4}-W{d:0>2}", .{ yd.year, week });
-}
-
-fn getStr(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
-    const val = obj.get(key) orelse return null;
-    return switch (val) {
-        .string => |s| s,
-        else => null,
+test "serializeTraceEvent omits null optional fields" {
+    const event: TraceEvent = .{
+        .ws_id = "ws-1",
+        .session_id = "sess-1",
+        .event_id = 0,
+        .type = "setup",
+        .timestamp = 100,
     };
-}
-
-test "workspaceId: deterministic from path" {
-    const id1 = try workspaceId(testing.allocator, "/path/to/project");
-    defer testing.allocator.free(id1);
-    const id2 = try workspaceId(testing.allocator, "/path/to/project");
-    defer testing.allocator.free(id2);
-
-    try testing.expectEqualStrings(id1, id2);
-    try testing.expect(std.mem.startsWith(u8, id1, "ws-"));
-}
-
-test "appendTraceEvent: writes jsonl" {
-    // Use a unique fake workspace root so the trace file doesn't collide
-    const root = "/tmp/clumsies-test-appendTraceEvent-unique";
-
-    try appendTraceEvent(testing.allocator, root, .{
-        .event_type = .setup,
-        .mpf_hash = "hash123",
-    });
-
-    try appendTraceEvent(testing.allocator, root, .{
-        .event_type = .refer,
-        .prompt_id = "rule:zig/00_STYLE.md",
-        .prompt_hash = "abc123",
-        .constraint_id = "c-1",
-        .reason = "applying naming rule",
-    });
-
-    // Read and verify
-    const trace_path = try traceFilePath(testing.allocator, root);
-    defer testing.allocator.free(trace_path);
-
-    // Clean up trace file after test
-    defer std.fs.deleteFileAbsolute(trace_path) catch {};
-
-    const file = try std.fs.openFileAbsolute(trace_path, .{});
-    defer file.close();
-    var tr_buf: [4096]u8 = undefined;
-    var tr = std.fs.File.Reader.init(file, &tr_buf);
-    const content = try tr.interface.readAllAlloc(testing.allocator, 16384);
-    defer testing.allocator.free(content);
-
-    // Should have 2 lines
-    var line_count: usize = 0;
-    var iter = std.mem.splitScalar(u8, content, '\n');
-    while (iter.next()) |line| {
-        if (line.len > 0) line_count += 1;
-    }
-    try testing.expectEqual(@as(usize, 2), line_count);
-
-    // Content checks
-    try testing.expect(std.mem.indexOf(u8, content, "\"type\":\"setup\"") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "\"mpf_hash\":\"hash123\"") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "\"type\":\"refer\"") != null);
-    try testing.expect(std.mem.indexOf(u8, content, "\"constraint_id\":\"c-1\"") != null);
+    const line = try serializeTraceEvent(testing.allocator, event);
+    defer testing.allocator.free(line);
+    try testing.expect(std.mem.indexOf(u8, line, "\"prompt_id\"") == null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"constraint_id\"") == null);
 }

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -2,10 +2,25 @@ const std = @import("std");
 const testing = std.testing;
 const lib = @import("clumsies_lib");
 const protocol = @import("protocol.zig");
+const ws_config = @import("../workspace_config.zig");
 
 const encoding = lib.encoding;
 const trace = lib.trace;
 const workspace_prompt = lib.workspace_prompt;
+
+pub const Session = struct {
+    ws_id: []const u8,
+    session_id: [32]u8,
+    event_counter: std.atomic.Value(i64) = std.atomic.Value(i64).init(0),
+
+    pub fn deinit(self: *Session, allocator: std.mem.Allocator) void {
+        allocator.free(self.ws_id);
+    }
+
+    pub fn nextEventId(self: *Session) i64 {
+        return self.event_counter.fetchAdd(1, .monotonic);
+    }
+};
 
 pub fn buildInitializeResult(allocator: std.mem.Allocator, version: []const u8) ![]u8 {
     const esc_version = try encoding.jsonEscapeAlloc(allocator, version);
@@ -50,7 +65,12 @@ const tool_refer =
     "{\"name\":\"memory.refer\",\"title\":\"Refer\",\"description\":\"Declare constraint references from loaded prompts. Pass an array of refs, each with promptId and optional constraintId.\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"refs\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"promptId\":{\"type\":\"string\"},\"promptHash\":{\"type\":\"string\"},\"constraintId\":{\"type\":\"string\"},\"reason\":{\"type\":\"string\"}},\"required\":[\"promptId\"]}}},\"required\":[\"refs\"],\"additionalProperties\":false}}";
 
-pub fn handleToolCall(allocator: std.mem.Allocator, workspace_root: []const u8, params: std.json.Value) ![]u8 {
+pub fn handleToolCall(
+    allocator: std.mem.Allocator,
+    workspace_root: []const u8,
+    session_ptr: *?Session,
+    params: std.json.Value,
+) ![]u8 {
     const params_obj = switch (params) {
         .object => |obj| obj,
         else => return error.InvalidParams,
@@ -68,28 +88,73 @@ pub fn handleToolCall(allocator: std.mem.Allocator, workspace_root: []const u8, 
     };
 
     if (std.mem.eql(u8, name, "memory.setup")) {
-        return try handleSetup(allocator, workspace_root, args_obj);
+        return try handleSetup(allocator, workspace_root, session_ptr, args_obj);
     }
     if (std.mem.eql(u8, name, "memory.search")) {
-        return try handleSearch(allocator, workspace_root, args_obj);
+        return try handleSearch(allocator, workspace_root, session_ptr, args_obj);
     }
     if (std.mem.eql(u8, name, "memory.load")) {
-        return handleLoad(allocator, workspace_root, args_obj) catch |err| switch (err) {
+        return handleLoad(allocator, workspace_root, session_ptr, args_obj) catch |err| switch (err) {
             error.UnknownPromptId => try buildToolErrorResult(allocator, "Unknown prompt id"),
             else => return err,
         };
     }
 
     if (std.mem.eql(u8, name, "memory.refer")) {
-        return try handleRefer(allocator, workspace_root, args_obj);
+        return try handleRefer(allocator, session_ptr, args_obj);
     }
 
     return try buildToolErrorResult(allocator, "Unknown tool");
 }
 
+fn initSession(allocator: std.mem.Allocator, workspace_root: []const u8) !Session {
+    const binding = try ws_config.resolveWorkspace(allocator, workspace_root);
+    defer allocator.free(binding.name);
+
+    var rand_bytes: [16]u8 = undefined;
+    std.crypto.random.bytes(&rand_bytes);
+    var session_id: [32]u8 = undefined;
+    const hex = "0123456789abcdef";
+    for (rand_bytes, 0..) |byte, i| {
+        session_id[i * 2] = hex[byte >> 4];
+        session_id[i * 2 + 1] = hex[byte & 0x0f];
+    }
+
+    return .{
+        .ws_id = binding.ws_id,
+        .session_id = session_id,
+        .event_counter = std.atomic.Value(i64).init(0),
+    };
+}
+
+fn writeTraceEvent(
+    allocator: std.mem.Allocator,
+    session_ptr: *?Session,
+    event_type: []const u8,
+    prompt_id: ?[]const u8,
+    prompt_hash: ?[]const u8,
+    constraint_id: ?[]const u8,
+    reason: ?[]const u8,
+) void {
+    const session = &(session_ptr.* orelse return);
+    const event_id = session.nextEventId();
+    trace.appendTraceEvent(allocator, .{
+        .ws_id = session.ws_id,
+        .session_id = session.session_id[0..],
+        .event_id = event_id,
+        .type = event_type,
+        .timestamp = std.time.milliTimestamp(),
+        .prompt_id = prompt_id,
+        .prompt_hash = prompt_hash,
+        .constraint_id = constraint_id,
+        .reason = reason,
+    }) catch {};
+}
+
 fn handleSetup(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
+    session_ptr: *?Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const known_hash: ?[]const u8 = if (args_obj.get("knownHash")) |value| switch (value) {
@@ -97,18 +162,20 @@ fn handleSetup(
         else => null,
     } else null;
 
+    if (session_ptr.* == null) {
+        session_ptr.* = initSession(allocator, workspace_root) catch |err| switch (err) {
+            error.NoWorkspaceFound, error.NoConfigFound => return try buildToolErrorResult(allocator, "Workspace is not bound. Run 'clumsies init' to bind this directory to a workspace."),
+            else => return err,
+        };
+    }
+
     var mpf = try workspace_prompt.loadMpf(allocator, workspace_root, known_hash);
     defer mpf.deinit(allocator);
 
-    const ws_id = try trace.workspaceId(allocator, workspace_root);
-    defer allocator.free(ws_id);
+    writeTraceEvent(allocator, session_ptr, "setup", null, mpf.hash, null, null);
 
-    try trace.appendTraceEvent(allocator, workspace_root, .{
-        .event_type = .setup,
-        .mpf_hash = mpf.hash,
-    });
-
-    const esc_ws = try encoding.jsonEscapeAlloc(allocator, ws_id);
+    const session = &session_ptr.*.?;
+    const esc_ws = try encoding.jsonEscapeAlloc(allocator, session.ws_id);
     defer allocator.free(esc_ws);
 
     if (mpf.content) |content| {
@@ -135,6 +202,7 @@ fn handleSetup(
 fn handleSearch(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
+    session_ptr: *?Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const kind = if (args_obj.get("kind")) |value|
@@ -149,12 +217,7 @@ fn handleSearch(
     var items = try workspace_prompt.discoverSearchable(allocator, workspace_root, kind, group);
     defer workspace_prompt.deinitPromptItems(allocator, &items);
 
-    // Trace: search event
-    const ws_id = try trace.workspaceId(allocator, workspace_root);
-    defer allocator.free(ws_id);
-    try trace.appendTraceEvent(allocator, workspace_root, .{
-        .event_type = .search,
-    });
+    writeTraceEvent(allocator, session_ptr, "search", null, null, null, null);
 
     const structured = try serializePromptList(allocator, items.items);
     defer allocator.free(structured);
@@ -164,6 +227,7 @@ fn handleSearch(
 fn handleLoad(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
+    session_ptr: *?Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     var ids = try parseRequiredIds(allocator, args_obj.get("ids"));
@@ -176,21 +240,17 @@ fn handleLoad(
     defer result.deinit(allocator);
 
     for (result.items.items) |item| {
-        try trace.appendTraceEvent(allocator, workspace_root, .{
-            .event_type = .load,
-            .prompt_id = item.id,
-            .prompt_hash = item.hash,
-        });
+        writeTraceEvent(allocator, session_ptr, "load", item.id, item.hash, null, null);
     }
 
-    const structured = try serializeLoadResultWithConstraints(allocator, &result, workspace_root);
+    const structured = try serializeLoadResultWithConstraints(allocator, &result, session_ptr);
     defer allocator.free(structured);
     return try buildToolSuccessResult(allocator, structured);
 }
 
 fn handleRefer(
     allocator: std.mem.Allocator,
-    workspace_root: []const u8,
+    session_ptr: *?Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const refs_val = args_obj.get("refs") orelse return error.InvalidParams;
@@ -228,13 +288,7 @@ fn handleRefer(
             else => null,
         } else null;
 
-        try trace.appendTraceEvent(allocator, workspace_root, .{
-            .event_type = .refer,
-            .prompt_id = prompt_id,
-            .prompt_hash = prompt_hash,
-            .constraint_id = constraint_id,
-            .reason = reason,
-        });
+        writeTraceEvent(allocator, session_ptr, "refer", prompt_id, prompt_hash, constraint_id, reason);
         count += 1;
     }
 
@@ -279,13 +333,15 @@ fn serializePromptList(allocator: std.mem.Allocator, items: []const workspace_pr
     return try buf.toOwnedSlice(allocator);
 }
 
-fn serializeLoadResultWithConstraints(allocator: std.mem.Allocator, result: *workspace_prompt.LoadResult, workspace_root: []const u8) ![]u8 {
+fn serializeLoadResultWithConstraints(
+    allocator: std.mem.Allocator,
+    result: *workspace_prompt.LoadResult,
+    session_ptr: *?Session,
+) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
 
-    const ws_id = try trace.workspaceId(allocator, workspace_root);
-    defer allocator.free(ws_id);
-
+    const ws_id: []const u8 = if (session_ptr.*) |s| s.ws_id else "";
     const esc_ws = try encoding.jsonEscapeAlloc(allocator, ws_id);
     defer allocator.free(esc_ws);
 
@@ -293,15 +349,12 @@ fn serializeLoadResultWithConstraints(allocator: std.mem.Allocator, result: *wor
     for (result.items.items, 0..) |item, idx| {
         if (idx > 0) try buf.append(allocator, ',');
 
-        // For Rule/Workflow with content, parse constraints first so we can
-        // include them in both the refer reminder and the JSON output
         if ((item.kind == .rule or item.kind == .workflow) and item.content != null) {
             var parsed = try workspace_prompt.parseConstraints(allocator, item.content.?);
             defer parsed.deinit(allocator);
 
             try appendLoadedPromptWithConstraints(allocator, &buf, item, parsed.constraints.items);
 
-            // Reopen the item JSON to append constraints array
             if (buf.items.len > 0 and buf.items[buf.items.len - 1] == '}') {
                 buf.items.len -= 1;
             }
@@ -375,7 +428,6 @@ fn appendLoadedPromptWithConstraints(
     if (item.content) |content| {
         const needs_reminder = item.kind == .rule or item.kind == .workflow;
         if (needs_reminder) {
-            // Build constraint list for the reminder
             var constraint_list_buf: std.ArrayList(u8) = .empty;
             defer constraint_list_buf.deinit(allocator);
             for (constraints) |c| {
@@ -477,7 +529,6 @@ test "buildToolsListResult: exposes all memory tools" {
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.load\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.refer\"") != null);
 
-    // Removed tools should NOT be present
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.begin\"") == null);
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.complete\"") == null);
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.startup\"") == null);
@@ -485,62 +536,17 @@ test "buildToolsListResult: exposes all memory tools" {
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.activate\"") == null);
 }
 
-test "handleToolCall: memory.setup returns mpf content" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    try tmp.dir.makePath(".prompts");
-    const file = try tmp.dir.createFile(".prompts/META_PROMPT.md", .{});
-    defer file.close();
-    var tw_buf1: [4096]u8 = undefined;
-    var tw1 = std.fs.File.Writer.init(file, &tw_buf1);
-    defer tw1.interface.flush() catch {};
-    try tw1.interface.writeAll("bootstrap content");
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root = tmp.dir.realpath(".", &buf) catch return error.RealPathFailed;
-
-    const params = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"memory.setup\",\"arguments\":{}}", .{});
-    defer params.deinit();
-
-    const result = try handleToolCall(testing.allocator, root, params.value);
-    defer testing.allocator.free(result);
-
-    try testing.expect(std.mem.indexOf(u8, result, "\"workspaceId\":\"ws-") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "bootstrap content") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"hash\":\"") != null);
-}
-
-test "handleToolCall: memory.setup returns null when no mpf" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    try tmp.dir.makePath(".prompts");
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root = tmp.dir.realpath(".", &buf) catch return error.RealPathFailed;
-
-    const params = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"memory.setup\",\"arguments\":{}}", .{});
-    defer params.deinit();
-
-    const result = try handleToolCall(testing.allocator, root, params.value);
-    defer testing.allocator.free(result);
-
-    try testing.expect(std.mem.indexOf(u8, result, "\"workspaceId\":\"ws-") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"mpf\":null") != null);
-}
-
-test "handleToolCall: memory.search returns rule metadata" {
+test "handleToolCall: memory.search returns rule metadata without session" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try tmp.dir.makePath(".prompts/rule/coding");
     const file = try tmp.dir.createFile(".prompts/rule/coding/00_COMPAT.md", .{});
     defer file.close();
-    var tw_buf2: [4096]u8 = undefined;
-    var tw2 = std.fs.File.Writer.init(file, &tw_buf2);
-    defer tw2.interface.flush() catch {};
-    try tw2.interface.writeAll("compat rule");
+    var tw_buf: [4096]u8 = undefined;
+    var tw = std.fs.File.Writer.init(file, &tw_buf);
+    defer tw.interface.flush() catch {};
+    try tw.interface.writeAll("compat rule");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmp.dir.realpath(".", &buf) catch return error.RealPathFailed;
@@ -548,24 +554,27 @@ test "handleToolCall: memory.search returns rule metadata" {
     const params = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"memory.search\",\"arguments\":{\"kind\":\"rule\"}}", .{});
     defer params.deinit();
 
-    const result = try handleToolCall(testing.allocator, root, params.value);
+    var session: ?Session = null;
+    defer if (session) |*s| s.deinit(testing.allocator);
+
+    const result = try handleToolCall(testing.allocator, root, &session, params.value);
     defer testing.allocator.free(result);
 
     try testing.expect(std.mem.indexOf(u8, result, "\"rule:coding/00_COMPAT.md\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"group\":\"coding\"") != null);
 }
 
-test "handleToolCall: memory.load returns content" {
+test "handleToolCall: memory.load returns content without session" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try tmp.dir.makePath(".prompts/rule");
     const file = try tmp.dir.createFile(".prompts/rule/00_STYLE.md", .{});
     defer file.close();
-    var tw_buf3: [4096]u8 = undefined;
-    var tw3 = std.fs.File.Writer.init(file, &tw_buf3);
-    defer tw3.interface.flush() catch {};
-    try tw3.interface.writeAll("style content");
+    var tw_buf: [4096]u8 = undefined;
+    var tw = std.fs.File.Writer.init(file, &tw_buf);
+    defer tw.interface.flush() catch {};
+    try tw.interface.writeAll("style content");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmp.dir.realpath(".", &buf) catch return error.RealPathFailed;
@@ -573,9 +582,39 @@ test "handleToolCall: memory.load returns content" {
     const params = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"memory.load\",\"arguments\":{\"ids\":[\"rule:00_STYLE.md\"]}}", .{});
     defer params.deinit();
 
-    const result = try handleToolCall(testing.allocator, root, params.value);
+    var session: ?Session = null;
+    defer if (session) |*s| s.deinit(testing.allocator);
+
+    const result = try handleToolCall(testing.allocator, root, &session, params.value);
     defer testing.allocator.free(result);
 
     try testing.expect(std.mem.indexOf(u8, result, "style content") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"changed\":true") != null);
+}
+
+test "handleToolCall: memory.setup returns structured error when no workspace binding" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath(".prompts");
+    const file = try tmp.dir.createFile(".prompts/META_PROMPT.md", .{});
+    defer file.close();
+    var tw_buf: [4096]u8 = undefined;
+    var tw = std.fs.File.Writer.init(file, &tw_buf);
+    defer tw.interface.flush() catch {};
+    try tw.interface.writeAll("bootstrap content");
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmp.dir.realpath(".", &buf) catch return error.RealPathFailed;
+
+    const params = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"name\":\"memory.setup\",\"arguments\":{}}", .{});
+    defer params.deinit();
+
+    var session: ?Session = null;
+    defer if (session) |*s| s.deinit(testing.allocator);
+
+    const result = try handleToolCall(testing.allocator, root, &session, params.value);
+    defer testing.allocator.free(result);
+
+    try testing.expect(std.mem.indexOf(u8, result, "\"isError\":true") != null);
 }

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -136,7 +136,8 @@ fn writeTraceEvent(
     constraint_id: ?[]const u8,
     reason: ?[]const u8,
 ) void {
-    const session = &(session_ptr.* orelse return);
+    if (session_ptr.* == null) return;
+    const session = &session_ptr.*.?;
     const event_id = session.nextEventId();
     trace.appendTraceEvent(allocator, .{
         .ws_id = session.ws_id,
@@ -148,7 +149,12 @@ fn writeTraceEvent(
         .prompt_hash = prompt_hash,
         .constraint_id = constraint_id,
         .reason = reason,
-    }) catch {};
+    }) catch |err| {
+        std.log.err(
+            "failed to append trace event type='{s}' session_id='{s}': {}",
+            .{ event_type, session.session_id[0..], err },
+        );
+    };
 }
 
 fn handleSetup(

--- a/src/mcp/server.zig
+++ b/src/mcp/server.zig
@@ -5,8 +5,13 @@ const handlers = @import("handlers.zig");
 
 pub const State = struct {
     workspace_root: []const u8,
+    session: ?handlers.Session = null,
     initialized: bool = false,
     initialize_seen: bool = false,
+
+    pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
+        if (self.session) |*s| s.deinit(allocator);
+    }
 };
 
 pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, version: []const u8) !void {
@@ -21,6 +26,7 @@ pub fn runWithRoot(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: st
     var state: State = .{
         .workspace_root = workspace_root,
     };
+    defer state.deinit(allocator);
 
     var stdin_buffer: [4096]u8 = undefined;
     var stdin_reader = std.fs.File.Reader.init(std.fs.File.stdin(), &stdin_buffer);
@@ -97,7 +103,7 @@ fn processMessage(allocator: std.mem.Allocator, state: *State, version: []const 
     }
 
     if (std.mem.eql(u8, method, "tools/call")) {
-        const result = handlers.handleToolCall(allocator, state.workspace_root, params) catch |err| switch (err) {
+        const result = handlers.handleToolCall(allocator, state.workspace_root, &state.session, params) catch |err| switch (err) {
             error.InvalidParams => return try protocol.buildErrorAlloc(allocator, id.?, .invalid_params, "Invalid tool arguments"),
             else => return err,
         };

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -8,7 +8,7 @@ pub const ROLES = [_][]const u8{ "maintainer", "member" };
 pub const WS_MEMBER_ROLES = [_][]const u8{ "member", "admin" };
 pub const PROMPT_PR_STATUSES = [_][]const u8{ "open", "accepted", "rejected" };
 pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "closed", "conflict" };
-pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "begin", "refer", "refer", "complete" };
+pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "refer", "refer" };
 
 // Counts for reset mode
 pub const USER_COUNT: usize = 8;

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -7,7 +7,7 @@ pub const ORG_NAME = "acme";
 pub const ROLES = [_][]const u8{ "maintainer", "member" };
 pub const WS_MEMBER_ROLES = [_][]const u8{ "member", "admin" };
 pub const PROMPT_PR_STATUSES = [_][]const u8{ "open", "accepted", "rejected" };
-pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "closed", "conflict" };
+pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "rejected", "conflicted" };
 pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "refer", "refer" };
 
 // Counts for reset mode
@@ -27,5 +27,4 @@ pub const CAP_PROMPT_PR_COMMENTS: i64 = 500;
 pub const CAP_PROMPT_PRS: i64 = 200;
 pub const CAP_CONTEXT_PRS: i64 = 200;
 pub const CAP_CONTEXT_FILES: i64 = 500;
-pub const CAP_CONTEXT_BRANCHES: i64 = 100;
 pub const CLEANUP_INTERVAL: u64 = 100;

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -7,7 +7,7 @@ pub const ORG_NAME = "acme";
 pub const ROLES = [_][]const u8{ "maintainer", "member" };
 pub const WS_MEMBER_ROLES = [_][]const u8{ "member", "admin" };
 pub const PROMPT_PR_STATUSES = [_][]const u8{ "open", "accepted", "rejected" };
-pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "rejected", "conflicted" };
+pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "rejected" };
 pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "refer", "refer" };
 
 // Counts for reset mode

--- a/src/seed/faker.zig
+++ b/src/seed/faker.zig
@@ -121,19 +121,15 @@ const WORKFLOW_NAMES = [_][]const u8{
     "CODE_REVIEW", "DEPLOY",  "ROLLBACK",       "INCIDENT_RESPONSE",
 };
 
-pub fn promptCanonicalName(self: *Self, buf: *[80]u8) []const u8 {
+pub fn promptPath(self: *Self, buf: *[80]u8) []const u8 {
     if (self.chance(70)) {
         const group = self.pick([]const u8, &RULE_GROUPS);
         const name = self.pick([]const u8, &RULE_NAMES);
-        return std.fmt.bufPrint(buf, "rule/{s}/{s}", .{ group, name }) catch "rule/coding/STYLE";
+        return std.fmt.bufPrint(buf, "rule/{s}/{s}.md", .{ group, name }) catch "rule/coding/STYLE.md";
     } else {
         const name = self.pick([]const u8, &WORKFLOW_NAMES);
-        return std.fmt.bufPrint(buf, "workflow/{s}", .{name}) catch "workflow/CODING";
+        return std.fmt.bufPrint(buf, "workflow/{s}.md", .{name}) catch "workflow/CODING.md";
     }
-}
-
-pub fn promptKind(self: *Self) []const u8 {
-    return if (self.chance(70)) "rule" else "workflow";
 }
 
 const RULE_CONTENT_TEMPLATES = [_][]const u8{

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -135,25 +135,18 @@ fn contextFileEdit(faker: *Faker, conn: *pg.Conn) void {
         row.deinit() catch {};
     }
 
-    var branch_buf: [40]u8 = undefined;
-    const branch = faker.branchName(&branch_buf);
-
-    _ = conn.exec(
-        "INSERT INTO context_branches (ws_id, branch_name, base_revision, revision) VALUES ($1, $2, 0, 1) ON CONFLICT (ws_id, branch_name) DO UPDATE SET revision = context_branches.revision + 1",
-        .{ ws_id, branch },
-    ) catch |err| {
-        log.warn("pump: {}", .{err});
-    };
-
     var path_buf: [80]u8 = undefined;
     const path = faker.contextPath(&path_buf);
     var content_buf: [256]u8 = undefined;
     const content = faker.contextContent(&content_buf);
+    var cid_buf: [24]u8 = undefined;
+    const cid = faker.hexId(&cid_buf, "ctx-");
 
     _ = conn.exec(
-        "INSERT INTO context_files (ws_id, branch_name, path, content, content_hash, author) VALUES ($1, $2, $3, $4, md5($4), $5) ON CONFLICT (ws_id, branch_name, path) DO UPDATE SET content = $4, content_hash = md5($4), updated_at = now()",
-        .{ ws_id, branch, path, content, author },
-    ) catch |err| {
+        \\INSERT INTO context_files (context_id, ws_id, path, content, content_hash, author)
+        \\VALUES ($1, $2, $3, $4, md5($4), $5)
+        \\ON CONFLICT (ws_id, path) DO UPDATE SET content = $4, content_hash = md5($4), author = $5, updated_at = now()
+    , .{ cid, ws_id, path, content, author }) catch |err| {
         log.warn("pump: {}", .{err});
     };
 }
@@ -350,15 +343,8 @@ fn cleanup(conn: *pg.Conn) void {
     };
 
     _ = conn.exec(
-        "DELETE FROM context_files WHERE (ws_id, branch_name, path) IN (SELECT ws_id, branch_name, path FROM context_files ORDER BY updated_at ASC LIMIT GREATEST(0, (SELECT count(*) FROM context_files) - $1))",
+        "DELETE FROM context_files WHERE context_id IN (SELECT context_id FROM context_files ORDER BY updated_at ASC LIMIT GREATEST(0, (SELECT count(*) FROM context_files) - $1))",
         .{data.CAP_CONTEXT_FILES},
-    ) catch |err| {
-        log.warn("pump: {}", .{err});
-    };
-
-    _ = conn.exec(
-        "DELETE FROM context_branches WHERE (ws_id, branch_name) IN (SELECT ws_id, branch_name FROM context_branches WHERE branch_name != 'main' ORDER BY created_at ASC LIMIT GREATEST(0, (SELECT count(*) FROM context_branches) - $1))",
-        .{data.CAP_CONTEXT_BRANCHES},
     ) catch |err| {
         log.warn("pump: {}", .{err});
     };

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -96,7 +96,7 @@ fn traceSession(faker: *Faker, conn: *pg.Conn) void {
     var session_buf: [24]u8 = undefined;
     const session_id = faker.hexId(&session_buf, "ses-");
 
-    const events = [_][]const u8{ "setup", "begin", "refer", "refer", "complete" };
+    const events = [_][]const u8{ "setup", "refer", "refer" };
     for (events, 0..) |event_type, ei| {
         const prompt_id: ?[]const u8 = if (std.mem.eql(u8, event_type, "refer"))
             prompt_ids[ei % prompt_count]
@@ -233,12 +233,12 @@ fn reviewComment(faker: *Faker, conn: *pg.Conn) void {
 fn openPromptPr(faker: *Faker, conn: *pg.Conn) void {
     var pid_buf: [64]u8 = undefined;
     var hash_buf: [64]u8 = undefined;
-    var kind_buf: [16]u8 = undefined;
+    var path_buf: [96]u8 = undefined;
     var prompt_id: []const u8 = undefined;
     var base_hash: []const u8 = undefined;
-    var kind: []const u8 = undefined;
+    var path: []const u8 = undefined;
     {
-        var row = (conn.row("SELECT prompt_id, content_hash, kind FROM prompts ORDER BY random() LIMIT 1", .{}) catch return) orelse return;
+        var row = (conn.row("SELECT prompt_id, content_hash, path FROM prompts ORDER BY random() LIMIT 1", .{}) catch return) orelse return;
         prompt_id = copyRowStr(&pid_buf, &row, 0) orelse {
             row.deinit() catch {};
             return;
@@ -247,7 +247,7 @@ fn openPromptPr(faker: *Faker, conn: *pg.Conn) void {
             row.deinit() catch {};
             return;
         };
-        kind = copyRowStr(&kind_buf, &row, 2) orelse {
+        path = copyRowStr(&path_buf, &row, 2) orelse {
             row.deinit() catch {};
             return;
         };
@@ -268,13 +268,22 @@ fn openPromptPr(faker: *Faker, conn: *pg.Conn) void {
     var id_buf: [24]u8 = undefined;
     const pr_id = faker.hexId(&id_buf, "ppr-");
     const desc = faker.prDescription();
+    const kind: []const u8 = if (std.mem.startsWith(u8, path, "rule/")) "rule" else "workflow";
     var content_buf: [512]u8 = undefined;
     const content = faker.promptContent(&content_buf, kind, "Proposed Update");
 
     _ = conn.exec(
-        "INSERT INTO prompt_prs (pr_id, org_id, prompt_id, author_id, base_hash, content, description, status) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, 'open')",
-        .{ pr_id, data.ORG_ID, prompt_id, author_id, base_hash, content, desc },
+        "INSERT INTO prompt_prs (pr_id, org_id, author_id, description, status) VALUES ($1, $2::uuid, $3, $4, 'open')",
+        .{ pr_id, data.ORG_ID, author_id, desc },
     ) catch |err| {
+        log.warn("pump: {}", .{err});
+        return;
+    };
+
+    _ = conn.exec(
+        \\INSERT INTO prompt_pr_operations (pr_id, op_index, type, prompt_id, base_hash, content, path)
+        \\VALUES ($1, 0, 'modify', $2, $3, $4, NULL)
+    , .{ pr_id, prompt_id, base_hash, content }) catch |err| {
         log.warn("pump: {}", .{err});
     };
 }

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -51,7 +51,7 @@ pub fn run(pool: *pg.Pool) !void {
     log.info("truncating all tables...", .{});
     _ = conn.exec(
         \\TRUNCATE orgs, users, tokens, workspaces, workspace_members, prompts, workspace_prompts,
-        \\  context_branches, context_files, context_prs, context_pr_files, context_pr_comments,
+        \\  context_files, context_prs, context_pr_operations, context_pr_comments,
         \\  bundles, bundle_prompts, prompt_prs, prompt_pr_operations, prompt_pr_comments,
         \\  trace_events, library_manifest, prompt_history
         \\CASCADE
@@ -69,7 +69,6 @@ pub fn run(pool: *pg.Pool) !void {
     try seedWorkspaces(conn, &faker, &state);
     try seedWorkspacePrompts(conn, &faker, &state);
     try seedWorkspaceMembers(conn, &faker, &state);
-    try seedContextBranches(conn, &faker, &state);
     try seedContextFiles(conn, &faker, &state);
     try seedContextPrs(conn, &faker, &state);
     try seedPromptPrs(conn, &faker, &state);
@@ -368,38 +367,10 @@ fn seedWorkspaceMembers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void 
     }
 }
 
-fn seedContextBranches(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
-    log.info("seeding context branches...", .{});
-
-    for (0..state.ws_count) |wi| {
-        // Every workspace gets a main branch
-        _ = conn.exec(
-            "INSERT INTO context_branches (ws_id, branch_name, base_revision, revision) VALUES ($1, 'main', 0, $2) ON CONFLICT DO NOTHING",
-            .{ state.wsId(wi), faker.intRange(i32, 1, 5) },
-        ) catch |err| {
-            log.warn("seed: {}", .{err});
-        };
-
-        // 1-2 feature branches
-        const branch_count = faker.intRange(usize, 1, 3);
-        for (0..branch_count) |_| {
-            var name_buf: [40]u8 = undefined;
-            const branch_name = faker.branchName(&name_buf);
-            _ = conn.exec(
-                "INSERT INTO context_branches (ws_id, branch_name, base_revision, revision) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING",
-                .{ state.wsId(wi), branch_name, faker.intRange(i32, 0, 3), faker.intRange(i32, 1, 6) },
-            ) catch |err| {
-                log.warn("seed: {}", .{err});
-            };
-        }
-    }
-}
-
 fn seedContextFiles(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding context files...", .{});
 
     for (0..state.ws_count) |wi| {
-        // 2-4 files on main
         const file_count = faker.intRange(usize, 2, 5);
         for (0..file_count) |_| {
             var path_buf: [80]u8 = undefined;
@@ -408,9 +379,12 @@ fn seedContextFiles(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
             const content = faker.contextContent(&content_buf);
             const author = state.user_names[faker.intRange(usize, 0, state.user_count)];
 
+            var cid_buf: [24]u8 = undefined;
+            const cid = faker.hexId(&cid_buf, "ctx-");
+
             _ = conn.exec(
-                "INSERT INTO context_files (ws_id, branch_name, path, content, content_hash, author) VALUES ($1, 'main', $2, $3, md5($3), $4) ON CONFLICT DO NOTHING",
-                .{ state.wsId(wi), path, content, author },
+                "INSERT INTO context_files (context_id, ws_id, path, content, content_hash, author) VALUES ($1, $2, $3, $4, md5($4), $5) ON CONFLICT DO NOTHING",
+                .{ cid, state.wsId(wi), path, content, author },
             ) catch |err| {
                 log.warn("seed: {}", .{err});
             };
@@ -426,32 +400,31 @@ fn seedContextPrs(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
         const pr_id = faker.hexId(&id_buf, "cpr-");
         const wi = faker.intRange(usize, 0, state.ws_count);
         const author = state.user_names[faker.intRange(usize, 0, state.user_count)];
-        var branch_buf: [40]u8 = undefined;
-        const branch = faker.branchName(&branch_buf);
         const desc = faker.prDescription();
         const status = faker.pick([]const u8, &data.CONTEXT_PR_STATUSES);
 
         _ = conn.exec(
-            "INSERT INTO context_prs (pr_id, ws_id, author, branch_name, description, status) VALUES ($1, $2, $3, $4, $5, $6)",
-            .{ pr_id, state.wsId(wi), author, branch, desc, status },
+            "INSERT INTO context_prs (pr_id, ws_id, author, description, status) VALUES ($1, $2, $3, $4, $5)",
+            .{ pr_id, state.wsId(wi), author, desc, status },
         ) catch |err| {
             log.warn("seed: {}", .{err});
+            continue;
         };
 
-        // 1-3 files per PR
-        const file_count = faker.intRange(usize, 1, 4);
-        for (0..file_count) |_| {
+        const op_count = faker.intRange(usize, 1, 4);
+        for (0..op_count) |opi| {
             var path_buf: [80]u8 = undefined;
             const path = faker.contextPath(&path_buf);
+            var content_buf: [256]u8 = undefined;
+            const new_content = faker.contextContent(&content_buf);
             _ = conn.exec(
-                "INSERT INTO context_pr_files (pr_id, path) VALUES ($1, $2) ON CONFLICT DO NOTHING",
-                .{ pr_id, path },
-            ) catch |err| {
+                \\INSERT INTO context_pr_operations (pr_id, op_index, type, context_id, base_hash, content, path)
+                \\VALUES ($1, $2, 'create', NULL, NULL, $3, $4)
+            , .{ pr_id, @as(i32, @intCast(opi)), new_content, path }) catch |err| {
                 log.warn("seed: {}", .{err});
             };
         }
 
-        // 0-3 comments per PR
         const comment_count = faker.intRange(usize, 0, 4);
         for (0..comment_count) |_| {
             var cmt_id_buf: [24]u8 = undefined;

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -14,7 +14,8 @@ const SeedState = struct {
 
     prompt_ids: [data.PROMPT_COUNT][24]u8 = undefined,
     prompt_hashes: [data.PROMPT_COUNT][24]u8 = undefined,
-    prompt_kinds: [data.PROMPT_COUNT][]const u8 = undefined,
+    prompt_paths: [data.PROMPT_COUNT][80]u8 = undefined,
+    prompt_path_lens: [data.PROMPT_COUNT]usize = .{0} ** data.PROMPT_COUNT,
     prompt_count: usize = 0,
 
     bundle_ids: [data.BUNDLE_COUNT][24]u8 = undefined,
@@ -51,7 +52,7 @@ pub fn run(pool: *pg.Pool) !void {
     _ = conn.exec(
         \\TRUNCATE orgs, users, tokens, workspaces, workspace_members, prompts, workspace_prompts,
         \\  context_branches, context_files, context_prs, context_pr_files, context_pr_comments,
-        \\  bundles, bundle_prompts, prompt_prs, prompt_pr_comments,
+        \\  bundles, bundle_prompts, prompt_prs, prompt_pr_operations, prompt_pr_comments,
         \\  trace_events, library_manifest, prompt_history
         \\CASCADE
     , .{}) catch |err| {
@@ -131,42 +132,36 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 fn seedPrompts(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding {d} prompts...", .{data.PROMPT_COUNT});
 
-    var used_names: [data.PROMPT_COUNT][80]u8 = undefined;
-    var used_name_lens: [data.PROMPT_COUNT]usize = .{0} ** data.PROMPT_COUNT;
-    var used_count: usize = 0;
-
     for (0..data.PROMPT_COUNT) |i| {
         const id = faker.hexId(&state.prompt_ids[i], "p-");
         const hash = faker.hexId(&state.prompt_hashes[i], "sha256:");
 
-        // Generate unique canonical_name
-        var name_buf: [80]u8 = undefined;
-        var canonical_name: []const u8 = undefined;
+        var path_buf: [80]u8 = undefined;
+        var path: []const u8 = undefined;
         var attempts: usize = 0;
         while (attempts < 50) : (attempts += 1) {
-            canonical_name = faker.promptCanonicalName(&name_buf);
+            path = faker.promptPath(&path_buf);
             var duplicate = false;
-            for (0..used_count) |j| {
-                if (std.mem.eql(u8, used_names[j][0..used_name_lens[j]], canonical_name)) {
+            for (0..state.prompt_count) |j| {
+                if (std.mem.eql(u8, state.prompt_paths[j][0..state.prompt_path_lens[j]], path)) {
                     duplicate = true;
                     break;
                 }
             }
             if (!duplicate) break;
         }
-        @memcpy(used_names[used_count][0..canonical_name.len], canonical_name);
-        used_name_lens[used_count] = canonical_name.len;
-        used_count += 1;
+        @memcpy(state.prompt_paths[i][0..path.len], path);
+        state.prompt_path_lens[i] = path.len;
+        const stable_path = state.prompt_paths[i][0..path.len];
 
-        const kind = faker.promptKind();
-        state.prompt_kinds[i] = kind;
+        const kind: []const u8 = if (std.mem.startsWith(u8, stable_path, "rule/")) "rule" else "workflow";
 
         var content_buf: [512]u8 = undefined;
-        const content = faker.promptContent(&content_buf, kind, canonical_name);
+        const content = faker.promptContent(&content_buf, kind, stable_path);
 
         _ = conn.exec(
-            "INSERT INTO prompts (prompt_id, org_id, canonical_name, kind, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5, $6)",
-            .{ id, data.ORG_ID, canonical_name, kind, content, hash },
+            "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5)",
+            .{ id, data.ORG_ID, stable_path, content, hash },
         ) catch |err| {
             log.warn("prompt insert failed: {}", .{err});
             continue;
@@ -247,7 +242,6 @@ fn seedLibraryManifest(conn: *pg.Conn) !void {
 fn seedPromptHistory(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding prompt history...", .{});
 
-    // Give ~40% of prompts 1-3 history entries
     for (0..state.prompt_count) |i| {
         if (!faker.chance(40)) continue;
 
@@ -260,10 +254,11 @@ fn seedPromptHistory(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
             var content_buf: [256]u8 = undefined;
             const content = std.fmt.bufPrint(&content_buf, "# Historical version {d}\n\nPrevious version of this prompt.", .{h + 1}) catch "# History";
+            const path = state.prompt_paths[i][0..state.prompt_path_lens[i]];
 
             _ = conn.exec(
-                "INSERT INTO prompt_history (prompt_id, content_hash, content, merged_at) VALUES ($1, $2, $3, now() - $4::interval) ON CONFLICT DO NOTHING",
-                .{ state.promptId(i), hash, content, interval },
+                "INSERT INTO prompt_history (prompt_id, content_hash, path, content, merged_at) VALUES ($1, $2, $3, $4, now() - $5::interval) ON CONFLICT DO NOTHING",
+                .{ state.promptId(i), hash, path, content, interval },
             ) catch |err| {
                 log.warn("seed: {}", .{err});
             };
@@ -481,22 +476,30 @@ fn seedPromptPrs(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
         var id_buf: [24]u8 = undefined;
         const pr_id = faker.hexId(&id_buf, "ppr-");
         const pi = faker.intRange(usize, 0, state.prompt_count);
-        // Only non-maintainer members create prompt PRs (index >= 2)
         const author_idx = faker.intRange(usize, 2, state.user_count);
         const desc = faker.prDescription();
         const status = faker.pick([]const u8, &data.PROMPT_PR_STATUSES);
 
+        _ = conn.exec(
+            "INSERT INTO prompt_prs (pr_id, org_id, author_id, description, status) VALUES ($1, $2::uuid, $3, $4, $5)",
+            .{ pr_id, data.ORG_ID, state.userId(author_idx), desc, status },
+        ) catch |err| {
+            log.warn("seed: {}", .{err});
+            continue;
+        };
+
         var content_buf: [512]u8 = undefined;
-        const content = faker.promptContent(&content_buf, state.prompt_kinds[pi], "Updated Version");
+        const path = state.prompt_paths[pi][0..state.prompt_path_lens[pi]];
+        const kind: []const u8 = if (std.mem.startsWith(u8, path, "rule/")) "rule" else "workflow";
+        const content = faker.promptContent(&content_buf, kind, "Updated Version");
 
         _ = conn.exec(
-            "INSERT INTO prompt_prs (pr_id, org_id, prompt_id, author_id, base_hash, content, description, status) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8)",
-            .{ pr_id, data.ORG_ID, state.promptId(pi), state.userId(author_idx), state.promptHash(pi), content, desc, status },
-        ) catch |err| {
+            \\INSERT INTO prompt_pr_operations (pr_id, op_index, type, prompt_id, base_hash, content, path)
+            \\VALUES ($1, 0, 'modify', $2, $3, $4, NULL)
+        , .{ pr_id, state.promptId(pi), state.promptHash(pi), content }) catch |err| {
             log.warn("seed: {}", .{err});
         };
 
-        // 0-3 review comments
         const comment_count = faker.intRange(usize, 0, 4);
         for (0..comment_count) |_| {
             var cmt_id_buf: [24]u8 = undefined;

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -37,9 +37,21 @@ assert_json() {
     fi
 }
 
-# Seed database with test org and maintainer user
+# Seed database with test org and maintainer user. Uses a local psql
+# if available, otherwise falls back to the docker-compose postgres container.
+run_psql() {
+    if command -v psql >/dev/null 2>&1; then
+        PGPASSWORD=clumsies psql -h 127.0.0.1 -U clumsies -d clumsies -q
+    elif docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^clumsies-postgres-1$'; then
+        docker exec -i -e PGPASSWORD=clumsies clumsies-postgres-1 psql -U clumsies -d clumsies -q
+    else
+        echo "FATAL: neither psql nor clumsies-postgres-1 container is available" >&2
+        return 1
+    fi
+}
+
 seed_db() {
-    PGPASSWORD=clumsies psql -h 127.0.0.1 -U clumsies -d clumsies -q <<'SQL'
+    run_psql <<'SQL'
 INSERT INTO orgs (org_id, name) VALUES ('a0000000-0000-0000-0000-000000000001', 'acme')
   ON CONFLICT DO NOTHING;
 INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUES
@@ -50,11 +62,11 @@ INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUE
   ON CONFLICT DO NOTHING;
 INSERT INTO library_manifest (org_id, revision) VALUES ('a0000000-0000-0000-0000-000000000001', 0)
   ON CONFLICT DO NOTHING;
-INSERT INTO prompts (prompt_id, org_id, canonical_name, kind, content, content_hash) VALUES
-  ('p-test-001', 'a0000000-0000-0000-0000-000000000001', 'coding/STYLE', 'rule', '# STYLE', 'sha256:abc123')
+INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+  ('p-test-001', 'a0000000-0000-0000-0000-000000000001', 'rule/coding/STYLE.md', '# STYLE', 'sha256:abc123')
   ON CONFLICT DO NOTHING;
-INSERT INTO prompts (prompt_id, org_id, canonical_name, kind, content, content_hash) VALUES
-  ('p-test-002', 'a0000000-0000-0000-0000-000000000001', 'cmd/COMMIT', 'workflow', '# COMMIT', 'sha256:def456')
+INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+  ('p-test-002', 'a0000000-0000-0000-0000-000000000001', 'workflow/cmd/COMMIT.md', '# COMMIT', 'sha256:def456')
   ON CONFLICT DO NOTHING;
 SQL
 }
@@ -182,13 +194,97 @@ step "Library: list prompts"
 RAW=$(call GET "/api/org/library/prompts")
 parse_response "$RAW"
 assert_status "list prompts" "200" "$STATUS"
-assert_json "contains STYLE" "STYLE" "$BODY"
+assert_json "contains STYLE path" "rule/coding/STYLE.md" "$BODY"
+assert_json "returns path field" '"path":' "$BODY"
+
+step "Library: get prompt by prompt_id"
+RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-001")
+parse_response "$RAW"
+assert_status "get by prompt_id" "200" "$STATUS"
+assert_json "contains path" "rule/coding/STYLE.md" "$BODY"
+
+step "Library: get prompt by path"
+RAW=$(call GET "/api/org/library/prompt?path=rule/coding/STYLE.md")
+parse_response "$RAW"
+assert_status "get by path" "200" "$STATUS"
+assert_json "contains prompt_id" "p-test-001" "$BODY"
+
+step "Library: get prompt content by prompt_id"
+RAW=$(call GET "/api/org/library/prompt/content?prompt_id=p-test-001")
+parse_response "$RAW"
+assert_status "get content" "200" "$STATUS"
+assert_json "contains body" "STYLE" "$BODY"
 
 step "Library: manifest"
 RAW=$(call GET "/api/org/library/manifest")
 parse_response "$RAW"
 assert_status "get manifest" "200" "$STATUS"
 assert_json "contains revision" "revision" "$BODY"
+
+# Prompt PRs (multi-operation model)
+step "Prompt PR: create with modify operation"
+RAW=$(call POST "/api/org/prompt-prs" '{"description":"Tighten STYLE rules","operations":[{"type":"modify","prompt_id":"p-test-001","base_hash":"sha256:abc123","content":"# STYLE\n\nTightened."}]}')
+parse_response "$RAW"
+assert_status "create prompt PR" "201" "$STATUS"
+assert_json "returns proposal_id" "proposal_id" "$BODY"
+assert_json "status open" "open" "$BODY"
+PPR_ID=$(echo "$BODY" | grep -o '"proposal_id":"[^"]*"' | cut -d'"' -f4)
+
+step "Prompt PR: reject empty operations"
+RAW=$(call POST "/api/org/prompt-prs" '{"description":"empty","operations":[]}')
+parse_response "$RAW"
+assert_status "empty ops rejected" "400" "$STATUS"
+
+step "Prompt PR: reject stale base_hash"
+RAW=$(call POST "/api/org/prompt-prs" '{"description":"stale","operations":[{"type":"modify","prompt_id":"p-test-001","base_hash":"sha256:wrong","content":"x"}]}')
+parse_response "$RAW"
+assert_status "stale base_hash 409" "409" "$STATUS"
+
+step "Prompt PR: list"
+RAW=$(call GET "/api/org/prompt-prs")
+parse_response "$RAW"
+assert_status "list prompt PRs" "200" "$STATUS"
+assert_json "contains PR" "$PPR_ID" "$BODY"
+
+step "Prompt PR: get detail"
+RAW=$(call GET "/api/org/prompt-prs/$PPR_ID")
+parse_response "$RAW"
+assert_status "get prompt PR" "200" "$STATUS"
+assert_json "has operations" "operations" "$BODY"
+assert_json "operation type modify" '"type":"modify"' "$BODY"
+
+step "Prompt PR: accept as maintainer"
+RAW=$(call PUT "/api/org/prompt-prs/$PPR_ID" '{"action":"accept"}')
+parse_response "$RAW"
+assert_status "accept prompt PR" "200" "$STATUS"
+assert_json "status accepted" "accepted" "$BODY"
+
+step "Prompt PR: library now reflects merged content"
+RAW=$(call GET "/api/org/library/prompt/content?prompt_id=p-test-001")
+parse_response "$RAW"
+assert_status "get updated content" "200" "$STATUS"
+assert_json "contains Tightened" "Tightened" "$BODY"
+
+step "Prompt PR: create with rename operation"
+# First get current hash of p-test-002
+RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-002")
+parse_response "$RAW"
+P002_HASH=$(echo "$BODY" | grep -o '"content_hash":"[^"]*"' | cut -d'"' -f4)
+RAW=$(call POST "/api/org/prompt-prs" "{\"description\":\"Relocate COMMIT\",\"operations\":[{\"type\":\"rename\",\"prompt_id\":\"p-test-002\",\"base_hash\":\"$P002_HASH\",\"new_path\":\"workflow/git/COMMIT.md\"}]}")
+parse_response "$RAW"
+assert_status "create rename PR" "201" "$STATUS"
+RENAME_PR_ID=$(echo "$BODY" | grep -o '"proposal_id":"[^"]*"' | cut -d'"' -f4)
+
+step "Prompt PR: accept rename"
+RAW=$(call PUT "/api/org/prompt-prs/$RENAME_PR_ID" '{"action":"accept"}')
+parse_response "$RAW"
+assert_status "accept rename" "200" "$STATUS"
+
+step "Prompt PR: path updated, prompt_id preserved"
+RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-002")
+parse_response "$RAW"
+assert_status "get by id after rename" "200" "$STATUS"
+assert_json "path is new" "workflow/git/COMMIT.md" "$BODY"
 
 # Bundles
 step "Bundle: create"
@@ -320,54 +416,25 @@ RAW=$(call POST "/api/workspaces/$CTX_WS/members" '{"user_id":"usr-member-001","
 parse_response "$RAW"
 assert_status "add bob to context ws" "201" "$STATUS"
 
-step "Context: list branches (empty)"
-RAW=$(call GET "/api/workspaces/$CTX_WS/context/branches")
-parse_response "$RAW"
-assert_status "list branches" "200" "$STATUS"
-assert_json "returns branches array" "branches" "$BODY"
-
-step "Context: write file (creates member branch)"
-RAW=$(curl -s -w "\n%{http_code}" -X PUT "$BASE/api/workspaces/$CTX_WS/context/file?path=spec/API.md" \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "Content-Type: application/octet-stream" \
-    -d "# API Design")
-parse_response "$RAW"
-assert_status "write context file" "200" "$STATUS"
-assert_json "returns branch name" "alice" "$BODY"
-assert_json "returns path" "spec/API.md" "$BODY"
-assert_json "returns hash" "hash" "$BODY"
-
-step "Context: list files on member branch"
-RAW=$(call GET "/api/workspaces/$CTX_WS/context/files?branch=alice")
-parse_response "$RAW"
-assert_status "list files on branch" "200" "$STATUS"
-assert_json "contains spec/API.md" "spec/API.md" "$BODY"
-
 step "Context: list files on main (empty)"
 RAW=$(call GET "/api/workspaces/$CTX_WS/context/files")
 parse_response "$RAW"
 assert_status "list files on main" "200" "$STATUS"
+assert_json "returns files array" "files" "$BODY"
 
-step "Context: read file content"
-RAW=$(curl -s -w "\n%{http_code}" -X GET "$BASE/api/workspaces/$CTX_WS/context/file/content?path=spec/API.md&branch=alice" \
-    -H "Authorization: Bearer $TOKEN")
-parse_response "$RAW"
-assert_status "read file content" "200" "$STATUS"
-assert_json "content matches" "API Design" "$BODY"
-
-step "Context: read nonexistent file"
-RAW=$(curl -s -w "\n%{http_code}" -X GET "$BASE/api/workspaces/$CTX_WS/context/file/content?path=nope.md&branch=alice" \
-    -H "Authorization: Bearer $TOKEN")
-parse_response "$RAW"
-assert_status "nonexistent file returns 404" "404" "$STATUS"
-
-step "Context: create PR"
-RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs" '{"description":"Add API spec"}')
+step "Context: create PR with create operation"
+RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs" '{"description":"Add API spec","operations":[{"type":"create","path":"spec/API.md","content":"# API Design"}]}')
 parse_response "$RAW"
 assert_status "create context PR" "201" "$STATUS"
 assert_json "returns pr_id" "pr_id" "$BODY"
 assert_json "status is open" "open" "$BODY"
+assert_json "operation_count is 1" "\"operation_count\":1" "$BODY"
 PR_ID=$(echo "$BODY" | grep -o '"pr_id":"[^"]*"' | cut -d'"' -f4)
+
+step "Context: reject PR missing operations"
+RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs" '{"description":"empty","operations":[]}')
+parse_response "$RAW"
+assert_status "empty operations rejected" "400" "$STATUS"
 
 step "Context: list PRs"
 RAW=$(call GET "/api/workspaces/$CTX_WS/context/prs")
@@ -386,7 +453,9 @@ RAW=$(call GET "/api/workspaces/$CTX_WS/context/prs/$PR_ID")
 parse_response "$RAW"
 assert_status "get PR detail" "200" "$STATUS"
 assert_json "has description" "Add API spec" "$BODY"
-assert_json "has files" "spec/API.md" "$BODY"
+assert_json "has operations" "operations" "$BODY"
+assert_json "operation type create" '"type":"create"' "$BODY"
+assert_json "operation path" "spec/API.md" "$BODY"
 
 step "Context: add PR comment"
 RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs/$PR_ID/comments" '{"body":"LGTM"}')
@@ -398,50 +467,68 @@ step "Context: merge PR (maintainer)"
 RAW=$(call PUT "/api/workspaces/$CTX_WS/context/prs/$PR_ID" '{"action":"merge"}')
 parse_response "$RAW"
 assert_status "merge PR" "200" "$STATUS"
-assert_json "merged is true" "true" "$BODY"
+assert_json "status merged" "merged" "$BODY"
 
 step "Context: file now on main after merge"
 RAW=$(call GET "/api/workspaces/$CTX_WS/context/files")
 parse_response "$RAW"
 assert_status "list main after merge" "200" "$STATUS"
 assert_json "main has spec/API.md" "spec/API.md" "$BODY"
+assert_json "file has context_id" "context_id" "$BODY"
+CTX_ID=$(echo "$BODY" | grep -o '"context_id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+step "Context: read file content by path"
+RAW=$(curl -s -w "\n%{http_code}" -X GET "$BASE/api/workspaces/$CTX_WS/context/file/content?path=spec/API.md" \
+    -H "Authorization: Bearer $TOKEN")
+parse_response "$RAW"
+assert_status "read file content by path" "200" "$STATUS"
+assert_json "content matches" "API Design" "$BODY"
+
+step "Context: read file content by context_id"
+RAW=$(curl -s -w "\n%{http_code}" -X GET "$BASE/api/workspaces/$CTX_WS/context/file/content?context_id=$CTX_ID" \
+    -H "Authorization: Bearer $TOKEN")
+parse_response "$RAW"
+assert_status "read by context_id" "200" "$STATUS"
+assert_json "content matches" "API Design" "$BODY"
+
+step "Context: read nonexistent file"
+RAW=$(curl -s -w "\n%{http_code}" -X GET "$BASE/api/workspaces/$CTX_WS/context/file/content?path=nope.md" \
+    -H "Authorization: Bearer $TOKEN")
+parse_response "$RAW"
+assert_status "nonexistent file returns 404" "404" "$STATUS"
 
 step "Context: manifest reflects context"
 RAW=$(call GET "/api/workspaces/$CTX_WS/manifest")
 parse_response "$RAW"
 assert_status "get manifest" "200" "$STATUS"
-assert_json "manifest has context" "spec/API.md" "$BODY"
+
+step "Context: branch endpoint is gone"
+RAW=$(call GET "/api/workspaces/$CTX_WS/context/branches")
+parse_response "$RAW"
+assert_status "branches endpoint 404" "404" "$STATUS"
+
+step "Context: PUT /context/file endpoint is gone"
+RAW=$(curl -s -w "\n%{http_code}" -X PUT "$BASE/api/workspaces/$CTX_WS/context/file?path=x.md" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/octet-stream" \
+    -d "junk")
+parse_response "$RAW"
+assert_status "PUT file endpoint 404" "404" "$STATUS"
 
 step "Context: member cannot merge"
 TOKEN="$BOB_TOKEN"
-# Bob writes a file first
-curl -s -X PUT "$BASE/api/workspaces/$CTX_WS/context/file?path=research/notes.md" \
-    -H "Authorization: Bearer $TOKEN" \
-    -H "Content-Type: application/octet-stream" \
-    -d "# Research Notes" > /dev/null
-RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs" '{"description":"Add research"}')
+RAW=$(call POST "/api/workspaces/$CTX_WS/context/prs" '{"description":"Add research","operations":[{"type":"create","path":"research/notes.md","content":"# Research Notes"}]}')
 parse_response "$RAW"
 BOB_PR_ID=$(echo "$BODY" | grep -o '"pr_id":"[^"]*"' | cut -d'"' -f4)
 RAW=$(call PUT "/api/workspaces/$CTX_WS/context/prs/$BOB_PR_ID" '{"action":"merge"}')
 parse_response "$RAW"
 assert_status "member cannot merge" "403" "$STATUS"
 
-step "Context: rebase branch"
-RAW=$(call POST "/api/workspaces/$CTX_WS/context/branches/bob/rebase")
+step "Context: member can reject own PR"
+RAW=$(call PUT "/api/workspaces/$CTX_WS/context/prs/$BOB_PR_ID" '{"action":"reject"}')
 parse_response "$RAW"
-assert_status "rebase succeeds" "200" "$STATUS"
-assert_json "status is rebased" "rebased" "$BODY"
-
-step "Context: cannot rebase main"
-RAW=$(call POST "/api/workspaces/$CTX_WS/context/branches/main/rebase")
-parse_response "$RAW"
-assert_status "cannot rebase main" "400" "$STATUS"
-
-step "Context: delete file on branch"
-RAW=$(curl -s -w "\n%{http_code}" -X DELETE "$BASE/api/workspaces/$CTX_WS/context/file?path=research/notes.md" \
-    -H "Authorization: Bearer $TOKEN")
-parse_response "$RAW"
-assert_status "delete file" "200" "$STATUS"
+assert_status "member can reject" "200" "$STATUS"
+assert_json "status rejected" "rejected" "$BODY"
 
 # Cleanup: delete context test workspace (as maintainer)
 TOKEN=$(call POST "/api/auth/login" '{"username":"alice","credential":"testpass"}' | sed '$d' | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)


### PR DESCRIPTION
## Summary

Two coordinated refactors bundled together because they both rewrite
the prompts/context schema and the seed module at once.

**Library identity.** prompts and context_files now use a stable
`prompt_id`/`context_id` primary key plus a mutable `path` column.
canonical_name, kind, branch_name, and the server-side long-lived
context branches are removed. Library lookups accept either
`?prompt_id=` or `?path=`, and PR endpoints (POST /api/org/prompt-prs
and POST /api/workspaces/{ws_id}/context/prs) take an operations
array containing modify/rename/create/delete entries. The merge
handler applies all operations inside a single transaction; if any
base_hash no longer matches the library, the whole PR rolls back and
the PR is marked conflicted. This promotes rename, batch
reorganization, and file creation to first-class operations, and
replaces the asymmetric "context via server branches, prompts via
local overrides" split with a single client drafts → PR → review →
merge flow on both sides.

**MCP trace format.** Local trace.jsonl is now byte-compatible with
the server's POST /api/traces request body: each line is a complete
TraceEventInput, so an upload worker can pipe lines straight through
without translation. The SHA-256 workspaceId helper is gone — ws_id
comes from `config.toml` via `workspace_config.resolveWorkspace(cwd)`
on the first memory.setup call, returning a structured tool error if
the workspace is not bound. Trace files move from
`~/.clumsies/log/{hash}.jsonl` to
`~/.clumsies/workspaces/{ws_id}/trace.jsonl`, and a `trace.cursor`
file is bootstrapped to `0\n` on first write. MCP gains a Session
struct on the server State holding ws_id, session_id, and an atomic
event_counter, so every search/load/refer write gets a
monotonically-allocated event_id scoped to the MCP process lifetime.

Breaking change: existing databases must be dropped and reseeded.
The project is still pre-release and no migration SQL is provided.
This PR lands the server-side schema and APIs only; the client-side
drafts directory, upload worker, and cc-plugin updates are separate
efforts.

## Test plan

- [x] `zig build && zig build test && zig fmt --check src/` — unit
      tests and formatting pass
- [x] `docker compose up -d postgres`, start `clumsies-hub`, run
      `./test/hub-e2e.sh ./zig-out/bin/clumsies-hub` — full assertion
      suite passes, covering library path/prompt_id lookups, prompt
      PR modify + rename flow, context PR create/merge/reject,
      reading context files by both `context_id` and `path`, and
      regressions that `GET /context/branches`, `PUT /context/file`,
      `DELETE /context/file` and the rebase route all return 404
- [ ] Manual MCP end-to-end with a real workspace binding: run
      `clumsies init` in a sample dir, then `clumsies mcp`, trigger a
      refer, confirm `~/.clumsies/workspaces/{ws_id}/trace.jsonl`
      matches the server TraceEventInput shape byte-for-byte