### PR TITLE
mcp: switch to cache-backed prompts with hub-issued ids and capture session input

### DIFF
--- a/cc-plugin/hooks/hooks.json
+++ b/cc-plugin/hooks/hooks.json
@@ -11,6 +11,17 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/user-prompt-submit.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/cc-plugin/scripts/resolve-binary.sh
+++ b/cc-plugin/scripts/resolve-binary.sh
@@ -1,21 +1,13 @@
 #!/usr/bin/env bash
 # Shared preamble for clumsies CC plugin hooks.
 # Source this file, don't execute it directly.
-# Exports: $CLUMSIES (binary path), $PROMPTS_DIR (.prompts/ path)
-# Exits 0 silently if clumsies or .prompts/ not found.
+# Exports: $CLUMSIES (binary path), $PROJECT_DIR
+# Exits 0 silently if the clumsies binary is not installed.
 
 set -euo pipefail
 
-# Resolve project directory
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-# Check .prompts/ exists
-PROMPTS_DIR="$PROJECT_DIR/.prompts"
-if [ ! -d "$PROMPTS_DIR" ]; then
-  exit 0
-fi
-
-# Resolve clumsies binary
 if command -v clumsies &>/dev/null; then
   CLUMSIES="clumsies"
 elif [ -x "$HOME/.clumsies/bin/clumsies" ]; then
@@ -24,4 +16,4 @@ else
   exit 0
 fi
 
-export CLUMSIES PROMPTS_DIR PROJECT_DIR
+export CLUMSIES PROJECT_DIR

--- a/cc-plugin/scripts/session-start.sh
+++ b/cc-plugin/scripts/session-start.sh
@@ -13,11 +13,18 @@ if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
   echo "export CLAUDE_PROJECT_DIR=\"$PROJECT_DIR\"" >> "$CLAUDE_ENV_FILE"
 fi
 
-# 2. Auto-generate workflow skills
-SKILLS_DIR="$PROJECT_DIR/.claude/skills"
-WORKFLOW_DIR="$PROMPTS_DIR/workflow"
+# 2. Resolve workspace binding to locate the cache directory
+WS_INFO=$("$CLUMSIES" _agent workspace-info 2>/dev/null || true)
+WS_ID=""
+CACHE_DIR=""
+if [ -n "$WS_INFO" ]; then
+  eval "$WS_INFO"
+fi
 
-if [ -d "$WORKFLOW_DIR" ]; then
+# 3. Auto-generate workflow skills from cache/workflow/ when bound
+SKILLS_DIR="$PROJECT_DIR/.claude/skills"
+if [ -n "${CACHE_DIR:-}" ] && [ -d "$CACHE_DIR/workflow" ]; then
+  WORKFLOW_DIR="$CACHE_DIR/workflow"
   find "$WORKFLOW_DIR" -name '*.md' -type f | while read -r filepath; do
     filename="$(basename "$filepath")"
     slug="$(echo "$filename" | sed 's/^[0-9]*_//; s/\.md$//; s/_/-/g' | tr '[:upper:]' '[:lower:]')"
@@ -43,7 +50,7 @@ SKILL
   done
 fi
 
-# 3. Bootstrap: run clumsies _agent setup to output META_PROMPT.md content directly
+# 4. Bootstrap: run clumsies _agent setup to output META_PROMPT.md content directly
 "$CLUMSIES" _agent setup
 
 # List available workflow skills

--- a/cc-plugin/scripts/session-start.sh
+++ b/cc-plugin/scripts/session-start.sh
@@ -18,7 +18,12 @@ WS_INFO=$("$CLUMSIES" _agent workspace-info 2>/dev/null || true)
 WS_ID=""
 CACHE_DIR=""
 if [ -n "$WS_INFO" ]; then
-  eval "$WS_INFO"
+  while IFS='=' read -r key value; do
+    case "$key" in
+      WS_ID) WS_ID="$value" ;;
+      CACHE_DIR) CACHE_DIR="$value" ;;
+    esac
+  done <<< "$WS_INFO"
 fi
 
 # 3. Auto-generate workflow skills from cache/workflow/ when bound

--- a/cc-plugin/scripts/user-prompt-submit.sh
+++ b/cc-plugin/scripts/user-prompt-submit.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: capture developer prompt text as a session_input
+# trace event. Best-effort — silent failures must never block CC.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/resolve-binary.sh"
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+PROMPT_TEXT=$(jq -r '.prompt // empty' 2>/dev/null || echo "")
+if [ -z "$PROMPT_TEXT" ]; then
+  exit 0
+fi
+
+"$CLUMSIES" trace append --type session_input --content "$PROMPT_TEXT" >/dev/null 2>&1 || true

--- a/src/commands/flush_trace_cmd.zig
+++ b/src/commands/flush_trace_cmd.zig
@@ -56,8 +56,8 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 }
 
 fn printHelp(w: *std.Io.Writer) !void {
-    try w.print("{s}{s}clumsies flush-trace{s}\n\n", .{ P, Color.bold, Color.reset });
+    try w.print("{s}{s}clumsies trace flush{s}\n\n", .{ P, Color.bold, Color.reset });
     try w.print("Upload pending trace events from this workspace to the hub.\n\n", .{});
     try w.print("{s}Usage:{s}\n", .{ Color.bold, Color.reset });
-    try w.print("  clumsies flush-trace\n", .{});
+    try w.print("  clumsies trace flush\n", .{});
 }

--- a/src/commands/help.zig
+++ b/src/commands/help.zig
@@ -11,7 +11,7 @@ pub fn run(stdout: *std.Io.Writer) !void {
     try stdout.print("{s}    {s}clumsies login{s}      Authenticate with Hub\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies init{s}       Bind workspace to current directory\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies sync{s}         Sync local cache from Hub\n", .{ P, Color.cyan, Color.reset });
-    try stdout.print("{s}    {s}clumsies flush-trace{s}  Upload pending trace events to Hub\n", .{ P, Color.cyan, Color.reset });
+    try stdout.print("{s}    {s}clumsies trace flush{s}  Upload pending trace events to Hub\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies mcp serve{s}    Start MCP server for AI agents\n\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}{s}Run {s}clumsies <command> -h{s}{s} for details.{s}\n", .{ P, Color.dim, Color.reset, Color.dim, Color.dim, Color.reset });
 }

--- a/src/commands/sync_cmd.zig
+++ b/src/commands/sync_cmd.zig
@@ -3,6 +3,7 @@ const flag = @import("../flags.zig");
 const auth_mod = @import("../auth.zig");
 const ws_config = @import("../workspace_config.zig");
 const HubClient = @import("../hub_client.zig").HubClient;
+const lib = @import("clumsies_lib");
 const styles = @import("../styles.zig");
 
 const Color = styles.Color;
@@ -180,24 +181,8 @@ fn ensureDir(path: []const u8) void {
     };
 }
 
