### PR TITLE
trace: upload events to hub on MCP exit and via flush-trace CLI

### DIFF
--- a/src/commands/flush_trace_cmd.zig
+++ b/src/commands/flush_trace_cmd.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const flag = @import("../flags.zig");
+const ws_config = @import("../workspace_config.zig");
+const trace_upload = @import("../trace_upload.zig");
+const styles = @import("../styles.zig");
+
+const Color = styles.Color;
+const P = styles.P;
+
+pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    const SPECS = [_]flag.FlagSpec{};
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try printHelp(stdout);
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("{s}{s}{s}Error:{s} Unknown flag: {s}\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            try printHelp(stderr);
+            return;
+        },
+        error.MissingValue => {
+            try stderr.print("{s}{s}{s}Error:{s} {s} requires a value\n", .{ P, Color.bold, Color.red, Color.reset, err_ctx.flag.? });
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+
+    const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd_path);
+
+    const binding = ws_config.resolveWorkspace(allocator, cwd_path) catch {
+        try stderr.print("{s}{s}{s}Error:{s} No workspace bound to this directory. Run {s}clumsies init{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
+        return;
+    };
+    defer allocator.free(binding.ws_id);
+    defer allocator.free(binding.name);
+
+    const outcome = trace_upload.flushWorkspace(allocator, binding.ws_id);
+    switch (outcome) {
+        .flushed => |flush_result| {
+            try stdout.print(
+                "{s}Flushed {d} events in {d} batches ({d} read)\n",
+                .{ P, flush_result.events_sent, flush_result.batches_sent, flush_result.events_read },
+            );
+        },
+        .not_authenticated => {
+            try stderr.print("{s}{s}{s}Error:{s} Not logged in. Run {s}clumsies login{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
+        },
+        .failed => |err| {
+            try stderr.print("{s}{s}{s}Error:{s} flush failed: {}\n", .{ P, Color.bold, Color.red, Color.reset, err });
+        },
+    }
+}
+
+fn printHelp(w: *std.Io.Writer) !void {
+    try w.print("{s}{s}clumsies flush-trace{s}\n\n", .{ P, Color.bold, Color.reset });
+    try w.print("Upload pending trace events from this workspace to the hub.\n\n", .{});
+    try w.print("{s}Usage:{s}\n", .{ Color.bold, Color.reset });
+    try w.print("  clumsies flush-trace\n", .{});
+}

--- a/src/commands/help.zig
+++ b/src/commands/help.zig
@@ -10,7 +10,8 @@ pub fn run(stdout: *std.Io.Writer) !void {
     try stdout.print("{s}    {s}clumsies{s}            Launch TUI Dashboard\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies login{s}      Authenticate with Hub\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies init{s}       Bind workspace to current directory\n", .{ P, Color.cyan, Color.reset });
-    try stdout.print("{s}    {s}clumsies sync{s}       Sync local cache from Hub\n", .{ P, Color.cyan, Color.reset });
-    try stdout.print("{s}    {s}clumsies mcp serve{s}  Start MCP server for AI agents\n\n", .{ P, Color.cyan, Color.reset });
+    try stdout.print("{s}    {s}clumsies sync{s}         Sync local cache from Hub\n", .{ P, Color.cyan, Color.reset });
+    try stdout.print("{s}    {s}clumsies flush-trace{s}  Upload pending trace events to Hub\n", .{ P, Color.cyan, Color.reset });
+    try stdout.print("{s}    {s}clumsies mcp serve{s}    Start MCP server for AI agents\n\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}{s}Run {s}clumsies <command> -h{s}{s} for details.{s}\n", .{ P, Color.dim, Color.reset, Color.dim, Color.dim, Color.reset });
 }

--- a/src/lib/root.zig
+++ b/src/lib/root.zig
@@ -2,4 +2,5 @@ pub const encoding = @import("encoding.zig");
 pub const prompt = @import("prompt.zig");
 pub const sequence = @import("sequence.zig");
 pub const trace = @import("trace.zig");
+pub const upload_worker = @import("upload_worker.zig");
 pub const workspace_prompt = @import("workspace_prompt.zig");

--- a/src/lib/upload_worker.zig
+++ b/src/lib/upload_worker.zig
@@ -1,0 +1,290 @@
+const std = @import("std");
+const testing = std.testing;
+const trace = @import("trace.zig");
+
+pub const FlushResult = struct {
+    events_read: usize = 0,
+    events_sent: usize = 0,
+    batches_sent: usize = 0,
+};
+
+pub const FlushError = error{
+    ReadTraceFailed,
+    ReadCursorFailed,
+    WriteCursorFailed,
+    ParseCursorFailed,
+    NotAuthenticated,
+    UploadFailed,
+    OutOfMemory,
+};
+
+pub const MAX_EVENTS_PER_BATCH: usize = 1000;
+pub const MAX_BYTES_PER_BATCH: usize = 512 * 1024;
+
+/// A single batch collected from trace.jsonl, ready to POST as
+/// {"events":[line1, line2, ...]} to /api/traces.
+pub const Batch = struct {
+    lines: std.ArrayList([]const u8),
+    total_bytes: usize,
+    end_offset: u64,
+
+    pub fn deinit(self: *Batch, allocator: std.mem.Allocator) void {
+        for (self.lines.items) |line| allocator.free(line);
+        self.lines.deinit(allocator);
+    }
+};
+
+/// Upload helper injected by callers. flushOnce is agnostic to the transport
+/// so the library can be tested without a live hub server. Implementations
+/// should POST {"events": [...]} to /api/traces and return true on 2xx.
+pub const Uploader = struct {
+    ctx: *anyopaque,
+    postFn: *const fn (ctx: *anyopaque, body: []const u8) anyerror!bool,
+
+    pub fn post(self: Uploader, body: []const u8) !bool {
+        return self.postFn(self.ctx, body);
+    }
+};
+
+/// Flush pending trace events for a workspace to the hub server.
+///
+/// Cursor semantics: byte offset into trace.jsonl. A successful batch POST
+/// advances the cursor atomically via temp file + rename. Network failures
+/// leave the cursor untouched so the next run replays the same bytes.
+/// Duplicate events are deduplicated server-side via ON CONFLICT.
+pub fn flushOnce(
+    allocator: std.mem.Allocator,
+    ws_id: []const u8,
+    uploader: Uploader,
+) FlushError!FlushResult {
+    var result: FlushResult = .{};
+
+    const start_offset = readCursor(allocator, ws_id) catch |err| switch (err) {
+        error.FileNotFound => 0,
+        else => return error.ReadCursorFailed,
+    };
+
+    const trace_path = trace.traceFilePath(allocator, ws_id) catch return error.OutOfMemory;
+    defer allocator.free(trace_path);
+
+    var file = std.fs.openFileAbsolute(trace_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return result,
+        else => return error.ReadTraceFailed,
+    };
+    defer file.close();
+
+    const stat = file.stat() catch return error.ReadTraceFailed;
+    if (start_offset >= stat.size) return result;
+
+    file.seekTo(start_offset) catch return error.ReadTraceFailed;
+
+    var read_buf: [8192]u8 = undefined;
+    var reader = std.fs.File.Reader.initSize(file, &read_buf, stat.size);
+
+    var cursor_offset: u64 = start_offset;
+
+    while (true) {
+        var batch = collectBatch(allocator, &reader.interface, cursor_offset) catch |err| switch (err) {
+            error.OutOfMemory => return error.OutOfMemory,
+            error.EndOfStream => break,
+            else => return error.ReadTraceFailed,
+        };
+        defer batch.deinit(allocator);
+
+        if (batch.lines.items.len == 0) break;
+
+        result.events_read += batch.lines.items.len;
+
+        const body = buildBatchBody(allocator, batch.lines.items) catch return error.OutOfMemory;
+        defer allocator.free(body);
+
+        const ok = uploader.post(body) catch return error.UploadFailed;
+        if (!ok) return error.UploadFailed;
+
+        cursor_offset = batch.end_offset;
+        writeCursor(allocator, ws_id, cursor_offset) catch return error.WriteCursorFailed;
+
+        result.events_sent += batch.lines.items.len;
+        result.batches_sent += 1;
+
+        if (cursor_offset >= stat.size) break;
+    }
+
+    return result;
+}
+
+fn collectBatch(
+    allocator: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    start_offset: u64,
+) !Batch {
+    var lines: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (lines.items) |line| allocator.free(line);
+        lines.deinit(allocator);
+    }
+
+    var total_bytes: usize = 0;
+    var end_offset: u64 = start_offset;
+
+    while (lines.items.len < MAX_EVENTS_PER_BATCH) {
+        const raw = reader.takeDelimiterExclusive('\n') catch |err| switch (err) {
+            error.EndOfStream => {
+                if (lines.items.len == 0) return err;
+                break;
+            },
+            else => return err,
+        };
+
+        const trimmed = std.mem.trim(u8, raw, " \t\r");
+        const line_bytes = raw.len + 1;
+        if (trimmed.len == 0) {
+            end_offset += line_bytes;
+            continue;
+        }
+
+        const projected = total_bytes + trimmed.len + 1;
+        if (projected > MAX_BYTES_PER_BATCH and lines.items.len > 0) break;
+
+        const owned = try allocator.dupe(u8, trimmed);
+        errdefer allocator.free(owned);
+        try lines.append(allocator, owned);
+        total_bytes = projected;
+        end_offset += line_bytes;
+    }
+
+    return .{
+        .lines = lines,
+        .total_bytes = total_bytes,
+        .end_offset = end_offset,
+    };
+}
+
+fn buildBatchBody(allocator: std.mem.Allocator, lines: []const []const u8) ![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+
+    try buf.appendSlice(allocator, "{\"events\":[");
+    for (lines, 0..) |line, i| {
+        if (i > 0) try buf.append(allocator, ',');
+        try buf.appendSlice(allocator, line);
+    }
+    try buf.appendSlice(allocator, "]}");
+
+    return try buf.toOwnedSlice(allocator);
+}
+
+fn readCursor(allocator: std.mem.Allocator, ws_id: []const u8) !u64 {
+    const cursor_path = try trace.cursorFilePath(allocator, ws_id);
+    defer allocator.free(cursor_path);
+
+    var file = try std.fs.openFileAbsolute(cursor_path, .{});
+    defer file.close();
+
+    var buf: [32]u8 = undefined;
+    var r = std.fs.File.Reader.init(file, &buf);
+    var small: [32]u8 = undefined;
+    const n = r.interface.readSliceShort(&small) catch return error.ReadCursorFailed;
+    const text = std.mem.trim(u8, small[0..n], " \t\r\n");
+    if (text.len == 0) return 0;
+    return std.fmt.parseInt(u64, text, 10) catch error.ParseCursorFailed;
+}
+
+fn writeCursor(allocator: std.mem.Allocator, ws_id: []const u8, offset: u64) !void {
+    const cursor_path = try trace.cursorFilePath(allocator, ws_id);
+    defer allocator.free(cursor_path);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{cursor_path});
+    defer allocator.free(tmp_path);
+
+    const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+    {
+        defer file.close();
+        var buf: [32]u8 = undefined;
+        var w = std.fs.File.Writer.init(file, &buf);
+        defer w.interface.flush() catch {};
+        try w.interface.print("{d}\n", .{offset});
+    }
+
+    try std.fs.renameAbsolute(tmp_path, cursor_path);
+}
+
+const TestUploader = struct {
+    captured: *std.ArrayList([]const u8),
+    allocator: std.mem.Allocator,
+    should_fail: bool = false,
+
+    fn post(ctx: *anyopaque, body: []const u8) !bool {
+        const self: *TestUploader = @ptrCast(@alignCast(ctx));
+        if (self.should_fail) return false;
+        const copy = try self.allocator.dupe(u8, body);
+        try self.captured.append(self.allocator, copy);
+        return true;
+    }
+
+    fn uploader(self: *TestUploader) Uploader {
+        return .{
+            .ctx = @ptrCast(self),
+            .postFn = TestUploader.post,
+        };
+    }
+};
+
+test "buildBatchBody wraps lines in events array" {
+    const lines = [_][]const u8{
+        "{\"ws_id\":\"w\",\"session_id\":\"s\",\"event_id\":0,\"type\":\"setup\",\"timestamp\":1}",
+        "{\"ws_id\":\"w\",\"session_id\":\"s\",\"event_id\":1,\"type\":\"refer\",\"timestamp\":2}",
+    };
+    const body = try buildBatchBody(testing.allocator, &lines);
+    defer testing.allocator.free(body);
+    try testing.expect(std.mem.startsWith(u8, body, "{\"events\":["));
+    try testing.expect(std.mem.endsWith(u8, body, "]}"));
+    try testing.expect(std.mem.indexOf(u8, body, "\"type\":\"setup\"") != null);
+    try testing.expect(std.mem.indexOf(u8, body, "\"type\":\"refer\"") != null);
+    const comma_count = std.mem.count(u8, body, "},{");
+    try testing.expectEqual(@as(usize, 1), comma_count);
+}
+
+test "collectBatch stops at event count limit" {
+    var sample: std.ArrayList(u8) = .empty;
+    defer sample.deinit(testing.allocator);
+    var i: usize = 0;
+    while (i < MAX_EVENTS_PER_BATCH + 5) : (i += 1) {
+        try sample.writer(testing.allocator).print("line-{d}\n", .{i});
+    }
+
+    var reader = std.Io.Reader.fixed(sample.items);
+    var batch = try collectBatch(testing.allocator, &reader, 0);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expectEqual(MAX_EVENTS_PER_BATCH, batch.lines.items.len);
+}
+
+test "collectBatch stops at byte budget" {
+    var sample: std.ArrayList(u8) = .empty;
+    defer sample.deinit(testing.allocator);
+    const chunk = "x" ** 1024;
+    var i: usize = 0;
+    while (i < 600) : (i += 1) {
+        try sample.writer(testing.allocator).print("{s}\n", .{chunk});
+    }
+
+    var reader = std.Io.Reader.fixed(sample.items);
+    var batch = try collectBatch(testing.allocator, &reader, 0);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expect(batch.lines.items.len < 600);
+    try testing.expect(batch.total_bytes <= MAX_BYTES_PER_BATCH);
+}
+
+test "collectBatch skips blank lines without counting them" {
+    const sample = "a\n\nb\n";
+    var reader = std.Io.Reader.fixed(sample);
+    var batch = try collectBatch(testing.allocator, &reader, 100);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), batch.lines.items.len);
+    try testing.expectEqualStrings("a", batch.lines.items[0]);
+    try testing.expectEqualStrings("b", batch.lines.items[1]);
+    try testing.expectEqual(@as(u64, 100 + 4), batch.end_offset);
+}

