### PR TITLE
bootstrap: align auth defaults and seed local trace inputs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -96,6 +96,7 @@ pub fn build(b: *std.Build) void {
             .target = target,
             .optimize = optimize,
             .imports = &.{
+                .{ .name = "clumsies_lib", .module = lib },
                 .{ .name = "pg", .module = pg.module("pg") },
             },
         }),
@@ -152,5 +153,4 @@ pub fn build(b: *std.Build) void {
     const run_hub_tests = b.addRunArtifact(hub_tests);
     const hub_test_step = b.step("test-hub", "Run Hub Server unit tests");
     hub_test_step.dependOn(&run_hub_tests.step);
-
 }

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const build_options = @import("build_options");
 const enable_keychain = build_options.enable_keychain;
+const log = std.log.scoped(.auth);
 
 pub const AuthInfo = struct {
     hub_url: []const u8,
@@ -16,6 +17,12 @@ pub const AuthInfo = struct {
     }
 };
 
+pub const SaveLocation = enum {
+    keychain,
+    file_default,
+    file_fallback,
+};
+
 const SERVICE_NAME = "clumsies";
 const ACCOUNT_NAME = "hub-auth";
 
@@ -27,7 +34,7 @@ pub fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
     return std.fs.path.join(allocator, &.{ home, ".clumsies" });
 }
 
-pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []const u8, access_token: []const u8, refresh_token: []const u8) !void {
+pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []const u8, access_token: []const u8, refresh_token: []const u8) !SaveLocation {
     const payload = AuthJson{
         .hub_url = hub_url,
         .username = username,
@@ -38,15 +45,26 @@ pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []c
     defer allocator.free(json);
 
     if (comptime enable_keychain) {
-        try keychainStore(json);
+        keychainStore(json) catch |err| {
+            log.warn("keychain store failed ({s}); falling back to auth.json", .{@errorName(err)});
+            try fileFallbackStore(allocator, json);
+            return .file_fallback;
+        };
+        return .keychain;
     } else {
         try fileFallbackStore(allocator, json);
+        return .file_default;
     }
 }
 
 pub fn loadAuth(allocator: std.mem.Allocator) !AuthInfo {
     const json = if (comptime enable_keychain)
-        keychainLookup(allocator) catch return error.NotAuthenticated
+        keychainLookup(allocator) catch |err| blk: {
+            if (err != error.NotAuthenticated) {
+                log.warn("keychain lookup failed ({s}); trying auth.json", .{@errorName(err)});
+            }
+            break :blk fileFallbackLoad(allocator) catch return error.NotAuthenticated;
+        }
     else
         fileFallbackLoad(allocator) catch return error.NotAuthenticated;
     defer allocator.free(json);
@@ -75,59 +93,87 @@ const c = if (enable_keychain) @cImport({
     @cInclude("CoreFoundation/CoreFoundation.h");
 }) else struct {};
 
-fn cfString(s: []const u8) ?*anyopaque {
-    if (comptime !enable_keychain) return null;
-    return @ptrCast(@constCast(c.CFStringCreateWithBytes(null, s.ptr, @intCast(s.len), c.kCFStringEncodingUTF8, 0)));
-}
-
 fn keychainStore(data: []const u8) !void {
-    const cf_service = cfString(SERVICE_NAME) orelse return error.KeychainError;
-    defer c.CFRelease(cf_service);
-    const cf_account = cfString(ACCOUNT_NAME) orelse return error.KeychainError;
-    defer c.CFRelease(cf_account);
-    const cf_data: c.CFDataRef = c.CFDataCreate(null, data.ptr, @intCast(data.len)) orelse return error.KeychainError;
-    defer c.CFRelease(cf_data);
+    if (comptime !enable_keychain) return error.KeychainError;
 
-    // Delete existing
-    var del_keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount };
-    var del_vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account };
-    const del_dict = c.CFDictionaryCreate(null, @ptrCast(&del_keys), @ptrCast(&del_vals), del_keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks);
-    if (del_dict) |d| {
-        _ = c.SecItemDelete(d);
-        c.CFRelease(d);
+    var item: c.SecKeychainItemRef = null;
+    const find_status = c.SecKeychainFindGenericPassword(
+        null,
+        @as(c.UInt32, @intCast(SERVICE_NAME.len)),
+        @as([*c]const u8, @ptrCast(SERVICE_NAME.ptr)),
+        @as(c.UInt32, @intCast(ACCOUNT_NAME.len)),
+        @as([*c]const u8, @ptrCast(ACCOUNT_NAME.ptr)),
+        null,
+        null,
+        &item,
+    );
+    defer if (item != null) c.CFRelease(item);
+
+    if (find_status == c.errSecSuccess) {
+        const update_status = c.SecKeychainItemModifyAttributesAndData(
+            item,
+            null,
+            @as(c.UInt32, @intCast(data.len)),
+            @ptrCast(data.ptr),
+        );
+        if (update_status != c.errSecSuccess) {
+            log.warn("SecKeychainItemModifyAttributesAndData failed with OSStatus {d}", .{update_status});
+            return error.KeychainError;
+        }
+        return;
     }
 
-    // Add new
-    var add_keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount, c.kSecValueData };
-    var add_vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account, @ptrCast(@constCast(cf_data)) };
-    const add_dict = c.CFDictionaryCreate(null, @ptrCast(&add_keys), @ptrCast(&add_vals), add_keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks) orelse return error.KeychainError;
-    defer c.CFRelease(add_dict);
+    if (find_status != c.errSecItemNotFound) {
+        log.warn("SecKeychainFindGenericPassword failed with OSStatus {d}", .{find_status});
+        return error.KeychainError;
+    }
 
-    const status = c.SecItemAdd(add_dict, null);
-    if (status != c.errSecSuccess) return error.KeychainError;
+    const add_status = c.SecKeychainAddGenericPassword(
+        null,
+        @as(c.UInt32, @intCast(SERVICE_NAME.len)),
+        @as([*c]const u8, @ptrCast(SERVICE_NAME.ptr)),
+        @as(c.UInt32, @intCast(ACCOUNT_NAME.len)),
+        @as([*c]const u8, @ptrCast(ACCOUNT_NAME.ptr)),
+        @as(c.UInt32, @intCast(data.len)),
+        @ptrCast(data.ptr),
+        null,
+    );
+    if (add_status != c.errSecSuccess) {
+        log.warn("SecKeychainAddGenericPassword failed with OSStatus {d}", .{add_status});
+        return error.KeychainError;
+    }
 }
 
 fn keychainLookup(allocator: std.mem.Allocator) ![]const u8 {
-    const cf_service = cfString(SERVICE_NAME) orelse return error.KeychainError;
-    defer c.CFRelease(cf_service);
-    const cf_account = cfString(ACCOUNT_NAME) orelse return error.KeychainError;
-    defer c.CFRelease(cf_account);
+    if (comptime !enable_keychain) return error.NotAuthenticated;
 
-    var keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount, c.kSecReturnData, c.kSecMatchLimit };
-    var vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account, c.kCFBooleanTrue, c.kSecMatchLimitOne };
-    const dict = c.CFDictionaryCreate(null, @ptrCast(&keys), @ptrCast(&vals), keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks) orelse return error.KeychainError;
-    defer c.CFRelease(dict);
+    var password_len: c.UInt32 = 0;
+    var password_data: ?*anyopaque = null;
+    var item: c.SecKeychainItemRef = null;
+    const status = c.SecKeychainFindGenericPassword(
+        null,
+        @as(c.UInt32, @intCast(SERVICE_NAME.len)),
+        @as([*c]const u8, @ptrCast(SERVICE_NAME.ptr)),
+        @as(c.UInt32, @intCast(ACCOUNT_NAME.len)),
+        @as([*c]const u8, @ptrCast(ACCOUNT_NAME.ptr)),
+        &password_len,
+        @ptrCast(&password_data),
+        &item,
+    );
+    defer {
+        if (password_data != null) _ = c.SecKeychainItemFreeContent(null, password_data);
+    }
+    defer if (item != null) c.CFRelease(item);
 