-fn isPathSafe(name: []const u8) bool {
-    if (name.len == 0) return false;
-    if (std.fs.path.isAbsolute(name)) return false;
-    var it = std.mem.splitScalar(u8, name, std.fs.path.sep);
-    while (it.next()) |component| {
-        if (std.mem.eql(u8, component, "..")) return false;
-    }
-    if (std.fs.path.sep != '/') {
-        var it2 = std.mem.splitScalar(u8, name, '/');
-        while (it2.next()) |component| {
-            if (std.mem.eql(u8, component, "..")) return false;
-        }
-    }
-    return true;
-}
-
 fn writeToCache(allocator: std.mem.Allocator, ws_cache_dir: []const u8, sub_dir: []const u8, name: []const u8, content: []const u8) !void {
-    if (!isPathSafe(name)) return error.UnsafePath;
+    if (!lib.path_util.isSafeRelative(name)) return error.UnsafePath;
     const dir_path = try std.fs.path.join(allocator, &.{ ws_cache_dir, sub_dir });
     defer allocator.free(dir_path);
     ensureDir(dir_path);
@@ -245,28 +230,6 @@ fn printHelp(out: *std.Io.Writer) !void {
 }
 
 const testing = std.testing;
-
-test "isPathSafe rejects traversal" {
-    try testing.expect(!isPathSafe("../etc/passwd"));
-    try testing.expect(!isPathSafe("foo/../../etc/passwd"));
-    try testing.expect(!isPathSafe(".."));
-}
-
-test "isPathSafe rejects absolute paths" {
-    try testing.expect(!isPathSafe("/etc/passwd"));
-    try testing.expect(!isPathSafe("/absolute/path"));
-}
-
-test "isPathSafe rejects empty" {
-    try testing.expect(!isPathSafe(""));
-}
-
-test "isPathSafe accepts valid relative paths" {
-    try testing.expect(isPathSafe("rule/coding/STYLE.md"));
-    try testing.expect(isPathSafe("context/readme.md"));
-    try testing.expect(isPathSafe("file.md"));
-    try testing.expect(isPathSafe("a/b/c/d.txt"));
-}
 
 test "percentEncode encodes special characters" {
     const allocator = testing.allocator;

--- a/src/commands/sync_cmd.zig
+++ b/src/commands/sync_cmd.zig
@@ -93,35 +93,24 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     ensureDir(ws_dir);
     ensureDir(cache_dir);
 
-    // Sync prompts — write to paths mirroring the Library.
-    // Manifest prompts are keyed by prompt_id; we look up each prompt's path via the library API.
+    // Sync prompts — manifest carries path directly post-ADR-011.
     var prompt_count: usize = 0;
     if (manifest.object.get("prompts")) |prompts_val| {
         if (prompts_val == .object) {
             var iter = prompts_val.object.iterator();
             while (iter.next()) |entry| {
                 const prompt_id = entry.key_ptr.*;
-                const encoded_prompt_id = try percentEncode(allocator, prompt_id);
-                defer allocator.free(encoded_prompt_id);
-                const api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt?prompt_id={s}", .{encoded_prompt_id});
-                defer allocator.free(api_path);
-
-                const response = client.get(api_path) catch continue;
-                defer response.deinit();
-                if (response.status != .ok) continue;
-
-                const prompt_parsed = std.json.parseFromSlice(std.json.Value, allocator, response.body, .{}) catch continue;
-                defer prompt_parsed.deinit();
-
-                const prompt_obj = switch (prompt_parsed.value) {
+                const value = switch (entry.value_ptr.*) {
                     .object => |obj| obj,
                     else => continue,
                 };
-                const prompt_path = if (prompt_obj.get("path")) |v| switch (v) {
+                const prompt_path = if (value.get("path")) |v| switch (v) {
                     .string => |s| s,
                     else => continue,
                 } else continue;
 
+                const encoded_prompt_id = try percentEncode(allocator, prompt_id);
+                defer allocator.free(encoded_prompt_id);
                 const content_api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt/content?prompt_id={s}", .{encoded_prompt_id});
                 defer allocator.free(content_api_path);
 
@@ -135,14 +124,23 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         }
     }
 
-    // Sync context files — write to context/ subdirectory
+    // Sync context files — manifest keys context entries by context_id and
+    // carries path in the value.
     var context_count: usize = 0;
     if (manifest.object.get("context")) |context_val| {
         if (context_val == .object) {
             var iter = context_val.object.iterator();
             while (iter.next()) |entry| {
-                const path = entry.key_ptr.*;
-                const encoded_path = try percentEncode(allocator, path);
+                const value = switch (entry.value_ptr.*) {
+                    .object => |obj| obj,
+                    else => continue,
+                };
+                const ctx_path = if (value.get("path")) |v| switch (v) {
+                    .string => |s| s,
+                    else => continue,
+                } else continue;
+
+                const encoded_path = try percentEncode(allocator, ctx_path);
                 defer allocator.free(encoded_path);
                 const api_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/context/file/content?path={s}", .{ ws_id, encoded_path });
                 defer allocator.free(api_path);
@@ -151,7 +149,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
                 defer response.deinit();
                 if (response.status != .ok) continue;
 
-                writeToCache(allocator, cache_dir, "context", path, response.body) catch continue;
+                writeToCache(allocator, cache_dir, "context", ctx_path, response.body) catch continue;
                 context_count += 1;
             }
         }

--- a/src/commands/trace_append_cmd.zig
+++ b/src/commands/trace_append_cmd.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const flag = @import("../flags.zig");
+const ws_config = @import("../workspace_config.zig");
+const lib = @import("clumsies_lib");
+const styles = @import("../styles.zig");
+
+const Color = styles.Color;
+const P = styles.P;
+
+const ALLOWED_TYPES = [_][]const u8{ "session_input", "setup", "search", "load", "refer" };
+
+const FLAG_TYPE: usize = 0;
+const FLAG_CONTENT: usize = 1;
+
+/// `clumsies trace append --type <type> [--content <text>]`
+///
+/// Append a single trace event to the current workspace's trace.jsonl. The
+/// session_id comes from current_session.json, written by the active MCP
+/// serve process. The event_id uses microseconds-since-epoch so it never
+/// collides with the in-process counter MCP uses for its own events.
+///
+/// Best-effort: silent failure on missing binding, missing session marker,
+/// or trace write errors. Designed to be called from cc-plugin hooks where
+/// blocking the user is unacceptable.
+pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
+    _ = stdout;
+
+    const SPECS = [_]flag.FlagSpec{
+        .{ .short = 't', .long = "type", .kind = .value },
+        .{ .short = 'c', .long = "content", .kind = .value },
+    };
+
+    var err_ctx: flag.ErrorContext = .{};
+    var result = flag.parse(&SPECS, allocator, args, &err_ctx) catch |err| switch (err) {
+        error.HelpRequested => {
+            try printHelp(stderr);
+            return;
+        },
+        error.UnknownFlag => {
+            try stderr.print("Error: unknown flag {s}\n", .{err_ctx.flag.?});
+            return;
+        },
+        error.MissingValue => {
+            try stderr.print("Error: {s} requires a value\n", .{err_ctx.flag.?});
+            return;
+        },
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    defer result.deinit(allocator);
+
+    const event_type = result.value(FLAG_TYPE) orelse {
+        try stderr.writeAll("Error: --type is required\n");
+        return;
+    };
+
+    var allowed = false;
+    for (ALLOWED_TYPES) |t| {
+        if (std.mem.eql(u8, t, event_type)) {
+            allowed = true;
+            break;
+        }
+    }
+    if (!allowed) {
+        try stderr.writeAll("Error: --type must be one of session_input/setup/search/load/refer\n");
+        return;
+    }
+
+    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch return;
+    defer allocator.free(cwd);
+
+    const binding = ws_config.resolveWorkspace(allocator, cwd) catch return;
+    defer allocator.free(binding.ws_id);
+    defer allocator.free(binding.name);
+
+    const ws_dir = ws_config.getWsDir(allocator, binding.ws_id) catch return;
+    defer allocator.free(ws_dir);
+
+    const marker_opt = lib.session_marker.read(allocator, ws_dir) catch null;
+    if (marker_opt == null) return;
+    const marker = marker_opt.?;
+    defer allocator.free(marker.session_id);
+
+    const content_opt = result.value(FLAG_CONTENT);
+    var content_hash_owned: ?[]const u8 = null;
+    defer if (content_hash_owned) |h| allocator.free(h);
+    if (content_opt) |c| {
+        content_hash_owned = try lib.prompt.hashContentHexAlloc(allocator, c);
+    }
+
+    const event_id = std.time.microTimestamp();
+
+    lib.trace.appendTraceEvent(allocator, .{
+        .ws_id = binding.ws_id,
+        .session_id = marker.session_id,
+        .event_id = event_id,
+        .type = event_type,
+        .timestamp = std.time.milliTimestamp(),
+        .content = content_opt,
+        .content_hash = content_hash_owned,
+    }) catch |err| {
+        std.log.warn("trace append failed: {}", .{err});
+        return;
+    };
+}
+
+fn printHelp(out: *std.Io.Writer) !void {
+    try out.print("{s}{s}clumsies trace append{s}\n\n", .{ P, Color.bold, Color.reset });
+    try out.print("Append a single trace event to the current workspace's trace.jsonl.\n", .{});
+    try out.print("Intended for cc-plugin hooks (UserPromptSubmit, etc).\n\n", .{});
+    try out.print("{s}Usage:{s}\n", .{ Color.bold, Color.reset });
+    try out.print("  clumsies trace append --type session_input --content \"hello\"\n", .{});
+}

--- a/src/commands/workspace_info_cmd.zig
+++ b/src/commands/workspace_info_cmd.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const ws_config = @import("../workspace_config.zig");
+const output = @import("../output.zig");
+
+/// Internal `_agent workspace-info` command. Resolves the workspace binding
+/// for the current directory and prints two shell-eval lines:
+///
+///     export WS_ID=ws-...
+///     export CACHE_DIR=/Users/.../.clumsies/workspaces/ws-.../cache
+///
+/// Used by cc-plugin hook scripts to locate the cache directory before
+/// scanning workflow files. Silent no-output if the current directory is
+/// not bound to any workspace — callers should treat empty output as
+/// "clumsies inactive in this project".
+pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator) !void {
+    if (output.detect() == .human) {
+        try stderr.writeAll("This command is for agent environments only (hooks/pipes).\n");
+        return;
+    }
+
+    const cwd = std.process.getCwdAlloc(allocator) catch return;
+    defer allocator.free(cwd);
+
+    const binding = ws_config.resolveWorkspace(allocator, cwd) catch return;
+    defer allocator.free(binding.ws_id);
+    defer allocator.free(binding.name);
+
+    const cache_dir = ws_config.getCachePath(allocator, binding.ws_id) catch return;
+    defer allocator.free(cache_dir);
+
+    try stdout.print("export WS_ID={s}\n", .{binding.ws_id});
+    try stdout.print("export CACHE_DIR={s}\n", .{cache_dir});
+}

--- a/src/commands/workspace_info_cmd.zig
+++ b/src/commands/workspace_info_cmd.zig
@@ -3,15 +3,17 @@ const ws_config = @import("../workspace_config.zig");
 const output = @import("../output.zig");
 
 /// Internal `_agent workspace-info` command. Resolves the workspace binding
-/// for the current directory and prints two shell-eval lines:
+/// for the current directory and prints bare KEY=VALUE lines:
 ///
-///     export WS_ID=ws-...
-///     export CACHE_DIR=/Users/.../.clumsies/workspaces/ws-.../cache
+///     WS_ID=ws-...
+///     CACHE_DIR=/Users/.../.clumsies/workspaces/ws-.../cache
 ///
 /// Used by cc-plugin hook scripts to locate the cache directory before
-/// scanning workflow files. Silent no-output if the current directory is
-/// not bound to any workspace — callers should treat empty output as
-/// "clumsies inactive in this project".
+/// scanning workflow files. The output is deliberately NOT shell-eval'd —
+/// callers should parse it with `while IFS='=' read -r key value; do ...`
+/// so values containing spaces or metacharacters are handled safely.
+/// Silent no-output if the current directory is not bound to any workspace;
+/// callers should treat empty output as "clumsies inactive in this project".
 pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator) !void {
     if (output.detect() == .human) {
         try stderr.writeAll("This command is for agent environments only (hooks/pipes).\n");
@@ -28,6 +30,6 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     const cache_dir = ws_config.getCachePath(allocator, binding.ws_id) catch return;
     defer allocator.free(cache_dir);
 
-    try stdout.print("export WS_ID={s}\n", .{binding.ws_id});
-    try stdout.print("export CACHE_DIR={s}\n", .{cache_dir});
+    try stdout.print("WS_ID={s}\n", .{binding.ws_id});
+    try stdout.print("CACHE_DIR={s}\n", .{cache_dir});
 }

--- a/src/hub/library.zig
+++ b/src/hub/library.zig
@@ -3,8 +3,8 @@ const httpz = @import("httpz");
 const Server = @import("server.zig");
 const auth = @import("auth.zig");
 const apiError = @import("../protocol/api_error.zig").send;
-const KvMap = @import("../protocol/manifest.zig").KvMap;
-const KvEntry = @import("../protocol/manifest.zig").KvEntry;
+const ManifestMap = @import("../protocol/manifest.zig").ManifestMap;
+const ManifestItem = @import("../protocol/manifest.zig").ManifestItem;
 
 pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
@@ -25,7 +25,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     } orelse {
         try res.json(.{
             .revision = @as(i32, 0),
-            .prompts = KvMap{ .entries = &.{} },
+            .prompts = ManifestMap{ .items = &.{} },
         }, .{});
         return;
     };
@@ -43,18 +43,21 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     }
 
     var result = conn.query(
-        "SELECT prompt_id, content_hash FROM prompts WHERE org_id = $1::uuid",
+        "SELECT prompt_id, path, content_hash FROM prompts WHERE org_id = $1::uuid",
         .{user.org_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
     defer result.deinit();
 
-    var entries: std.ArrayList(KvEntry) = .empty;
+    var items: std.ArrayList(ManifestItem) = .empty;
     while (try result.next()) |row| {
-        try entries.append(req.arena, .{
+        try items.append(req.arena, .{
             .key = try req.arena.dupe(u8, try row.get([]const u8, 0)),
-            .value = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+            .value = .{
+                .path = try req.arena.dupe(u8, try row.get([]const u8, 1)),
+                .hash = try req.arena.dupe(u8, try row.get([]const u8, 2)),
+            },
         });
     }
 
@@ -64,7 +67,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
 
     try res.json(.{
         .revision = revision,
-        .prompts = KvMap{ .entries = entries.items },
+        .prompts = ManifestMap{ .items = items.items },
     }, .{});
 }
 

--- a/src/hub/workspace.zig
+++ b/src/hub/workspace.zig
@@ -3,8 +3,9 @@ const httpz = @import("httpz");
 const Server = @import("server.zig");
 const auth = @import("auth.zig");
 const apiError = @import("../protocol/api_error.zig").send;
-const KvMap = @import("../protocol/manifest.zig").KvMap;
-const KvEntry = @import("../protocol/manifest.zig").KvEntry;
+const ManifestMap = @import("../protocol/manifest.zig").ManifestMap;
+const ManifestItem = @import("../protocol/manifest.zig").ManifestItem;
+const ManifestEntry = @import("../protocol/manifest.zig").ManifestEntry;
 
 const CreateRequest = struct {
     name: []const u8,
@@ -203,9 +204,9 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         }
     }
 
-    const prompts = try collectKvMap(req.arena, conn, "SELECT wp.prompt_id, p.content_hash FROM workspace_prompts wp JOIN prompts p ON p.prompt_id = wp.prompt_id WHERE wp.ws_id = $1", .{ws_id});
+    const prompts = try collectManifestMap(req.arena, conn, "SELECT wp.prompt_id, p.path, p.content_hash FROM workspace_prompts wp JOIN prompts p ON p.prompt_id = wp.prompt_id WHERE wp.ws_id = $1", .{ws_id});
 
-    const context = try collectKvMap(req.arena, conn, "SELECT path, content_hash FROM context_files WHERE ws_id = $1 AND branch_name = 'main'", .{ws_id});
+    const context = try collectManifestMap(req.arena, conn, "SELECT context_id, path, content_hash FROM context_files WHERE ws_id = $1", .{ws_id});
 
     var etag_buf: [32]u8 = undefined;
     const etag_slice = std.fmt.bufPrint(&etag_buf, "\"rev-{d}\"", .{revision}) catch "";
@@ -692,17 +693,20 @@ pub fn handleRemoveWsMember(ctx: *Server.Context, req: *httpz.Request, res: *htt
     res.status = 204;
 }
 
-fn collectKvMap(arena: std.mem.Allocator, conn: anytype, sql: []const u8, params: anytype) !KvMap {
-    var result = conn.query(sql, params) catch return KvMap{ .entries = &.{} };
+fn collectManifestMap(arena: std.mem.Allocator, conn: anytype, sql: []const u8, params: anytype) !ManifestMap {
+    var result = conn.query(sql, params) catch return ManifestMap{ .items = &.{} };
     defer result.deinit();
 
-    var entries: std.ArrayList(KvEntry) = .empty;
+    var items: std.ArrayList(ManifestItem) = .empty;
     while (try result.next()) |row| {
-        try entries.append(arena, .{
+        try items.append(arena, .{
             .key = try arena.dupe(u8, try row.get([]const u8, 0)),
-            .value = try arena.dupe(u8, try row.get([]const u8, 1)),
+            .value = .{
+                .path = try arena.dupe(u8, try row.get([]const u8, 1)),
+                .hash = try arena.dupe(u8, try row.get([]const u8, 2)),
+            },
         });
     }
 
-    return KvMap{ .entries = entries.items };
+    return ManifestMap{ .items = items.items };
 }

--- a/src/lib/drafts.zig
+++ b/src/lib/drafts.zig
@@ -1,0 +1,298 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const DraftCategory = enum {
+    prompt,
+    context,
+
+    pub fn toString(self: DraftCategory) []const u8 {
+        return switch (self) {
+            .prompt => "prompt",
+            .context => "context",
+        };
+    }
+};
+
+pub const DraftOperation = enum {
+    create,
+    modify,
+    rename,
+    delete,
+};
+
+pub const DraftStatus = enum {
+    editing,
+    submitted,
+    merged,
+    rejected,
+    conflicted,
+};
+
+pub const DraftEntry = struct {
+    category: DraftCategory,
+    prompt_id: ?[]const u8 = null,
+    context_id: ?[]const u8 = null,
+    local_temp_id: ?[]const u8 = null,
+    current_path: ?[]const u8 = null,
+    draft_path: []const u8,
+    operation: DraftOperation,
+    base_hash: ?[]const u8 = null,
+    status: DraftStatus,
+};
+
+/// Parsed drafts index. Strings borrow from an arena; deinit drops the arena.
+pub const DraftsIndex = struct {
+    arena_state: *std.heap.ArenaAllocator,
+    entries: std.ArrayListUnmanaged(DraftEntry) = .empty,
+
+    pub fn deinit(self: *DraftsIndex, allocator: std.mem.Allocator) void {
+        self.arena_state.deinit();
+        allocator.destroy(self.arena_state);
+    }
+
+    /// Find an active draft entry matching the given category and current path.
+    /// Returns null if no entry matches or if the matching entry is a delete
+    /// operation (callers should treat delete as NotFound).
+    pub fn findByCurrentPath(self: *const DraftsIndex, category: DraftCategory, path: []const u8) ?*const DraftEntry {
+        for (self.entries.items) |*entry| {
+            if (entry.category != category) continue;
+            const cur = entry.current_path orelse continue;
+            if (std.mem.eql(u8, cur, path)) return entry;
+        }
+        return null;
+    }
+};
+
+/// Load `{ws_dir}/drafts/_index.json` into memory. Returns an empty index if
+/// the file does not exist; this is the expected state before any drafts exist.
+pub fn loadIndex(allocator: std.mem.Allocator, ws_dir: []const u8) !DraftsIndex {
+    const arena_state = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena_state);
+    arena_state.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena_state.deinit();
+
+    var index: DraftsIndex = .{ .arena_state = arena_state };
+    const arena = arena_state.allocator();
+
+    const index_path = try std.fs.path.join(arena, &.{ ws_dir, "drafts", "_index.json" });
+
+    const file = std.fs.openFileAbsolute(index_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return index,
+        else => return err,
+    };
+    defer file.close();
+
+    var read_buf: [4096]u8 = undefined;
+    var fr = std.fs.File.Reader.init(file, &read_buf);
+    const content = try fr.interface.allocRemaining(arena, std.io.Limit.limited(1 * 1024 * 1024));
+
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, content, .{}) catch return error.InvalidDraftsIndex;
+    if (parsed != .object) return error.InvalidDraftsIndex;
+
+    const drafts_val = parsed.object.get("drafts") orelse return index;
+    if (drafts_val != .array) return error.InvalidDraftsIndex;
+
+    for (drafts_val.array.items) |item| {
+        const obj = switch (item) {
+            .object => |o| o,
+            else => continue,
+        };
+        const entry = parseEntry(obj) orelse continue;
+        try index.entries.append(arena, entry);
+    }
+
+    return index;
+}
+
+fn parseEntry(obj: std.json.ObjectMap) ?DraftEntry {
+    const category_str = stringField(obj, "category") orelse return null;
+    const category: DraftCategory = if (std.mem.eql(u8, category_str, "prompt"))
+        .prompt
+    else if (std.mem.eql(u8, category_str, "context"))
+        .context
+    else
+        return null;
+
+    const draft_path = stringField(obj, "draft_path") orelse return null;
+
+    const op_str = stringField(obj, "operation") orelse return null;
+    const operation: DraftOperation = if (std.mem.eql(u8, op_str, "create"))
+        .create
+    else if (std.mem.eql(u8, op_str, "modify"))
+        .modify
+    else if (std.mem.eql(u8, op_str, "rename"))
+        .rename
+    else if (std.mem.eql(u8, op_str, "delete"))
+        .delete
+    else
+        return null;
+
+    const status_str = stringField(obj, "status") orelse return null;
+    const status: DraftStatus = if (std.mem.eql(u8, status_str, "editing"))
+        .editing
+    else if (std.mem.eql(u8, status_str, "submitted"))
+        .submitted
+    else if (std.mem.eql(u8, status_str, "merged"))
+        .merged
+    else if (std.mem.eql(u8, status_str, "rejected"))
+        .rejected
+    else if (std.mem.eql(u8, status_str, "conflicted"))
+        .conflicted
+    else
+        return null;
+
+    return .{
+        .category = category,
+        .prompt_id = stringField(obj, "prompt_id"),
+        .context_id = stringField(obj, "context_id"),
+        .local_temp_id = stringField(obj, "local_temp_id"),
+        .current_path = stringField(obj, "current_path"),
+        .draft_path = draft_path,
+        .operation = operation,
+        .base_hash = stringField(obj, "base_hash"),
+        .status = status,
+    };
+}
+
+fn stringField(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
+    const value = obj.get(key) orelse return null;
+    return switch (value) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
+/// Read a draft file from `{ws_dir}/drafts/{category}/{draft_path}`.
+pub fn readDraftFile(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    category: DraftCategory,
+    draft_path: []const u8,
+) ![]const u8 {
+    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "drafts", category.toString(), draft_path });
+    defer allocator.free(abs_path);
+
+    const file = try std.fs.openFileAbsolute(abs_path, .{});
+    defer file.close();
+
+    var read_buf: [4096]u8 = undefined;
+    var fr = std.fs.File.Reader.init(file, &read_buf);
+    return try fr.interface.allocRemaining(allocator, std.io.Limit.limited(10 * 1024 * 1024));
+}
+
+fn writeFile(dir: std.fs.Dir, sub_path: []const u8, content: []const u8) !void {
+    const file = try dir.createFile(sub_path, .{});
+    defer file.close();
+    var buf: [4096]u8 = undefined;
+    var fw = std.fs.File.Writer.init(file, &buf);
+    defer fw.interface.flush() catch {};
+    try fw.interface.writeAll(content);
+}
+
+fn tmpDirAbsolutePath(tmp: *std.testing.TmpDir, buf: *[std.fs.max_path_bytes]u8) []const u8 {
+    return tmp.dir.realpath(".", buf) catch "";
+}
+
+test "loadIndex: missing file returns empty index" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), index.entries.items.len);
+}
+
+test "loadIndex: parses prompt and context entries" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/_index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "prompt",
+        \\      "prompt_id": "p-style",
+        \\      "current_path": "rule/coding/STYLE.md",
+        \\      "draft_path": "rule/coding/STYLE.md",
+        \\      "operation": "modify",
+        \\      "base_hash": "sha256:abc",
+        \\      "status": "editing"
+        \\    },
+        \\    {
+        \\      "category": "context",
+        \\      "context_id": "c-spec",
+        \\      "current_path": "spec/API.md",
+        \\      "draft_path": "spec/API.md",
+        \\      "operation": "modify",
+        \\      "base_hash": "sha256:xyz",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), index.entries.items.len);
+
+    const prompt_entry = index.findByCurrentPath(.prompt, "rule/coding/STYLE.md").?;
+    try testing.expectEqual(DraftOperation.modify, prompt_entry.operation);
+    try testing.expectEqualStrings("p-style", prompt_entry.prompt_id.?);
+
+    const ctx_entry = index.findByCurrentPath(.context, "spec/API.md").?;
+    try testing.expectEqual(DraftCategory.context, ctx_entry.category);
+    try testing.expectEqualStrings("c-spec", ctx_entry.context_id.?);
+}
+
+test "loadIndex: invalid drafts array returns error" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/_index.json",
+        \\{"drafts": "not an array"}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try testing.expectError(error.InvalidDraftsIndex, loadIndex(testing.allocator, root));
+}
+
+test "findByCurrentPath: returns null for unknown path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+
+    try testing.expect(index.findByCurrentPath(.prompt, "anything") == null);
+}
+
+test "readDraftFile: reads from drafts/{category}/{draft_path}" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("drafts/prompt/rule/coding");
+    try writeFile(tmp.dir, "drafts/prompt/rule/coding/STYLE.md", "draft override content");
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    const content = try readDraftFile(testing.allocator, root, .prompt, "rule/coding/STYLE.md");
+    defer testing.allocator.free(content);
+
+    try testing.expectEqualStrings("draft override content", content);
+}