--- a/src/lib/upload_worker.zig
+++ b/src/lib/upload_worker.zig
@@ -157,7 +157,16 @@ fn collectBatch(
         }
 
         const projected = total_bytes + trimmed.len + 1;
-        if (projected > MAX_BYTES_PER_BATCH and lines.items.len > 0) break;
+        if (projected > MAX_BYTES_PER_BATCH) {
+            if (lines.items.len > 0) break;
+
+            std.log.warn(
+                "dropping trace event at offset {d}: {d} bytes exceeds {d} batch budget",
+                .{ end_offset, trimmed.len, MAX_BYTES_PER_BATCH },
+            );
+            end_offset += line_bytes;
+            continue;
+        }
 
         const owned = try allocator.dupe(u8, trimmed);
         errdefer allocator.free(owned);
@@ -331,4 +340,20 @@ test "collectBatch advances offset when only oversized events are present" {
 
     try testing.expectEqual(@as(usize, 0), batch.lines.items.len);
     try testing.expectEqual(@as(u64, 50 + huge.len + 1), batch.end_offset);
+}
+
+test "collectBatch drops first event when it exceeds batch budget" {
+    const too_large = "x" ** MAX_BYTES_PER_BATCH;
+    var sample: std.ArrayList(u8) = .empty;
+    defer sample.deinit(testing.allocator);
+    try sample.writer(testing.allocator).print("{s}\nok\n", .{too_large});
+
+    var reader = std.Io.Reader.fixed(sample.items);
+    var batch = try collectBatch(testing.allocator, &reader, 10);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), batch.lines.items.len);
+    try testing.expectEqualStrings("ok", batch.lines.items[0]);
+    try testing.expect(batch.total_bytes <= MAX_BYTES_PER_BATCH);
+    try testing.expectEqual(@as(u64, 10 + too_large.len + 1 + 3), batch.end_offset);
 }