-    var result: c.CFTypeRef = null;
-    const status = c.SecItemCopyMatching(dict, &result);
-    if (status != c.errSecSuccess) return error.NotAuthenticated;
+    if (status != c.errSecSuccess) {
+        if (status != c.errSecItemNotFound) {
+            log.warn("SecKeychainFindGenericPassword failed with OSStatus {d}", .{status});
+        }
+        return error.NotAuthenticated;
+    }
 
-    const cf_data: c.CFDataRef = @ptrCast(result.?);
-    defer c.CFRelease(result.?);
-
-    const len: usize = @intCast(c.CFDataGetLength(cf_data));
-    const ptr = c.CFDataGetBytePtr(cf_data);
-    return try allocator.dupe(u8, ptr[0..len]);
+    const bytes: [*]const u8 = @ptrCast(password_data.?);
+    return try allocator.dupe(u8, bytes[0..@as(usize, @intCast(password_len))]);
 }
 
 // File fallback for non-macOS (Linux CI etc)

--- a/src/auth.zig
+++ b/src/auth.zig
@@ -187,7 +187,10 @@ fn fileFallbackStore(allocator: std.mem.Allocator, data: []const u8) !void {
     };
     const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
     defer file.close();
-    _ = try file.write(data);
+    var buf: [4096]u8 = undefined;
+    var writer = std.fs.File.Writer.init(file, &buf);
+    defer writer.interface.flush() catch {};
+    try writer.interface.writeAll(data);
 }
 
 fn fileFallbackLoad(allocator: std.mem.Allocator) ![]const u8 {

--- a/src/commands/login_cmd.zig
+++ b/src/commands/login_cmd.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const testing = std.testing;
 const flag = @import("../flags.zig");
 const auth_mod = @import("../auth.zig");
 const HubClient = @import("../hub_client.zig").HubClient;
@@ -63,13 +64,20 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     defer response.deinit();
 
     if (response.status == .ok) {
-        const parsed = std.json.parseFromSlice(LoginResponse, allocator, response.body, .{ .allocate = .alloc_always }) catch {
+        const parsed = std.json.parseFromSlice(LoginResponse, allocator, response.body, .{
+            .allocate = .alloc_always,
+            .ignore_unknown_fields = true,
+        }) catch {
             try stderr.print("{s}{s}{s}Error:{s} Failed to parse login response\n", .{ P, Color.bold, Color.red, Color.reset });
             return;
         };
         defer parsed.deinit();
-        try auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token);
+        const save_location = auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token) catch |err| {
+            try stderr.print("{s}{s}{s}Error:{s} Failed to save login credentials ({s})\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
+            return;
+        };
         try stdout.print("{s}{s}{s}Logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
+        try printStorageNote(stderr, allocator, save_location);
         return;
     }
 
@@ -117,13 +125,20 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         return;
     }
 
-    const parsed = std.json.parseFromSlice(LoginResponse, allocator, activate_resp.body, .{ .allocate = .alloc_always }) catch {
+    const parsed = std.json.parseFromSlice(LoginResponse, allocator, activate_resp.body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch {
         try stderr.print("{s}{s}{s}Error:{s} Failed to parse activation response\n", .{ P, Color.bold, Color.red, Color.reset });
         return;
     };
     defer parsed.deinit();
-    try auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token);
+    const save_location = auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token) catch |err| {
+        try stderr.print("{s}{s}{s}Error:{s} Failed to save login credentials ({s})\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
+        return;
+    };
     try stdout.print("{s}{s}{s}Account activated and logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
+    try printStorageNote(stderr, allocator, save_location);
 }
 
 fn readLine(allocator: std.mem.Allocator) ![]const u8 {
@@ -164,6 +179,39 @@ const LoginResponse = struct {
     access_token: []const u8,
     refresh_token: []const u8,
 };
+
+fn printStorageNote(stderr: *std.Io.Writer, allocator: std.mem.Allocator, save_location: auth_mod.SaveLocation) !void {
+    if (save_location != .file_fallback) return;
+
+    const base = auth_mod.getBasePath(allocator) catch {
+        try stderr.print("{s}Note: Keychain was unavailable; credentials were stored in ~/.clumsies/auth.json\n", .{P});
+        return;
+    };
+    defer allocator.free(base);
+
+    const path = std.fs.path.join(allocator, &.{ base, "auth.json" }) catch {
+        try stderr.print("{s}Note: Keychain was unavailable; credentials were stored in ~/.clumsies/auth.json\n", .{P});
+        return;
+    };
+    defer allocator.free(path);
+
+    try stderr.print("{s}Note: Keychain was unavailable; credentials were stored in {s}\n", .{ P, path });
+}
+
+test "LoginResponse parsing ignores expires_in" {
+    const body =
+        \\{"access_token":"acc","refresh_token":"ref","expires_in":3600}
+    ;
+
+    const parsed = try std.json.parseFromSlice(LoginResponse, testing.allocator, body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("acc", parsed.value.access_token);
+    try testing.expectEqualStrings("ref", parsed.value.refresh_token);
+}
 
 fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}Usage: {s}clumsies login [--hub-url <url>] [--username <user>]{s}\n", .{ P, Color.cyan, Color.reset });

--- a/src/commands/login_cmd.zig
+++ b/src/commands/login_cmd.zig
@@ -74,7 +74,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         defer parsed.deinit();
         const save_location = auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token) catch |err| {
             try stderr.print("{s}{s}{s}Error:{s} Failed to save login credentials ({s})\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
-            return;
+            return error.CommandFailed;
         };
         try stdout.print("{s}{s}{s}Logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
         try printStorageNote(stderr, allocator, save_location);
@@ -135,7 +135,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     defer parsed.deinit();
     const save_location = auth_mod.saveAuth(allocator, hub_url, username, parsed.value.access_token, parsed.value.refresh_token) catch |err| {
         try stderr.print("{s}{s}{s}Error:{s} Failed to save login credentials ({s})\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
-        return;
+        return error.CommandFailed;
     };
     try stdout.print("{s}{s}{s}Account activated and logged in{s} as {s}{s}{s}\n", .{ P, Color.bold, Color.green, Color.reset, Color.cyan, username, Color.reset });
     try printStorageNote(stderr, allocator, save_location);

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -52,15 +52,32 @@ pub fn bootstrap(pool: *Pool) !void {
         if (count > 0) return;
     }
 
-    const username = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_USERNAME") catch blk: {
-        log.warn("HUB_BOOTSTRAP_USERNAME missing; defaulting to 'admin'", .{});
-        break :blk "admin";
+    const username_owned = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_USERNAME") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => blk: {
+            log.warn("HUB_BOOTSTRAP_USERNAME missing; defaulting to 'admin'", .{});
+            break :blk null;
+        },
+        else => return err,
     };
-    const password = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_PASSWORD") catch blk: {
-        log.warn("HUB_BOOTSTRAP_PASSWORD missing; defaulting to 'admin'", .{});
-        break :blk "admin";
+    defer if (username_owned) |value| alloc.free(value);
+    const username = username_owned orelse "admin";
+
+    const password_owned = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_PASSWORD") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => blk: {
+            log.warn("HUB_BOOTSTRAP_PASSWORD missing; defaulting to 'admin'", .{});
+            break :blk null;
+        },
+        else => return err,
     };
-    const org_name = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_ORG") catch "default";
+    defer if (password_owned) |value| alloc.free(value);
+    const password = password_owned orelse "admin";
+
+    const org_name_owned = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_ORG") catch |err| switch (err) {
+        error.EnvironmentVariableNotFound => null,
+        else => return err,
+    };
+    defer if (org_name_owned) |value| alloc.free(value);
+    const org_name = org_name_owned orelse "default";
 
     // Create org
     _ = conn.exec(

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -39,9 +39,7 @@ pub fn migrate(pool: *Pool) !void {
 
 pub fn bootstrap(pool: *Pool) !void {
     const alloc = std.heap.page_allocator;
-    const username = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_USERNAME") catch return;
-    const password = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_PASSWORD") catch return;
-    const org_name = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_ORG") catch "default";
+    const log = std.log.scoped(.bootstrap);
 
     const conn = try pool.acquire();
     defer conn.release();
@@ -54,7 +52,15 @@ pub fn bootstrap(pool: *Pool) !void {
         if (count > 0) return;
     }
 
-    const log = std.log.scoped(.bootstrap);
+    const username = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_USERNAME") catch blk: {
+        log.warn("HUB_BOOTSTRAP_USERNAME missing; defaulting to 'admin'", .{});
+        break :blk "admin";
+    };
+    const password = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_PASSWORD") catch blk: {
+        log.warn("HUB_BOOTSTRAP_PASSWORD missing; defaulting to 'admin'", .{});
+        break :blk "admin";
+    };
+    const org_name = std.process.getEnvVarOwned(alloc, "HUB_BOOTSTRAP_ORG") catch "default";
 
     // Create org
     _ = conn.exec(

--- a/src/main.zig
+++ b/src/main.zig
@@ -105,7 +105,13 @@ pub fn main() !void {
             try stdout_writer.print("{s}{s}{s}clumsies{s} {s}\n", .{ P, Color.bold, Color.orange, Color.reset, version });
         },
         .help => try cmd_help.run(stdout_writer),
-        .login => try cmd_login.run(stdout_writer, stderr_writer, allocator, cmd_args),
+        .login => cmd_login.run(stdout_writer, stderr_writer, allocator, cmd_args) catch |err| switch (err) {
+            error.CommandFailed => {
+                stderr_file_writer.interface.flush() catch {};
+                std.process.exit(1);
+            },
+            else => return err,
+        },
         .init_cmd => try cmd_init.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .sync => try cmd_sync.run(stdout_writer, stderr_writer, allocator, cmd_args),
         .mcp => try cmd_mcp.run(stdout_writer, stderr_writer, allocator, cmd_args, version),

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -32,7 +32,7 @@ pub const ROLES = [_][]const u8{ "maintainer", "member" };
 pub const WS_MEMBER_ROLES = [_][]const u8{ "member", "admin" };
 pub const PROMPT_PR_STATUSES = [_][]const u8{ "open", "accepted", "rejected" };
 pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "rejected" };
-pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "refer", "refer" };
+pub const TRACE_EVENT_TYPES = [_][]const u8{ "session_input", "refer", "refer", "refer" };
 
 // Counts for reset mode
 pub const USER_COUNT: usize = SEED_USERNAMES.len;

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -3,6 +3,30 @@
 
 pub const ORG_ID = "a0000000-0000-0000-0000-000000000001";
 pub const ORG_NAME = "acme";