--- a/src/lib/drafts.zig
+++ b/src/lib/drafts.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const testing = std.testing;
+const path_util = @import("path_util.zig");
 
 pub const DraftCategory = enum {
     prompt,
@@ -50,9 +51,11 @@ pub const DraftsIndex = struct {
         allocator.destroy(self.arena_state);
     }
 
-    /// Find an active draft entry matching the given category and current path.
-    /// Returns null if no entry matches or if the matching entry is a delete
-    /// operation (callers should treat delete as NotFound).
+    /// Find a draft entry matching the given category and current path.
+    /// Returns null only when no entry matches — delete-operation entries
+    /// are still returned. Callers are expected to inspect `operation` and
+    /// handle `.delete` as NotFound themselves, so the lookup stays usable
+    /// for other callers that need the full set of tracked drafts.
     pub fn findByCurrentPath(self: *const DraftsIndex, category: DraftCategory, path: []const u8) ?*const DraftEntry {
         for (self.entries.items) |*entry| {
             if (entry.category != category) continue;
@@ -169,6 +172,8 @@ pub fn readDraftFile(
     category: DraftCategory,
     draft_path: []const u8,
 ) ![]const u8 {
+    if (!path_util.isSafeRelative(draft_path)) return error.UnsafeDraftPath;
+
     const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "drafts", category.toString(), draft_path });
     defer allocator.free(abs_path);
 

--- a/src/lib/path_util.zig
+++ b/src/lib/path_util.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+const testing = std.testing;
+
+/// Return true if `name` is a safe relative path that does not escape its
+/// base directory. Rejects absolute paths and any path containing a `..`
+/// component (using either the platform separator or forward slashes).
+///
+/// Callers should use this before joining a user- or manifest-provided
+/// relative path onto a controlled base directory.
+pub fn isSafeRelative(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (std.fs.path.isAbsolute(name)) return false;
+
+    var it = std.mem.splitScalar(u8, name, std.fs.path.sep);
+    while (it.next()) |component| {
+        if (std.mem.eql(u8, component, "..")) return false;
+    }
+    if (std.fs.path.sep != '/') {
+        var it2 = std.mem.splitScalar(u8, name, '/');
+        while (it2.next()) |component| {
+            if (std.mem.eql(u8, component, "..")) return false;
+        }
+    }
+    return true;
+}
+
+test "isSafeRelative rejects traversal" {
+    try testing.expect(!isSafeRelative("../etc/passwd"));
+    try testing.expect(!isSafeRelative("foo/../bar"));
+    try testing.expect(!isSafeRelative(".."));
+}
+
+test "isSafeRelative rejects absolute paths" {
+    try testing.expect(!isSafeRelative("/etc/passwd"));
+}
+
+test "isSafeRelative rejects empty" {
+    try testing.expect(!isSafeRelative(""));
+}
+
+test "isSafeRelative accepts plain relative paths" {
+    try testing.expect(isSafeRelative("rule/coding/STYLE.md"));
+    try testing.expect(isSafeRelative("META_PROMPT.md"));
+    try testing.expect(isSafeRelative("workflow/cmd/COMMIT.md"));
+}

--- a/src/lib/root.zig
+++ b/src/lib/root.zig
@@ -1,3 +1,4 @@
+pub const drafts = @import("drafts.zig");
 pub const encoding = @import("encoding.zig");
 pub const prompt = @import("prompt.zig");
 pub const sequence = @import("sequence.zig");

--- a/src/lib/root.zig
+++ b/src/lib/root.zig
@@ -1,5 +1,6 @@
 pub const drafts = @import("drafts.zig");
 pub const encoding = @import("encoding.zig");
+pub const path_util = @import("path_util.zig");
 pub const prompt = @import("prompt.zig");
 pub const sequence = @import("sequence.zig");
 pub const session_marker = @import("session_marker.zig");

--- a/src/lib/root.zig
+++ b/src/lib/root.zig
@@ -2,6 +2,7 @@ pub const drafts = @import("drafts.zig");
 pub const encoding = @import("encoding.zig");
 pub const prompt = @import("prompt.zig");
 pub const sequence = @import("sequence.zig");
+pub const session_marker = @import("session_marker.zig");
 pub const trace = @import("trace.zig");
 pub const upload_worker = @import("upload_worker.zig");
 pub const workspace_prompt = @import("workspace_prompt.zig");

--- a/src/lib/session_marker.zig
+++ b/src/lib/session_marker.zig
@@ -3,7 +3,6 @@ const testing = std.testing;
 
 pub const SessionMarker = struct {
     session_id: []const u8,
-    pid: i64,
     started_at: i64,
 };
 
@@ -21,7 +20,6 @@ pub fn write(allocator: std.mem.Allocator, ws_dir: []const u8, session_id: []con
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
     defer allocator.free(tmp_path);
 
-    const pid: i64 = @intCast(std.c.getpid());
     const started_at = std.time.milliTimestamp();
 
     {
@@ -30,8 +28,8 @@ pub fn write(allocator: std.mem.Allocator, ws_dir: []const u8, session_id: []con
         var buf: [512]u8 = undefined;
         var w = std.fs.File.Writer.init(file, &buf);
         try w.interface.print(
-            "{{\"session_id\":\"{s}\",\"pid\":{d},\"started_at\":{d}}}\n",
-            .{ session_id, pid, started_at },
+            "{{\"session_id\":\"{s}\",\"started_at\":{d}}}\n",
+            .{ session_id, started_at },
         );
         try w.interface.flush();
     }
@@ -76,12 +74,6 @@ pub fn read(allocator: std.mem.Allocator, ws_dir: []const u8) !?SessionMarker {
         else => return error.InvalidSessionMarker,
     };
 
-    const pid_val = obj.get("pid") orelse return error.InvalidSessionMarker;
-    const pid: i64 = switch (pid_val) {
-        .integer => |n| n,
-        else => return error.InvalidSessionMarker,
-    };
-
     const started_val = obj.get("started_at") orelse return error.InvalidSessionMarker;
     const started_at: i64 = switch (started_val) {
         .integer => |n| n,
@@ -90,7 +82,6 @@ pub fn read(allocator: std.mem.Allocator, ws_dir: []const u8) !?SessionMarker {
 
     return .{
         .session_id = try allocator.dupe(u8, sid_str),
-        .pid = pid,
         .started_at = started_at,
     };
 }
@@ -108,7 +99,6 @@ test "write then read roundtrip" {
     defer testing.allocator.free(marker.session_id);
 
     try testing.expectEqualStrings("sess-test123", marker.session_id);
-    try testing.expect(marker.pid > 0);
     try testing.expect(marker.started_at > 0);
 }
 

--- a/src/lib/session_marker.zig
+++ b/src/lib/session_marker.zig
@@ -1,0 +1,135 @@
+const std = @import("std");
+const testing = std.testing;
+
+pub const SessionMarker = struct {
+    session_id: []const u8,
+    pid: i64,
+    started_at: i64,
+};
+
+fn markerPath(allocator: std.mem.Allocator, ws_dir: []const u8) ![]const u8 {
+    return std.fs.path.join(allocator, &.{ ws_dir, "current_session.json" });
+}
+
+/// Write `{ws_dir}/current_session.json` with the current MCP serve session
+/// metadata. Atomic temp + rename so a concurrent reader never sees a partial
+/// file. Called once at MCP serve startup.
+pub fn write(allocator: std.mem.Allocator, ws_dir: []const u8, session_id: []const u8) !void {
+    const path = try markerPath(allocator, ws_dir);
+    defer allocator.free(path);
+
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(tmp_path);
+
+    const pid: i64 = @intCast(std.c.getpid());
+    const started_at = std.time.milliTimestamp();
+
+    {
+        const file = try std.fs.createFileAbsolute(tmp_path, .{ .truncate = true });
+        defer file.close();
+        var buf: [512]u8 = undefined;
+        var w = std.fs.File.Writer.init(file, &buf);
+        try w.interface.print(
+            "{{\"session_id\":\"{s}\",\"pid\":{d},\"started_at\":{d}}}\n",
+            .{ session_id, pid, started_at },
+        );
+        try w.interface.flush();
+    }
+
+    try std.fs.renameAbsolute(tmp_path, path);
+}
+
+/// Best-effort delete of the current session marker. Called during MCP serve
+/// shutdown. Failures are ignored (the next startup will overwrite anyway).
+pub fn clear(allocator: std.mem.Allocator, ws_dir: []const u8) void {
+    const path = markerPath(allocator, ws_dir) catch return;
+    defer allocator.free(path);
+    std.fs.deleteFileAbsolute(path) catch {};
+}
+
+/// Read the current session marker. Returns null if the file does not exist.
+/// Caller owns `session_id` and must free it.
+pub fn read(allocator: std.mem.Allocator, ws_dir: []const u8) !?SessionMarker {
+    const path = try markerPath(allocator, ws_dir);
+    defer allocator.free(path);
+
+    const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => return err,
+    };
+    defer file.close();
+
+    var read_buf: [1024]u8 = undefined;
+    var fr = std.fs.File.Reader.init(file, &read_buf);
+    const content = try fr.interface.allocRemaining(allocator, std.io.Limit.limited(8 * 1024));
+    defer allocator.free(content);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch return error.InvalidSessionMarker;
+    defer parsed.deinit();
+
+    if (parsed.value != .object) return error.InvalidSessionMarker;
+    const obj = parsed.value.object;
+
+    const sid_val = obj.get("session_id") orelse return error.InvalidSessionMarker;
+    const sid_str = switch (sid_val) {
+        .string => |s| s,
+        else => return error.InvalidSessionMarker,
+    };
+
+    const pid_val = obj.get("pid") orelse return error.InvalidSessionMarker;
+    const pid: i64 = switch (pid_val) {
+        .integer => |n| n,
+        else => return error.InvalidSessionMarker,
+    };
+
+    const started_val = obj.get("started_at") orelse return error.InvalidSessionMarker;
+    const started_at: i64 = switch (started_val) {
+        .integer => |n| n,
+        else => return error.InvalidSessionMarker,
+    };
+
+    return .{
+        .session_id = try allocator.dupe(u8, sid_str),
+        .pid = pid,
+        .started_at = started_at,
+    };
+}
+
+test "write then read roundtrip" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmp.dir.realpath(".", &buf) catch unreachable;
+
+    try write(testing.allocator, root, "sess-test123");
+
+    const marker = (try read(testing.allocator, root)).?;
+    defer testing.allocator.free(marker.session_id);
+
+    try testing.expectEqualStrings("sess-test123", marker.session_id);
+    try testing.expect(marker.pid > 0);
+    try testing.expect(marker.started_at > 0);
+}
+
+test "read returns null when marker missing" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmp.dir.realpath(".", &buf) catch unreachable;
+
+    try testing.expect(try read(testing.allocator, root) == null);
+}
+
+test "clear removes the file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmp.dir.realpath(".", &buf) catch unreachable;
+
+    try write(testing.allocator, root, "sess-x");
+    clear(testing.allocator, root);
+    try testing.expect(try read(testing.allocator, root) == null);
+}

--- a/src/lib/workspace_prompt.zig
+++ b/src/lib/workspace_prompt.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const testing = std.testing;
 const prompt = @import("prompt.zig");
+const drafts = @import("drafts.zig");
 
 pub const PromptKind = enum {
     rule,
@@ -37,6 +38,8 @@ pub const LoadedPrompt = struct {
     hash: []const u8,
     changed: bool,
     content: ?[]const u8,
+    has_draft: bool = false,
+    draft_base_hash: ?[]const u8 = null,
 };
 
 pub const LoadResult = struct {
@@ -50,6 +53,7 @@ pub const LoadResult = struct {
             if (item.group) |group| allocator.free(group);
             allocator.free(item.hash);
             if (item.content) |content| allocator.free(content);
+            if (item.draft_base_hash) |bh| allocator.free(bh);
         }
         self.items.deinit(allocator);
     }
@@ -288,8 +292,9 @@ fn lessThanPromptItem(_: void, a: PromptItem, b: PromptItem) bool {
 }
 
 /// Load prompt content by hub-issued prompt_id. Resolves each id through
-/// the local manifest, reads the cache file, and returns content + metadata.
-/// Unknown ids return `error.UnknownPromptId`.
+/// the local manifest, then consults drafts/_index.json: an active draft
+/// with operation != "delete" wins over the cache copy. Unknown ids return
+/// `error.UnknownPromptId`. Drafts marked for deletion behave as NotFound.
 pub fn loadPrompts(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
@@ -298,6 +303,9 @@ pub fn loadPrompts(
 ) !LoadResult {
     var manifest = try loadManifest(allocator, ws_dir);
     defer manifest.deinit(allocator);
+
+    var draft_index = try drafts.loadIndex(allocator, ws_dir);
+    defer draft_index.deinit(allocator);
 
     var result: LoadResult = .{};
     errdefer result.deinit(allocator);
@@ -323,14 +331,28 @@ pub fn loadPrompts(
         const known_hash = knownHashFor(id, known);
         const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
 
-        const content = if (changed)
-            try readCacheFileAlloc(allocator, ws_dir, m_entry.path)
-        else
-            null;
+        const draft_entry = draft_index.findByCurrentPath(.prompt, m_entry.path);
+        if (draft_entry) |entry| {
+            if (entry.operation == .delete) return error.UnknownPromptId;
+        }
+
+        const content = if (changed) blk: {
+            if (draft_entry) |entry| {
+                break :blk try drafts.readDraftFile(allocator, ws_dir, .prompt, entry.draft_path);
+            }
+            break :blk try readCacheFileAlloc(allocator, ws_dir, m_entry.path);
+        } else null;
         errdefer if (content) |owned| allocator.free(owned);
 
         const display_name = prompt.displayNameFromFilename(std.fs.path.basename(m_entry.path));
         const group_slice = groupFromPath(m_entry.path);
+
+        const has_draft = draft_entry != null;
+        const draft_base = if (draft_entry) |entry|
+            if (entry.base_hash) |bh| try allocator.dupe(u8, bh) else null
+        else
+            null;
+        errdefer if (draft_base) |bh| allocator.free(bh);
 
         try result.items.append(allocator, .{
             .id = try allocator.dupe(u8, id),
@@ -341,6 +363,8 @@ pub fn loadPrompts(
             .hash = try allocator.dupe(u8, m_entry.hash),
             .changed = changed,
             .content = content,
+            .has_draft = has_draft,
+            .draft_base_hash = draft_base,
         });
     }
 
@@ -774,6 +798,90 @@ test "loadPrompts: unknown id returns UnknownPromptId" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"p-missing"}, &.{}));
+}
+
+test "loadPrompts: draft content overrides cache when indexed" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule");
+    try writeFile(tmp.dir, "cache/rule/STYLE.md", "cache content");
+
+    try tmp.dir.makePath("drafts/prompt/rule");
+    try writeFile(tmp.dir, "drafts/prompt/rule/STYLE.md", "draft override");
+    try writeFile(tmp.dir, "drafts/_index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "prompt",
+        \\      "prompt_id": "p-style",
+        \\      "current_path": "rule/STYLE.md",
+        \\      "draft_path": "rule/STYLE.md",
+        \\      "operation": "modify",
+        \\      "base_hash": "sha256:original",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &.{});
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), result.items.items.len);
+    const item = result.items.items[0];
+    try testing.expect(item.has_draft);
+    try testing.expectEqualStrings("sha256:original", item.draft_base_hash.?);
+    try testing.expectEqualStrings("draft override", item.content.?);
+}
+
+test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule");
+    try writeFile(tmp.dir, "cache/rule/STYLE.md", "cache content");
+
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/_index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "prompt",
+        \\      "prompt_id": "p-style",
+        \\      "current_path": "rule/STYLE.md",
+        \\      "draft_path": "rule/STYLE.md",
+        \\      "operation": "delete",
+        \\      "base_hash": "sha256:original",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"p-style"}, &.{}));
 }
 
 test "loadMpf: returns content and hash from cache subdirectory" {

--- a/src/lib/workspace_prompt.zig
+++ b/src/lib/workspace_prompt.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const testing = std.testing;
 const prompt = @import("prompt.zig");
 const drafts = @import("drafts.zig");
+const path_util = @import("path_util.zig");
 
 pub const PromptKind = enum {
     rule,
@@ -132,7 +133,10 @@ pub const Manifest = struct {
 
 /// Read `{ws_dir}/manifest.json` into an in-memory map. Returns an empty
 /// manifest (no error) if the file does not exist — that is the expected
-/// state before the first sync. Format mismatch returns InvalidManifest.
+/// state before the first sync. Invalid JSON or a non-object top-level
+/// value returns `InvalidManifest`. Malformed prompts/context entries
+/// inside an otherwise valid top-level object are silently skipped so a
+/// single bad row doesn't block discovery of the rest.
 pub fn loadManifest(allocator: std.mem.Allocator, ws_dir: []const u8) !Manifest {
     const arena_state = try allocator.create(std.heap.ArenaAllocator);
     errdefer allocator.destroy(arena_state);
@@ -372,6 +376,8 @@ pub fn loadPrompts(
 }
 
 fn readCacheFileAlloc(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
+    if (!path_util.isSafeRelative(rel_path)) return error.UnsafeCachePath;
+
     const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", rel_path });
     defer allocator.free(abs_path);
 

--- a/src/lib/workspace_prompt.zig
+++ b/src/lib/workspace_prompt.zig
@@ -55,14 +55,6 @@ pub const LoadResult = struct {
     }
 };
 
-// Kind directory mapping
-
-const kind_dirs = [_]struct { dir: []const u8, kind: PromptKind }{
-    .{ .dir = "rule", .kind = .rule },
-    .{ .dir = "workflow", .kind = .workflow },
-    .{ .dir = "context", .kind = .context },
-};
-
 fn priorityForKind(kind: PromptKind) SetupPriority {
     return switch (kind) {
         .rule, .workflow, .context => .normal,
@@ -87,8 +79,12 @@ pub const MpfResult = struct {
     }
 };
 
-pub fn loadMpf(allocator: std.mem.Allocator, workspace_root: []const u8, known_hash: ?[]const u8) !MpfResult {
-    const mpf_path = try std.fs.path.join(allocator, &.{ workspace_root, "META_PROMPT.md" });
+/// Load META_PROMPT.md from the workspace cache directory.
+/// `ws_dir` is the workspace root (~/.clumsies/workspaces/{ws_id}).
+/// MPF lives at `{ws_dir}/cache/META_PROMPT.md` per Library reserved-path
+/// convention (see s1-1).
+pub fn loadMpf(allocator: std.mem.Allocator, ws_dir: []const u8, known_hash: ?[]const u8) !MpfResult {
+    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
     defer allocator.free(mpf_path);
 
     const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return .{ .content = null, .hash = null };
@@ -112,7 +108,85 @@ pub fn loadMpf(allocator: std.mem.Allocator, workspace_root: []const u8, known_h
     return .{ .content = content, .hash = hash };
 }
 
-// Public API
+pub const ManifestEntry = struct {
+    path: []const u8,
+    hash: []const u8,
+};
+
+/// Parsed local manifest. Both maps borrow strings from an arena owned by
+/// this struct; deinit drops the arena and invalidates all keys/values.
+pub const Manifest = struct {
+    arena_state: *std.heap.ArenaAllocator,
+    prompts: std.StringHashMapUnmanaged(ManifestEntry) = .empty,
+    context: std.StringHashMapUnmanaged(ManifestEntry) = .empty,
+
+    pub fn deinit(self: *Manifest, allocator: std.mem.Allocator) void {
+        self.arena_state.deinit();
+        allocator.destroy(self.arena_state);
+    }
+};
+
+/// Read `{ws_dir}/manifest.json` into an in-memory map. Returns an empty
+/// manifest (no error) if the file does not exist — that is the expected
+/// state before the first sync. Format mismatch returns InvalidManifest.
+pub fn loadManifest(allocator: std.mem.Allocator, ws_dir: []const u8) !Manifest {
+    const arena_state = try allocator.create(std.heap.ArenaAllocator);
+    errdefer allocator.destroy(arena_state);
+    arena_state.* = std.heap.ArenaAllocator.init(allocator);
+    errdefer arena_state.deinit();
+
+    var manifest: Manifest = .{ .arena_state = arena_state };
+    const arena = arena_state.allocator();
+
+    const manifest_path = try std.fs.path.join(arena, &.{ ws_dir, "manifest.json" });
+
+    const file = std.fs.openFileAbsolute(manifest_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return manifest,
+        else => return err,
+    };
+    defer file.close();
+
+    var read_buf: [4096]u8 = undefined;
+    var fr = std.fs.File.Reader.init(file, &read_buf);
+    const content = try fr.interface.allocRemaining(arena, std.io.Limit.limited(4 * 1024 * 1024));
+
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, content, .{}) catch return error.InvalidManifest;
+    if (parsed != .object) return error.InvalidManifest;
+
+    if (parsed.object.get("prompts")) |prompts_val| {
+        try parseManifestSection(arena, &manifest.prompts, prompts_val);
+    }
+    if (parsed.object.get("context")) |context_val| {
+        try parseManifestSection(arena, &manifest.context, context_val);
+    }
+
+    return manifest;
+}
+
+fn parseManifestSection(
+    arena: std.mem.Allocator,
+    map: *std.StringHashMapUnmanaged(ManifestEntry),
+    value: std.json.Value,
+) !void {
+    if (value != .object) return;
+    var it = value.object.iterator();
+    while (it.next()) |entry| {
+        const obj = switch (entry.value_ptr.*) {
+            .object => |o| o,
+            else => continue,
+        };
+        const path_str = if (obj.get("path")) |v| switch (v) {
+            .string => |s| s,
+            else => continue,
+        } else continue;
+        const hash_str = if (obj.get("hash")) |v| switch (v) {
+            .string => |s| s,
+            else => continue,
+        } else continue;
+
+        try map.put(arena, entry.key_ptr.*, .{ .path = path_str, .hash = hash_str });
+    }
+}
 
 fn freePromptItem(allocator: std.mem.Allocator, item: PromptItem) void {
     allocator.free(item.id);
@@ -127,125 +201,84 @@ pub fn deinitPromptItems(allocator: std.mem.Allocator, items: *std.ArrayList(Pro
     items.deinit(allocator);
 }
 
-/// Discover all prompts in the workspace cache directory, organized by kind.
-pub fn discoverAll(allocator: std.mem.Allocator, workspace_root: []const u8) !std.ArrayList(PromptItem) {
-    var items: std.ArrayList(PromptItem) = .empty;
-    errdefer deinitPromptItems(allocator, &items);
-
-    const prompts_root = workspace_root;
-
-    for (kind_dirs) |kd| {
-        try scanKindDirectory(allocator, prompts_root, kd.dir, kd.kind, &items);
-    }
-
-    std.mem.sort(PromptItem, items.items, {}, lessThanPromptItem);
-    return items;
+fn kindFromPath(path: []const u8) ?PromptKind {
+    if (std.mem.startsWith(u8, path, "rule/")) return .rule;
+    if (std.mem.startsWith(u8, path, "workflow/")) return .workflow;
+    if (std.mem.startsWith(u8, path, "context/")) return .context;
+    return null;
 }
 
-/// Discover prompts for memory.search.
-pub fn discoverSearchable(allocator: std.mem.Allocator, workspace_root: []const u8, kind_filter: ?PromptKind, group_filter: ?[]const u8) !std.ArrayList(PromptItem) {
-    var items: std.ArrayList(PromptItem) = .empty;
-    errdefer deinitPromptItems(allocator, &items);
-
-    const prompts_root = workspace_root;
-
-    const searchable_kinds = [_]struct { dir: []const u8, kind: PromptKind }{
-        .{ .dir = "rule", .kind = .rule },
-        .{ .dir = "workflow", .kind = .workflow },
-        .{ .dir = "context", .kind = .context },
-    };
-
-    for (searchable_kinds) |kd| {
-        if (kind_filter) |filter| {
-            if (filter != kd.kind) continue;
-        }
-        try scanKindDirectory(allocator, prompts_root, kd.dir, kd.kind, &items);
-    }
-
-    // Apply group filter in-place to avoid double-free on shared pointers
-    if (group_filter) |gf| {
-        var write_idx: usize = 0;
-        for (items.items) |item| {
-            const item_group = item.group orelse {
-                freePromptItem(allocator, item);
-                continue;
-            };
-            if (std.mem.eql(u8, item_group, gf) or
-                (std.mem.startsWith(u8, item_group, gf) and gf.len < item_group.len and item_group[gf.len] == '/'))
-            {
-                items.items[write_idx] = item;
-                write_idx += 1;
-            } else {
-                freePromptItem(allocator, item);
-            }
-        }
-        items.items.len = write_idx;
-    }
-
-    std.mem.sort(PromptItem, items.items, {}, lessThanPromptItem);
-    return items;
+fn groupFromPath(path: []const u8) ?[]const u8 {
+    const slash = std.mem.indexOfScalar(u8, path, '/') orelse return null;
+    const after_kind = path[slash + 1 ..];
+    const next_slash = std.mem.indexOfScalar(u8, after_kind, '/') orelse return null;
+    return after_kind[0..next_slash];
 }
 
-/// Load prompts by ids, returning content for changed items (delta).
-pub fn loadPrompts(allocator: std.mem.Allocator, workspace_root: []const u8, ids: []const []const u8, known: []const KnownHash) !LoadResult {
-    var inventory = try discoverAll(allocator, workspace_root);
-    defer deinitPromptItems(allocator, &inventory);
-
-    return try materializeSelection(allocator, workspace_root, inventory.items, ids, known);
+fn matchesGroup(item_group: []const u8, filter: []const u8) bool {
+    if (std.mem.eql(u8, item_group, filter)) return true;
+    if (std.mem.startsWith(u8, item_group, filter) and filter.len < item_group.len and item_group[filter.len] == '/') return true;
+    return false;
 }
 
-fn scanKindDirectory(
+/// Discover prompts available for memory.search. Iterates the local
+/// manifest, classifies each entry by path prefix, and applies optional
+/// kind/group filters. Reserved paths (META_PROMPT.md) are excluded.
+pub fn discoverSearchable(
     allocator: std.mem.Allocator,
-    prompts_root: []const u8,
-    dir_name: []const u8,
-    kind: PromptKind,
-    items: *std.ArrayList(PromptItem),
-) !void {
-    const kind_path = try std.fs.path.join(allocator, &.{ prompts_root, dir_name });
-    defer allocator.free(kind_path);
+    ws_dir: []const u8,
+    kind_filter: ?PromptKind,
+    group_filter: ?[]const u8,
+) !std.ArrayList(PromptItem) {
+    var items: std.ArrayList(PromptItem) = .empty;
+    errdefer deinitPromptItems(allocator, &items);
 
-    var kind_dir = std.fs.openDirAbsolute(kind_path, .{ .iterate = true }) catch return;
-    defer kind_dir.close();
+    var manifest = try loadManifest(allocator, ws_dir);
+    defer manifest.deinit(allocator);
 
-    var walker = try kind_dir.walk(allocator);
-    defer walker.deinit();
+    var it = manifest.prompts.iterator();
+    while (it.next()) |entry| {
+        const m_entry = entry.value_ptr.*;
 
-    const kind_str = kindToString(kind);
+        if (std.mem.eql(u8, m_entry.path, "META_PROMPT.md")) continue;
 
-    while (try walker.next()) |entry| {
-        if (entry.kind != .file) continue;
-        if (std.mem.startsWith(u8, entry.path, ".")) continue;
+        const kind = kindFromPath(m_entry.path) orelse continue;
+        if (kind_filter) |kf| {
+            if (kf != kind) continue;
+        }
 
-        const abs_path = try std.fs.path.join(allocator, &.{ kind_path, entry.path });
-        defer allocator.free(abs_path);
+        const group_slice = groupFromPath(m_entry.path);
+        if (group_filter) |gf| {
+            const g = group_slice orelse continue;
+            if (!matchesGroup(g, gf)) continue;
+        }
 
-        // id = "kind:relative_path" where relative_path is relative to the kind directory
-        const id = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ kind_str, entry.path });
-        errdefer allocator.free(id);
+        const display_name = prompt.displayNameFromFilename(std.fs.path.basename(m_entry.path));
 
-        // path = relative to workspace root
-        const rel_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir_name, entry.path });
-        errdefer allocator.free(rel_path);
-
-        // group = first subdirectory under the kind directory, or null
-        const group = if (std.fs.path.dirname(entry.path)) |dir|
-            try allocator.dupe(u8, dir)
-        else
-            null;
-        errdefer if (group) |g| allocator.free(g);
-
-        const display_name = prompt.displayNameFromFilename(std.fs.path.basename(entry.path));
+        const id_owned = try allocator.dupe(u8, entry.key_ptr.*);
+        errdefer allocator.free(id_owned);
+        const path_owned = try allocator.dupe(u8, m_entry.path);
+        errdefer allocator.free(path_owned);
+        const name_owned = try allocator.dupe(u8, display_name);
+        errdefer allocator.free(name_owned);
+        const group_owned = if (group_slice) |g| try allocator.dupe(u8, g) else null;
+        errdefer if (group_owned) |g| allocator.free(g);
+        const hash_owned = try allocator.dupe(u8, m_entry.hash);
+        errdefer allocator.free(hash_owned);
 
         try items.append(allocator, .{
-            .id = id,
+            .id = id_owned,
             .kind = kind,
-            .path = rel_path,
-            .name = try allocator.dupe(u8, display_name),
-            .group = group,
-            .hash = try prompt.readFileHashHexAlloc(allocator, abs_path),
+            .path = path_owned,
+            .name = name_owned,
+            .group = group_owned,
+            .hash = hash_owned,
             .priority = priorityForKind(kind),
         });
     }
+
+    std.mem.sort(PromptItem, items.items, {}, lessThanPromptItem);
+    return items;
 }
 
 fn lessThanPromptItem(_: void, a: PromptItem, b: PromptItem) bool {
@@ -254,82 +287,68 @@ fn lessThanPromptItem(_: void, a: PromptItem, b: PromptItem) bool {
     return std.mem.order(u8, a.id, b.id) == .lt;
 }
 
-fn materializeAll(
+/// Load prompt content by hub-issued prompt_id. Resolves each id through
+/// the local manifest, reads the cache file, and returns content + metadata.
+/// Unknown ids return `error.UnknownPromptId`.
+pub fn loadPrompts(
     allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    items: []const PromptItem,
-    known: []const KnownHash,
-) !LoadResult {
-    var result: LoadResult = .{};
-    errdefer result.deinit(allocator);
-
-    try result.items.ensureTotalCapacity(allocator, items.len);
-    for (items) |item| {
-        try result.items.append(allocator, try materializeItem(allocator, workspace_root, item, knownHashFor(item.id, known)));
-    }
-    return result;
-}
-
-fn materializeSelection(
-    allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    inventory: []const PromptItem,
+    ws_dir: []const u8,
     ids: []const []const u8,
     known: []const KnownHash,
 ) !LoadResult {
+    var manifest = try loadManifest(allocator, ws_dir);
+    defer manifest.deinit(allocator);
+
     var result: LoadResult = .{};
     errdefer result.deinit(allocator);
 
-    var seen_ids = std.StringHashMap(void).init(allocator);
+    var seen = std.StringHashMap(void).init(allocator);
     defer {
-        var key_iter = seen_ids.keyIterator();
-        while (key_iter.next()) |key| allocator.free(@constCast(key.*));
-        seen_ids.deinit();
+        var it = seen.keyIterator();
+        while (it.next()) |k| allocator.free(@constCast(k.*));
+        seen.deinit();
     }
 
     for (ids) |id| {
-        if (seen_ids.contains(id)) continue;
-
+        if (seen.contains(id)) continue;
         const seen_key = try allocator.dupe(u8, id);
-        seen_ids.put(seen_key, {}) catch |err| {
+        seen.put(seen_key, {}) catch |err| {
             allocator.free(seen_key);
             return err;
         };
 
-        const item = findPromptById(inventory, id) orelse return error.UnknownPromptId;
-        try result.items.append(allocator, try materializeItem(allocator, workspace_root, item, knownHashFor(id, known)));
+        const m_entry = manifest.prompts.get(id) orelse return error.UnknownPromptId;
+        const kind = kindFromPath(m_entry.path) orelse return error.UnknownPromptId;
+
+        const known_hash = knownHashFor(id, known);
+        const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
+
+        const content = if (changed)
+            try readCacheFileAlloc(allocator, ws_dir, m_entry.path)
+        else
+            null;
+        errdefer if (content) |owned| allocator.free(owned);
+
+        const display_name = prompt.displayNameFromFilename(std.fs.path.basename(m_entry.path));
+        const group_slice = groupFromPath(m_entry.path);
+
+        try result.items.append(allocator, .{
+            .id = try allocator.dupe(u8, id),
+            .kind = kind,
+            .path = try allocator.dupe(u8, m_entry.path),
+            .name = try allocator.dupe(u8, display_name),
+            .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
+            .hash = try allocator.dupe(u8, m_entry.hash),
+            .changed = changed,
+            .content = content,
+        });
     }
 
     return result;
 }
 
-fn materializeItem(
-    allocator: std.mem.Allocator,
-    workspace_root: []const u8,
-    item: PromptItem,
-    known_hash: ?[]const u8,
-) !LoadedPrompt {
-    const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, item.hash);
-    const content = if (changed)
-        try readWorkspaceFileAlloc(allocator, workspace_root, item.path)
-    else
-        null;
-    errdefer if (content) |owned| allocator.free(owned);
-
-    return .{
-        .id = try allocator.dupe(u8, item.id),
-        .kind = item.kind,
-        .path = try allocator.dupe(u8, item.path),
-        .name = try allocator.dupe(u8, item.name),
-        .group = if (item.group) |group| try allocator.dupe(u8, group) else null,
-        .hash = try allocator.dupe(u8, item.hash),
-        .changed = changed,
-        .content = content,
-    };
-}
-
-fn readWorkspaceFileAlloc(allocator: std.mem.Allocator, workspace_root: []const u8, rel_path: []const u8) ![]const u8 {
-    const abs_path = try std.fs.path.join(allocator, &.{ workspace_root, rel_path });
+fn readCacheFileAlloc(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
+    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", rel_path });
     defer allocator.free(abs_path);
 
     const file = try std.fs.openFileAbsolute(abs_path, .{});
@@ -340,21 +359,12 @@ fn readWorkspaceFileAlloc(allocator: std.mem.Allocator, workspace_root: []const 
     return try fr.interface.allocRemaining(allocator, std.io.Limit.limited(prompt.MAX_FILE_SIZE));
 }
 
-fn findPromptById(inventory: []const PromptItem, id: []const u8) ?PromptItem {
-    for (inventory) |item| {
-        if (std.mem.eql(u8, item.id, id)) return item;
-    }
-    return null;
-}
-
 fn knownHashFor(id: []const u8, known: []const KnownHash) ?[]const u8 {
     for (known) |entry| {
         if (std.mem.eql(u8, entry.id, id)) return entry.hash;
     }
     return null;
 }
-
-// Constraint parsing (for validate)
 
 pub const ParsedConstraint = struct {
     id: []const u8,
@@ -412,7 +422,6 @@ pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !Vali
     var line_num: usize = 0;
     var constraint_counter: usize = 0;
 
-    // State: are we inside a ## region?
     var in_region = false;
     var region_start: usize = 0;
     var region_has_list = false;
@@ -422,25 +431,20 @@ pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !Vali
         line_num += 1;
         const trimmed = std.mem.trimLeft(u8, line, " \t");
 
-        // # heading = title, skip
         if (std.mem.startsWith(u8, trimmed, "# ") and !std.mem.startsWith(u8, trimmed, "## ")) {
             continue;
         }
 
-        // ## heading = new constraint region (with reserved heading exceptions)
         if (std.mem.startsWith(u8, trimmed, "## ")) {
             const heading_text = trimmed[3..];
 
-            // Reserved: ## Steps — execution steps, not constraints
             const is_steps = std.ascii.eqlIgnoreCase(heading_text, "Steps") or
                 std.ascii.eqlIgnoreCase(heading_text, "steps");
-            // Reserved: ## Examples — supporting material
             const is_examples = std.ascii.eqlIgnoreCase(heading_text, "Examples") or
                 std.ascii.eqlIgnoreCase(heading_text, "examples") or
                 std.ascii.eqlIgnoreCase(heading_text, "Example") or
                 std.ascii.eqlIgnoreCase(heading_text, "example");
 
-            // Close previous region if open
             if (in_region and !region_has_list) {
                 constraint_counter += 1;
                 const id = try std.fmt.allocPrint(allocator, "c-{d}", .{constraint_counter});
@@ -463,9 +467,7 @@ pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !Vali
             continue;
         }
 
-        // List item (- or 1.) within a region = individual constraint
         if (in_region and (std.mem.startsWith(u8, trimmed, "- ") or isOrderedListItem(trimmed))) {
-            // Skip support material lines
             if (std.mem.startsWith(u8, trimmed, "- **理由**") or
                 std.mem.startsWith(u8, trimmed, "- **示例**"))
                 continue;
@@ -481,7 +483,6 @@ pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !Vali
             continue;
         }
 
-        // **理由** / **示例** = support material, skip
         if (std.mem.startsWith(u8, trimmed, "**理由**") or
             std.mem.startsWith(u8, trimmed, "**示例**") or
             std.mem.startsWith(u8, trimmed, "✅") or
@@ -491,7 +492,6 @@ pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !Vali
         }
     }
 
-    // Close last region
     if (in_region and !region_has_list) {
         constraint_counter += 1;
         const id = try std.fmt.allocPrint(allocator, "c-{d}", .{constraint_counter});
@@ -530,46 +530,6 @@ fn isOrderedListItem(line: []const u8) bool {
     return line[i] == '.' and i + 1 < line.len and line[i + 1] == ' ';
 }
 
-/// Validate a prompt file. For Rule/Workflow: parse constraints. For Data: just check readable.
-pub fn validatePrompt(allocator: std.mem.Allocator, workspace_root: []const u8, prompt_id: []const u8) !ValidateResult {
-    var all = try discoverAll(allocator, workspace_root);
-    defer deinitPromptItems(allocator, &all);
-
-    const item = findPromptById(all.items, prompt_id) orelse {
-        var issues: std.ArrayList([]const u8) = .empty;
-        try issues.append(allocator, try allocator.dupe(u8, "Prompt not found"));
-        return .{
-            .valid = false,
-            .constraints = .empty,
-            .issues = issues,
-        };
-    };
-
-    if (item.kind == .context) {
-        // Just check readable
-        const content = readWorkspaceFileAlloc(allocator, workspace_root, item.path) catch {
-            var issues: std.ArrayList([]const u8) = .empty;
-            try issues.append(allocator, try allocator.dupe(u8, "File not readable"));
-            return .{
-                .valid = false,
-                .constraints = .empty,
-                .issues = issues,
-            };
-        };
-        allocator.free(content);
-        return .{
-            .valid = true,
-            .constraints = .empty,
-            .issues = .empty,
-        };
-    }
-
-    // Rule or Workflow: parse constraints
-    const content = try readWorkspaceFileAlloc(allocator, workspace_root, item.path);
-    defer allocator.free(content);
-    return try parseConstraints(allocator, content);
-}
-
 fn writeFile(dir: std.fs.Dir, sub_path: []const u8, content: []const u8) !void {
     const file = try dir.createFile(sub_path, .{});
     defer file.close();
@@ -583,54 +543,245 @@ fn tmpDirAbsolutePath(tmp: *std.testing.TmpDir, buf: *[std.fs.max_path_bytes]u8)
     return tmp.dir.realpath(".", buf) catch "";
 }
 
-test "discoverAll: finds rules workflows and data by kind directory" {
+fn writeTestManifest(dir: std.fs.Dir, json: []const u8) !void {
+    try writeFile(dir, "manifest.json", json);
+}
+
+test "loadManifest: parses prompts and context entries" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("rule/coding");
-    try tmp.dir.makePath("workflow");
-    try tmp.dir.makePath("context/research");
-
-    try writeFile(tmp.dir, "rule/coding/00_COMPAT.md", "compat rule");
-    try writeFile(tmp.dir, "workflow/00_GEN_COMMIT.md", "commit workflow");
-    try writeFile(tmp.dir, "context/research/R1-0.md", "research data");
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "revision": 7,
+        \\  "prompts": {
+        \\    "p-1": {"path": "rule/coding/STYLE.md", "hash": "sha256:abc"},
+        \\    "p-2": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:def"}
+        \\  },
+        \\  "context": {
+        \\    "c-1": {"path": "spec/API.md", "hash": "sha256:xyz"}
+        \\  }
+        \\}
+    );
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    var items = try discoverAll(testing.allocator, root);
-    defer deinitPromptItems(testing.allocator, &items);
+    var manifest = try loadManifest(testing.allocator, root);
+    defer manifest.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(usize, 3), items.items.len);
+    try testing.expectEqual(@as(usize, 2), manifest.prompts.count());
+    try testing.expectEqual(@as(usize, 1), manifest.context.count());
 
-    var found_rule = false;
-    var found_workflow = false;
-    var found_data = false;
-    for (items.items) |item| {
-        if (std.mem.eql(u8, item.id, "rule:coding/00_COMPAT.md")) {
-            found_rule = true;
-            try testing.expectEqualStrings("coding", item.group.?);
-        }
-        if (std.mem.eql(u8, item.id, "workflow:00_GEN_COMMIT.md")) {
-            found_workflow = true;
-            try testing.expect(item.group == null);
-        }
-        if (std.mem.eql(u8, item.id, "context:research/R1-0.md")) {
-            found_data = true;
-            try testing.expectEqualStrings("research", item.group.?);
-        }
-    }
-    try testing.expect(found_rule);
-    try testing.expect(found_workflow);
-    try testing.expect(found_data);
+    const p1 = manifest.prompts.get("p-1").?;
+    try testing.expectEqualStrings("rule/coding/STYLE.md", p1.path);
+    try testing.expectEqualStrings("sha256:abc", p1.hash);
+
+    const c1 = manifest.context.get("c-1").?;
+    try testing.expectEqualStrings("spec/API.md", c1.path);
 }
 
-test "loadMpf: returns content and hash" {
+test "loadManifest: missing file returns empty manifest" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath(".prompts");
-    try writeFile(tmp.dir, "META_PROMPT.md", "bootstrap rules");
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var manifest = try loadManifest(testing.allocator, root);
+    defer manifest.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 0), manifest.prompts.count());
+    try testing.expectEqual(@as(usize, 0), manifest.context.count());
+}
+
+test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule/coding");
+    try tmp.dir.makePath("cache/workflow/cmd");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style");
+    try writeFile(tmp.dir, "cache/workflow/cmd/COMMIT.md", "commit");
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
+        \\    "p-commit": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:2"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var items = try discoverSearchable(testing.allocator, root, null, null);
+    defer deinitPromptItems(testing.allocator, &items);
+
+    try testing.expectEqual(@as(usize, 2), items.items.len);
+
+    var found_style = false;
+    var found_commit = false;
+    for (items.items) |item| {
+        if (std.mem.eql(u8, item.id, "p-style")) {
+            found_style = true;
+            try testing.expectEqual(PromptKind.rule, item.kind);
+            try testing.expectEqualStrings("rule/coding/STYLE.md", item.path);
+            try testing.expectEqualStrings("coding", item.group.?);
+        }
+        if (std.mem.eql(u8, item.id, "p-commit")) {
+            found_commit = true;
+            try testing.expectEqual(PromptKind.workflow, item.kind);
+            try testing.expectEqualStrings("cmd", item.group.?);
+        }
+    }
+    try testing.expect(found_style);
+    try testing.expect(found_commit);
+}
+
+test "discoverSearchable: kind filter narrows results" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
+        \\    "p-commit": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:2"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var rules = try discoverSearchable(testing.allocator, root, .rule, null);
+    defer deinitPromptItems(testing.allocator, &rules);
+
+    try testing.expectEqual(@as(usize, 1), rules.items.len);
+    try testing.expectEqualStrings("p-style", rules.items[0].id);
+}
+
+test "discoverSearchable: group filter matches first path component after kind" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-1": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
+        \\    "p-2": {"path": "rule/zig/NAMING.md", "hash": "sha256:2"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var zig_rules = try discoverSearchable(testing.allocator, root, .rule, "zig");
+    defer deinitPromptItems(testing.allocator, &zig_rules);
+
+    try testing.expectEqual(@as(usize, 1), zig_rules.items.len);
+    try testing.expectEqualStrings("p-2", zig_rules.items[0].id);
+}
+
+test "discoverSearchable: META_PROMPT.md is excluded" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-mpf": {"path": "META_PROMPT.md", "hash": "sha256:abc"},
+        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var items = try discoverSearchable(testing.allocator, root, null, null);
+    defer deinitPromptItems(testing.allocator, &items);
+
+    try testing.expectEqual(@as(usize, 1), items.items.len);
+    try testing.expectEqualStrings("p-style", items.items[0].id);
+}
+
+test "loadPrompts: looks up by hub prompt_id and reads cache file" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule");
+    try writeFile(tmp.dir, "cache/rule/STYLE.md", "style content");
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &.{});
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), result.items.items.len);
+    try testing.expectEqualStrings("p-style", result.items.items[0].id);
+    try testing.expect(result.items.items[0].changed);
+    try testing.expectEqualStrings("style content", result.items.items[0].content.?);
+}
+
+test "loadPrompts: known hash matches returns delta with no content" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule");
+    try writeFile(tmp.dir, "cache/rule/STYLE.md", "style content");
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "prompts": {
+        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    const known = [_]KnownHash{.{ .id = "p-style", .hash = "sha256:zzz" }};
+    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &known);
+    defer result.deinit(testing.allocator);
+
+    try testing.expect(!result.items.items[0].changed);
+    try testing.expect(result.items.items[0].content == null);
+}
+
+test "loadPrompts: unknown id returns UnknownPromptId" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{"prompts": {}}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"p-missing"}, &.{}));
+}
+
+test "loadMpf: returns content and hash from cache subdirectory" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
@@ -647,19 +798,17 @@ test "loadMpf: delta when hash matches" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath(".prompts");
-    try writeFile(tmp.dir, "META_PROMPT.md", "bootstrap rules");
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    // First load to get hash
     var first = try loadMpf(testing.allocator, root, null);
     const hash = try testing.allocator.dupe(u8, first.hash.?);
     defer testing.allocator.free(hash);
     first.deinit(testing.allocator);
 