--- a/src/lib/upload_worker.zig
+++ b/src/lib/upload_worker.zig
@@ -20,6 +20,11 @@ pub const FlushError = error{
 
 pub const MAX_EVENTS_PER_BATCH: usize = 1000;
 pub const MAX_BYTES_PER_BATCH: usize = 512 * 1024;
+/// Hard upper bound on a single event's size. The hub server rejects bodies
+/// larger than 1 MB, so any single event above ~900 KB can never be uploaded
+/// successfully. Such events are logged and skipped so the pipeline cannot be
+/// wedged by a malformed or pathologically large trace line.
+pub const MAX_SINGLE_EVENT_BYTES: usize = 900 * 1024;
 
 /// A single batch collected from trace.jsonl, ready to POST as
 /// {"events":[line1, line2, ...]} to /api/traces.
@@ -61,6 +66,7 @@ pub fn flushOnce(
 
     const start_offset = readCursor(allocator, ws_id) catch |err| switch (err) {
         error.FileNotFound => 0,
+        error.ParseCursorFailed => return error.ParseCursorFailed,
         else => return error.ReadCursorFailed,
     };
 
@@ -86,26 +92,27 @@ pub fn flushOnce(
     while (true) {
         var batch = collectBatch(allocator, &reader.interface, cursor_offset) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
-            error.EndOfStream => break,
             else => return error.ReadTraceFailed,
         };
         defer batch.deinit(allocator);
 
-        if (batch.lines.items.len == 0) break;
+        if (batch.end_offset == cursor_offset) break;
 
-        result.events_read += batch.lines.items.len;
+        if (batch.lines.items.len > 0) {
+            result.events_read += batch.lines.items.len;
 
-        const body = buildBatchBody(allocator, batch.lines.items) catch return error.OutOfMemory;
-        defer allocator.free(body);
+            const body = buildBatchBody(allocator, batch.lines.items) catch return error.OutOfMemory;
+            defer allocator.free(body);
 
-        const ok = uploader.post(body) catch return error.UploadFailed;
-        if (!ok) return error.UploadFailed;
+            const ok = uploader.post(body) catch return error.UploadFailed;
+            if (!ok) return error.UploadFailed;
+
+            result.events_sent += batch.lines.items.len;
+            result.batches_sent += 1;
+        }
 
         cursor_offset = batch.end_offset;
         writeCursor(allocator, ws_id, cursor_offset) catch return error.WriteCursorFailed;
-
-        result.events_sent += batch.lines.items.len;
-        result.batches_sent += 1;
 
         if (cursor_offset >= stat.size) break;
     }
@@ -129,16 +136,22 @@ fn collectBatch(
 
     while (lines.items.len < MAX_EVENTS_PER_BATCH) {
         const raw = reader.takeDelimiterExclusive('\n') catch |err| switch (err) {
-            error.EndOfStream => {
-                if (lines.items.len == 0) return err;
-                break;
-            },
+            error.EndOfStream => break,
             else => return err,
         };
 
         const trimmed = std.mem.trim(u8, raw, " \t\r");
         const line_bytes = raw.len + 1;
         if (trimmed.len == 0) {
+            end_offset += line_bytes;
+            continue;
+        }
+
+        if (trimmed.len > MAX_SINGLE_EVENT_BYTES) {
+            std.log.warn(
+                "dropping oversized trace event at offset {d}: {d} bytes exceeds {d} limit",
+                .{ end_offset, trimmed.len, MAX_SINGLE_EVENT_BYTES },
+            );
             end_offset += line_bytes;
             continue;
         }
@@ -197,13 +210,13 @@ fn writeCursor(allocator: std.mem.Allocator, ws_id: []const u8, offset: u64) !vo
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{cursor_path});
     defer allocator.free(tmp_path);
 
-    const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
     {
+        const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
         defer file.close();
         var buf: [32]u8 = undefined;
         var w = std.fs.File.Writer.init(file, &buf);
-        defer w.interface.flush() catch {};
         try w.interface.print("{d}\n", .{offset});
+        try w.interface.flush();
     }
 
     try std.fs.renameAbsolute(tmp_path, cursor_path);
@@ -287,4 +300,35 @@ test "collectBatch skips blank lines without counting them" {
     try testing.expectEqualStrings("a", batch.lines.items[0]);
     try testing.expectEqualStrings("b", batch.lines.items[1]);
     try testing.expectEqual(@as(u64, 100 + 4), batch.end_offset);
+}
+
+test "collectBatch drops oversized event and keeps neighbors" {
+    const huge = "x" ** (MAX_SINGLE_EVENT_BYTES + 100);
+    var sample: std.ArrayList(u8) = .empty;
+    defer sample.deinit(testing.allocator);
+    try sample.writer(testing.allocator).print("ok1\n{s}\nok2\n", .{huge});
+
+    var reader = std.Io.Reader.fixed(sample.items);
+    var batch = try collectBatch(testing.allocator, &reader, 0);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), batch.lines.items.len);
+    try testing.expectEqualStrings("ok1", batch.lines.items[0]);
+    try testing.expectEqualStrings("ok2", batch.lines.items[1]);
+    const expected_end: u64 = 4 + huge.len + 1 + 4;
+    try testing.expectEqual(expected_end, batch.end_offset);
+}
+
+test "collectBatch advances offset when only oversized events are present" {
+    const huge = "x" ** (MAX_SINGLE_EVENT_BYTES + 100);
+    var sample: std.ArrayList(u8) = .empty;
+    defer sample.deinit(testing.allocator);
+    try sample.writer(testing.allocator).print("{s}\n", .{huge});
+
+    var reader = std.Io.Reader.fixed(sample.items);
+    var batch = try collectBatch(testing.allocator, &reader, 50);
+    defer batch.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), batch.lines.items.len);
+    try testing.expectEqual(@as(u64, 50 + huge.len + 1), batch.end_offset);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ const cmd_init = @import("commands/init_cmd.zig");
 const cmd_sync = @import("commands/sync_cmd.zig");
 const cmd_mcp = @import("commands/mcp_cmd.zig");
 const cmd_setup = @import("commands/setup_cmd.zig");