+pub const SEED_PASSWORD = "admin";
+
+pub const BASE_MAINTAINER_ID = "usr-seed-maintainer";
+pub const BASE_MAINTAINER_USERNAME = "admin";
+pub const SEED_USERNAMES = [_][]const u8{
+    BASE_MAINTAINER_USERNAME,
+    "Dylan",
+    "lilhammer",
+    "Joji",
+    "amimibear",
+    "Milo",
+    "Nori",
+    "Sora",
+};
+pub const BASE_MEMBER_ID = "usr-seed-member";
+pub const BASE_MEMBER_USERNAME = SEED_USERNAMES[1];
+pub const BASE_PROMPT_ID = "p-seed-default";
+pub const BASE_PROMPT_PATH = "rule/testing/SEED_PUMP.md";
+pub const BASE_PROMPT_CONTENT =
+    "# SEED_PUMP\n\nSynthetic baseline prompt used by clumsies-seed.\n";
+pub const BASE_PROMPT_HASH =
+    "sha256:seed000000000000000000000000000000000000000000000000000000000";
+pub const BASE_WORKSPACE_ID = "ws-seed-default";
+pub const BASE_WORKSPACE_NAME = "seed-sandbox";
 
 pub const ROLES = [_][]const u8{ "maintainer", "member" };
 pub const WS_MEMBER_ROLES = [_][]const u8{ "member", "admin" };
@@ -11,7 +35,7 @@ pub const CONTEXT_PR_STATUSES = [_][]const u8{ "open", "merged", "rejected" };
 pub const TRACE_EVENT_TYPES = [_][]const u8{ "setup", "refer", "refer" };
 
 // Counts for reset mode
-pub const USER_COUNT: usize = 8;
+pub const USER_COUNT: usize = SEED_USERNAMES.len;
 pub const PROMPT_COUNT: usize = 15;
 pub const BUNDLE_COUNT: usize = 3;
 pub const WORKSPACE_COUNT: usize = 4;

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -23,8 +23,6 @@ pub const BASE_PROMPT_ID = "p-seed-default";
 pub const BASE_PROMPT_PATH = "rule/testing/SEED_PUMP.md";
 pub const BASE_PROMPT_CONTENT =
     "# SEED_PUMP\n\nSynthetic baseline prompt used by clumsies-seed.\n";
-pub const BASE_PROMPT_HASH =
-    "sha256:seed000000000000000000000000000000000000000000000000000000000";
 pub const BASE_WORKSPACE_ID = "ws-seed-default";
 pub const BASE_WORKSPACE_NAME = "seed-sandbox";
 

--- a/src/seed/ensure.zig
+++ b/src/seed/ensure.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const pg = @import("pg");
 const data = @import("data.zig");
+const seed_hash = @import("hash.zig");
 const password = @import("password.zig");
 
 const log = std.log.scoped(.seed);