-    // Second load with known hash — content should be null (no delta)
     var second = try loadMpf(testing.allocator, root, hash);
     defer second.deinit(testing.allocator);
 
@@ -671,8 +820,6 @@ test "loadMpf: returns null when file missing" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath(".prompts");
-
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
@@ -681,61 +828,6 @@ test "loadMpf: returns null when file missing" {
 
     try testing.expect(result.content == null);
     try testing.expect(result.hash == null);
-}
-
-test "discoverSearchable: filters by kind and group" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    try tmp.dir.makePath("rule/coding");
-    try tmp.dir.makePath("rule/zig");
-    try tmp.dir.makePath("workflow");
-
-    try writeFile(tmp.dir, "rule/coding/00_COMPAT.md", "compat");
-    try writeFile(tmp.dir, "rule/zig/00_STYLE.md", "style");
-    try writeFile(tmp.dir, "workflow/00_COMMIT.md", "commit");
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root = tmpDirAbsolutePath(&tmp, &buf);
-
-    // Filter by kind=rule
-    var rules = try discoverSearchable(testing.allocator, root, .rule, null);
-    defer deinitPromptItems(testing.allocator, &rules);
-    try testing.expectEqual(@as(usize, 2), rules.items.len);
-
-    // Filter by kind=rule, group=zig
-    var zig_rules = try discoverSearchable(testing.allocator, root, .rule, "zig");
-    defer deinitPromptItems(testing.allocator, &zig_rules);
-    try testing.expectEqual(@as(usize, 1), zig_rules.items.len);
-    try testing.expectEqualStrings("rule:zig/00_STYLE.md", zig_rules.items[0].id);
-}
-
-test "loadPrompts: loads by id with delta" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    try tmp.dir.makePath("rule");
-    try writeFile(tmp.dir, "rule/00_STYLE.md", "style content");
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root = tmpDirAbsolutePath(&tmp, &buf);
-
-    var result = try loadPrompts(testing.allocator, root, &.{"rule:00_STYLE.md"}, &.{});
-    defer result.deinit(testing.allocator);
-
-    try testing.expectEqual(@as(usize, 1), result.items.items.len);
-    try testing.expect(result.items.items[0].changed);
-    try testing.expectEqualStrings("style content", result.items.items[0].content.?);
-}
-
-test "loadPrompts: unknown id fails" {
-    var tmp = std.testing.tmpDir(.{});
-    defer tmp.cleanup();
-
-    var buf: [std.fs.max_path_bytes]u8 = undefined;
-    const root = tmpDirAbsolutePath(&tmp, &buf);
-
-    try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"rule:missing.md"}, &.{}));
 }
 
 test "parseConstraints: list items become individual constraints" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@ const cmd_mcp = @import("commands/mcp_cmd.zig");
 const cmd_setup = @import("commands/setup_cmd.zig");
 const cmd_workspace_info = @import("commands/workspace_info_cmd.zig");
 const cmd_flush_trace = @import("commands/flush_trace_cmd.zig");