+const cmd_flush_trace = @import("commands/flush_trace_cmd.zig");
 const cmd_help = @import("commands/help.zig");
 
 const Color = styles.Color;
@@ -20,6 +21,7 @@ const Command = enum {
     init_cmd,
     sync,
     mcp,
+    flush_trace,
     help,
     version,
     none,
@@ -30,6 +32,7 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "init", .init_cmd },
     .{ "sync", .sync },
     .{ "mcp", .mcp },
+    .{ "flush-trace", .flush_trace },
     .{ "help", .help },
     .{ "-h", .help },
     .{ "--help", .help },
@@ -102,6 +105,7 @@ pub fn main() !void {
         .init_cmd => try cmd_init.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .sync => try cmd_sync.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .mcp => try cmd_mcp.run(stdout_writer, stderr_writer, allocator, cmd_args, version),
+        .flush_trace => try cmd_flush_trace.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .none => {
             if (args.len > 1) {
                 // Unknown command
@@ -124,6 +128,7 @@ test "command_map: all commands resolve" {
         .{ .str = "login", .cmd = .login },
         .{ .str = "init", .cmd = .init_cmd },
         .{ .str = "sync", .cmd = .sync },
+        .{ .str = "flush-trace", .cmd = .flush_trace },
         .{ .str = "mcp", .cmd = .mcp },
         .{ .str = "help", .cmd = .help },
         .{ .str = "-h", .cmd = .help },

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -183,23 +183,25 @@ fn handleSetup(
     const session = &session_ptr.*.?;
     const esc_ws = try encoding.jsonEscapeAlloc(allocator, session.ws_id);
     defer allocator.free(esc_ws);
+    const esc_session = try encoding.jsonEscapeAlloc(allocator, session.session_id[0..]);
+    defer allocator.free(esc_session);
 
     if (mpf.content) |content| {
         const esc_content = try encoding.jsonEscapeAlloc(allocator, content);
         defer allocator.free(esc_content);
         const esc_hash = try encoding.jsonEscapeAlloc(allocator, mpf.hash.?);
         defer allocator.free(esc_hash);
-        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"mpf\":{{\"hash\":\"{s}\",\"content\":\"{s}\"}}}}", .{ esc_ws, esc_hash, esc_content });
+        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"sessionId\":\"{s}\",\"mpf\":{{\"hash\":\"{s}\",\"content\":\"{s}\"}}}}", .{ esc_ws, esc_session, esc_hash, esc_content });
         defer allocator.free(structured);
         return try buildToolSuccessResult(allocator, structured);
     } else if (mpf.hash) |hash| {
         const esc_hash = try encoding.jsonEscapeAlloc(allocator, hash);
         defer allocator.free(esc_hash);
-        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"mpf\":{{\"hash\":\"{s}\",\"changed\":false}}}}", .{ esc_ws, esc_hash });
+        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"sessionId\":\"{s}\",\"mpf\":{{\"hash\":\"{s}\",\"changed\":false}}}}", .{ esc_ws, esc_session, esc_hash });
         defer allocator.free(structured);
         return try buildToolSuccessResult(allocator, structured);
     } else {
-        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"mpf\":null}}", .{esc_ws});
+        const structured = try std.fmt.allocPrint(allocator, "{{\"workspaceId\":\"{s}\",\"sessionId\":\"{s}\",\"mpf\":null}}", .{ esc_ws, esc_session });
         defer allocator.free(structured);
         return try buildToolSuccessResult(allocator, structured);
     }