@@ -13,6 +14,7 @@ pub fn run(pool: *pg.Pool) !void {
 
     var hash_buf: [128]u8 = undefined;
     const password_hash = try password.hashPassword(data.SEED_PASSWORD, &hash_buf);
+    const prompt_hash = seed_hash.contentHash(data.BASE_PROMPT_CONTENT);
     var maintainer_id_buf: [64]u8 = undefined;
     var member_id_buf: [64]u8 = undefined;
 
@@ -58,7 +60,7 @@ pub fn run(pool: *pg.Pool) !void {
         data.ORG_ID,
         data.BASE_PROMPT_PATH,
         data.BASE_PROMPT_CONTENT,
-        data.BASE_PROMPT_HASH,
+        prompt_hash[0..],
     }) catch |err| {
         logPgError(conn, "ensure prompt failed", err);
         return err;

--- a/src/seed/ensure.zig
+++ b/src/seed/ensure.zig
@@ -1,0 +1,174 @@
+const std = @import("std");
+const pg = @import("pg");
+const data = @import("data.zig");
+const password = @import("password.zig");
+
+const log = std.log.scoped(.seed);
+
+pub fn run(pool: *pg.Pool) !void {
+    const conn = try pool.acquire();
+    defer conn.release();
+
+    log.info("ensuring base data for pump...", .{});
+
+    var hash_buf: [128]u8 = undefined;
+    const password_hash = try password.hashPassword(data.SEED_PASSWORD, &hash_buf);
+    var maintainer_id_buf: [64]u8 = undefined;
+    var member_id_buf: [64]u8 = undefined;
+
+    _ = conn.exec(
+        "INSERT INTO orgs (org_id, name) VALUES ($1::uuid, $2) ON CONFLICT (org_id) DO NOTHING",
+        .{ data.ORG_ID, data.ORG_NAME },
+    ) catch |err| {
+        logPgError(conn, "ensure org failed", err);
+        return err;
+    };
+
+    _ = conn.exec(
+        "INSERT INTO library_manifest (org_id, revision) VALUES ($1::uuid, 0) ON CONFLICT DO NOTHING",
+        .{data.ORG_ID},
+    ) catch |err| {
+        logPgError(conn, "ensure library manifest failed", err);
+        return err;
+    };
+
+    const maintainer_id = try ensureUser(
+        conn,
+        &maintainer_id_buf,
+        data.BASE_MAINTAINER_ID,
+        data.BASE_MAINTAINER_USERNAME,
+        "maintainer",
+        password_hash,
+    );
+    const member_id = try ensureUser(
+        conn,
+        &member_id_buf,
+        data.BASE_MEMBER_ID,
+        data.BASE_MEMBER_USERNAME,
+        "member",
+        password_hash,
+    );
+
+    _ = conn.exec(
+        \\INSERT INTO prompts (prompt_id, org_id, path, content, content_hash)
+        \\VALUES ($1, $2::uuid, $3, $4, $5)
+        \\ON CONFLICT (prompt_id) DO NOTHING
+    , .{
+        data.BASE_PROMPT_ID,
+        data.ORG_ID,
+        data.BASE_PROMPT_PATH,
+        data.BASE_PROMPT_CONTENT,
+        data.BASE_PROMPT_HASH,
+    }) catch |err| {
+        logPgError(conn, "ensure prompt failed", err);
+        return err;
+    };
+
+    _ = conn.exec(
+        \\INSERT INTO workspaces (ws_id, org_id, name, revision)
+        \\VALUES ($1, $2::uuid, $3, 1)
+        \\ON CONFLICT (ws_id) DO NOTHING
+    , .{
+        data.BASE_WORKSPACE_ID,
+        data.ORG_ID,
+        data.BASE_WORKSPACE_NAME,
+    }) catch |err| {
+        logPgError(conn, "ensure workspace failed", err);
+        return err;
+    };
+
+    _ = conn.exec(
+        \\INSERT INTO workspace_members (ws_id, user_id, role)
+        \\VALUES ($1, $2, 'admin')
+        \\ON CONFLICT DO NOTHING
+    , .{
+        data.BASE_WORKSPACE_ID,
+        maintainer_id,
+    }) catch |err| {
+        logPgError(conn, "ensure maintainer workspace membership failed", err);
+        return err;
+    };
+
+    _ = conn.exec(
+        \\INSERT INTO workspace_members (ws_id, user_id, role)
+        \\VALUES ($1, $2, 'member')
+        \\ON CONFLICT DO NOTHING
+    , .{
+        data.BASE_WORKSPACE_ID,
+        member_id,
+    }) catch |err| {
+        logPgError(conn, "ensure member workspace membership failed", err);
+        return err;
+    };
+
+    _ = conn.exec(
+        \\INSERT INTO workspace_prompts (ws_id, prompt_id)
+        \\VALUES ($1, $2)
+        \\ON CONFLICT DO NOTHING
+    , .{
+        data.BASE_WORKSPACE_ID,
+        data.BASE_PROMPT_ID,
+    }) catch |err| {
+        logPgError(conn, "ensure workspace prompt binding failed", err);
+        return err;
+    };
+}
+
+fn ensureUser(conn: *pg.Conn, id_buf: *[64]u8, preferred_id: []const u8, username: []const u8, role: []const u8, password_hash: []const u8) ![]const u8 {
+    var row = conn.row("SELECT user_id FROM users WHERE username = $1", .{username}) catch |err| {
+        logPgError(conn, "ensure user lookup failed", err);
+        return err;
+    };
+
+    if (row) |*r| {
+        const existing_id = r.get([]const u8, 0) catch |err| {
+            r.deinit() catch {};
+            return err;
+        };
+        const stable_id = copySlice(id_buf, existing_id);
+        r.deinit() catch {};
+
+        _ = conn.exec(
+            \\UPDATE users
+            \\SET org_id = $1::uuid,
+            \\    username = $2,
+            \\    password_hash = $3,
+            \\    role = $4,
+            \\    status = 'active'
+            \\WHERE user_id = $5
+        , .{ data.ORG_ID, username, password_hash, role, stable_id }) catch |err| {
+            logPgError(conn, "ensure user update failed", err);
+            return err;
+        };
+        return stable_id;
+    }
+
+    _ = conn.exec(
+        \\INSERT INTO users (user_id, org_id, username, password_hash, role, status)
+        \\VALUES ($1, $2::uuid, $3, $4, $5, 'active')
+        \\ON CONFLICT (user_id) DO UPDATE
+        \\SET org_id = EXCLUDED.org_id,
+        \\    username = EXCLUDED.username,
+        \\    password_hash = EXCLUDED.password_hash,
+        \\    role = EXCLUDED.role,
+        \\    status = EXCLUDED.status
+    , .{ preferred_id, data.ORG_ID, username, password_hash, role }) catch |err| {
+        logPgError(conn, "ensure user insert failed", err);
+        return err;
+    };
+
+    return copySlice(id_buf, preferred_id);
+}
+
+fn copySlice(dest: *[64]u8, src: []const u8) []const u8 {
+    const len = @min(dest.len, src.len);
+    @memcpy(dest[0..len], src[0..len]);
+    return dest[0..len];
+}
+
+fn logPgError(conn: *pg.Conn, msg: []const u8, err: anytype) void {
+    log.err("{s}: {}", .{ msg, err });
+    if (conn.err) |pg_err| {
+        log.err("pg detail: {s}", .{pg_err.message});
+    }
+}

--- a/src/seed/ensure.zig
+++ b/src/seed/ensure.zig
@@ -127,7 +127,7 @@ fn ensureUser(conn: *pg.Conn, id_buf: *[64]u8, preferred_id: []const u8, usernam
             r.deinit() catch {};
             return err;
         };
-        const stable_id = copySlice(id_buf, existing_id);
+        const stable_id = try copySlice(id_buf, existing_id);
         r.deinit() catch {};
 
         _ = conn.exec(
@@ -159,13 +159,13 @@ fn ensureUser(conn: *pg.Conn, id_buf: *[64]u8, preferred_id: []const u8, usernam
         return err;
     };
 
-    return copySlice(id_buf, preferred_id);
+    return try copySlice(id_buf, preferred_id);
 }
 
-fn copySlice(dest: *[64]u8, src: []const u8) []const u8 {
-    const len = @min(dest.len, src.len);
-    @memcpy(dest[0..len], src[0..len]);
-    return dest[0..len];
+fn copySlice(dest: *[64]u8, src: []const u8) ![]const u8 {
+    if (src.len > dest.len) return error.IdentifierTooLong;
+    @memcpy(dest[0..src.len], src);
+    return dest[0..src.len];
 }
 
 fn logPgError(conn: *pg.Conn, msg: []const u8, err: anytype) void {
@@ -173,4 +173,9 @@ fn logPgError(conn: *pg.Conn, msg: []const u8, err: anytype) void {
     if (conn.err) |pg_err| {
         log.err("pg detail: {s}", .{pg_err.message});
     }
+}
+
+test "copySlice rejects oversized ids" {
+    var buf: [4]u8 = undefined;
+    try std.testing.expectError(error.IdentifierTooLong, copySlice(&buf, "12345"));
 }

--- a/src/seed/faker.zig
+++ b/src/seed/faker.zig
@@ -213,6 +213,38 @@ pub fn reviewComment(self: *Self) []const u8 {
     return self.pick([]const u8, &REVIEW_COMMENTS);
 }
 
+// Synthetic user prompts for local trace/session_input seeding
+
+const SESSION_INPUT_TEMPLATES = [_][]const u8{
+    "Find the prompt that covers {topic} and summarize the key rules before I start coding.",
+    "Search the library for guidance on {topic}; I need the shortest useful checklist.",
+    "Load the most relevant prompt for {topic} and tell me what constraints I should follow.",
+    "I am about to touch {topic}. Which prompt or workflow should I read first?",
+    "Give me the best prompt for {topic} and explain the tradeoffs in plain language.",
+    "Before I change anything, pull the rule for {topic} and highlight the risky parts.",
+};
+
+pub fn sessionInput(self: *Self, buf: *[256]u8) []const u8 {
+    const topic = self.pick([]const u8, &TOPICS);
+    const template = self.pick([]const u8, &SESSION_INPUT_TEMPLATES);
+
+    if (std.mem.indexOf(u8, template, "{topic}")) |idx| {
+        const before = template[0..idx];
+        const after = template[idx + 7 ..];
+        const len = before.len + topic.len + after.len;
+        if (len <= buf.len) {
+            @memcpy(buf[0..before.len], before);
+            @memcpy(buf[before.len..][0..topic.len], topic);
+            @memcpy(buf[before.len + topic.len ..][0..after.len], after);
+            return buf[0..len];
+        }
+    }
+
+    const out_len = @min(template.len, buf.len);
+    @memcpy(buf[0..out_len], template[0..out_len]);
+    return buf[0..out_len];
+}
+
 // PR descriptions
 
 const PR_DESCRIPTIONS = [_][]const u8{
@@ -317,4 +349,13 @@ pub fn branchName(self: *Self, buf: *[40]u8) []const u8 {
     const prefix = self.pick([]const u8, &BRANCH_PREFIXES);
     const topic = self.pick([]const u8, &BRANCH_TOPICS);
     return std.fmt.bufPrint(buf, "{s}/{s}", .{ prefix, topic }) catch "feat/update";
+}
+
+test "sessionInput renders concrete text" {
+    var faker = Self.initWithSeed(std.testing.allocator, 42);
+    var buf: [256]u8 = undefined;
+    const input = faker.sessionInput(&buf);
+
+    try std.testing.expect(input.len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, input, "{topic}") == null);
 }

--- a/src/seed/hash.zig
+++ b/src/seed/hash.zig
@@ -1,0 +1,23 @@
+const std = @import("std");
+
+pub fn contentHash(content: []const u8) [71]u8 {
+    var out: [71]u8 = undefined;
+    var digest: [32]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(content, &digest, .{});
+
+    @memcpy(out[0..7], "sha256:");
+    const hex = "0123456789abcdef";
+    for (digest, 0..) |byte, i| {
+        out[7 + i * 2] = hex[byte >> 4];
+        out[7 + i * 2 + 1] = hex[byte & 0x0f];
+    }
+    return out;
+}
+
+test "contentHash prefixes sha256 and is stable" {
+    const hash = contentHash("hello");
+    try std.testing.expectEqualStrings(
+        "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        &hash,
+    );
+}

--- a/src/seed/main.zig
+++ b/src/seed/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const pg = @import("pg");
+const ensure = @import("ensure.zig");
 const reset = @import("reset.zig");
 const pump = @import("pump.zig");
 
@@ -37,14 +38,11 @@ pub fn main() !void {
     defer std.process.argsFree(std.heap.page_allocator, args);
 
     var do_reset = false;
-    var do_pump = false;
     var interval_ms: u64 = 3000;
 
     for (args[1..]) |arg| {
         if (std.mem.eql(u8, arg, "--reset")) {
             do_reset = true;
-        } else if (std.mem.eql(u8, arg, "--pump")) {
-            do_pump = true;
         } else if (std.mem.startsWith(u8, arg, "--interval=")) {
             interval_ms = std.fmt.parseInt(u64, arg["--interval=".len..], 10) catch 3000;
             if (interval_ms < 100) {
@@ -59,12 +57,6 @@ pub fn main() !void {
             printUsage();
             std.process.exit(1);
         }
-    }
-
-    if (!do_reset and !do_pump) {
-        log.err("specify --reset and/or --pump", .{});
-        printUsage();
-        std.process.exit(1);
     }
 
     const config = Config.fromEnv();
@@ -94,14 +86,17 @@ pub fn main() !void {
             log.err("reset failed: {}", .{err});
             std.process.exit(1);
         };
-    }
-
-    if (do_pump) {
-        pump.run(pool, interval_ms) catch |err| {
-            log.err("pump failed: {}", .{err});
+    } else {
+        ensure.run(pool) catch |err| {
+            log.err("ensure base data failed: {}", .{err});
             std.process.exit(1);
         };
     }
+
+    pump.run(pool, interval_ms) catch |err| {
+        log.err("pump failed: {}", .{err});
+        std.process.exit(1);
+    };
 
     log.info("done", .{});
 }
@@ -111,16 +106,14 @@ fn printUsage() void {
         \\Usage: clumsies-seed [options]
         \\
         \\Options:
-        \\  --reset          Truncate all tables and seed initial data
-        \\  --pump           Continuously inject new data (Ctrl-C to stop)
+        \\  --reset          Truncate all tables, seed fresh data, then start pump
         \\  --interval=N     Pump interval in milliseconds (default: 3000)
         \\  --help, -h       Show this help
         \\
         \\Examples:
-        \\  clumsies-seed --reset              Reset database with seed data
-        \\  clumsies-seed --pump               Start continuous data pump
-        \\  clumsies-seed --reset --pump       Reset then pump
-        \\  clumsies-seed --pump --interval=1000  Pump every second
+        \\  clumsies-seed                      Ensure base data, then start pump
+        \\  clumsies-seed --reset             Reset database, then start pump
+        \\  clumsies-seed --interval=1000     Pump every second
         \\
         \\Environment variables:
         \\  HUB_DB_HOST      Database host (default: 127.0.0.1)

--- a/src/seed/password.zig
+++ b/src/seed/password.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+const bcrypt = std.crypto.pwhash.bcrypt;
+
+pub fn hashPassword(password: []const u8, out: *[128]u8) ![]const u8 {
+    return bcrypt.strHash(password, .{
+        .params = .{ .rounds_log = 10, .silently_truncate_password = false },
+        .encoding = .phc,
+    }, out);
+}

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const pg = @import("pg");
 const data = @import("data.zig");
 const Faker = @import("faker.zig");
-const local_trace = @import("clumsies_lib").trace;
+const clumsies_lib = @import("clumsies_lib");
+const local_trace = clumsies_lib.trace;
+const prompt_lib = clumsies_lib.prompt;
 
 const log = std.log.scoped(.pump);
 
@@ -14,7 +16,7 @@ fn copyRowStr(dest: []u8, row: anytype, col: usize) ?[]const u8 {
     return dest[0..val.len];
 }
 
-fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8) void {
+fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8, content: ?[]const u8, content_hash: ?[]const u8) void {
     local_trace.appendTraceEvent(std.heap.page_allocator, .{
         .ws_id = ws_id,
         .session_id = session_id,
@@ -22,6 +24,8 @@ fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i6
         .type = event_type,
         .timestamp = timestamp,
         .prompt_id = prompt_id,
+        .content = content,
+        .content_hash = content_hash,
     }) catch |err| {
         log.warn("pump: local trace append failed: {}", .{err});
     };
@@ -110,21 +114,35 @@ fn traceSession(faker: *Faker, conn: *pg.Conn) void {
     var session_buf: [24]u8 = undefined;
     const session_id = faker.hexId(&session_buf, "ses-");
 
-    const events = [_][]const u8{ "setup", "refer", "refer" };
+    const events = [_][]const u8{ "setup", "session_input", "refer", "refer" };
     for (events, 0..) |event_type, ei| {
         const prompt_id: ?[]const u8 = if (std.mem.eql(u8, event_type, "refer"))
             prompt_ids[ei % prompt_count]
         else
             null;
-        const timestamp = std.time.milliTimestamp();
+        var content_buf: [256]u8 = undefined;
+        const content: ?[]const u8 = if (std.mem.eql(u8, event_type, "session_input"))
+            faker.sessionInput(&content_buf)
+        else
+            null;
+        const content_hash: ?[]const u8 = if (content) |body|
+            prompt_lib.hashContentHexAlloc(std.heap.page_allocator, body) catch |err| blk: {
+                log.warn("pump: content hash failed: {}", .{err});
+                break :blk null;
+            }
+        else
+            null;
+        defer if (content_hash) |hash| std.heap.page_allocator.free(hash);
+
+        const timestamp = std.time.milliTimestamp() + @as(i64, @intCast(ei));
 
         _ = conn.exec(
-            "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING",
-            .{ ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id },
+            "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id, content, content_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING",
+            .{ ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id, content, content_hash },
         ) catch |err| {
             log.warn("pump: {}", .{err});
         };
-        appendLocalTraceEvent(ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id);
+        appendLocalTraceEvent(ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id, content, content_hash);
     }
 }
 
@@ -340,6 +358,13 @@ fn cleanup(conn: *pg.Conn) void {
     _ = conn.exec(
         "DELETE FROM prompt_pr_comments WHERE comment_id IN (SELECT comment_id FROM prompt_pr_comments ORDER BY created_at ASC LIMIT GREATEST(0, (SELECT count(*) FROM prompt_pr_comments) - $1))",
         .{data.CAP_PROMPT_PR_COMMENTS},
+    ) catch |err| {
+        log.warn("pump: {}", .{err});
+    };
+
+    _ = conn.exec(
+        "DELETE FROM prompt_pr_comments WHERE pr_id IN (SELECT pr_id FROM prompt_prs WHERE status != 'open' ORDER BY created_at ASC LIMIT GREATEST(0, (SELECT count(*) FROM prompt_prs) - $1))",
+        .{data.CAP_PROMPT_PRS},
     ) catch |err| {
         log.warn("pump: {}", .{err});
     };

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const pg = @import("pg");
 const data = @import("data.zig");
 const Faker = @import("faker.zig");
+const local_trace = @import("clumsies_lib").trace;
 
 const log = std.log.scoped(.pump);
 
@@ -11,6 +12,19 @@ fn copyRowStr(dest: []u8, row: anytype, col: usize) ?[]const u8 {
     if (val.len > dest.len) return null;
     @memcpy(dest[0..val.len], val);
     return dest[0..val.len];
+}
+
+fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8) void {
+    local_trace.appendTraceEvent(std.heap.page_allocator, .{
+        .ws_id = ws_id,
+        .session_id = session_id,
+        .event_id = event_id,
+        .type = event_type,
+        .timestamp = timestamp,
+        .prompt_id = prompt_id,
+    }) catch |err| {
+        log.warn("pump: local trace append failed: {}", .{err});
+    };
 }
 
 pub fn run(pool: *pg.Pool, interval_ms: u64) !void {
@@ -102,13 +116,15 @@ fn traceSession(faker: *Faker, conn: *pg.Conn) void {
             prompt_ids[ei % prompt_count]
         else
             null;
+        const timestamp = std.time.milliTimestamp();
 
         _ = conn.exec(
-            "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, (extract(epoch from now()) * 1000)::bigint, $5) ON CONFLICT DO NOTHING",
-            .{ ws_id, session_id, @as(i64, @intCast(ei)), event_type, prompt_id },
+            "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING",
+            .{ ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id },
         ) catch |err| {
             log.warn("pump: {}", .{err});
         };
+        appendLocalTraceEvent(ws_id, session_id, @as(i64, @intCast(ei)), event_type, timestamp, prompt_id);
     }
 }
 

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -3,7 +3,9 @@ const pg = @import("pg");
 const data = @import("data.zig");
 const Faker = @import("faker.zig");
 const password = @import("password.zig");
-const local_trace = @import("clumsies_lib").trace;
+const clumsies_lib = @import("clumsies_lib");
+const local_trace = clumsies_lib.trace;
+const prompt_lib = clumsies_lib.prompt;
 
 const log = std.log.scoped(.seed);
 
@@ -113,7 +115,7 @@ fn deleteLocalCursorFile(ws_id: []const u8) void {
     };
 }
 
-fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8) void {
+fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8, content: ?[]const u8, content_hash: ?[]const u8) void {
     local_trace.appendTraceEvent(std.heap.page_allocator, .{
         .ws_id = ws_id,
         .session_id = session_id,
@@ -121,6 +123,8 @@ fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i6
         .type = event_type,
         .timestamp = timestamp,
         .prompt_id = prompt_id,
+        .content = content,
+        .content_hash = content_hash,
     }) catch |err| {
         log.warn("seed: local trace append failed: {}", .{err});
     };
@@ -541,7 +545,10 @@ fn seedTraceEvents(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
         const wi = faker.intRange(usize, 0, state.ws_count);
 
         for (0..data.TRACE_EVENTS_PER_SESSION) |ei| {
-            const event_type = faker.pick([]const u8, &data.TRACE_EVENT_TYPES);
+            const event_type: []const u8 = if (ei == 0)
+                "setup"
+            else
+                faker.pick([]const u8, &data.TRACE_EVENT_TYPES);
             const timestamp = std.time.milliTimestamp() + faker.pastDaysMs(30);
 
             const is_refer = std.mem.eql(u8, event_type, "refer");
@@ -549,16 +556,29 @@ fn seedTraceEvents(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
                 state.promptId(faker.intRange(usize, 0, state.prompt_count))
             else
                 null;
+            var content_buf: [256]u8 = undefined;
+            const content: ?[]const u8 = if (std.mem.eql(u8, event_type, "session_input"))
+                faker.sessionInput(&content_buf)
+            else
+                null;
+            const content_hash: ?[]const u8 = if (content) |body|
+                prompt_lib.hashContentHexAlloc(std.heap.page_allocator, body) catch |err| blk: {
+                    log.warn("seed: session input hash failed: {}", .{err});
+                    break :blk null;
+                }
+            else
+                null;
+            defer if (content_hash) |hash| std.heap.page_allocator.free(hash);
 
             const event_id: i64 = @intCast(si * data.TRACE_EVENTS_PER_SESSION + ei);
 
             _ = conn.exec(
-                "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING",
-                .{ state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id },
+                "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id, content, content_hash) VALUES ($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT DO NOTHING",
+                .{ state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id, content, content_hash },
             ) catch |err| {
                 log.warn("seed: {}", .{err});
             };
-            appendLocalTraceEvent(state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id);
+            appendLocalTraceEvent(state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id, content, content_hash);
         }
     }
 }

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -2,6 +2,8 @@ const std = @import("std");
 const pg = @import("pg");
 const data = @import("data.zig");
 const Faker = @import("faker.zig");
+const password = @import("password.zig");
+const local_trace = @import("clumsies_lib").trace;
 
 const log = std.log.scoped(.seed);
 
@@ -48,6 +50,7 @@ pub fn run(pool: *pg.Pool) !void {
     var faker = Faker.init(std.heap.page_allocator);
     var state = SeedState{};
 
+    clearExistingLocalTrace(conn);
     log.info("truncating all tables...", .{});
     _ = conn.exec(
         \\TRUNCATE orgs, users, tokens, workspaces, workspace_members, prompts, workspace_prompts,
@@ -77,6 +80,52 @@ pub fn run(pool: *pg.Pool) !void {
     log.info("reset complete", .{});
 }
 
+fn clearExistingLocalTrace(conn: *pg.Conn) void {
+    var result = conn.query("SELECT ws_id FROM workspaces", .{}) catch return;
+    defer result.deinit();
+
+    while (result.next() catch null) |row| {
+        const ws_id = row.get([]const u8, 0) catch continue;
+        deleteLocalTraceFile(ws_id);
+        deleteLocalCursorFile(ws_id);
+    }
+}
+
+fn deleteLocalTraceFile(ws_id: []const u8) void {
+    const alloc = std.heap.page_allocator;
+    const path = local_trace.traceFilePath(alloc, ws_id) catch return;
+    defer alloc.free(path);
+
+    std.fs.deleteFileAbsolute(path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("seed: local trace cleanup failed: {}", .{err}),
+    };
+}
+
+fn deleteLocalCursorFile(ws_id: []const u8) void {
+    const alloc = std.heap.page_allocator;
+    const path = local_trace.cursorFilePath(alloc, ws_id) catch return;
+    defer alloc.free(path);
+
+    std.fs.deleteFileAbsolute(path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => log.warn("seed: local cursor cleanup failed: {}", .{err}),
+    };
+}
+
+fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i64, event_type: []const u8, timestamp: i64, prompt_id: ?[]const u8) void {
+    local_trace.appendTraceEvent(std.heap.page_allocator, .{
+        .ws_id = ws_id,
+        .session_id = session_id,
+        .event_id = event_id,
+        .type = event_type,
+        .timestamp = timestamp,
+        .prompt_id = prompt_id,
+    }) catch |err| {
+        log.warn("seed: local trace append failed: {}", .{err});
+    };
+}
+
 fn seedOrg(conn: *pg.Conn) !void {
     log.info("seeding org...", .{});
     _ = try conn.exec(
@@ -88,34 +137,16 @@ fn seedOrg(conn: *pg.Conn) !void {
 fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding {d} users...", .{data.USER_COUNT});
 
-    // Track used names to avoid duplicates
-    var used_names: [data.USER_COUNT][]const u8 = undefined;
-    var used_count: usize = 0;
+    var hash_buf: [128]u8 = undefined;
+    const active_password_hash = try password.hashPassword(data.SEED_PASSWORD, &hash_buf);
 
-    for (0..data.USER_COUNT) |i| {
-        // Generate unique name
-        var name: []const u8 = undefined;
-        var attempts: usize = 0;
-        while (attempts < 50) : (attempts += 1) {
-            name = faker.firstName();
-            var duplicate = false;
-            for (used_names[0..used_count]) |used| {
-                if (std.mem.eql(u8, used, name)) {
-                    duplicate = true;
-                    break;
-                }
-            }
-            if (!duplicate) break;
-        }
-        used_names[used_count] = name;
-        used_count += 1;
-
+    for (data.SEED_USERNAMES, 0..) |name, i| {
         const id = faker.hexId(&state.user_ids[i], "usr-");
         // First 2 users are maintainers, rest are members; last 2 are invited
         const role: []const u8 = if (i < 2) "maintainer" else "member";
         const is_invited = i >= data.USER_COUNT - 2;
         const status: []const u8 = if (is_invited) "invited" else "active";
-        const password: []const u8 = if (is_invited) "" else "testpass";
+        const password_hash: []const u8 = if (is_invited) "!invited" else active_password_hash;
 
         state.user_names[i] = name;
         state.user_roles[i] = role;
@@ -123,7 +154,7 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
         _ = try conn.exec(
             "INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUES ($1, $2::uuid, $3, $4, $5, $6)",
-            .{ id, data.ORG_ID, name, password, role, status },
+            .{ id, data.ORG_ID, name, password_hash, role, status },
         );
     }
 }
@@ -511,8 +542,7 @@ fn seedTraceEvents(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
         for (0..data.TRACE_EVENTS_PER_SESSION) |ei| {
             const event_type = faker.pick([]const u8, &data.TRACE_EVENT_TYPES);
-            var interval_buf: [64]u8 = undefined;
-            const interval = faker.pastInterval(&interval_buf, 30);
+            const timestamp = std.time.milliTimestamp() + faker.pastDaysMs(30);
 
             const is_refer = std.mem.eql(u8, event_type, "refer");
             const prompt_id: ?[]const u8 = if (is_refer)
@@ -523,11 +553,12 @@ fn seedTraceEvents(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
             const event_id: i64 = @intCast(si * data.TRACE_EVENTS_PER_SESSION + ei);
 
             _ = conn.exec(
-                "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, (extract(epoch from (now() - $5::interval)) * 1000)::bigint, $6) ON CONFLICT DO NOTHING",
-                .{ state.wsId(wi), session_id, event_id, event_type, interval, prompt_id },
+                "INSERT INTO trace_events (ws_id, session_id, event_id, type, timestamp, prompt_id) VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING",
+                .{ state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id },
             ) catch |err| {
                 log.warn("seed: {}", .{err});
             };
+            appendLocalTraceEvent(state.wsId(wi), session_id, event_id, event_type, timestamp, prompt_id);
         }
     }
 }

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const pg = @import("pg");
 const data = @import("data.zig");
 const Faker = @import("faker.zig");
+const seed_hash = @import("hash.zig");
 const password = @import("password.zig");
 const clumsies_lib = @import("clumsies_lib");
 const local_trace = clumsies_lib.trace;
@@ -17,7 +18,7 @@ const SeedState = struct {
     user_count: usize = 0,
 
     prompt_ids: [data.PROMPT_COUNT][24]u8 = undefined,
-    prompt_hashes: [data.PROMPT_COUNT][24]u8 = undefined,
+    prompt_hashes: [data.PROMPT_COUNT][71]u8 = undefined,
     prompt_paths: [data.PROMPT_COUNT][80]u8 = undefined,
     prompt_path_lens: [data.PROMPT_COUNT]usize = .{0} ** data.PROMPT_COUNT,
     prompt_count: usize = 0,
@@ -146,8 +147,8 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
     for (data.SEED_USERNAMES, 0..) |name, i| {
         const id = faker.hexId(&state.user_ids[i], "usr-");
-        // First 2 users are maintainers, rest are members; last 2 are invited
-        const role: []const u8 = if (i < 2) "maintainer" else "member";
+        // Keep reset aligned with ensure: only the base admin user is a maintainer.
+        const role: []const u8 = if (std.mem.eql(u8, name, data.BASE_MAINTAINER_USERNAME)) "maintainer" else "member";
         const is_invited = i >= data.USER_COUNT - 2;
         const status: []const u8 = if (is_invited) "invited" else "active";
         const password_hash: []const u8 = if (is_invited) "!invited" else active_password_hash;
@@ -166,20 +167,23 @@ fn seedUsers(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 fn seedPrompts(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
     log.info("seeding {d} prompts...", .{data.PROMPT_COUNT});
 
+    const mpf_content =
+        "# clumsies Protocol Bootstrap\n\nUse memory.search to discover rules, memory.load to read them, memory.refer to declare what you applied.\n";
+    const mpf_hash = seed_hash.contentHash(mpf_content);
+
     _ = conn.exec(
         "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5) ON CONFLICT (prompt_id) DO NOTHING",
         .{
             "p-mpf",
             data.ORG_ID,
             "META_PROMPT.md",
-            "# clumsies Protocol Bootstrap\n\nUse memory.search to discover rules, memory.load to read them, memory.refer to declare what you applied.\n",
-            "sha256:mpf0000000000000000000000000000000000000000000000000000000000",
+            mpf_content,
+            mpf_hash[0..],
         },
     ) catch |err| log.warn("MPF seed insert failed: {}", .{err});
 
     for (0..data.PROMPT_COUNT) |i| {
         const id = faker.hexId(&state.prompt_ids[i], "p-");
-        const hash = faker.hexId(&state.prompt_hashes[i], "sha256:");
 
         var path_buf: [80]u8 = undefined;
         var path: []const u8 = undefined;
@@ -203,10 +207,11 @@ fn seedPrompts(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
         var content_buf: [512]u8 = undefined;
         const content = faker.promptContent(&content_buf, kind, stable_path);
+        state.prompt_hashes[i] = seed_hash.contentHash(content);
 
         _ = conn.exec(
             "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES ($1, $2::uuid, $3, $4, $5)",
-            .{ id, data.ORG_ID, stable_path, content, hash },
+            .{ id, data.ORG_ID, stable_path, content, state.promptHash(i) },
         ) catch |err| {
             log.warn("prompt insert failed: {}", .{err});
             continue;
@@ -292,18 +297,17 @@ fn seedPromptHistory(conn: *pg.Conn, faker: *Faker, state: *SeedState) !void {
 
         const history_count = faker.intRange(usize, 1, 4);
         for (0..history_count) |h| {
-            var hash_buf: [24]u8 = undefined;
-            const hash = faker.hexId(&hash_buf, "sha256:");
             var interval_buf: [64]u8 = undefined;
             const interval = faker.pastInterval(&interval_buf, 30 - @as(u32, @intCast(h * 7)));
 
             var content_buf: [256]u8 = undefined;
             const content = std.fmt.bufPrint(&content_buf, "# Historical version {d}\n\nPrevious version of this prompt.", .{h + 1}) catch "# History";
+            const hash = seed_hash.contentHash(content);
             const path = state.prompt_paths[i][0..state.prompt_path_lens[i]];
 
             _ = conn.exec(
                 "INSERT INTO prompt_history (prompt_id, content_hash, path, content, merged_at) VALUES ($1, $2, $3, $4, now() - $5::interval) ON CONFLICT DO NOTHING",
-                .{ state.promptId(i), hash, path, content, interval },
+                .{ state.promptId(i), hash[0..], path, content, interval },
             ) catch |err| {
                 log.warn("seed: {}", .{err});
             };

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -89,9 +89,20 @@ fn clearExistingLocalTrace(conn: *pg.Conn) void {
 
     while (result.next() catch null) |row| {
         const ws_id = row.get([]const u8, 0) catch continue;
+        if (!isSafeWorkspaceId(ws_id)) {
+            log.warn("seed: skipping unsafe workspace id during local trace cleanup: {s}", .{ws_id});
+            continue;
+        }
         deleteLocalTraceFile(ws_id);
         deleteLocalCursorFile(ws_id);
     }
+}
+
+fn isSafeWorkspaceId(ws_id: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, ws_id, '/')) |_| return false;
+    if (std.mem.indexOfScalar(u8, ws_id, '\\')) |_| return false;
+    if (std.mem.indexOf(u8, ws_id, "..")) |_| return false;
+    return true;
 }
 
 fn deleteLocalTraceFile(ws_id: []const u8) void {
@@ -129,6 +140,13 @@ fn appendLocalTraceEvent(ws_id: []const u8, session_id: []const u8, event_id: i6
     }) catch |err| {
         log.warn("seed: local trace append failed: {}", .{err});
     };
+}
+
+test "isSafeWorkspaceId rejects path traversal markers" {
+    try std.testing.expect(isSafeWorkspaceId("ws-seed-default"));
+    try std.testing.expect(!isSafeWorkspaceId("../escape"));
+    try std.testing.expect(!isSafeWorkspaceId("nested/ws"));
+    try std.testing.expect(!isSafeWorkspaceId("nested\\ws"));
 }
 
 fn seedOrg(conn: *pg.Conn) !void {

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -86,7 +86,7 @@ start_hub() {
     "$HUB" &
     HUB_PID=$!
 
-    local attempts=50
+    local attempts=150
     local delay_s=0.2
     local i
     for ((i = 1; i <= attempts; i++)); do
@@ -94,14 +94,14 @@ start_hub() {
             echo "FATAL: Hub server failed to start"
             exit 1
         fi
-        if curl -s -o /dev/null --connect-timeout 1 "$BASE/api/auth/me"; then
+        if curl -s -o /dev/null --connect-timeout 1 --max-time 1 "$BASE/api/auth/me"; then
             echo "Hub server running (PID $HUB_PID)"
             return
         fi
         sleep "$delay_s"
     done
 
-    echo "FATAL: Hub server did not become ready at $BASE"
+    echo "FATAL: Hub server did not become ready at $BASE after $attempts attempts"
     exit 1
 }
 

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -89,15 +89,19 @@ start_hub() {
     local attempts=150
     local delay_s=0.2
     local i
+    local http_status
     for ((i = 1; i <= attempts; i++)); do
         if ! kill -0 "$HUB_PID" 2>/dev/null; then
             echo "FATAL: Hub server failed to start"
             exit 1
         fi
-        if curl -s -o /dev/null --connect-timeout 1 --max-time 1 "$BASE/api/auth/me"; then
-            echo "Hub server running (PID $HUB_PID)"
-            return
-        fi
+        http_status="$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 1 --max-time 1 "$BASE/api/auth/me" || true)"
+        case "$http_status" in
+            200|401|403)
+                echo "Hub server running (PID $HUB_PID)"
+                return
+                ;;
+        esac
         sleep "$delay_s"
     done
 

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -85,13 +85,24 @@ start_hub() {
 
     "$HUB" &
     HUB_PID=$!
-    sleep 2
 
-    if ! kill -0 "$HUB_PID" 2>/dev/null; then
-        echo "FATAL: Hub server failed to start"
-        exit 1
-    fi
-    echo "Hub server running (PID $HUB_PID)"
+    local attempts=50
+    local delay_s=0.2
+    local i
+    for ((i = 1; i <= attempts; i++)); do
+        if ! kill -0 "$HUB_PID" 2>/dev/null; then
+            echo "FATAL: Hub server failed to start"
+            exit 1
+        fi
+        if curl -s -o /dev/null --connect-timeout 1 "$BASE/api/auth/me"; then
+            echo "Hub server running (PID $HUB_PID)"
+            return
+        fi
+        sleep "$delay_s"
+    done
+
+    echo "FATAL: Hub server did not become ready at $BASE"
+    exit 1
 }
 
 cleanup() {


### PR DESCRIPTION
## Summary

This PR makes a fresh local Clumsies install usable without extra bootstrap setup and keeps the seed command aligned with how the client and TUI now consume data. The hub now provisions an `admin` maintainer when the database is empty and no bootstrap credentials are provided, and the login client tolerates the current auth response shape while using platform storage more reliably. Seeded accounts now use hashed passwords and the default seed flow reuses bootstrap users instead of failing on duplicate usernames.

The seed command is consolidated around ensure-and-pump by default, with `--reset` clearing and reseeding before entering the same loop. Pumped trace activity now writes local `session_input` events with content and content hashes so the TUI Recent Inputs panel is populated by seed traffic instead of staying empty. Cleanup also deletes prompt PR comments before removing closed prompt PRs, which avoids the PostgreSQL errors that showed up under fast pump intervals.

## Test plan

- [x] `zig build test`
- [x] `zig build seed -- --help`
- [x] `zig build seed`
- [x] `./zig-out/bin/clumsies-seed --interval=100`
- [x]  Inspect `~/.clumsies/workspaces/*/trace.jsonl` and confirm `session_input` entries contain `content` and `content_hash`
- [x]  Run `./zig-out/bin/clumsies login` with `admin/admin` and verify local auth storage succeeds