+const cmd_trace_append = @import("commands/trace_append_cmd.zig");
 const cmd_help = @import("commands/help.zig");
 
 const Color = styles.Color;
@@ -22,7 +23,7 @@ const Command = enum {
     init_cmd,
     sync,
     mcp,
-    flush_trace,
+    trace,
     help,
     version,
     none,
@@ -33,7 +34,7 @@ const command_map = std.StaticStringMap(Command).initComptime(.{
     .{ "init", .init_cmd },
     .{ "sync", .sync },
     .{ "mcp", .mcp },
-    .{ "flush-trace", .flush_trace },
+    .{ "trace", .trace },
     .{ "help", .help },
     .{ "-h", .help },
     .{ "--help", .help },
@@ -108,7 +109,18 @@ pub fn main() !void {
         .init_cmd => try cmd_init.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .sync => try cmd_sync.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .mcp => try cmd_mcp.run(stdout_writer, stderr_writer, allocator, cmd_args, version),
-        .flush_trace => try cmd_flush_trace.run(stdout_writer, stderr_writer, allocator, cmd_args),
+        .trace => {
+            const subcmd = if (cmd_args.len > 0) cmd_args[0] else "";
+            if (std.mem.eql(u8, subcmd, "flush")) {
+                try cmd_flush_trace.run(stdout_writer, stderr_writer, allocator, cmd_args[1..]);
+            } else if (std.mem.eql(u8, subcmd, "append")) {
+                try cmd_trace_append.run(stdout_writer, stderr_writer, allocator, cmd_args[1..]);
+            } else {
+                try stderr_writer.print("{s}{s}{s}Error:{s} unknown trace subcommand: {s}\n", .{ P, Color.bold, Color.red, Color.reset, subcmd });
+                stderr_file_writer.interface.flush() catch {};
+                std.process.exit(1);
+            }
+        },
         .none => {
             if (args.len > 1) {
                 // Unknown command
@@ -131,7 +143,7 @@ test "command_map: all commands resolve" {
         .{ .str = "login", .cmd = .login },
         .{ .str = "init", .cmd = .init_cmd },
         .{ .str = "sync", .cmd = .sync },
-        .{ .str = "flush-trace", .cmd = .flush_trace },
+        .{ .str = "trace", .cmd = .trace },
         .{ .str = "mcp", .cmd = .mcp },
         .{ .str = "help", .cmd = .help },
         .{ .str = "-h", .cmd = .help },

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ const cmd_init = @import("commands/init_cmd.zig");
 const cmd_sync = @import("commands/sync_cmd.zig");
 const cmd_mcp = @import("commands/mcp_cmd.zig");
 const cmd_setup = @import("commands/setup_cmd.zig");
+const cmd_workspace_info = @import("commands/workspace_info_cmd.zig");
 const cmd_flush_trace = @import("commands/flush_trace_cmd.zig");
 const cmd_help = @import("commands/help.zig");
 
@@ -88,6 +89,8 @@ pub fn main() !void {
         const subcmd = if (cmd_args.len > 0) cmd_args[0] else "";
         if (std.mem.eql(u8, subcmd, "setup")) {
             try cmd_setup.run(stdout_writer, stderr_writer, allocator);
+        } else if (std.mem.eql(u8, subcmd, "workspace-info")) {
+            try cmd_workspace_info.run(stdout_writer, stderr_writer, allocator);
         } else {
             try stderr_writer.print("{s}{s}{s}Error:{s} unknown agent command: {s}\n", .{ P, Color.bold, Color.red, Color.reset, subcmd });
             stderr_file_writer.interface.flush() catch {};

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -435,11 +435,26 @@ fn appendLoadedPromptWithConstraints(
 ) !void {
     const esc_id = try encoding.jsonEscapeAlloc(allocator, item.id);
     defer allocator.free(esc_id);
+    const esc_path = try encoding.jsonEscapeAlloc(allocator, item.path);
+    defer allocator.free(esc_path);
 
     try buf.writer(allocator).print(
-        "{{\"id\":\"{s}\",\"kind\":\"{s}\",\"changed\":{s},\"hash\":\"{s}\",\"content\":",
-        .{ esc_id, workspace_prompt.kindToString(item.kind), if (item.changed) "true" else "false", item.hash },
+        "{{\"id\":\"{s}\",\"kind\":\"{s}\",\"path\":\"{s}\",\"changed\":{s},\"hash\":\"{s}\",\"hasDraft\":{s},",
+        .{
+            esc_id,
+            workspace_prompt.kindToString(item.kind),
+            esc_path,
+            if (item.changed) "true" else "false",
+            item.hash,
+            if (item.has_draft) "true" else "false",
+        },
     );
+    if (item.draft_base_hash) |bh| {
+        const esc_bh = try encoding.jsonEscapeAlloc(allocator, bh);
+        defer allocator.free(esc_bh);
+        try buf.writer(allocator).print("\"draftBaseHash\":\"{s}\",", .{esc_bh});
+    }
+    try buf.appendSlice(allocator, "\"content\":");
     if (item.content) |content| {
         const needs_reminder = item.kind == .rule or item.kind == .workflow;
         if (needs_reminder) {

--- a/src/mcp/handlers.zig
+++ b/src/mcp/handlers.zig
@@ -68,7 +68,7 @@ const tool_refer =
 pub fn handleToolCall(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
-    session_ptr: *?Session,
+    session: *Session,
     params: std.json.Value,
 ) ![]u8 {
     const params_obj = switch (params) {
@@ -88,26 +88,30 @@ pub fn handleToolCall(
     };
 
     if (std.mem.eql(u8, name, "memory.setup")) {
-        return try handleSetup(allocator, workspace_root, session_ptr, args_obj);
+        return try handleSetup(allocator, workspace_root, session, args_obj);
     }
     if (std.mem.eql(u8, name, "memory.search")) {
-        return try handleSearch(allocator, workspace_root, session_ptr, args_obj);
+        return try handleSearch(allocator, workspace_root, session, args_obj);
     }
     if (std.mem.eql(u8, name, "memory.load")) {
-        return handleLoad(allocator, workspace_root, session_ptr, args_obj) catch |err| switch (err) {
+        return handleLoad(allocator, workspace_root, session, args_obj) catch |err| switch (err) {
             error.UnknownPromptId => try buildToolErrorResult(allocator, "Unknown prompt id"),
             else => return err,
         };
     }
 
     if (std.mem.eql(u8, name, "memory.refer")) {
-        return try handleRefer(allocator, session_ptr, args_obj);
+        return try handleRefer(allocator, session, args_obj);
     }
 
     return try buildToolErrorResult(allocator, "Unknown tool");
 }
 
-fn initSession(allocator: std.mem.Allocator, workspace_root: []const u8) !Session {
+/// Initialize an MCP session for the given workspace. Resolves the workspace
+/// binding from config.toml, generates a random session_id, and writes the
+/// first setup trace event (event_id=0) to trace.jsonl. Called once per MCP
+/// server process at startup, not from a tool handler.
+pub fn initSession(allocator: std.mem.Allocator, workspace_root: []const u8) !Session {
     const binding = try ws_config.resolveWorkspace(allocator, workspace_root);
     defer allocator.free(binding.name);
 
@@ -120,24 +124,38 @@ fn initSession(allocator: std.mem.Allocator, workspace_root: []const u8) !Sessio
         session_id[i * 2 + 1] = hex[byte & 0x0f];
     }
 
-    return .{
+    var session: Session = .{
         .ws_id = binding.ws_id,
         .session_id = session_id,
         .event_counter = std.atomic.Value(i64).init(0),
     };
+
+    const event_id = session.nextEventId();
+    trace.appendTraceEvent(allocator, .{
+        .ws_id = session.ws_id,
+        .session_id = session.session_id[0..],
+        .event_id = event_id,
+        .type = "setup",
+        .timestamp = std.time.milliTimestamp(),
+    }) catch |err| {
+        std.log.err(
+            "failed to write initial setup trace event session_id='{s}': {}",
+            .{ session.session_id[0..], err },
+        );
+    };
+
+    return session;
 }
 
 fn writeTraceEvent(
     allocator: std.mem.Allocator,
-    session_ptr: *?Session,
+    session: *Session,
     event_type: []const u8,
     prompt_id: ?[]const u8,
     prompt_hash: ?[]const u8,
     constraint_id: ?[]const u8,
     reason: ?[]const u8,
 ) void {
-    if (session_ptr.* == null) return;
-    const session = &session_ptr.*.?;
     const event_id = session.nextEventId();
     trace.appendTraceEvent(allocator, .{
         .ws_id = session.ws_id,
@@ -160,7 +178,7 @@ fn writeTraceEvent(
 fn handleSetup(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
-    session_ptr: *?Session,
+    session: *Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const known_hash: ?[]const u8 = if (args_obj.get("knownHash")) |value| switch (value) {
@@ -168,19 +186,9 @@ fn handleSetup(
         else => null,
     } else null;
 
-    if (session_ptr.* == null) {
-        session_ptr.* = initSession(allocator, workspace_root) catch |err| switch (err) {
-            error.NoWorkspaceFound, error.NoConfigFound => return try buildToolErrorResult(allocator, "Workspace is not bound. Run 'clumsies init' to bind this directory to a workspace."),
-            else => return err,
-        };
-    }
-
     var mpf = try workspace_prompt.loadMpf(allocator, workspace_root, known_hash);
     defer mpf.deinit(allocator);
 
-    writeTraceEvent(allocator, session_ptr, "setup", null, mpf.hash, null, null);
-
-    const session = &session_ptr.*.?;
     const esc_ws = try encoding.jsonEscapeAlloc(allocator, session.ws_id);
     defer allocator.free(esc_ws);
     const esc_session = try encoding.jsonEscapeAlloc(allocator, session.session_id[0..]);
@@ -210,7 +218,7 @@ fn handleSetup(
 fn handleSearch(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
-    session_ptr: *?Session,
+    session: *Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const kind = if (args_obj.get("kind")) |value|
@@ -225,7 +233,7 @@ fn handleSearch(
     var items = try workspace_prompt.discoverSearchable(allocator, workspace_root, kind, group);
     defer workspace_prompt.deinitPromptItems(allocator, &items);
 
-    writeTraceEvent(allocator, session_ptr, "search", null, null, null, null);
+    writeTraceEvent(allocator, session, "search", null, null, null, null);
 
     const structured = try serializePromptList(allocator, items.items);
     defer allocator.free(structured);
@@ -235,7 +243,7 @@ fn handleSearch(
 fn handleLoad(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
-    session_ptr: *?Session,
+    session: *Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     var ids = try parseRequiredIds(allocator, args_obj.get("ids"));
@@ -248,17 +256,17 @@ fn handleLoad(
     defer result.deinit(allocator);
 
     for (result.items.items) |item| {
-        writeTraceEvent(allocator, session_ptr, "load", item.id, item.hash, null, null);
+        writeTraceEvent(allocator, session, "load", item.id, item.hash, null, null);
     }
 
-    const structured = try serializeLoadResultWithConstraints(allocator, &result, session_ptr);
+    const structured = try serializeLoadResultWithConstraints(allocator, &result, session);
     defer allocator.free(structured);
     return try buildToolSuccessResult(allocator, structured);
 }
 
 fn handleRefer(
     allocator: std.mem.Allocator,
-    session_ptr: *?Session,
+    session: *Session,
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const refs_val = args_obj.get("refs") orelse return error.InvalidParams;
@@ -296,7 +304,7 @@ fn handleRefer(
             else => null,
         } else null;
 
-        writeTraceEvent(allocator, session_ptr, "refer", prompt_id, prompt_hash, constraint_id, reason);
+        writeTraceEvent(allocator, session, "refer", prompt_id, prompt_hash, constraint_id, reason);
         count += 1;
     }
 
@@ -344,13 +352,12 @@ fn serializePromptList(allocator: std.mem.Allocator, items: []const workspace_pr
 fn serializeLoadResultWithConstraints(
     allocator: std.mem.Allocator,
     result: *workspace_prompt.LoadResult,
-    session_ptr: *?Session,
+    session: *Session,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
 
-    const ws_id: []const u8 = if (session_ptr.*) |s| s.ws_id else "";
-    const esc_ws = try encoding.jsonEscapeAlloc(allocator, ws_id);
+    const esc_ws = try encoding.jsonEscapeAlloc(allocator, session.ws_id);
     defer allocator.free(esc_ws);
 
     try buf.writer(allocator).print("{{\"workspaceId\":\"{s}\",\"items\":[", .{esc_ws});

--- a/src/mcp/server.zig
+++ b/src/mcp/server.zig
@@ -6,13 +6,9 @@ const trace_upload = @import("../trace_upload.zig");
 
 pub const State = struct {
     workspace_root: []const u8,
-    session: handlers.Session,
+    session: *handlers.Session,
     initialized: bool = false,
     initialize_seen: bool = false,
-
-    pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
-        self.session.deinit(allocator);
-    }
 };
 
 pub fn runWithRoot(
@@ -21,7 +17,7 @@ pub fn runWithRoot(
     allocator: std.mem.Allocator,
     version: []const u8,
     workspace_root: []const u8,
-    session: handlers.Session,
+    session: *handlers.Session,
 ) !void {
     _ = stderr;
 
@@ -29,7 +25,6 @@ pub fn runWithRoot(
         .workspace_root = workspace_root,
         .session = session,
     };
-    defer state.deinit(allocator);
     defer flushOnExit(allocator, &state);
 
     var stdin_buffer: [4096]u8 = undefined;
@@ -123,7 +118,7 @@ fn processMessage(allocator: std.mem.Allocator, state: *State, version: []const 
     }
 
     if (std.mem.eql(u8, method, "tools/call")) {
-        const result = handlers.handleToolCall(allocator, state.workspace_root, &state.session, params) catch |err| switch (err) {
+        const result = handlers.handleToolCall(allocator, state.workspace_root, state.session, params) catch |err| switch (err) {
             error.InvalidParams => return try protocol.buildErrorAlloc(allocator, id.?, .invalid_params, "Invalid tool arguments"),
             else => return err,
         };
@@ -143,14 +138,16 @@ fn handleNotification(state: *State, method: []const u8) ?[]u8 {
 }
 
 test "processLine: initialize then tools list" {
+    var session: handlers.Session = .{
+        .ws_id = try testing.allocator.dupe(u8, "ws-test"),
+        .session_id = [_]u8{'a'} ** 32,
+    };
+    defer session.deinit(testing.allocator);
+
     var state: State = .{
         .workspace_root = "/tmp/workspace",
-        .session = .{
-            .ws_id = try testing.allocator.dupe(u8, "ws-test"),
-            .session_id = [_]u8{'a'} ** 32,
-        },
+        .session = &session,
     };
-    defer state.deinit(testing.allocator);
 
     const init_response = (try processLine(
         testing.allocator,

--- a/src/mcp/server.zig
+++ b/src/mcp/server.zig
@@ -6,26 +6,28 @@ const trace_upload = @import("../trace_upload.zig");
 
 pub const State = struct {
     workspace_root: []const u8,
-    session: ?handlers.Session = null,
+    session: handlers.Session,
     initialized: bool = false,
     initialize_seen: bool = false,
 
     pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
-        if (self.session) |*s| s.deinit(allocator);
+        self.session.deinit(allocator);
     }
 };
 
-pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, version: []const u8) !void {
-    const workspace_root = try std.process.getCwdAlloc(allocator);
-    defer allocator.free(workspace_root);
-    try runWithRoot(stdout, stderr, allocator, version, workspace_root);
-}
-
-pub fn runWithRoot(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, version: []const u8, workspace_root: []const u8) !void {
+pub fn runWithRoot(
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    version: []const u8,
+    workspace_root: []const u8,
+    session: handlers.Session,
+) !void {
     _ = stderr;
 
     var state: State = .{
         .workspace_root = workspace_root,
+        .session = session,
     };
     defer state.deinit(allocator);
     defer flushOnExit(allocator, &state);
@@ -56,8 +58,7 @@ pub fn runWithRoot(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: st
 }
 
 fn flushOnExit(allocator: std.mem.Allocator, state: *State) void {
-    const session = state.session orelse return;
-    const outcome = trace_upload.flushWorkspace(allocator, session.ws_id);
+    const outcome = trace_upload.flushWorkspace(allocator, state.session.ws_id);
     switch (outcome) {
         .flushed => |result| {
             if (result.events_sent > 0) {
@@ -142,7 +143,14 @@ fn handleNotification(state: *State, method: []const u8) ?[]u8 {
 }
 
 test "processLine: initialize then tools list" {
-    var state: State = .{ .workspace_root = "/tmp/workspace" };
+    var state: State = .{
+        .workspace_root = "/tmp/workspace",
+        .session = .{
+            .ws_id = try testing.allocator.dupe(u8, "ws-test"),
+            .session_id = [_]u8{'a'} ** 32,
+        },
+    };
+    defer state.deinit(testing.allocator);
 
     const init_response = (try processLine(
         testing.allocator,

--- a/src/protocol/manifest.zig
+++ b/src/protocol/manifest.zig
@@ -1,18 +1,23 @@
 const std = @import("std");
 
-pub const KvEntry = struct {
-    key: []const u8,
-    value: []const u8,
+pub const ManifestEntry = struct {
+    path: []const u8,
+    hash: []const u8,
 };
 
-pub const KvMap = struct {
-    entries: []const KvEntry,
+pub const ManifestItem = struct {
+    key: []const u8,
+    value: ManifestEntry,
+};
+
+pub const ManifestMap = struct {
+    items: []const ManifestItem,
 
     pub fn jsonStringify(self: *const @This(), jw: anytype) !void {
         try jw.beginObject();
-        for (self.entries) |e| {
-            try jw.objectField(e.key);
-            try jw.write(e.value);
+        for (self.items) |item| {
+            try jw.objectField(item.key);
+            try jw.write(item.value);
         }
         try jw.endObject();
     }

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -131,6 +131,17 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 fn seedPrompts(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding {d} prompts...", .{data.PROMPT_COUNT});
 
+    _ = conn.exec(
+        "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5)",
+        .{
+            "p-mpf",
+            data.ORG_ID,
+            "META_PROMPT.md",
+            "# clumsies Protocol Bootstrap\n\nUse memory.search to discover rules, memory.load to read them, memory.refer to declare what you applied.\n",
+            "sha256:mpf0000000000000000000000000000000000000000000000000000000000",
+        },
+    ) catch |err| log.warn("MPF seed insert failed: {}", .{err});
+
     for (0..data.PROMPT_COUNT) |i| {
         const id = faker.hexId(&state.prompt_ids[i], "p-");
         const hash = faker.hexId(&state.prompt_hashes[i], "sha256:");

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -132,7 +132,7 @@ fn seedPrompts(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding {d} prompts...", .{data.PROMPT_COUNT});
 
     _ = conn.exec(
-        "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5)",
+        "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5) ON CONFLICT (prompt_id) DO NOTHING",
         .{
             "p-mpf",
             data.ORG_ID,

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -16,7 +16,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         },
         else => return err,
     };
-    errdefer session.deinit(allocator);
+    defer session.deinit(allocator);
 
     const ws_dir = try ws_config.getWsDir(allocator, session.ws_id);
     defer allocator.free(ws_dir);
@@ -26,5 +26,5 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     };
     defer lib.session_marker.clear(allocator, ws_dir);
 
-    try mcp_server.runWithRoot(stdout, stderr, allocator, version, ws_dir, session);
+    try mcp_server.runWithRoot(stdout, stderr, allocator, version, ws_dir, &session);
 }

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -17,8 +17,8 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     };
     errdefer session.deinit(allocator);
 
-    const cache_path = try ws_config.getCachePath(allocator, session.ws_id);
-    defer allocator.free(cache_path);
+    const ws_dir = try ws_config.getWsDir(allocator, session.ws_id);
+    defer allocator.free(ws_dir);
 
-    try mcp_server.runWithRoot(stdout, stderr, allocator, version, cache_path, session);
+    try mcp_server.runWithRoot(stdout, stderr, allocator, version, ws_dir, session);
 }

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const mcp_server = @import("mcp/server.zig");
 const mcp_handlers = @import("mcp/handlers.zig");
 const ws_config = @import("workspace_config.zig");
+const lib = @import("clumsies_lib");
 
 pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, version: []const u8) !void {
     const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
@@ -19,6 +20,11 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     const ws_dir = try ws_config.getWsDir(allocator, session.ws_id);
     defer allocator.free(ws_dir);
+
+    lib.session_marker.write(allocator, ws_dir, session.session_id[0..]) catch |err| {
+        std.log.warn("failed to write current_session.json: {}", .{err});
+    };
+    defer lib.session_marker.clear(allocator, ws_dir);
 
     try mcp_server.runWithRoot(stdout, stderr, allocator, version, ws_dir, session);
 }

--- a/src/serve.zig
+++ b/src/serve.zig
@@ -1,21 +1,24 @@
 const std = @import("std");
 const mcp_server = @import("mcp/server.zig");
+const mcp_handlers = @import("mcp/handlers.zig");
 const ws_config = @import("workspace_config.zig");
 
 pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, version: []const u8) !void {
-    // Resolve workspace cache path from config
     const cwd = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd);
 
-    var owned_cache_path: ?[]const u8 = null;
-    defer if (owned_cache_path) |p| allocator.free(p);
+    var session = mcp_handlers.initSession(allocator, cwd) catch |err| switch (err) {
+        error.NoWorkspaceFound, error.NoConfigFound => {
+            try stderr.print("Error: this directory is not bound to a clumsies workspace.\n", .{});
+            try stderr.print("Run 'clumsies init' to bind it to a workspace.\n", .{});
+            return;
+        },
+        else => return err,
+    };
+    errdefer session.deinit(allocator);
 
-    const workspace_root = if (ws_config.resolveWorkspace(allocator, cwd)) |binding| blk: {
-        defer allocator.free(binding.ws_id);
-        defer allocator.free(binding.name);
-        owned_cache_path = ws_config.getCachePath(allocator, binding.ws_id) catch null;
-        break :blk owned_cache_path orelse cwd;
-    } else |_| cwd;
+    const cache_path = try ws_config.getCachePath(allocator, session.ws_id);
+    defer allocator.free(cache_path);
 
-    try mcp_server.runWithRoot(stdout, stderr, allocator, version, workspace_root);
+    try mcp_server.runWithRoot(stdout, stderr, allocator, version, cache_path, session);
 }

--- a/src/workspace_config.zig
+++ b/src/workspace_config.zig
@@ -37,7 +37,14 @@ pub fn resolveWorkspace(allocator: std.mem.Allocator, cwd: []const u8) !Workspac
     return error.NoWorkspaceFound;
 }
 
-/// Get the cache directory for a workspace.
+/// Get the workspace directory for a workspace: ~/.clumsies/workspaces/{ws_id}
+pub fn getWsDir(allocator: std.mem.Allocator, ws_id: []const u8) ![]const u8 {
+    const base = try auth.getBasePath(allocator);
+    defer allocator.free(base);
+    return std.fs.path.join(allocator, &.{ base, "workspaces", ws_id });
+}
+
+/// Get the cache directory for a workspace: ~/.clumsies/workspaces/{ws_id}/cache
 pub fn getCachePath(allocator: std.mem.Allocator, ws_id: []const u8) ![]const u8 {
     const base = try auth.getBasePath(allocator);
     defer allocator.free(base);

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -220,6 +220,8 @@ RAW=$(call GET "/api/org/library/manifest")
 parse_response "$RAW"
 assert_status "get manifest" "200" "$STATUS"
 assert_json "contains revision" "revision" "$BODY"
+assert_json "prompt entries carry path" '"path":"rule/coding/STYLE.md"' "$BODY"
+assert_json "prompt entries carry hash" '"hash":"sha256:abc123"' "$BODY"
 
 # Prompt PRs (multi-operation model)
 step "Prompt PR: create with modify operation"
@@ -543,6 +545,8 @@ step "Context: manifest reflects context"
 RAW=$(call GET "/api/workspaces/$CTX_WS/manifest")
 parse_response "$RAW"
 assert_status "get manifest" "200" "$STATUS"
+assert_json "context entries keyed by context_id" "$CTX_ID" "$BODY"
+assert_json "context entries carry path" '"path":"spec/API.md"' "$BODY"
 
 step "Context: branch endpoint is gone"
 RAW=$(call GET "/api/workspaces/$CTX_WS/context/branches")

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -68,6 +68,9 @@ INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
 INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
   ('p-test-002', 'a0000000-0000-0000-0000-000000000001', 'workflow/cmd/COMMIT.md', '# COMMIT', 'sha256:def456')
   ON CONFLICT DO NOTHING;
+INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+  ('p-test-mpf', 'a0000000-0000-0000-0000-000000000001', 'META_PROMPT.md', '# clumsies Protocol Bootstrap', 'sha256:mpf001')
+  ON CONFLICT DO NOTHING;
 SQL
 }
 
@@ -222,6 +225,7 @@ assert_status "get manifest" "200" "$STATUS"
 assert_json "contains revision" "revision" "$BODY"
 assert_json "prompt entries carry path" '"path":"rule/coding/STYLE.md"' "$BODY"
 assert_json "prompt entries carry hash" '"hash":"sha256:abc123"' "$BODY"
+assert_json "includes reserved MPF path" '"path":"META_PROMPT.md"' "$BODY"
 
 # Prompt PRs (multi-operation model)
 step "Prompt PR: create with modify operation"


### PR DESCRIPTION
## Summary

The previous identity refactor and trace upload PR put the data plane
in place, but the MCP server was still deriving prompt_ids from local
file paths like `rule:coding/STYLE.md`, which never matched the hub's
opaque UUIDs. Real refer events from the MCP tool flow were silently
dropped on ingest — the server skipped any event whose prompt_id
missed the prompts table — so `/api/stats` reported zeros even when
agents were actively annotating constraints. Other gaps piled on:
session creation was tied to the memory.setup tool handler (forcing
duplicate work in CC mode where cc-plugin already injected MPF), the
local cache layout had no place for in-progress edits, cc-plugin
read workflow files from the project's `.prompts/` instead of the
synced cache, and developer prompts captured by hooks had no
producer pipeline at all.

This PR closes all of it as one bundled change. The workspace
manifest now carries `{path, hash}` per prompt and per context entry,
keyed by stable hub-issued ids; `sync_cmd` reads paths directly and
drops the N+1 library round-trips it used to do; `workspace_prompt`
loads the manifest as its source of truth and emits real hub
prompt_ids end to end. MCP session creation moves to `serve.zig`
startup so `memory.setup` becomes a read-only query, and the same
startup point writes a session marker file that external hook
processes can read. A new `clumsies trace append` CLI consumes that
marker for a `UserPromptSubmit` hook script that captures developer
prompt text as `session_input` events. The existing `flush-trace`
top-level command also moves under `clumsies trace flush` for
namespace consistency. A new `drafts/` directory with a unified
`resolveLocal` helper lets MCP serve in-progress local edits before
falling back to cache, and `META_PROMPT.md` becomes a Library
reserved-path prompt so MPF flows through the same sync pipeline as
everything else. cc-plugin's `resolve-binary.sh` drops its
`.prompts/` gate check, and `session-start.sh` resolves the cache
location through a new `clumsies _agent workspace-info` CLI before
scanning workflow files.

## Test plan

- [x] `zig build` and `zig build test` pass; new unit tests cover
  manifest parsing, draft override resolution, oversized-event skip,
  session marker roundtrip, and the cc-plugin workflow scan layout
- [x] `test/hub-e2e.sh` passes end to end with the new manifest shape
  assertions (workspace context manifest keyed by `context_id`,
  library manifest entries carrying path and hash, reserved
  `META_PROMPT.md` path present)
- [ ] Manual: `clumsies _agent workspace-info` prints `WS_ID` and
  `CACHE_DIR` shell-eval lines in a bound directory and exits silently
  in an unbound one
- [ ] Manual: `clumsies trace flush -h` and `clumsies trace append -h`
  print help; `clumsies` top-level help lists `trace flush`
- [ ] Manual: in a bound CC session with the plugin enabled, the
  `UserPromptSubmit` hook produces a `session_input` line in
  `~/.clumsies/workspaces/{ws_id}/trace.jsonl`