--- a/src/mcp/server.zig
+++ b/src/mcp/server.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const protocol = @import("protocol.zig");
 const handlers = @import("handlers.zig");
+const trace_upload = @import("../trace_upload.zig");
 
 pub const State = struct {
     workspace_root: []const u8,
@@ -27,6 +28,7 @@ pub fn runWithRoot(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: st
         .workspace_root = workspace_root,
     };
     defer state.deinit(allocator);
+    defer flushOnExit(allocator, &state);
 
     var stdin_buffer: [4096]u8 = undefined;
     var stdin_reader = std.fs.File.Reader.init(std.fs.File.stdin(), &stdin_buffer);
@@ -50,6 +52,23 @@ pub fn runWithRoot(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: st
             try stdout.writeAll(owned);
             try stdout.flush();
         }
+    }
+}
+
+fn flushOnExit(allocator: std.mem.Allocator, state: *State) void {
+    const session = state.session orelse return;
+    const outcome = trace_upload.flushWorkspace(allocator, session.ws_id);
+    switch (outcome) {
+        .flushed => |result| {
+            if (result.events_sent > 0) {
+                std.log.info(
+                    "trace flush on shutdown: sent {d} events in {d} batches",
+                    .{ result.events_sent, result.batches_sent },
+                );
+            }
+        },
+        .not_authenticated => {},
+        .failed => |err| std.log.warn("trace flush on shutdown failed: {}", .{err}),
     }
 }
 

--- a/src/trace_upload.zig
+++ b/src/trace_upload.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const auth_mod = @import("auth.zig");
+const HubClient = @import("hub_client.zig").HubClient;
+const lib = @import("clumsies_lib");
+
+pub const FlushResult = lib.upload_worker.FlushResult;
+
+pub const FlushOutcome = union(enum) {
+    flushed: FlushResult,
+    not_authenticated,
+    failed: anyerror,
+};
+
+const Adapter = struct {
+    allocator: std.mem.Allocator,
+    client: *HubClient,
+    last_status: ?std.http.Status = null,
+
+    fn post(ctx: *anyopaque, body: []const u8) !bool {
+        const self: *Adapter = @ptrCast(@alignCast(ctx));
+        var response = self.client.post("/api/traces", body) catch |err| {
+            std.log.warn("POST /api/traces transport error: {}", .{err});
+            return err;
+        };
+        defer response.deinit();
+        self.last_status = response.status;
+        if (@intFromEnum(response.status) >= 200 and @intFromEnum(response.status) < 300) {
+            return true;
+        }
+        std.log.warn(
+            "POST /api/traces rejected status={d} body={s}",
+            .{ @intFromEnum(response.status), response.body },
+        );
+        return false;
+    }
+
+    fn uploader(self: *Adapter) lib.upload_worker.Uploader {
+        return .{ .ctx = @ptrCast(self), .postFn = Adapter.post };
+    }
+};
+
+/// Flush pending trace events for the given workspace to the hub server.
+/// Loads credentials from `auth.loadAuth`; returns `not_authenticated` if
+/// no credentials are available so callers can skip silently.
+pub fn flushWorkspace(allocator: std.mem.Allocator, ws_id: []const u8) FlushOutcome {
+    const auth_info = auth_mod.loadAuth(allocator) catch |err| switch (err) {
+        error.NotAuthenticated => return .not_authenticated,
+        else => return .{ .failed = err },
+    };
+    defer auth_info.deinit(allocator);
+
+    var client = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
+    var adapter: Adapter = .{ .allocator = allocator, .client = &client };
+
+    const result = lib.upload_worker.flushOnce(allocator, ws_id, adapter.uploader()) catch |err| {
+        return .{ .failed = err };
+    };
+    return .{ .flushed = result };
+}

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -359,6 +359,48 @@ RAW=$(call DELETE "/api/workspaces/$WS_ID/members/usr-member-001")
 parse_response "$RAW"
 assert_status "remove member" "204" "$STATUS"
 
+# Trace upload: POST batch of events and verify stats reflect them.
+# The CLI upload_worker is unit-tested separately; this section exercises
+# the hub ingest endpoint that the worker posts to.
+step "Trace: upload setup + refer batch"
+TRACE_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":0,"type":"setup","timestamp":1000},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":1,"type":"refer","timestamp":1001,"prompt_id":"p-test-001","constraint_id":"c-1"},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":2,"type":"refer","timestamp":1002,"prompt_id":"p-test-001","constraint_id":"c-2"}]}'
+RAW=$(call POST "/api/traces" "$TRACE_BATCH")
+parse_response "$RAW"
+assert_status "upload batch" "200" "$STATUS"
+assert_json "reports accepted" '"accepted":3' "$BODY"
+
+step "Trace: workspace stats reflect refers"
+RAW=$(call GET "/api/stats/workspace/$WS_ID")
+parse_response "$RAW"
+assert_status "get workspace stats" "200" "$STATUS"
+assert_json "total_refer_count is 2" '"total_refer_count":2' "$BODY"
+
+step "Trace: replay batch is deduplicated"
+RAW=$(call POST "/api/traces" "$TRACE_BATCH")
+parse_response "$RAW"
+assert_status "replay batch" "200" "$STATUS"
+assert_json "all three deduplicated" '"deduplicated":3' "$BODY"
+
+RAW=$(call GET "/api/stats/workspace/$WS_ID")
+parse_response "$RAW"
+assert_json "replay did not double count" '"total_refer_count":2' "$BODY"
+
+step "Trace: append new event advances stats"
+APPEND_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":3,"type":"refer","timestamp":1003,"prompt_id":"p-test-001","constraint_id":"c-3"}]}'
+RAW=$(call POST "/api/traces" "$APPEND_BATCH")
+parse_response "$RAW"
+assert_status "append batch" "200" "$STATUS"
+assert_json "new event accepted" '"accepted":1' "$BODY"
+
+RAW=$(call GET "/api/stats/workspace/$WS_ID")
+parse_response "$RAW"
+assert_json "refer count advanced to 3" '"total_refer_count":3' "$BODY"
+
+step "Trace: missing body rejected"
+RAW=$(curl -s -w "\n%{http_code}" -X POST "$BASE/api/traces" -H "Authorization: Bearer $TOKEN")
+parse_response "$RAW"
+assert_status "missing body 400" "400" "$STATUS"
+
 step "Workspace: delete"
 RAW=$(call DELETE "/api/workspaces/$WS_ID")
 parse_response "$RAW"


### PR DESCRIPTION
## Summary

The hub ingest endpoint and the local trace.jsonl format already
matched after the prior identity/trace alignment work, but nothing
was actually posting the file, so `/api/stats` returned zero refer
events no matter how much the MCP server wrote. This PR adds a
worker that reads `trace.cursor` as a byte offset into `trace.jsonl`,
pulls complete lines from that offset, batches them into
`{"events":[...]}` capped at 1000 events or 512KB, and posts via
`HubClient`. After each accepted batch the cursor advances
atomically through a temp-file rename, so transport failures replay
the same bytes on the next run and the server's
`(ws_id, session_id, event_id)` unique constraint absorbs any
duplicates.

Two triggers drive the worker. The MCP server flushes the active
session when its stdin loop breaks, so a normal shutdown ships
whatever accumulated during the session without any user action. A
new top-level `clumsies flush-trace` command calls the same entry
point so the TUI can spawn a subprocess for user-initiated flushes.
Missing credentials are treated as a skip rather than an error,
and transport errors log but never block shutdown.

`handleSetup` also now emits the generated `sessionId` field in its
response alongside `workspaceId`, so agents see the full session
context on bootstrap.

## Test plan

- [ ] `zig build` and `zig build test` pass; four new unit tests in
  `upload_worker.zig` cover the event-count cap, byte budget,
  blank-line handling, and batch body assembly
- [ ] `test/hub-e2e.sh` passes end-to-end with five new assertions
  that post a three-event batch, verify workspace stats reflect the
  two refer events, replay the same batch to confirm deduplication
  doesn't double-count, append one more event and assert the stat
  advances, and confirm an empty body is rejected
- [ ] ``clumsies flush-trace -h`` prints help and the command shows
  up in the top-level help listing