### PR TITLE
tui: add the initial terminal UI client

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -95,6 +95,11 @@ pub fn build(b: *std.Build) void {
     });
     tui_module.addImport("vaxis", vaxis_dep.module("vaxis"));
 
+    if (enable_keychain) {
+        tui_module.linkFramework("Security", .{});
+        tui_module.linkFramework("CoreFoundation", .{});
+    }
+
     const tui_exe = b.addExecutable(.{
         .name = "clumsies-tui",
         .root_module = tui_module,

--- a/build.zig
+++ b/build.zig
@@ -79,6 +79,40 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(hub);
 
+    // TUI Dashboard executable
+    const vaxis_dep = b.dependency("vaxis", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const tui_module = b.createModule(.{
+        .root_source_file = b.path("src/tui/main.zig"),
+        .target = target,
+        .optimize = optimize,
+        .imports = &.{
+            .{ .name = "build_options", .module = options.createModule() },
+        },
+    });
+    tui_module.addImport("vaxis", vaxis_dep.module("vaxis"));
+
+    const tui_exe = b.addExecutable(.{
+        .name = "clumsies-tui",
+        .root_module = tui_module,
+    });
+    b.installArtifact(tui_exe);
+
+    const tui_run_cmd = b.addRunArtifact(tui_exe);
+    tui_run_cmd.step.dependOn(b.getInstallStep());
+    if (b.args) |args| {
+        tui_run_cmd.addArgs(args);
+    }
+
+    const tui_build_step = b.step("tui", "Build TUI dashboard");
+    tui_build_step.dependOn(b.getInstallStep());
+
+    const tui_run_step = b.step("run-tui", "Run TUI dashboard");
+    tui_run_step.dependOn(&tui_run_cmd.step);
+
     const hub_run_cmd = b.addRunArtifact(hub);
     hub_run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,6 +15,10 @@
             .url = "git+https://github.com/sam701/zig-toml#a73c9423d88ed413204b39638fab7e9bccdb83fd",
             .hash = "toml-0.3.0-bV14Be6EAQDr0fkyURz4jYFyTAMPcwlNN0FEPVjDnXTR",
         },
+        .vaxis = .{
+            .url = "https://github.com/rockorager/libvaxis/archive/refs/heads/main.tar.gz",
+            .hash = "vaxis-0.5.1-BWNV_JJOCQAtdJyLvrYCKbKIhX9q3liQkKMAzujWS4HJ",
+        },
     },
     .paths = .{
         "build.zig",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,7 +16,7 @@
             .hash = "toml-0.3.0-bV14Be6EAQDr0fkyURz4jYFyTAMPcwlNN0FEPVjDnXTR",
         },
         .vaxis = .{
-            .url = "https://github.com/rockorager/libvaxis/archive/refs/heads/main.tar.gz",
+            .url = "https://github.com/rockorager/libvaxis/archive/3d37f043a161fd32897ad44a2dddbfaab75faa8a.tar.gz",
             .hash = "vaxis-0.5.1-BWNV_JJOCQAtdJyLvrYCKbKIhX9q3liQkKMAzujWS4HJ",
         },
     },

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -2,9 +2,11 @@ const std = @import("std");
 const HubClient = @import("hub_client.zig").HubClient;
 const data = @import("mock_data.zig");
 const trace_reader = @import("trace_reader.zig");
+const session_reader = @import("session_reader.zig");
 const drafts_reader = @import("drafts_reader.zig");
 
 pub const DraftEntry = drafts_reader.DraftEntry;
+pub const ActiveSession = session_reader.ActiveSession;
 
 pub const ConnectionStatus = enum {
     disconnected,
@@ -156,6 +158,8 @@ pub const ApiState = struct {
     local_stats: ?trace_reader.LocalStats = null,
     // Local drafts from ~/.clumsies/workspaces/*/drafts/_index.json
     drafts: ?[]const DraftEntry = null,
+    // Active MCP sessions from ~/.clumsies/workspaces/*/current_session.json
+    active_sessions: ?[]const ActiveSession = null,
     prompt_content: ?[]const u8 = null,
     prompt_content_name: ?[]const u8 = null,
     // PR detail (on-demand)
@@ -351,9 +355,11 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     // Read local trace.jsonl first (available even if server is unreachable)
     const local = trace_reader.readLocalStats(alloc);
     const local_drafts = drafts_reader.readAllDrafts(alloc);
+    const sessions = session_reader.readAllSessions(alloc);
     api_state.mutex.lock();
     api_state.local_stats = local;
     api_state.drafts = local_drafts;
+    api_state.active_sessions = sessions;
     api_state.mutex.unlock();
 
     var client = HubClient.init(alloc, hub_url, access_token);

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -672,6 +672,42 @@ pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []
     return list.items;
 }
 
+// Convert API PromptPr to mock-compatible PullRequestEntry slice,
+// filtered by canonical_name. Diff/comments are empty (need PR detail fetch).
+pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_name: []const u8, library: ?[]const LibraryPrompt) []const data.PullRequestEntry {
+    // Find prompt_id for the given canonical_name
+    const target_id: ?[]const u8 = if (library) |lib| blk: {
+        for (lib) |lp| {
+            if (std.mem.eql(u8, lp.canonical_name, canonical_name))
+                break :blk lp.prompt_id;
+        }
+        break :blk null;
+    } else null;
+
+    var list: std.ArrayList(data.PullRequestEntry) = .empty;
+    for (prs) |pr| {
+        // Filter by prompt_id if we found one, otherwise skip
+        if (target_id) |tid| {
+            if (!std.mem.eql(u8, pr.prompt_id, tid)) continue;
+        } else continue;
+
+        list.append(alloc, .{
+            .id = pr.pr_id,
+            .prompt_name = canonical_name,
+            .status = pr.status,
+            .author = pr.author,
+            .created = pr.created_at,
+            .description = pr.description,
+            .base_hash = "",
+            .diff = &.{},
+            .comments = &.{},
+            .trace_refers = 0,
+            .trace_sessions = 0,
+        }) catch continue;
+    }
+    return list.items;
+}
+
 // Build InsightsData from OrgStats.
 // Members/models/alerts fall back to mock (need workspace-level stats).
 pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt) data.InsightsData {

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -93,6 +93,19 @@ pub const TrendPoint = struct {
     refer_count: i64,
 };
 
+// Workspace stats (members + models from /api/stats/workspace/{id})
+pub const WsStatsMember = struct {
+    username: []const u8,
+    refer_count: i64,
+    active_days: i64,
+    trend: []const i64,
+};
+
+pub const WsStatsModel = struct {
+    model_id: []const u8,
+    refer_count: i64,
+};
+
 // Workspace-specific data (fetched on demand)
 pub const WsDetail = struct {
     ws_id: []const u8,
@@ -127,6 +140,9 @@ pub const ApiState = struct {
     org_stats: ?OrgStats = null,
     // Workspace detail (on-demand)
     ws_detail: ?WsDetail = null,
+    // Workspace stats (for Insights team activity)
+    ws_stats_members: ?[]const WsStatsMember = null,
+    ws_stats_models: ?[]const WsStatsModel = null,
     prompt_content: ?[]const u8 = null,
     prompt_content_name: ?[]const u8 = null,
     // Fetch coordination
@@ -253,6 +269,24 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     // GET /api/org/prompt-prs
     const prs = doFetchParse(&client, alloc, "/api/org/prompt-prs", []const PromptPr, parsePromptPrs);
 
+    // GET /api/stats/workspace/{first_ws_id}?period=daily&days=30
+    var ws_members: ?[]const WsStatsMember = null;
+    var ws_models: ?[]const WsStatsModel = null;
+    if (user.workspaces.len > 0) {
+        const ws_stats_path = std.fmt.allocPrint(alloc, "/api/stats/workspace/{s}?period=daily&days=30", .{user.workspaces[0].ws_id}) catch null;
+        if (ws_stats_path) |path| {
+            const ws_resp = client.get(path) catch null;
+            if (ws_resp) |resp| {
+                defer resp.deinit();
+                if (resp.status == .ok) {
+                    const result = parseWsStats(alloc, resp.body);
+                    ws_members = result.members;
+                    ws_models = result.models;
+                }
+            }
+        }
+    }
+
     api_state.mutex.lock();
     api_state.current_user = user;
     api_state.directory = directory;
@@ -260,6 +294,8 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     api_state.bundles = bundles;
     api_state.prompt_prs = prs;
     api_state.org_stats = org_stats;
+    api_state.ws_stats_members = ws_members;
+    api_state.ws_stats_models = ws_models;
     api_state.status = .connected;
     api_state.mutex.unlock();
 }
@@ -413,6 +449,55 @@ fn parseManifestPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const WsP
         }) catch continue;
     }
     return list.items;
+}
+
+const WsStatsResult = struct {
+    members: ?[]const WsStatsMember,
+    models: ?[]const WsStatsModel,
+};
+
+fn parseWsStats(alloc: std.mem.Allocator, body: []const u8) WsStatsResult {
+    const Json = struct {
+        members: []const struct {
+            username: []const u8 = "",
+            refer_count: i64 = 0,
+            active_days: i64 = 0,
+            trend: []const i64 = &.{},
+        } = &.{},
+        models: []const struct {
+            model_id: []const u8 = "",
+            refer_count: i64 = 0,
+        } = &.{},
+    };
+    const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return .{ .members = null, .models = null };
+    defer parsed.deinit();
+
+    var members: std.ArrayList(WsStatsMember) = .empty;
+    for (parsed.value.members) |m| {
+        var trend_copy: std.ArrayList(i64) = .empty;
+        for (m.trend) |t| {
+            trend_copy.append(alloc, t) catch continue;
+        }
+        members.append(alloc, .{
+            .username = alloc.dupe(u8, m.username) catch continue,
+            .refer_count = m.refer_count,
+            .active_days = m.active_days,
+            .trend = trend_copy.items,
+        }) catch continue;
+    }
+
+    var models: std.ArrayList(WsStatsModel) = .empty;
+    for (parsed.value.models) |m| {
+        models.append(alloc, .{
+            .model_id = alloc.dupe(u8, m.model_id) catch continue,
+            .refer_count = m.refer_count,
+        }) catch continue;
+    }
+
+    return .{
+        .members = members.items,
+        .models = models.items,
+    };
 }
 
 fn setStatus(api_state: *ApiState, status: ConnectionStatus) void {
@@ -708,9 +793,44 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_na
     return list.items;
 }
 
+fn toInsightsMembers(alloc: std.mem.Allocator, members: []const WsStatsMember) []const data.InsightsMember {
+    var list: std.ArrayList(data.InsightsMember) = .empty;
+    for (members) |m| {
+        var trend30: [30]u16 = .{0} ** 30;
+        const count = @min(m.trend.len, 30);
+        for (0..count) |i| {
+            trend30[i] = @intCast(@min(@max(m.trend[i], 0), std.math.maxInt(u16)));
+        }
+        list.append(alloc, .{
+            .username = m.username,
+            .refer_count = @intCast(@min(m.refer_count, std.math.maxInt(u32))),
+            .active_days = @intCast(@min(m.active_days, 255)),
+            .trend = trend30,
+            .top_prompts = &.{},
+            .models = &.{},
+        }) catch continue;
+    }
+    return list.items;
+}
+
+fn toInsightsModels(alloc: std.mem.Allocator, models: []const WsStatsModel) []const data.InsightsModel {
+    var total: i64 = 0;
+    for (models) |m| total += m.refer_count;
+    var list: std.ArrayList(data.InsightsModel) = .empty;
+    for (models) |m| {
+        const pct: u8 = if (total > 0) @intCast(@min(@divTrunc(m.refer_count * 100, total), 100)) else 0;
+        list.append(alloc, .{
+            .model_id = m.model_id,
+            .refer_count = @intCast(@min(m.refer_count, std.math.maxInt(u32))),
+            .pct = pct,
+        }) catch continue;
+    }
+    return list.items;
+}
+
 // Build InsightsData from OrgStats.
 // Members/models/alerts fall back to mock (need workspace-level stats).
-pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt) data.InsightsData {
+pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt, ws_members: ?[]const WsStatsMember, ws_models: ?[]const WsStatsModel) data.InsightsData {
     var trend: [30]u16 = .{0} ** 30;
     const tcount = @min(stats.trend.len, 30);
     for (0..tcount) |i| {
@@ -770,8 +890,8 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
         .last_event_minutes_ago = 0,
         .refer_trend = trend,
         .prompts = prompts_list.items,
-        .members = data.INSIGHTS.members,
-        .models = data.INSIGHTS.models,
+        .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else data.INSIGHTS.members,
+        .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else data.INSIGHTS.models,
         .alerts = data.INSIGHTS.alerts,
     };
 }

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1094,6 +1094,23 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
     // Prefer local trace data for chart and prompts (personal real-time)
     // Fall back to server stats for team-level data
     if (local) |l| {
+        // trace_reader fills .name with the raw prompt_id; remap to path via
+        // library so the Insights Prompts Rank shows friendly labels.
+        const remapped_prompts: []const data.InsightsPrompt = if (library) |lib| blk: {
+            var remapped: std.ArrayList(data.InsightsPrompt) = .empty;
+            for (l.prompts) |p| {
+                var copy = p;
+                for (lib) |lp| {
+                    if (std.mem.eql(u8, lp.prompt_id, p.name)) {
+                        copy.name = lp.path;
+                        break;
+                    }
+                }
+                remapped.append(alloc, copy) catch continue;
+            }
+            break :blk remapped.items;
+        } else l.prompts;
+
         return .{
             .constraint_count = l.constraint_count,
             .active_constraint_count = l.active_constraint_count,
@@ -1103,7 +1120,7 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
             .today_delta_pct = 0,
             .last_event_minutes_ago = 0,
             .refer_trend = l.refer_trend,
-            .prompts = l.prompts,
+            .prompts = remapped_prompts,
             .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else &.{},
             .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else &.{},
             .alerts = &.{},

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -181,14 +181,18 @@ pub const ApiState = struct {
     // Arena for all fetched data
     backing_allocator: std.mem.Allocator,
     arena: *std.heap.ArenaAllocator,
+    local_arena: *std.heap.ArenaAllocator,
     ts_allocator: std.heap.ThreadSafeAllocator,
 
     pub fn init(base_allocator: std.mem.Allocator) ApiState {
         const arena_ptr = base_allocator.create(std.heap.ArenaAllocator) catch @panic("ApiState.init: arena allocation failed");
         arena_ptr.* = std.heap.ArenaAllocator.init(base_allocator);
+        const local_arena_ptr = base_allocator.create(std.heap.ArenaAllocator) catch @panic("ApiState.init: local arena allocation failed");
+        local_arena_ptr.* = std.heap.ArenaAllocator.init(base_allocator);
         return .{
             .backing_allocator = base_allocator,
             .arena = arena_ptr,
+            .local_arena = local_arena_ptr,
             .ts_allocator = undefined,
         };
     }
@@ -199,7 +203,9 @@ pub const ApiState = struct {
 
     pub fn deinit(self: *ApiState) void {
         self.arena.deinit();
+        self.local_arena.deinit();
         self.backing_allocator.destroy(self.arena);
+        self.backing_allocator.destroy(self.local_arena);
     }
 
     pub fn allocator(self: *ApiState) std.mem.Allocator {
@@ -220,16 +226,15 @@ pub fn startFetch(api_state: *ApiState, hub_url: []const u8, access_token: []con
 }
 
 pub fn refreshLocalState(api_state: *ApiState) void {
-    const alloc = api_state.allocator();
-    const local = trace_reader.readLocalStats(alloc);
-    const local_drafts = drafts_reader.readAllDrafts(alloc);
-    const sessions = session_reader.readAllSessions(alloc);
-
     api_state.mutex.lock();
-    api_state.local_stats = local;
-    api_state.drafts = local_drafts;
-    api_state.active_sessions = sessions;
-    api_state.mutex.unlock();
+    defer api_state.mutex.unlock();
+
+    _ = api_state.local_arena.reset(.retain_capacity);
+    const alloc = api_state.local_arena.allocator();
+
+    api_state.local_stats = trace_reader.readLocalStats(alloc);
+    api_state.drafts = drafts_reader.readAllDrafts(alloc);
+    api_state.active_sessions = session_reader.readAllSessions(alloc);
 }
 
 pub fn refetchAllAsync(api_state: *ApiState) void {
@@ -769,7 +774,15 @@ fn fetchPromptContent(api_state: *ApiState, prompt_path: []const u8) void {
     api_state.mutex.unlock();
 
     var client = HubClient.init(alloc, hub_url, token);
-    const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?path={s}", .{prompt_path}) catch {
+    const encoded_path = std.fmt.allocPrint(alloc, "{f}", .{
+        std.fmt.alt(std.Uri.Component{ .raw = prompt_path }, .formatQuery),
+    }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?path={s}", .{encoded_path}) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
         api_state.mutex.unlock();

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -127,6 +127,10 @@ pub const ContextFileData = struct {
 pub const WsPromptData = struct {
     prompt_id: []const u8,
     content_hash: []const u8,
+    // Populated when the server manifest carries structured values
+    // ({path, hash}). Empty on the older string-valued manifest schema,
+    // in which case callers still resolve path via library lookup.
+    path: []const u8 = "",
 };
 
 pub const ApiState = struct {
@@ -785,16 +789,30 @@ fn parseManifestPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const WsP
         else => return null,
     };
 
+    // The manifest historically mapped prompt_id to a plain hash string;
+    // the post-alignment schema maps it to {path, hash}. Accept both so
+    // the TUI keeps working across the server-side migration.
     var list: std.ArrayList(WsPromptData) = .empty;
     var it = map.iterator();
     while (it.next()) |entry| {
-        const hash = switch (entry.value_ptr.*) {
-            .string => |s| s,
-            else => "",
-        };
+        var hash: []const u8 = "";
+        var path: []const u8 = "";
+        switch (entry.value_ptr.*) {
+            .string => |s| hash = s,
+            .object => |obj| {
+                if (obj.get("hash")) |h| if (h == .string) {
+                    hash = h.string;
+                };
+                if (obj.get("path")) |p| if (p == .string) {
+                    path = p.string;
+                };
+            },
+            else => {},
+        }
         list.append(alloc, .{
             .prompt_id = alloc.dupe(u8, entry.key_ptr.*) catch continue,
             .content_hash = alloc.dupe(u8, hash) catch continue,
+            .path = alloc.dupe(u8, path) catch continue,
         }) catch continue;
     }
     return list.items;

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -61,11 +61,11 @@ pub const BundleData = struct {
 
 pub const PromptPr = struct {
     pr_id: []const u8,
-    prompt_id: []const u8,
     status: []const u8,
     description: []const u8,
     created_at: []const u8,
     author: []const u8,
+    operation_count: i32 = 0,
 };
 
 // Stats / Insights data
@@ -139,6 +139,8 @@ pub const ApiState = struct {
     prompts: ?[]const LibraryPrompt = null,
     bundles: ?[]const BundleData = null,
     prompt_prs: ?[]const PromptPr = null,
+    prompt_prs_for_path: ?[]const u8 = null,
+    prompt_prs_for_id: ?[]const u8 = null,
     // Insights
     org_stats: ?OrgStats = null,
     // Workspace detail (on-demand)
@@ -204,6 +206,93 @@ pub fn fetchWorkspaceAsync(api_state: *ApiState, ws_id: []const u8) void {
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
     };
+}
+
+// Fetch the PR list scoped to a single prompt. Re-issued whenever the
+// user selects a different prompt in Library; the hub returns only PRs
+// whose operations[] touches that prompt_id.
+pub fn fetchPromptPrsAsync(api_state: *ApiState, prompt_path: []const u8) void {
+    api_state.mutex.lock();
+    if (api_state.fetch_busy or api_state.hub_url == null) {
+        api_state.mutex.unlock();
+        return;
+    }
+    if (api_state.prompt_prs_for_path) |cached| {
+        if (std.mem.eql(u8, cached, prompt_path)) {
+            api_state.mutex.unlock();
+            return;
+        }
+    }
+    const lib = api_state.prompts orelse {
+        api_state.mutex.unlock();
+        return;
+    };
+    const alloc = api_state.arena.allocator();
+    const prompt_id: ?[]const u8 = for (lib) |lp| {
+        if (std.mem.eql(u8, lp.path, prompt_path)) break alloc.dupe(u8, lp.prompt_id) catch null;
+    } else null;
+    api_state.mutex.unlock();
+    if (prompt_id == null) return;
+
+    const path_copy = alloc.dupe(u8, prompt_path) catch return;
+
+    api_state.mutex.lock();
+    api_state.fetch_busy = true;
+    api_state.mutex.unlock();
+
+    _ = std.Thread.spawn(.{}, fetchPromptPrs, .{ api_state, path_copy, prompt_id.? }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    };
+}
+
+fn fetchPromptPrs(api_state: *ApiState, prompt_path: []const u8, prompt_id: []const u8) void {
+    const alloc = api_state.arena.allocator();
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const token = api_state.access_token orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    api_state.mutex.unlock();
+
+    var client = HubClient.init(alloc, hub_url, token);
+    const path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs?prompt_id={s}", .{prompt_id}) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+
+    const resp = client.get(path) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    defer resp.deinit();
+
+    var prs: ?[]const PromptPr = null;
+    if (resp.status == .ok) {
+        prs = parsePromptPrs(alloc, resp.body);
+    }
+
+    api_state.mutex.lock();
+    api_state.prompt_prs = prs;
+    api_state.prompt_prs_for_path = prompt_path;
+    api_state.prompt_prs_for_id = prompt_id;
+    api_state.pr_detail_id = null;
+    api_state.pr_detail_diff = null;
+    api_state.pr_detail_comments = null;
+    api_state.pr_detail_trace_refers = 0;
+    api_state.fetch_busy = false;
+    api_state.mutex.unlock();
 }
 
 // Fetch prompt content on demand
@@ -286,8 +375,7 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     // GET /api/org/bundles
     const bundles = doFetchParse(&client, alloc, "/api/org/bundles", []const BundleData, parseBundles);
 
-    // GET /api/org/prompt-prs
-    const prs = doFetchParse(&client, alloc, "/api/org/prompt-prs", []const PromptPr, parsePromptPrs);
+    // PR list is fetched per prompt via fetchPromptPrsAsync when selection changes.
 
     // GET /api/stats/workspace/{first_ws_id}?period=daily&days=30
     var ws_members: ?[]const WsStatsMember = null;
@@ -312,7 +400,6 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     api_state.directory = directory;
     api_state.prompts = prompts_list;
     api_state.bundles = bundles;
-    api_state.prompt_prs = prs;
     api_state.org_stats = org_stats;
     api_state.ws_stats_members = ws_members;
     api_state.ws_stats_models = ws_models;
@@ -386,10 +473,16 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
     var trace_refers: u16 = 0;
     if (detail_resp.status == .ok) {
         const DetailJson = struct {
-            diff: ?struct {
-                base: []const u8 = "",
-                proposed: []const u8 = "",
-            } = null,
+            operations: []const struct {
+                op_index: i32 = 0,
+                type: []const u8 = "",
+                prompt_id: ?[]const u8 = null,
+                base_hash: ?[]const u8 = null,
+                content: ?[]const u8 = null,
+                path: ?[]const u8 = null,
+                base_content: ?[]const u8 = null,
+                current_path: ?[]const u8 = null,
+            } = &.{},
             trace_summary: ?struct {
                 refer_count: i64 = 0,
             } = null,
@@ -397,8 +490,33 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
         const parsed = std.json.parseFromSlice(DetailJson, alloc, detail_resp.body, .{ .allocate = .alloc_always }) catch null;
         if (parsed) |p| {
             defer p.deinit();
-            if (p.value.diff) |d| {
-                diff_lines = computeDiffLines(alloc, d.base, d.proposed);
+            // Pick the operation scoped to the currently selected prompt if we
+            // can resolve it; otherwise fall back to the first op. A PR with
+            // rename-only or delete-only targeting this prompt still renders
+            // its base content diffed against empty (or new path header).
+            const target_id = blk: {
+                api_state.mutex.lock();
+                defer api_state.mutex.unlock();
+                break :blk if (api_state.prompt_prs_for_id) |id| alloc.dupe(u8, id) catch null else null;
+            };
+            var pick_idx: ?usize = null;
+            if (target_id) |tid| {
+                for (p.value.operations, 0..) |op, i| {
+                    if (op.prompt_id) |pid| {
+                        if (std.mem.eql(u8, pid, tid)) {
+                            pick_idx = i;
+                            break;
+                        }
+                    }
+                }
+            }
+            if (pick_idx == null and p.value.operations.len > 0) pick_idx = 0;
+
+            if (pick_idx) |i| {
+                const op = p.value.operations[i];
+                const base = op.base_content orelse "";
+                const proposed = op.content orelse "";
+                diff_lines = computeDiffLines(alloc, base, proposed);
             }
             if (p.value.trace_summary) |ts| {
                 trace_refers = @intCast(@min(ts.refer_count, std.math.maxInt(u16)));
@@ -887,12 +1005,12 @@ fn parseBundles(alloc: std.mem.Allocator, body: []const u8) ?[]const BundleData 
 fn parsePromptPrs(alloc: std.mem.Allocator, body: []const u8) ?[]const PromptPr {
     const Json = struct {
         prs: []const struct {
-            pr_id: []const u8,
-            prompt_id: []const u8,
+            proposal_id: []const u8,
             status: []const u8,
             description: []const u8,
             created_at: []const u8,
             author: []const u8 = "",
+            operation_count: i32 = 0,
         },
     };
     const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
@@ -901,12 +1019,12 @@ fn parsePromptPrs(alloc: std.mem.Allocator, body: []const u8) ?[]const PromptPr 
     var list: std.ArrayList(PromptPr) = .empty;
     for (parsed.value.prs) |pr| {
         list.append(alloc, .{
-            .pr_id = alloc.dupe(u8, pr.pr_id) catch continue,
-            .prompt_id = alloc.dupe(u8, pr.prompt_id) catch continue,
+            .pr_id = alloc.dupe(u8, pr.proposal_id) catch continue,
             .status = alloc.dupe(u8, pr.status) catch continue,
             .description = alloc.dupe(u8, pr.description) catch continue,
             .created_at = alloc.dupe(u8, pr.created_at) catch continue,
             .author = alloc.dupe(u8, pr.author) catch continue,
+            .operation_count = pr.operation_count,
         }) catch continue;
     }
     return list.items;
@@ -960,22 +1078,12 @@ pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []
 }
 
 // Convert API PromptPr to mock-compatible PullRequestEntry slice.
-// If pr_detail is available for a PR, its diff/comments are populated.
-pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, prompt_path: []const u8, library: ?[]const LibraryPrompt, api_state: *ApiState) []const data.PullRequestEntry {
-    const target_id: ?[]const u8 = if (library) |lib| blk: {
-        for (lib) |lp| {
-            if (std.mem.eql(u8, lp.path, prompt_path))
-                break :blk lp.prompt_id;
-        }
-        break :blk null;
-    } else null;
-
+// The caller is responsible for ensuring `prs` is already scoped to the
+// intended prompt (the hub PR list now supports ?prompt_id= filtering, so
+// this converter no longer filters client-side).
+pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, prompt_path: []const u8, api_state: *ApiState) []const data.PullRequestEntry {
     var list: std.ArrayList(data.PullRequestEntry) = .empty;
     for (prs) |pr| {
-        if (target_id) |tid| {
-            if (!std.mem.eql(u8, pr.prompt_id, tid)) continue;
-        } else continue;
-
         var diff: []const []const u8 = &.{};
         var comments: []const data.CommentEntry = &.{};
         var trace_refers: u16 = 0;

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -340,6 +340,7 @@ fn fetchPromptPrs(api_state: *ApiState, prompt_path: []const u8, prompt_id: []co
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(path);
 
     const resp = client.get(path) catch {
         api_state.mutex.lock();
@@ -459,6 +460,7 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     if (user.workspaces.len > 0) {
         const ws_stats_path = std.fmt.allocPrint(alloc, "/api/stats/workspace/{s}?period=daily&days=30", .{user.workspaces[0].ws_id}) catch null;
         if (ws_stats_path) |path| {
+            defer alloc.free(path);
             const ws_resp = client.get(path) catch null;
             if (ws_resp) |resp| {
                 defer resp.deinit();
@@ -537,6 +539,7 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(detail_path);
     const detail_resp = client.get(detail_path) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
@@ -582,6 +585,7 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
             };
             var pick_idx: ?usize = null;
             if (target_id) |tid| {
+                defer alloc.free(tid);
                 for (p.value.operations, 0..) |op, i| {
                     if (op.prompt_id) |pid| {
                         if (std.mem.eql(u8, pid, tid)) {
@@ -614,6 +618,7 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
     const comments_path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{pr_id}) catch null;
     var comments: ?[]const data.CommentEntry = null;
     if (comments_path) |cpath| {
+        defer alloc.free(cpath);
         const c_resp = client.get(cpath) catch null;
         if (c_resp) |resp| {
             defer resp.deinit();
@@ -737,6 +742,7 @@ fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(files_path);
     const files = doFetchParse(&client, alloc, files_path, []const ContextFileData, parseContextFiles);
 
     // GET /api/workspaces/{ws_id}/manifest
@@ -746,6 +752,7 @@ fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(manifest_path);
     const ws_prompts = doFetchParse(&client, alloc, manifest_path, []const WsPromptData, parseManifestPrompts);
 
     api_state.mutex.lock();
@@ -782,12 +789,14 @@ fn fetchPromptContent(api_state: *ApiState, prompt_path: []const u8) void {
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(encoded_path);
     const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?path={s}", .{encoded_path}) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
         return;
     };
+    defer alloc.free(path);
 
     const resp = client.get(path) catch {
         api_state.mutex.lock();

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const HubClient = @import("hub_client.zig").HubClient;
 const data = @import("mock_data.zig");
+const trace_reader = @import("trace_reader.zig");
 
 pub const ConnectionStatus = enum {
     disconnected,
@@ -143,6 +144,8 @@ pub const ApiState = struct {
     // Workspace stats (for Insights team activity)
     ws_stats_members: ?[]const WsStatsMember = null,
     ws_stats_models: ?[]const WsStatsModel = null,
+    // Local trace stats from ~/.clumsies/log/*.jsonl
+    local_stats: ?trace_reader.LocalStats = null,
     prompt_content: ?[]const u8 = null,
     prompt_content_name: ?[]const u8 = null,
     // PR detail (on-demand)
@@ -236,6 +239,13 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     api_state.mutex.unlock();
 
     const alloc = api_state.arena.allocator();
+
+    // Read local trace.jsonl first (available even if server is unreachable)
+    const local = trace_reader.readLocalStats(alloc);
+    api_state.mutex.lock();
+    api_state.local_stats = local;
+    api_state.mutex.unlock();
+
     var client = HubClient.init(alloc, hub_url, access_token);
 
     // GET /api/auth/me
@@ -1031,7 +1041,7 @@ fn toInsightsModels(alloc: std.mem.Allocator, models: []const WsStatsModel) []co
 
 // Build InsightsData from OrgStats.
 // Members/models/alerts fall back to mock (need workspace-level stats).
-pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt, ws_members: ?[]const WsStatsMember, ws_models: ?[]const WsStatsModel) data.InsightsData {
+pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt, ws_members: ?[]const WsStatsMember, ws_models: ?[]const WsStatsModel, local: ?trace_reader.LocalStats) data.InsightsData {
     var trend: [30]u16 = .{0} ** 30;
     const tcount = @min(stats.trend.len, 30);
     for (0..tcount) |i| {
@@ -1079,6 +1089,25 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
             .trend = .{0} ** 30,
             .constraints = &.{},
         }) catch continue;
+    }
+
+    // Prefer local trace data for chart and prompts (personal real-time)
+    // Fall back to server stats for team-level data
+    if (local) |l| {
+        return .{
+            .constraint_count = l.constraint_count,
+            .active_constraint_count = l.active_constraint_count,
+            .idle_constraint_count = if (l.constraint_count > l.active_constraint_count) l.constraint_count - l.active_constraint_count else 0,
+            .signal_ratio = l.signal_ratio,
+            .refers_per_hour = refers_per_hour,
+            .today_delta_pct = 0,
+            .last_event_minutes_ago = 0,
+            .refer_trend = l.refer_trend,
+            .prompts = l.prompts,
+            .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else &.{},
+            .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else &.{},
+            .alerts = &.{},
+        };
     }
 
     return .{

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const HubClient = @import("hub_client.zig").HubClient;
 const data = @import("mock_data.zig");
 const trace_reader = @import("trace_reader.zig");
+const drafts_reader = @import("drafts_reader.zig");
+
+pub const DraftEntry = drafts_reader.DraftEntry;
 
 pub const ConnectionStatus = enum {
     disconnected,
@@ -145,6 +148,8 @@ pub const ApiState = struct {
     ws_stats_models: ?[]const WsStatsModel = null,
     // Local trace stats from ~/.clumsies/log/*.jsonl
     local_stats: ?trace_reader.LocalStats = null,
+    // Local drafts from ~/.clumsies/workspaces/*/drafts/_index.json
+    drafts: ?[]const DraftEntry = null,
     prompt_content: ?[]const u8 = null,
     prompt_content_name: ?[]const u8 = null,
     // PR detail (on-demand)
@@ -240,8 +245,10 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
 
     // Read local trace.jsonl first (available even if server is unreachable)
     const local = trace_reader.readLocalStats(alloc);
+    const local_drafts = drafts_reader.readAllDrafts(alloc);
     api_state.mutex.lock();
     api_state.local_stats = local;
+    api_state.drafts = local_drafts;
     api_state.mutex.unlock();
 
     var client = HubClient.init(alloc, hub_url, access_token);

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const HubClient = @import("hub_client.zig").HubClient;
+const data = @import("mock_data.zig");
 
 pub const ConnectionStatus = enum {
     disconnected,
@@ -397,4 +398,88 @@ fn parsePromptPrs(alloc: std.mem.Allocator, body: []const u8) ?[]const PromptPr 
         }) catch continue;
     }
     return list.items;
+}
+
+// Convert API LibraryPrompts to mock-compatible PromptEntry slice.
+// This lets syncLibraryWidgets work unchanged with live data.
+pub fn toPromptEntries(alloc: std.mem.Allocator, prompts: []const LibraryPrompt) []const data.PromptEntry {
+    var list: std.ArrayList(data.PromptEntry) = .empty;
+    for (prompts) |p| {
+        const refer_str = formatCount(alloc, p.refer_count) catch "";
+        list.append(alloc, .{
+            .canonical_name = p.canonical_name,
+            .kind = p.kind,
+            .refer_count = refer_str,
+            .constraint_count = @intCast(@min(p.active_constraint_count, 255)),
+            .bundle_count = @intCast(@min(p.bundle_count, 255)),
+            .bundle_names = "",
+            .updated = p.updated_at,
+            .age = "",
+            .summary = "",
+            .trend = .{0} ** 8,
+            .content_hash = p.content_hash,
+            .open_pr_count = @intCast(@min(p.open_pr_count, 255)),
+            .workspace_count = @intCast(@min(p.workspace_count, 255)),
+            .workspace_names = "",
+            .revision = 0,
+        }) catch continue;
+    }
+    return list.items;
+}
+
+fn formatCount(alloc: std.mem.Allocator, n: i64) ![]const u8 {
+    if (n >= 1000) {
+        const k = @as(f64, @floatFromInt(n)) / 1000.0;
+        return std.fmt.allocPrint(alloc, "{d:.1}k", .{k});
+    }
+    return std.fmt.allocPrint(alloc, "{d}", .{n});
+}
+
+// Convert API BundleData to mock-compatible BundleEntry slice.
+pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []const data.BundleEntry {
+    var list: std.ArrayList(data.BundleEntry) = .empty;
+    for (bundles) |b| {
+        list.append(alloc, .{
+            .name = b.name,
+            .count = @intCast(@min(b.prompt_count, std.math.maxInt(u16))),
+        }) catch continue;
+    }
+    return list.items;
+}
+
+// Build InsightsData from OrgStats for chart header.
+// Prompts/members/models/alerts fall back to mock data.
+pub fn insightsFromStats(stats: OrgStats) data.InsightsData {
+    var trend: [30]u16 = .{0} ** 30;
+    const count = @min(stats.trend.len, 30);
+    for (0..count) |i| {
+        const idx = if (stats.trend.len > 30) stats.trend.len - 30 + i else i;
+        trend[i] = @intCast(@min(stats.trend[idx].refer_count, std.math.maxInt(u16)));
+    }
+
+    const ratio_pct: u8 = @intCast(@min(@as(u64, @intFromFloat(stats.signal_ratio * 100)), 100));
+    const idle: u32 = @intCast(@max(stats.idle_constraint_count, 0));
+    const active: u32 = @intCast(@max(stats.active_constraint_count, 0));
+    const total: u32 = @intCast(@max(stats.constraint_count, 0));
+
+    var refers_per_hour: u16 = 0;
+    if (count > 0) {
+        const last_day = stats.trend[stats.trend.len - 1].refer_count;
+        refers_per_hour = @intCast(@min(@divTrunc(@max(last_day, 0), 24), std.math.maxInt(u16)));
+    }
+
+    return .{
+        .constraint_count = total,
+        .active_constraint_count = active,
+        .idle_constraint_count = idle,
+        .signal_ratio = ratio_pct,
+        .refers_per_hour = refers_per_hour,
+        .today_delta_pct = 0,
+        .last_event_minutes_ago = 0,
+        .refer_trend = trend,
+        .prompts = data.INSIGHTS.prompts,
+        .members = data.INSIGHTS.members,
+        .models = data.INSIGHTS.models,
+        .alerts = data.INSIGHTS.alerts,
+    };
 }

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -179,24 +179,75 @@ pub const ApiState = struct {
     access_token: ?[]const u8 = null,
     fetch_busy: bool = false,
     // Arena for all fetched data
-    arena: std.heap.ArenaAllocator,
+    backing_allocator: std.mem.Allocator,
+    arena: *std.heap.ArenaAllocator,
+    ts_allocator: std.heap.ThreadSafeAllocator,
 
-    pub fn init(allocator: std.mem.Allocator) ApiState {
-        return .{ .arena = std.heap.ArenaAllocator.init(allocator) };
+    pub fn init(base_allocator: std.mem.Allocator) ApiState {
+        const arena_ptr = base_allocator.create(std.heap.ArenaAllocator) catch @panic("ApiState.init: arena allocation failed");
+        arena_ptr.* = std.heap.ArenaAllocator.init(base_allocator);
+        return .{
+            .backing_allocator = base_allocator,
+            .arena = arena_ptr,
+            .ts_allocator = undefined,
+        };
+    }
+
+    pub fn bindAllocator(self: *ApiState) void {
+        self.ts_allocator = .{ .child_allocator = self.arena.allocator() };
     }
 
     pub fn deinit(self: *ApiState) void {
         self.arena.deinit();
+        self.backing_allocator.destroy(self.arena);
+    }
+
+    pub fn allocator(self: *ApiState) std.mem.Allocator {
+        return self.ts_allocator.allocator();
     }
 };
 
 pub fn startFetch(api_state: *ApiState, hub_url: []const u8, access_token: []const u8) !std.Thread {
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     const url_copy = try alloc.dupe(u8, hub_url);
     const token_copy = try alloc.dupe(u8, access_token);
+    api_state.mutex.lock();
     api_state.hub_url = url_copy;
     api_state.access_token = token_copy;
+    api_state.fetch_busy = true;
+    api_state.mutex.unlock();
     return std.Thread.spawn(.{}, fetchAll, .{ api_state, url_copy, token_copy });
+}
+
+pub fn refreshLocalState(api_state: *ApiState) void {
+    const alloc = api_state.allocator();
+    const local = trace_reader.readLocalStats(alloc);
+    const local_drafts = drafts_reader.readAllDrafts(alloc);
+    const sessions = session_reader.readAllSessions(alloc);
+
+    api_state.mutex.lock();
+    api_state.local_stats = local;
+    api_state.drafts = local_drafts;
+    api_state.active_sessions = sessions;
+    api_state.mutex.unlock();
+}
+
+pub fn refetchAllAsync(api_state: *ApiState) void {
+    api_state.mutex.lock();
+    if (api_state.fetch_busy or api_state.hub_url == null or api_state.access_token == null) {
+        api_state.mutex.unlock();
+        return;
+    }
+    api_state.fetch_busy = true;
+    const hub_url = api_state.hub_url.?;
+    const access_token = api_state.access_token.?;
+    api_state.mutex.unlock();
+
+    _ = std.Thread.spawn(.{}, fetchAll, .{ api_state, hub_url, access_token }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    };
 }
 
 // Fetch workspace detail on demand (context files + prompts from manifest)
@@ -209,7 +260,7 @@ pub fn fetchWorkspaceAsync(api_state: *ApiState, ws_id: []const u8) void {
     api_state.fetch_busy = true;
     api_state.mutex.unlock();
 
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     const ws_id_copy = alloc.dupe(u8, ws_id) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
@@ -242,7 +293,7 @@ pub fn fetchPromptPrsAsync(api_state: *ApiState, prompt_path: []const u8) void {
         api_state.mutex.unlock();
         return;
     };
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     const prompt_id: ?[]const u8 = for (lib) |lp| {
         if (std.mem.eql(u8, lp.path, prompt_path)) break alloc.dupe(u8, lp.prompt_id) catch null;
     } else null;
@@ -263,7 +314,7 @@ pub fn fetchPromptPrsAsync(api_state: *ApiState, prompt_path: []const u8) void {
 }
 
 fn fetchPromptPrs(api_state: *ApiState, prompt_path: []const u8, prompt_id: []const u8) void {
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     api_state.mutex.lock();
     const hub_url = api_state.hub_url orelse {
         api_state.fetch_busy = false;
@@ -331,7 +382,7 @@ pub fn fetchPromptContentAsync(api_state: *ApiState, prompt_path: []const u8) vo
     api_state.fetch_busy = true;
     api_state.mutex.unlock();
 
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     const path_copy = alloc.dupe(u8, prompt_path) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
@@ -346,21 +397,19 @@ pub fn fetchPromptContentAsync(api_state: *ApiState, prompt_path: []const u8) vo
 }
 
 fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8) void {
+    defer {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    }
     api_state.mutex.lock();
     api_state.status = .connecting;
     api_state.mutex.unlock();
 
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
 
     // Read local trace.jsonl first (available even if server is unreachable)
-    const local = trace_reader.readLocalStats(alloc);
-    const local_drafts = drafts_reader.readAllDrafts(alloc);
-    const sessions = session_reader.readAllSessions(alloc);
-    api_state.mutex.lock();
-    api_state.local_stats = local;
-    api_state.drafts = local_drafts;
-    api_state.active_sessions = sessions;
-    api_state.mutex.unlock();
+    refreshLocalState(api_state);
 
     var client = HubClient.init(alloc, hub_url, access_token);
 
@@ -445,7 +494,7 @@ pub fn fetchPrDetailAsync(api_state: *ApiState, pr_id: []const u8) void {
     api_state.fetch_busy = true;
     api_state.mutex.unlock();
 
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     const id_copy = alloc.dupe(u8, pr_id) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
@@ -460,7 +509,7 @@ pub fn fetchPrDetailAsync(api_state: *ApiState, pr_id: []const u8) void {
 }
 
 fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     api_state.mutex.lock();
     const hub_url = api_state.hub_url orelse {
         api_state.fetch_busy = false;
@@ -660,7 +709,7 @@ pub fn postAction(api_state: *ApiState, alloc: std.mem.Allocator, method: std.ht
 }
 
 fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     api_state.mutex.lock();
     const hub_url = api_state.hub_url orelse {
         api_state.fetch_busy = false;
@@ -705,7 +754,7 @@ fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
 }
 
 fn fetchPromptContent(api_state: *ApiState, prompt_path: []const u8) void {
-    const alloc = api_state.arena.allocator();
+    const alloc = api_state.allocator();
     api_state.mutex.lock();
     const hub_url = api_state.hub_url orelse {
         api_state.fetch_busy = false;
@@ -1255,9 +1304,10 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
             .idle_constraint_count = c_idle,
             .signal_ratio = sig,
             .refer_count = @intCast(@min(ps.refer_count, std.math.maxInt(u32))),
+            .workspace_count = @intCast(@min(ps.workspace_count, 255)),
             .rate_per_day = rate,
             .delta_pct = 0,
-            .last_referred_days_ago = 0,
+            .last_referred_days_ago = null,
             .trend = .{0} ** 30,
             .constraints = &.{},
         }) catch continue;

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1283,6 +1283,11 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
             break :blk remapped.items;
         } else l.prompts;
 
+        var inputs_list: std.ArrayList(data.InputItem) = .empty;
+        for (l.inputs) |iv| {
+            inputs_list.append(alloc, .{ .timestamp = iv.timestamp, .content = iv.content }) catch break;
+        }
+
         return .{
             .constraint_count = l.constraint_count,
             .active_constraint_count = l.active_constraint_count,
@@ -1296,6 +1301,7 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
             .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else &.{},
             .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else &.{},
             .alerts = &.{},
+            .inputs = inputs_list.items,
         };
     }
 

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -40,8 +40,7 @@ pub const DirectoryData = struct {
 // Library data
 pub const LibraryPrompt = struct {
     prompt_id: []const u8,
-    canonical_name: []const u8,
-    kind: []const u8,
+    path: []const u8,
     content_hash: []const u8,
     updated_at: []const u8,
     refer_count: i64 = 0,
@@ -203,15 +202,14 @@ pub fn fetchWorkspaceAsync(api_state: *ApiState, ws_id: []const u8) void {
 }
 
 // Fetch prompt content on demand
-pub fn fetchPromptContentAsync(api_state: *ApiState, canonical_name: []const u8) void {
+pub fn fetchPromptContentAsync(api_state: *ApiState, prompt_path: []const u8) void {
     api_state.mutex.lock();
     if (api_state.fetch_busy or api_state.hub_url == null) {
         api_state.mutex.unlock();
         return;
     }
-    // Skip if already cached
     if (api_state.prompt_content_name) |cached| {
-        if (std.mem.eql(u8, cached, canonical_name)) {
+        if (std.mem.eql(u8, cached, prompt_path)) {
             api_state.mutex.unlock();
             return;
         }
@@ -220,13 +218,13 @@ pub fn fetchPromptContentAsync(api_state: *ApiState, canonical_name: []const u8)
     api_state.mutex.unlock();
 
     const alloc = api_state.arena.allocator();
-    const name_copy = alloc.dupe(u8, canonical_name) catch {
+    const path_copy = alloc.dupe(u8, prompt_path) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
         return;
     };
-    _ = std.Thread.spawn(.{}, fetchPromptContent, .{ api_state, name_copy }) catch {
+    _ = std.Thread.spawn(.{}, fetchPromptContent, .{ api_state, path_copy }) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
@@ -544,7 +542,7 @@ fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
     api_state.mutex.unlock();
 }
 
-fn fetchPromptContent(api_state: *ApiState, canonical_name: []const u8) void {
+fn fetchPromptContent(api_state: *ApiState, prompt_path: []const u8) void {
     const alloc = api_state.arena.allocator();
     api_state.mutex.lock();
     const hub_url = api_state.hub_url orelse {
@@ -560,7 +558,7 @@ fn fetchPromptContent(api_state: *ApiState, canonical_name: []const u8) void {
     api_state.mutex.unlock();
 
     var client = HubClient.init(alloc, hub_url, token);
-    const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?name={s}", .{canonical_name}) catch {
+    const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?path={s}", .{prompt_path}) catch {
         api_state.mutex.lock();
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
@@ -586,7 +584,7 @@ fn fetchPromptContent(api_state: *ApiState, canonical_name: []const u8) void {
 
         api_state.mutex.lock();
         api_state.prompt_content = content;
-        api_state.prompt_content_name = canonical_name;
+        api_state.prompt_content_name = prompt_path;
         api_state.fetch_busy = false;
         api_state.mutex.unlock();
     } else {
@@ -771,9 +769,8 @@ fn parseLibraryPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const Libr
     const Json = struct {
         prompts: []const struct {
             prompt_id: []const u8,
-            kind: []const u8,
             source: []const u8 = "",
-            canonical_name: []const u8,
+            path: []const u8,
             content_hash: []const u8,
             updated_at: []const u8,
         },
@@ -785,8 +782,7 @@ fn parseLibraryPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const Libr
     for (parsed.value.prompts) |p| {
         list.append(alloc, .{
             .prompt_id = alloc.dupe(u8, p.prompt_id) catch continue,
-            .canonical_name = alloc.dupe(u8, p.canonical_name) catch continue,
-            .kind = alloc.dupe(u8, p.kind) catch continue,
+            .path = alloc.dupe(u8, p.path) catch continue,
             .content_hash = alloc.dupe(u8, p.content_hash) catch continue,
             .updated_at = alloc.dupe(u8, p.updated_at) catch continue,
         }) catch continue;
@@ -916,8 +912,8 @@ pub fn toPromptEntries(alloc: std.mem.Allocator, prompts: []const LibraryPrompt)
     for (prompts) |p| {
         const refer_str = formatCount(alloc, p.refer_count) catch "";
         list.append(alloc, .{
-            .canonical_name = p.canonical_name,
-            .kind = p.kind,
+            .path = p.path,
+            .kind = data.kindFromPath(p.path),
             .refer_count = refer_str,
             .constraint_count = @intCast(@min(p.active_constraint_count, 255)),
             .bundle_count = @intCast(@min(p.bundle_count, 255)),
@@ -958,11 +954,10 @@ pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []
 
 // Convert API PromptPr to mock-compatible PullRequestEntry slice.
 // If pr_detail is available for a PR, its diff/comments are populated.
-pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_name: []const u8, library: ?[]const LibraryPrompt, api_state: *ApiState) []const data.PullRequestEntry {
-    // Find prompt_id for the given canonical_name
+pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, prompt_path: []const u8, library: ?[]const LibraryPrompt, api_state: *ApiState) []const data.PullRequestEntry {
     const target_id: ?[]const u8 = if (library) |lib| blk: {
         for (lib) |lp| {
-            if (std.mem.eql(u8, lp.canonical_name, canonical_name))
+            if (std.mem.eql(u8, lp.path, prompt_path))
                 break :blk lp.prompt_id;
         }
         break :blk null;
@@ -970,12 +965,10 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_na
 
     var list: std.ArrayList(data.PullRequestEntry) = .empty;
     for (prs) |pr| {
-        // Filter by prompt_id if we found one, otherwise skip
         if (target_id) |tid| {
             if (!std.mem.eql(u8, pr.prompt_id, tid)) continue;
         } else continue;
 
-        // Populate diff/comments from cached PR detail if matching
         var diff: []const []const u8 = &.{};
         var comments: []const data.CommentEntry = &.{};
         var trace_refers: u16 = 0;
@@ -989,7 +982,7 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_na
 
         list.append(alloc, .{
             .id = pr.pr_id,
-            .prompt_name = canonical_name,
+            .prompt_name = prompt_path,
             .status = pr.status,
             .author = pr.author,
             .created = pr.created_at,
@@ -1066,7 +1059,7 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
         const name = if (library) |lib| blk: {
             for (lib) |lp| {
                 if (std.mem.eql(u8, lp.prompt_id, ps.prompt_id))
-                    break :blk lp.canonical_name;
+                    break :blk lp.path;
             }
             break :blk ps.prompt_id;
         } else ps.prompt_id;

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -66,6 +66,15 @@ pub const PromptPr = struct {
 };
 
 // Stats / Insights data
+pub const PromptStats = struct {
+    prompt_id: []const u8,
+    refer_count: i64,
+    active_constraint_count: i64,
+    workspace_count: i64,
+    bundle_count: i64,
+    open_pr_count: i64,
+};
+
 pub const OrgStats = struct {
     total_refer_count: i64,
     workspace_count: i64,
@@ -76,6 +85,7 @@ pub const OrgStats = struct {
     signal_ratio: f64 = 0,
     last_event_at: ?i64 = null,
     trend: []const TrendPoint,
+    prompts: []const PromptStats = &.{},
 };
 
 pub const TrendPoint = struct {
@@ -302,6 +312,18 @@ fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?OrgStats {
         }) catch continue;
     }
 
+    var prompt_stats: std.ArrayList(PromptStats) = .empty;
+    for (v.prompts) |p| {
+        prompt_stats.append(alloc, .{
+            .prompt_id = alloc.dupe(u8, p.prompt_id) catch continue,
+            .refer_count = p.refer_count,
+            .active_constraint_count = p.active_constraint_count,
+            .workspace_count = p.workspace_count,
+            .bundle_count = p.bundle_count,
+            .open_pr_count = p.open_pr_count,
+        }) catch continue;
+    }
+
     return .{
         .total_refer_count = v.total_refer_count,
         .workspace_count = v.workspace_count,
@@ -312,6 +334,7 @@ fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?OrgStats {
         .signal_ratio = v.signal_ratio,
         .last_event_at = v.last_event_at,
         .trend = trend_list.items,
+        .prompts = prompt_stats.items,
     };
 }
 
@@ -413,12 +436,12 @@ pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []
     return list.items;
 }
 
-// Build InsightsData from OrgStats for chart header.
-// Prompts/members/models/alerts fall back to mock data.
-pub fn insightsFromStats(stats: OrgStats) data.InsightsData {
+// Build InsightsData from OrgStats.
+// Members/models/alerts fall back to mock (need workspace-level stats).
+pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]const LibraryPrompt) data.InsightsData {
     var trend: [30]u16 = .{0} ** 30;
-    const count = @min(stats.trend.len, 30);
-    for (0..count) |i| {
+    const tcount = @min(stats.trend.len, 30);
+    for (0..tcount) |i| {
         const idx = if (stats.trend.len > 30) stats.trend.len - 30 + i else i;
         trend[i] = @intCast(@min(stats.trend[idx].refer_count, std.math.maxInt(u16)));
     }
@@ -429,9 +452,40 @@ pub fn insightsFromStats(stats: OrgStats) data.InsightsData {
     const total: u32 = @intCast(@max(stats.constraint_count, 0));
 
     var refers_per_hour: u16 = 0;
-    if (count > 0) {
+    if (tcount > 0) {
         const last_day = stats.trend[stats.trend.len - 1].refer_count;
         refers_per_hour = @intCast(@min(@divTrunc(@max(last_day, 0), 24), std.math.maxInt(u16)));
+    }
+
+    // Build InsightsPrompt from per-prompt stats
+    var prompts_list: std.ArrayList(data.InsightsPrompt) = .empty;
+    for (stats.prompts) |ps| {
+        const name = if (library) |lib| blk: {
+            for (lib) |lp| {
+                if (std.mem.eql(u8, lp.prompt_id, ps.prompt_id))
+                    break :blk lp.canonical_name;
+            }
+            break :blk ps.prompt_id;
+        } else ps.prompt_id;
+
+        const c_total: u8 = @intCast(@min(ps.active_constraint_count, 255));
+        const c_idle: u8 = 0;
+        const sig: u8 = if (c_total > 0) @intCast(@min(@divTrunc(ps.active_constraint_count * 100, @max(c_total, 1)), 100)) else 0;
+        const rate: u16 = @intCast(@min(@divTrunc(@max(ps.refer_count, 0), @max(@as(i64, @intCast(tcount)), 1)), std.math.maxInt(u16)));
+
+        prompts_list.append(alloc, .{
+            .name = name,
+            .constraint_count = c_total,
+            .active_constraint_count = c_total,
+            .idle_constraint_count = c_idle,
+            .signal_ratio = sig,
+            .refer_count = @intCast(@min(ps.refer_count, std.math.maxInt(u32))),
+            .rate_per_day = rate,
+            .delta_pct = 0,
+            .last_referred_days_ago = 0,
+            .trend = .{0} ** 30,
+            .constraints = &.{},
+        }) catch continue;
     }
 
     return .{
@@ -443,7 +497,7 @@ pub fn insightsFromStats(stats: OrgStats) data.InsightsData {
         .today_delta_pct = 0,
         .last_event_minutes_ago = 0,
         .refer_trend = trend,
-        .prompts = data.INSIGHTS.prompts,
+        .prompts = prompts_list.items,
         .members = data.INSIGHTS.members,
         .models = data.INSIGHTS.models,
         .alerts = data.INSIGHTS.alerts,

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -159,6 +159,13 @@ pub const ApiState = struct {
     pr_detail_diff: ?[]const []const u8 = null,
     pr_detail_comments: ?[]const data.CommentEntry = null,
     pr_detail_trace_refers: u16 = 0,
+    // Summary of the operation currently shown in the diff pane. Set by
+    // fetchPrDetail when it picks an operation for rendering.
+    pr_detail_op_type: ?[]const u8 = null,
+    pr_detail_op_current_path: ?[]const u8 = null,
+    pr_detail_op_new_path: ?[]const u8 = null,
+    pr_detail_op_index: u16 = 0,
+    pr_detail_op_total: u16 = 0,
     // Fetch coordination
     hub_url: ?[]const u8 = null,
     access_token: ?[]const u8 = null,
@@ -291,6 +298,11 @@ fn fetchPromptPrs(api_state: *ApiState, prompt_path: []const u8, prompt_id: []co
     api_state.pr_detail_diff = null;
     api_state.pr_detail_comments = null;
     api_state.pr_detail_trace_refers = 0;
+    api_state.pr_detail_op_type = null;
+    api_state.pr_detail_op_current_path = null;
+    api_state.pr_detail_op_new_path = null;
+    api_state.pr_detail_op_index = 0;
+    api_state.pr_detail_op_total = 0;
     api_state.fetch_busy = false;
     api_state.mutex.unlock();
 }
@@ -471,6 +483,11 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
 
     var diff_lines: ?[]const []const u8 = null;
     var trace_refers: u16 = 0;
+    var picked_op_type: ?[]const u8 = null;
+    var picked_op_current_path: ?[]const u8 = null;
+    var picked_op_new_path: ?[]const u8 = null;
+    var picked_op_index: u16 = 0;
+    var picked_op_total: u16 = 0;
     if (detail_resp.status == .ok) {
         const DetailJson = struct {
             operations: []const struct {
@@ -512,11 +529,16 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
             }
             if (pick_idx == null and p.value.operations.len > 0) pick_idx = 0;
 
+            picked_op_total = @intCast(@min(p.value.operations.len, std.math.maxInt(u16)));
             if (pick_idx) |i| {
                 const op = p.value.operations[i];
                 const base = op.base_content orelse "";
                 const proposed = op.content orelse "";
                 diff_lines = computeDiffLines(alloc, base, proposed);
+                picked_op_type = alloc.dupe(u8, op.type) catch null;
+                if (op.current_path) |cp| picked_op_current_path = alloc.dupe(u8, cp) catch null;
+                if (op.path) |np| picked_op_new_path = alloc.dupe(u8, np) catch null;
+                picked_op_index = @intCast(@min(i, std.math.maxInt(u16)));
             }
             if (p.value.trace_summary) |ts| {
                 trace_refers = @intCast(@min(ts.refer_count, std.math.maxInt(u16)));
@@ -542,6 +564,11 @@ fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
     api_state.pr_detail_diff = diff_lines;
     api_state.pr_detail_comments = comments;
     api_state.pr_detail_trace_refers = trace_refers;
+    api_state.pr_detail_op_type = picked_op_type;
+    api_state.pr_detail_op_current_path = picked_op_current_path;
+    api_state.pr_detail_op_new_path = picked_op_new_path;
+    api_state.pr_detail_op_index = picked_op_index;
+    api_state.pr_detail_op_total = picked_op_total;
     api_state.fetch_busy = false;
     api_state.mutex.unlock();
 }
@@ -1087,11 +1114,19 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, prompt_path:
         var diff: []const []const u8 = &.{};
         var comments: []const data.CommentEntry = &.{};
         var trace_refers: u16 = 0;
+        var op_type: []const u8 = "";
+        var op_current_path: []const u8 = "";
+        var op_new_path: []const u8 = "";
+        var op_index: u16 = 0;
         if (api_state.pr_detail_id) |cached_id| {
             if (std.mem.eql(u8, cached_id, pr.pr_id)) {
                 diff = api_state.pr_detail_diff orelse &.{};
                 comments = api_state.pr_detail_comments orelse &.{};
                 trace_refers = api_state.pr_detail_trace_refers;
+                op_type = api_state.pr_detail_op_type orelse "";
+                op_current_path = api_state.pr_detail_op_current_path orelse "";
+                op_new_path = api_state.pr_detail_op_new_path orelse "";
+                op_index = api_state.pr_detail_op_index;
             }
         }
 
@@ -1107,6 +1142,11 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, prompt_path:
             .comments = comments,
             .trace_refers = trace_refers,
             .trace_sessions = 0,
+            .operation_count = @intCast(@max(pr.operation_count, 0)),
+            .op_type = op_type,
+            .op_current_path = op_current_path,
+            .op_new_path = op_new_path,
+            .op_index = op_index,
         }) catch continue;
     }
     return list.items;

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1091,8 +1091,8 @@ pub fn insightsFromStats(alloc: std.mem.Allocator, stats: OrgStats, library: ?[]
         .last_event_minutes_ago = 0,
         .refer_trend = trend,
         .prompts = prompts_list.items,
-        .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else data.INSIGHTS.members,
-        .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else data.INSIGHTS.models,
-        .alerts = data.INSIGHTS.alerts,
+        .members = if (ws_members) |wm| toInsightsMembers(alloc, wm) else &.{},
+        .models = if (ws_models) |wmod| toInsightsModels(alloc, wmod) else &.{},
+        .alerts = &.{},
     };
 }

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -22,6 +22,7 @@ pub const UserData = struct {
 pub const WsData = struct {
     ws_id: []const u8,
     name: []const u8,
+    role: []const u8 = "",
 };
 
 pub const DirectoryMember = struct {
@@ -29,18 +30,10 @@ pub const DirectoryMember = struct {
     username: []const u8,
     role: []const u8,
     joined_at: []const u8,
-    team_ids: []const []const u8,
-};
-
-pub const DirectoryTeam = struct {
-    team_id: []const u8,
-    name: []const u8,
-    member_ids: []const []const u8,
 };
 
 pub const DirectoryData = struct {
     members: []const DirectoryMember,
-    teams: []const DirectoryTeam,
 };
 
 // Library data
@@ -195,7 +188,7 @@ fn parseUser(alloc: std.mem.Allocator, body: []const u8) ?UserData {
         username: []const u8,
         role: []const u8,
         scopes: []const u8,
-        workspaces: []const struct { ws_id: []const u8, name: []const u8 },
+        workspaces: []const struct { ws_id: []const u8, name: []const u8, role: []const u8 = "" },
     };
     const parsed = std.json.parseFromSlice(MeJson, alloc, body, .{ .allocate = .alloc_always }) catch return null;
     defer parsed.deinit();
@@ -206,6 +199,7 @@ fn parseUser(alloc: std.mem.Allocator, body: []const u8) ?UserData {
         ws_list.append(alloc, .{
             .ws_id = alloc.dupe(u8, ws.ws_id) catch continue,
             .name = alloc.dupe(u8, ws.name) catch continue,
+            .role = alloc.dupe(u8, ws.role) catch continue,
         }) catch continue;
     }
 
@@ -225,50 +219,22 @@ fn parseDirectory(alloc: std.mem.Allocator, body: []const u8) ?DirectoryData {
             username: []const u8,
             role: []const u8,
             joined_at: []const u8,
-            team_ids: []const []const u8,
-        },
-        teams: []const struct {
-            team_id: []const u8,
-            name: []const u8,
-            member_ids: []const []const u8,
         },
     };
     const parsed = std.json.parseFromSlice(DirJson, alloc, body, .{ .allocate = .alloc_always }) catch return null;
     defer parsed.deinit();
-    const v = parsed.value;
 
     var members: std.ArrayList(DirectoryMember) = .empty;
-    for (v.members) |m| {
-        var tids: std.ArrayList([]const u8) = .empty;
-        for (m.team_ids) |tid| {
-            tids.append(alloc, alloc.dupe(u8, tid) catch continue) catch continue;
-        }
+    for (parsed.value.members) |m| {
         members.append(alloc, .{
             .user_id = alloc.dupe(u8, m.user_id) catch continue,
             .username = alloc.dupe(u8, m.username) catch continue,
             .role = alloc.dupe(u8, m.role) catch continue,
             .joined_at = alloc.dupe(u8, m.joined_at) catch continue,
-            .team_ids = tids.items,
         }) catch continue;
     }
 
-    var teams: std.ArrayList(DirectoryTeam) = .empty;
-    for (v.teams) |t| {
-        var mids: std.ArrayList([]const u8) = .empty;
-        for (t.member_ids) |mid| {
-            mids.append(alloc, alloc.dupe(u8, mid) catch continue) catch continue;
-        }
-        teams.append(alloc, .{
-            .team_id = alloc.dupe(u8, t.team_id) catch continue,
-            .name = alloc.dupe(u8, t.name) catch continue,
-            .member_ids = mids.items,
-        }) catch continue;
-    }
-
-    return .{
-        .members = members.items,
-        .teams = teams.items,
-    };
+    return .{ .members = members.items };
 }
 
 fn parseLibraryPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const LibraryPrompt {

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -1,0 +1,400 @@
+const std = @import("std");
+const HubClient = @import("hub_client.zig").HubClient;
+
+pub const ConnectionStatus = enum {
+    disconnected,
+    connecting,
+    connected,
+    error_auth,
+    error_network,
+};
+
+// Settings data
+pub const UserData = struct {
+    user_id: []const u8,
+    username: []const u8,
+    role: []const u8,
+    scopes: []const u8,
+    workspaces: []const WsData,
+};
+
+pub const WsData = struct {
+    ws_id: []const u8,
+    name: []const u8,
+};
+
+pub const DirectoryMember = struct {
+    user_id: []const u8,
+    username: []const u8,
+    role: []const u8,
+    joined_at: []const u8,
+    team_ids: []const []const u8,
+};
+
+pub const DirectoryTeam = struct {
+    team_id: []const u8,
+    name: []const u8,
+    member_ids: []const []const u8,
+};
+
+pub const DirectoryData = struct {
+    members: []const DirectoryMember,
+    teams: []const DirectoryTeam,
+};
+
+// Library data
+pub const LibraryPrompt = struct {
+    prompt_id: []const u8,
+    canonical_name: []const u8,
+    kind: []const u8,
+    content_hash: []const u8,
+    updated_at: []const u8,
+    refer_count: i64 = 0,
+    active_constraint_count: i64 = 0,
+    workspace_count: i64 = 0,
+    bundle_count: i64 = 0,
+    open_pr_count: i64 = 0,
+};
+
+pub const BundleData = struct {
+    name: []const u8,
+    description: []const u8,
+    prompt_count: usize,
+};
+
+pub const PromptPr = struct {
+    pr_id: []const u8,
+    prompt_id: []const u8,
+    status: []const u8,
+    description: []const u8,
+    created_at: []const u8,
+    author: []const u8,
+};
+
+// Stats / Insights data
+pub const OrgStats = struct {
+    total_refer_count: i64,
+    workspace_count: i64,
+    prompt_count: i64,
+    constraint_count: i64 = 0,
+    active_constraint_count: i64 = 0,
+    idle_constraint_count: i64 = 0,
+    signal_ratio: f64 = 0,
+    last_event_at: ?i64 = null,
+    trend: []const TrendPoint,
+};
+
+pub const TrendPoint = struct {
+    date: []const u8,
+    refer_count: i64,
+};
+
+pub const ApiState = struct {
+    mutex: std.Thread.Mutex = .{},
+    status: ConnectionStatus = .disconnected,
+    // Settings
+    current_user: ?UserData = null,
+    directory: ?DirectoryData = null,
+    // Library
+    prompts: ?[]const LibraryPrompt = null,
+    bundles: ?[]const BundleData = null,
+    prompt_prs: ?[]const PromptPr = null,
+    // Insights
+    org_stats: ?OrgStats = null,
+    // Arena for all fetched data
+    arena: std.heap.ArenaAllocator,
+
+    pub fn init(allocator: std.mem.Allocator) ApiState {
+        return .{ .arena = std.heap.ArenaAllocator.init(allocator) };
+    }
+
+    pub fn deinit(self: *ApiState) void {
+        self.arena.deinit();
+    }
+};
+
+pub fn startFetch(api_state: *ApiState, hub_url: []const u8, access_token: []const u8) !std.Thread {
+    const alloc = api_state.arena.allocator();
+    const url_copy = try alloc.dupe(u8, hub_url);
+    const token_copy = try alloc.dupe(u8, access_token);
+    return std.Thread.spawn(.{}, fetchAll, .{ api_state, url_copy, token_copy });
+}
+
+fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8) void {
+    api_state.mutex.lock();
+    api_state.status = .connecting;
+    api_state.mutex.unlock();
+
+    const alloc = api_state.arena.allocator();
+    var client = HubClient.init(alloc, hub_url, access_token);
+
+    // GET /api/auth/me
+    const me_resp = client.get("/api/auth/me") catch {
+        setStatus(api_state, .error_network);
+        return;
+    };
+    defer me_resp.deinit();
+
+    if (me_resp.status == .unauthorized) {
+        setStatus(api_state, .error_auth);
+        return;
+    }
+    if (me_resp.status != .ok) {
+        setStatus(api_state, .error_network);
+        return;
+    }
+
+    const user = parseUser(alloc, me_resp.body) orelse {
+        setStatus(api_state, .error_network);
+        return;
+    };
+
+    // GET /api/org/directory
+    const directory = doFetchParse(&client, alloc, "/api/org/directory", DirectoryData, parseDirectory);
+
+    // GET /api/org/library/prompts
+    const prompts_list = doFetchParse(&client, alloc, "/api/org/library/prompts", []const LibraryPrompt, parseLibraryPrompts);
+
+    // GET /api/stats?period=daily&days=30
+    const org_stats = doFetchParse(&client, alloc, "/api/stats?period=daily&days=30", OrgStats, parseOrgStats);
+
+    // GET /api/org/bundles
+    const bundles = doFetchParse(&client, alloc, "/api/org/bundles", []const BundleData, parseBundles);
+
+    // GET /api/org/prompt-prs
+    const prs = doFetchParse(&client, alloc, "/api/org/prompt-prs", []const PromptPr, parsePromptPrs);
+
+    api_state.mutex.lock();
+    api_state.current_user = user;
+    api_state.directory = directory;
+    api_state.prompts = prompts_list;
+    api_state.bundles = bundles;
+    api_state.prompt_prs = prs;
+    api_state.org_stats = org_stats;
+    api_state.status = .connected;
+    api_state.mutex.unlock();
+}
+
+fn setStatus(api_state: *ApiState, status: ConnectionStatus) void {
+    api_state.mutex.lock();
+    api_state.status = status;
+    api_state.mutex.unlock();
+}
+
+fn doFetchParse(client: *HubClient, alloc: std.mem.Allocator, path: []const u8, comptime T: type, comptime parseFn: *const fn (std.mem.Allocator, []const u8) ?T) ?T {
+    const resp = client.get(path) catch return null;
+    defer resp.deinit();
+    if (resp.status != .ok) return null;
+    return parseFn(alloc, resp.body);
+}
+
+fn parseUser(alloc: std.mem.Allocator, body: []const u8) ?UserData {
+    const MeJson = struct {
+        user_id: []const u8,
+        username: []const u8,
+        role: []const u8,
+        scopes: []const u8,
+        workspaces: []const struct { ws_id: []const u8, name: []const u8 },
+    };
+    const parsed = std.json.parseFromSlice(MeJson, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+    const v = parsed.value;
+
+    var ws_list: std.ArrayList(WsData) = .empty;
+    for (v.workspaces) |ws| {
+        ws_list.append(alloc, .{
+            .ws_id = alloc.dupe(u8, ws.ws_id) catch continue,
+            .name = alloc.dupe(u8, ws.name) catch continue,
+        }) catch continue;
+    }
+
+    return .{
+        .user_id = alloc.dupe(u8, v.user_id) catch return null,
+        .username = alloc.dupe(u8, v.username) catch return null,
+        .role = alloc.dupe(u8, v.role) catch return null,
+        .scopes = alloc.dupe(u8, v.scopes) catch return null,
+        .workspaces = ws_list.items,
+    };
+}
+
+fn parseDirectory(alloc: std.mem.Allocator, body: []const u8) ?DirectoryData {
+    const DirJson = struct {
+        members: []const struct {
+            user_id: []const u8,
+            username: []const u8,
+            role: []const u8,
+            joined_at: []const u8,
+            team_ids: []const []const u8,
+        },
+        teams: []const struct {
+            team_id: []const u8,
+            name: []const u8,
+            member_ids: []const []const u8,
+        },
+    };
+    const parsed = std.json.parseFromSlice(DirJson, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+    const v = parsed.value;
+
+    var members: std.ArrayList(DirectoryMember) = .empty;
+    for (v.members) |m| {
+        var tids: std.ArrayList([]const u8) = .empty;
+        for (m.team_ids) |tid| {
+            tids.append(alloc, alloc.dupe(u8, tid) catch continue) catch continue;
+        }
+        members.append(alloc, .{
+            .user_id = alloc.dupe(u8, m.user_id) catch continue,
+            .username = alloc.dupe(u8, m.username) catch continue,
+            .role = alloc.dupe(u8, m.role) catch continue,
+            .joined_at = alloc.dupe(u8, m.joined_at) catch continue,
+            .team_ids = tids.items,
+        }) catch continue;
+    }
+
+    var teams: std.ArrayList(DirectoryTeam) = .empty;
+    for (v.teams) |t| {
+        var mids: std.ArrayList([]const u8) = .empty;
+        for (t.member_ids) |mid| {
+            mids.append(alloc, alloc.dupe(u8, mid) catch continue) catch continue;
+        }
+        teams.append(alloc, .{
+            .team_id = alloc.dupe(u8, t.team_id) catch continue,
+            .name = alloc.dupe(u8, t.name) catch continue,
+            .member_ids = mids.items,
+        }) catch continue;
+    }
+
+    return .{
+        .members = members.items,
+        .teams = teams.items,
+    };
+}
+
+fn parseLibraryPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const LibraryPrompt {
+    const Json = struct {
+        prompts: []const struct {
+            prompt_id: []const u8,
+            kind: []const u8,
+            source: []const u8 = "",
+            canonical_name: []const u8,
+            content_hash: []const u8,
+            updated_at: []const u8,
+        },
+    };
+    const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    var list: std.ArrayList(LibraryPrompt) = .empty;
+    for (parsed.value.prompts) |p| {
+        list.append(alloc, .{
+            .prompt_id = alloc.dupe(u8, p.prompt_id) catch continue,
+            .canonical_name = alloc.dupe(u8, p.canonical_name) catch continue,
+            .kind = alloc.dupe(u8, p.kind) catch continue,
+            .content_hash = alloc.dupe(u8, p.content_hash) catch continue,
+            .updated_at = alloc.dupe(u8, p.updated_at) catch continue,
+        }) catch continue;
+    }
+    return list.items;
+}
+
+fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?OrgStats {
+    const StatsJson = struct {
+        total_refer_count: i64 = 0,
+        workspace_count: i64 = 0,
+        prompt_count: i64 = 0,
+        constraint_count: i64 = 0,
+        active_constraint_count: i64 = 0,
+        idle_constraint_count: i64 = 0,
+        signal_ratio: f64 = 0,
+        last_event_at: ?i64 = null,
+        prompts: []const struct {
+            prompt_id: []const u8,
+            refer_count: i64 = 0,
+            active_constraint_count: i64 = 0,
+            workspace_count: i64 = 0,
+            bundle_count: i64 = 0,
+            open_pr_count: i64 = 0,
+        } = &.{},
+        trend: struct {
+            period: []const u8 = "",
+            data: []const struct {
+                date: []const u8,
+                refer_count: i64 = 0,
+            } = &.{},
+        } = .{},
+    };
+    const parsed = std.json.parseFromSlice(StatsJson, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+    const v = parsed.value;
+
+    var trend_list: std.ArrayList(TrendPoint) = .empty;
+    for (v.trend.data) |t| {
+        trend_list.append(alloc, .{
+            .date = alloc.dupe(u8, t.date) catch continue,
+            .refer_count = t.refer_count,
+        }) catch continue;
+    }
+
+    return .{
+        .total_refer_count = v.total_refer_count,
+        .workspace_count = v.workspace_count,
+        .prompt_count = v.prompt_count,
+        .constraint_count = v.constraint_count,
+        .active_constraint_count = v.active_constraint_count,
+        .idle_constraint_count = v.idle_constraint_count,
+        .signal_ratio = v.signal_ratio,
+        .last_event_at = v.last_event_at,
+        .trend = trend_list.items,
+    };
+}
+
+fn parseBundles(alloc: std.mem.Allocator, body: []const u8) ?[]const BundleData {
+    const Json = struct {
+        bundles: []const struct {
+            name: []const u8,
+            description: []const u8 = "",
+            updated_at: []const u8 = "",
+            prompt_ids: []const []const u8 = &.{},
+        },
+    };
+    const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    var list: std.ArrayList(BundleData) = .empty;
+    for (parsed.value.bundles) |b| {
+        list.append(alloc, .{
+            .name = alloc.dupe(u8, b.name) catch continue,
+            .description = alloc.dupe(u8, b.description) catch continue,
+            .prompt_count = b.prompt_ids.len,
+        }) catch continue;
+    }
+    return list.items;
+}
+
+fn parsePromptPrs(alloc: std.mem.Allocator, body: []const u8) ?[]const PromptPr {
+    const Json = struct {
+        prs: []const struct {
+            pr_id: []const u8,
+            prompt_id: []const u8,
+            status: []const u8,
+            description: []const u8,
+            created_at: []const u8,
+            author: []const u8 = "",
+        },
+    };
+    const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    var list: std.ArrayList(PromptPr) = .empty;
+    for (parsed.value.prs) |pr| {
+        list.append(alloc, .{
+            .pr_id = alloc.dupe(u8, pr.pr_id) catch continue,
+            .prompt_id = alloc.dupe(u8, pr.prompt_id) catch continue,
+            .status = alloc.dupe(u8, pr.status) catch continue,
+            .description = alloc.dupe(u8, pr.description) catch continue,
+            .created_at = alloc.dupe(u8, pr.created_at) catch continue,
+            .author = alloc.dupe(u8, pr.author) catch continue,
+        }) catch continue;
+    }
+    return list.items;
+}

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -93,6 +93,26 @@ pub const TrendPoint = struct {
     refer_count: i64,
 };
 
+// Workspace-specific data (fetched on demand)
+pub const WsDetail = struct {
+    ws_id: []const u8,
+    context_files: []const ContextFileData,
+    ws_prompts: []const WsPromptData,
+};
+
+pub const ContextFileData = struct {
+    path: []const u8,
+    hash: []const u8,
+    size: i64,
+    author: []const u8 = "",
+    updated_at: []const u8 = "",
+};
+
+pub const WsPromptData = struct {
+    prompt_id: []const u8,
+    content_hash: []const u8,
+};
+
 pub const ApiState = struct {
     mutex: std.Thread.Mutex = .{},
     status: ConnectionStatus = .disconnected,
@@ -105,6 +125,14 @@ pub const ApiState = struct {
     prompt_prs: ?[]const PromptPr = null,
     // Insights
     org_stats: ?OrgStats = null,
+    // Workspace detail (on-demand)
+    ws_detail: ?WsDetail = null,
+    prompt_content: ?[]const u8 = null,
+    prompt_content_name: ?[]const u8 = null,
+    // Fetch coordination
+    hub_url: ?[]const u8 = null,
+    access_token: ?[]const u8 = null,
+    fetch_busy: bool = false,
     // Arena for all fetched data
     arena: std.heap.ArenaAllocator,
 
@@ -121,7 +149,64 @@ pub fn startFetch(api_state: *ApiState, hub_url: []const u8, access_token: []con
     const alloc = api_state.arena.allocator();
     const url_copy = try alloc.dupe(u8, hub_url);
     const token_copy = try alloc.dupe(u8, access_token);
+    api_state.hub_url = url_copy;
+    api_state.access_token = token_copy;
     return std.Thread.spawn(.{}, fetchAll, .{ api_state, url_copy, token_copy });
+}
+
+// Fetch workspace detail on demand (context files + prompts from manifest)
+pub fn fetchWorkspaceAsync(api_state: *ApiState, ws_id: []const u8) void {
+    api_state.mutex.lock();
+    if (api_state.fetch_busy or api_state.hub_url == null) {
+        api_state.mutex.unlock();
+        return;
+    }
+    api_state.fetch_busy = true;
+    api_state.mutex.unlock();
+
+    const alloc = api_state.arena.allocator();
+    const ws_id_copy = alloc.dupe(u8, ws_id) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    _ = std.Thread.spawn(.{}, fetchWorkspace, .{ api_state, ws_id_copy }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    };
+}
+
+// Fetch prompt content on demand
+pub fn fetchPromptContentAsync(api_state: *ApiState, canonical_name: []const u8) void {
+    api_state.mutex.lock();
+    if (api_state.fetch_busy or api_state.hub_url == null) {
+        api_state.mutex.unlock();
+        return;
+    }
+    // Skip if already cached
+    if (api_state.prompt_content_name) |cached| {
+        if (std.mem.eql(u8, cached, canonical_name)) {
+            api_state.mutex.unlock();
+            return;
+        }
+    }
+    api_state.fetch_busy = true;
+    api_state.mutex.unlock();
+
+    const alloc = api_state.arena.allocator();
+    const name_copy = alloc.dupe(u8, canonical_name) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    _ = std.Thread.spawn(.{}, fetchPromptContent, .{ api_state, name_copy }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    };
 }
 
 fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8) void {
@@ -177,6 +262,157 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     api_state.org_stats = org_stats;
     api_state.status = .connected;
     api_state.mutex.unlock();
+}
+
+fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
+    const alloc = api_state.arena.allocator();
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const token = api_state.access_token orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    api_state.mutex.unlock();
+
+    var client = HubClient.init(alloc, hub_url, token);
+
+    // GET /api/workspaces/{ws_id}/context/files
+    const files_path = std.fmt.allocPrint(alloc, "/api/workspaces/{s}/context/files", .{ws_id}) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const files = doFetchParse(&client, alloc, files_path, []const ContextFileData, parseContextFiles);
+
+    // GET /api/workspaces/{ws_id}/manifest
+    const manifest_path = std.fmt.allocPrint(alloc, "/api/workspaces/{s}/manifest", .{ws_id}) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const ws_prompts = doFetchParse(&client, alloc, manifest_path, []const WsPromptData, parseManifestPrompts);
+
+    api_state.mutex.lock();
+    api_state.ws_detail = .{
+        .ws_id = ws_id,
+        .context_files = files orelse &.{},
+        .ws_prompts = ws_prompts orelse &.{},
+    };
+    api_state.fetch_busy = false;
+    api_state.mutex.unlock();
+}
+
+fn fetchPromptContent(api_state: *ApiState, canonical_name: []const u8) void {
+    const alloc = api_state.arena.allocator();
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const token = api_state.access_token orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    api_state.mutex.unlock();
+
+    var client = HubClient.init(alloc, hub_url, token);
+    const path = std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?name={s}", .{canonical_name}) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+
+    const resp = client.get(path) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    defer resp.deinit();
+
+    if (resp.status == .ok) {
+        // Parse {"body": "content..."} or use raw body
+        const ContentJson = struct { body: []const u8 = "" };
+        const parsed = std.json.parseFromSlice(ContentJson, alloc, resp.body, .{ .allocate = .alloc_always }) catch null;
+        const content = if (parsed) |p| blk: {
+            defer p.deinit();
+            break :blk alloc.dupe(u8, p.value.body) catch null;
+        } else null;
+
+        api_state.mutex.lock();
+        api_state.prompt_content = content;
+        api_state.prompt_content_name = canonical_name;
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    } else {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    }
+}
+
+fn parseContextFiles(alloc: std.mem.Allocator, body: []const u8) ?[]const ContextFileData {
+    const Json = struct {
+        files: []const struct {
+            path: []const u8,
+            hash: []const u8,
+            size: i64 = 0,
+            author: []const u8 = "",
+            updated_at: []const u8 = "",
+        } = &.{},
+    };
+    const parsed = std.json.parseFromSlice(Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    var list: std.ArrayList(ContextFileData) = .empty;
+    for (parsed.value.files) |f| {
+        list.append(alloc, .{
+            .path = alloc.dupe(u8, f.path) catch continue,
+            .hash = alloc.dupe(u8, f.hash) catch continue,
+            .size = f.size,
+            .author = alloc.dupe(u8, f.author) catch continue,
+            .updated_at = alloc.dupe(u8, f.updated_at) catch continue,
+        }) catch continue;
+    }
+    return list.items;
+}
+
+fn parseManifestPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const WsPromptData {
+    const parsed = std.json.parseFromSlice(std.json.Value, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    const prompts_obj = switch (parsed.value) {
+        .object => |obj| obj.get("prompts") orelse return null,
+        else => return null,
+    };
+    const map = switch (prompts_obj) {
+        .object => |obj| obj,
+        else => return null,
+    };
+
+    var list: std.ArrayList(WsPromptData) = .empty;
+    var it = map.iterator();
+    while (it.next()) |entry| {
+        const hash = switch (entry.value_ptr.*) {
+            .string => |s| s,
+            else => "",
+        };
+        list.append(alloc, .{
+            .prompt_id = alloc.dupe(u8, entry.key_ptr.*) catch continue,
+            .content_hash = alloc.dupe(u8, hash) catch continue,
+        }) catch continue;
+    }
+    return list.items;
 }
 
 fn setStatus(api_state: *ApiState, status: ConnectionStatus) void {

--- a/src/tui/api.zig
+++ b/src/tui/api.zig
@@ -145,6 +145,11 @@ pub const ApiState = struct {
     ws_stats_models: ?[]const WsStatsModel = null,
     prompt_content: ?[]const u8 = null,
     prompt_content_name: ?[]const u8 = null,
+    // PR detail (on-demand)
+    pr_detail_id: ?[]const u8 = null,
+    pr_detail_diff: ?[]const []const u8 = null,
+    pr_detail_comments: ?[]const data.CommentEntry = null,
+    pr_detail_trace_refers: u16 = 0,
     // Fetch coordination
     hub_url: ?[]const u8 = null,
     access_token: ?[]const u8 = null,
@@ -298,6 +303,190 @@ fn fetchAll(api_state: *ApiState, hub_url: []const u8, access_token: []const u8)
     api_state.ws_stats_models = ws_models;
     api_state.status = .connected;
     api_state.mutex.unlock();
+}
+
+// Fetch PR detail (diff + comments) on demand
+pub fn fetchPrDetailAsync(api_state: *ApiState, pr_id: []const u8) void {
+    api_state.mutex.lock();
+    if (api_state.fetch_busy or api_state.hub_url == null) {
+        api_state.mutex.unlock();
+        return;
+    }
+    if (api_state.pr_detail_id) |cached| {
+        if (std.mem.eql(u8, cached, pr_id)) {
+            api_state.mutex.unlock();
+            return;
+        }
+    }
+    api_state.fetch_busy = true;
+    api_state.mutex.unlock();
+
+    const alloc = api_state.arena.allocator();
+    const id_copy = alloc.dupe(u8, pr_id) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    _ = std.Thread.spawn(.{}, fetchPrDetail, .{ api_state, id_copy }) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+    };
+}
+
+fn fetchPrDetail(api_state: *ApiState, pr_id: []const u8) void {
+    const alloc = api_state.arena.allocator();
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const token = api_state.access_token orelse {
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    api_state.mutex.unlock();
+
+    var client = HubClient.init(alloc, hub_url, token);
+
+    // GET /api/org/prompt-prs/{id}
+    const detail_path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}", .{pr_id}) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    const detail_resp = client.get(detail_path) catch {
+        api_state.mutex.lock();
+        api_state.fetch_busy = false;
+        api_state.mutex.unlock();
+        return;
+    };
+    defer detail_resp.deinit();
+
+    var diff_lines: ?[]const []const u8 = null;
+    var trace_refers: u16 = 0;
+    if (detail_resp.status == .ok) {
+        const DetailJson = struct {
+            diff: ?struct {
+                base: []const u8 = "",
+                proposed: []const u8 = "",
+            } = null,
+            trace_summary: ?struct {
+                refer_count: i64 = 0,
+            } = null,
+        };
+        const parsed = std.json.parseFromSlice(DetailJson, alloc, detail_resp.body, .{ .allocate = .alloc_always }) catch null;
+        if (parsed) |p| {
+            defer p.deinit();
+            if (p.value.diff) |d| {
+                diff_lines = computeDiffLines(alloc, d.base, d.proposed);
+            }
+            if (p.value.trace_summary) |ts| {
+                trace_refers = @intCast(@min(ts.refer_count, std.math.maxInt(u16)));
+            }
+        }
+    }
+
+    // GET /api/org/prompt-prs/{id}/comments
+    const comments_path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{pr_id}) catch null;
+    var comments: ?[]const data.CommentEntry = null;
+    if (comments_path) |cpath| {
+        const c_resp = client.get(cpath) catch null;
+        if (c_resp) |resp| {
+            defer resp.deinit();
+            if (resp.status == .ok) {
+                comments = parseComments(alloc, resp.body);
+            }
+        }
+    }
+
+    api_state.mutex.lock();
+    api_state.pr_detail_id = pr_id;
+    api_state.pr_detail_diff = diff_lines;
+    api_state.pr_detail_comments = comments;
+    api_state.pr_detail_trace_refers = trace_refers;
+    api_state.fetch_busy = false;
+    api_state.mutex.unlock();
+}
+
+fn computeDiffLines(alloc: std.mem.Allocator, base: []const u8, proposed: []const u8) []const []const u8 {
+    // Simple line-level diff: lines in base but not proposed get "-", new lines get "+"
+    var lines: std.ArrayList([]const u8) = .empty;
+    var base_it = std.mem.splitScalar(u8, base, '\n');
+    var prop_it = std.mem.splitScalar(u8, proposed, '\n');
+
+    while (true) {
+        const b = base_it.next();
+        const p = prop_it.next();
+        if (b == null and p == null) break;
+        if (b != null and p != null and std.mem.eql(u8, b.?, p.?)) {
+            lines.append(alloc, std.fmt.allocPrint(alloc, "  {s}", .{b.?}) catch continue) catch continue;
+        } else {
+            if (b) |bl| {
+                lines.append(alloc, std.fmt.allocPrint(alloc, "- {s}", .{bl}) catch continue) catch continue;
+            }
+            if (p) |pl| {
+                lines.append(alloc, std.fmt.allocPrint(alloc, "+ {s}", .{pl}) catch continue) catch continue;
+            }
+        }
+    }
+    return lines.items;
+}
+
+fn parseComments(alloc: std.mem.Allocator, body: []const u8) ?[]const data.CommentEntry {
+    const Json = struct {
+        comment_id: []const u8 = "",
+        body: []const u8 = "",
+        author: []const u8 = "",
+        created_at: []const u8 = "",
+    };
+    // Response is an array of comments
+    const parsed = std.json.parseFromSlice([]const Json, alloc, body, .{ .allocate = .alloc_always }) catch return null;
+    defer parsed.deinit();
+
+    var list: std.ArrayList(data.CommentEntry) = .empty;
+    for (parsed.value) |c| {
+        list.append(alloc, .{
+            .id = alloc.dupe(u8, c.comment_id) catch continue,
+            .author = alloc.dupe(u8, c.author) catch continue,
+            .body = alloc.dupe(u8, c.body) catch continue,
+            .created = alloc.dupe(u8, c.created_at) catch continue,
+        }) catch continue;
+    }
+    return list.items;
+}
+
+// Write operations
+pub fn postAction(api_state: *ApiState, alloc: std.mem.Allocator, method: std.http.Method, path: []const u8, body: ?[]const u8) ![]const u8 {
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url orelse {
+        api_state.mutex.unlock();
+        return error.NotConnected;
+    };
+    const token = api_state.access_token orelse {
+        api_state.mutex.unlock();
+        return error.NotConnected;
+    };
+    api_state.mutex.unlock();
+
+    var client = HubClient.init(alloc, hub_url, token);
+    const resp = switch (method) {
+        .POST => try client.post(path, body orelse "{}"),
+        .PUT => try client.put(path, body orelse "{}"),
+        .PATCH => try client.patch(path, body orelse "{}"),
+        .DELETE => try client.delete(path),
+        else => return error.UnsupportedMethod,
+    };
+    defer resp.deinit();
+
+    if (resp.status == .ok or resp.status == .created or resp.status == .no_content) {
+        return alloc.dupe(u8, resp.body);
+    }
+    return error.RequestFailed;
 }
 
 fn fetchWorkspace(api_state: *ApiState, ws_id: []const u8) void {
@@ -757,9 +946,9 @@ pub fn toBundleEntries(alloc: std.mem.Allocator, bundles: []const BundleData) []
     return list.items;
 }
 
-// Convert API PromptPr to mock-compatible PullRequestEntry slice,
-// filtered by canonical_name. Diff/comments are empty (need PR detail fetch).
-pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_name: []const u8, library: ?[]const LibraryPrompt) []const data.PullRequestEntry {
+// Convert API PromptPr to mock-compatible PullRequestEntry slice.
+// If pr_detail is available for a PR, its diff/comments are populated.
+pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_name: []const u8, library: ?[]const LibraryPrompt, api_state: *ApiState) []const data.PullRequestEntry {
     // Find prompt_id for the given canonical_name
     const target_id: ?[]const u8 = if (library) |lib| blk: {
         for (lib) |lp| {
@@ -776,6 +965,18 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_na
             if (!std.mem.eql(u8, pr.prompt_id, tid)) continue;
         } else continue;
 
+        // Populate diff/comments from cached PR detail if matching
+        var diff: []const []const u8 = &.{};
+        var comments: []const data.CommentEntry = &.{};
+        var trace_refers: u16 = 0;
+        if (api_state.pr_detail_id) |cached_id| {
+            if (std.mem.eql(u8, cached_id, pr.pr_id)) {
+                diff = api_state.pr_detail_diff orelse &.{};
+                comments = api_state.pr_detail_comments orelse &.{};
+                trace_refers = api_state.pr_detail_trace_refers;
+            }
+        }
+
         list.append(alloc, .{
             .id = pr.pr_id,
             .prompt_name = canonical_name,
@@ -784,9 +985,9 @@ pub fn toPrEntries(alloc: std.mem.Allocator, prs: []const PromptPr, canonical_na
             .created = pr.created_at,
             .description = pr.description,
             .base_hash = "",
-            .diff = &.{},
-            .comments = &.{},
-            .trace_refers = 0,
+            .diff = diff,
+            .comments = comments,
+            .trace_refers = trace_refers,
             .trace_sessions = 0,
         }) catch continue;
     }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -45,6 +45,31 @@ const Period = enum(u8) {
     }
 };
 
+const SettingsTab = enum(u8) {
+    members,
+    bundles,
+    workspaces,
+    token,
+
+    fn label(self: SettingsTab) []const u8 {
+        return switch (self) {
+            .members => "Members",
+            .bundles => "Bundles",
+            .workspaces => "Workspaces",
+            .token => "Token",
+        };
+    }
+};
+
+const settings_tabs = [_]SettingsTab{ .members, .bundles, .workspaces, .token };
+
+const ConfirmAction = enum {
+    none,
+    remove_member,
+    delete_bundle,
+    delete_workspace,
+};
+
 const TopModule = enum(u8) {
     library,
     proposals,
@@ -83,9 +108,20 @@ pub const Dashboard = struct {
     selected_prompt: usize = 0,
     show_help: bool = false,
     show_detail: bool = false,
+    show_settings: bool = false,
+    show_confirm: bool = false,
+    confirm_message: []const u8 = "",
+    confirm_action: ConfirmAction = .none,
     detail_origin: TopModule = .library,
     detail_tab: DetailTab = .overview,
+    settings_tab: SettingsTab = .members,
     status_line: []const u8 = "Ready.",
+
+    // Settings
+    settings_member_scroll: vxfw.ScrollBars,
+    settings_member_widgets: [data.MEMBERS.len]vxfw.Widget = undefined,
+    settings_member_rows: [data.MEMBERS.len]TableRow = undefined,
+    settings_member_cols: [data.MEMBERS.len][3]Column = undefined,
 
     // ScrollBars for each module
     library_scroll_bars: vxfw.ScrollBars,
@@ -135,6 +171,7 @@ pub const Dashboard = struct {
             .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
             .workspace_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .compliance_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .settings_member_scroll = w.initCursorScrollBars(theme.PANEL),
         };
     }
 
@@ -159,6 +196,34 @@ pub const Dashboard = struct {
     fn handleEvent(self: *Dashboard, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
         switch (event) {
             .key_press => |key| {
+                // Confirm overlay absorbs all keys
+                if (self.show_confirm) {
+                    if (key.matches('y', .{})) {
+                        switch (self.confirm_action) {
+                            .remove_member => {
+                                self.status_line = "Member removed (mock).";
+                            },
+                            .delete_bundle => {
+                                self.status_line = "Bundle deleted (mock).";
+                            },
+                            .delete_workspace => {
+                                self.status_line = "Workspace deleted (mock).";
+                            },
+                            .none => {},
+                        }
+                        self.show_confirm = false;
+                        self.confirm_action = .none;
+                        ctx.consumeAndRedraw();
+                    }
+                    if (key.matches('n', .{}) or key.matches(vaxis.Key.escape, .{})) {
+                        self.show_confirm = false;
+                        self.confirm_action = .none;
+                        self.status_line = "Cancelled.";
+                        ctx.consumeAndRedraw();
+                    }
+                    return;
+                }
+
                 // Help overlay absorbs all keys
                 if (self.show_help) {
                     if (key.matches(vaxis.Key.escape, .{}) or key.matches('?', .{}) or key.matches('q', .{})) {
@@ -174,7 +239,7 @@ pub const Dashboard = struct {
                     ctx.quit = true;
                     return;
                 }
-                if (key.matches('q', .{}) and !self.show_detail) {
+                if (key.matches('q', .{}) and !self.show_detail and !self.show_settings) {
                     ctx.consumeEvent();
                     ctx.quit = true;
                     return;
@@ -183,6 +248,79 @@ pub const Dashboard = struct {
                 // Help toggle
                 if (key.matches('?', .{})) {
                     self.show_help = true;
+                    ctx.consumeAndRedraw();
+                    return;
+                }
+
+                // Settings mode
+                if (self.show_settings) {
+                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('q', .{})) {
+                        self.show_settings = false;
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                        self.shiftSettingsTab(-1);
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                        self.shiftSettingsTab(1);
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (self.settings_tab == .members) {
+                        // r: toggle role of selected member
+                        if (key.matches('r', .{})) {
+                            const sel = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
+                            const m = &data.MEMBERS[sel];
+                            const new_role: []const u8 = if (std.mem.eql(u8, m.role, "member")) "maintainer" else "member";
+                            _ = new_role;
+                            self.status_line = "Role change requires Hub API (mock).";
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        // x: remove selected member (confirm)
+                        if (key.matches('x', .{})) {
+                            const sel = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
+                            self.confirm_message = data.MEMBERS[sel].username;
+                            self.confirm_action = .remove_member;
+                            self.show_confirm = true;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        // a: invite (placeholder)
+                        if (key.matches('a', .{})) {
+                            self.status_line = "Invite requires TextField input (next iteration).";
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        try self.settings_member_scroll.scroll_view.handleEvent(ctx, event);
+                    }
+                    if (self.settings_tab == .bundles) {
+                        if (key.matches('x', .{})) {
+                            self.confirm_message = "selected bundle";
+                            self.confirm_action = .delete_bundle;
+                            self.show_confirm = true;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                    }
+                    if (self.settings_tab == .workspaces) {
+                        if (key.matches('x', .{})) {
+                            self.confirm_message = "selected workspace";
+                            self.confirm_action = .delete_workspace;
+                            self.show_confirm = true;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                    }
+                    return;
+                }
+
+                // Settings toggle (S key)
+                if (key.matches('S', .{})) {
+                    self.show_settings = true;
                     ctx.consumeAndRedraw();
                     return;
                 }
@@ -318,7 +456,7 @@ pub const Dashboard = struct {
         );
 
         var child_count: usize = 3;
-        if (self.show_help) child_count = 4;
+        if (self.show_help or self.show_confirm) child_count = 4;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
@@ -332,6 +470,13 @@ pub const Dashboard = struct {
             );
             children[3] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHelpOverlay(help_ctx) };
         }
+        if (self.show_confirm) {
+            const confirm_ctx = ctx.withConstraints(
+                .{ .width = size.width, .height = size.height },
+                .{ .width = size.width, .height = size.height },
+            );
+            children[3] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawConfirmOverlay(confirm_ctx) };
+        }
 
         root.children = children;
         return root;
@@ -341,9 +486,9 @@ pub const Dashboard = struct {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.HEADER);
 
-        // Row 0: Accent band with org/ws/user context
+        // Row 0: Accent band with org/ws/user/role context
         w.paintBand(&surface, 0, theme.ACCENT, theme.CANVAS);
-        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 org: acme \xe2\x94\x80 ws: payments-api \xe2\x94\x80 user: alice", .{
+        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", .{
             .fg = theme.CANVAS,
             .bg = theme.ACCENT,
             .bold = true,
@@ -367,6 +512,7 @@ pub const Dashboard = struct {
     }
 
     fn drawBody(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        if (self.show_settings) return self.drawSettings(ctx);
         if (self.show_detail) return self.drawPromptDetail(ctx);
         return switch (self.selected_module) {
             .library => self.drawLibrary(ctx),
@@ -382,13 +528,17 @@ pub const Dashboard = struct {
 
         const keys = if (self.show_help)
             "Esc close help"
+        else if (self.show_confirm)
+            "y confirm  n cancel  Esc cancel"
+        else if (self.show_settings)
+            "h/l tab  j/k move  a add  r role  x remove  Esc back"
         else if (self.show_detail)
             "h/l tab  j/k move  Enter diff  p propose  Esc back  ? help"
         else switch (self.selected_module) {
-            .library => "j/k move  Enter open  1-4 switch  ? help  q quit",
-            .proposals => "j/k move  a accept  x reject  c comment  ? help  q quit",
-            .workspace => "h/l tab  j/k move  r sync  ? help  q quit",
-            .compliance => "j/k move  t period  ? help  q quit",
+            .library => "j/k move  Enter open  S settings  1-4 switch  ? help  q quit",
+            .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
+            .workspace => "h/l tab  j/k move  r sync  S settings  ? help  q quit",
+            .compliance => "j/k move  t period  S settings  ? help  q quit",
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.textOn(theme.RAIL, theme.TEXT_SOFT));
         return surface;
@@ -1010,6 +1160,176 @@ pub const Dashboard = struct {
         return panel.draw(ctx);
     }
 
+    // Settings: drill-down view with inner tabs (Members/Bundles/Workspaces/Token)
+    fn drawSettings(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        // Inner tab strip
+        var tab_surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = 1 });
+        w.fillSurface(&tab_surface, theme.CANVAS);
+        var tab_col: u16 = 1;
+        for (settings_tabs) |tab| {
+            tab_col = w.drawInnerTabBadge(&tab_surface, ctx, 0, tab_col, tab.label(), tab == self.settings_tab);
+            tab_col +|= 1;
+        }
+
+        // Content area
+        const content_h = size.height -| 2;
+        const content_ctx = ctx.withConstraints(
+            .{ .width = size.width, .height = content_h },
+            .{ .width = size.width, .height = content_h },
+        );
+        const content = switch (self.settings_tab) {
+            .members => try self.drawSettingsMembers(content_ctx),
+            .bundles => try self.drawSettingsBundles(content_ctx),
+            .workspaces => try self.drawSettingsWorkspaces(content_ctx),
+            .token => try self.drawSettingsToken(content_ctx),
+        };
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = tab_surface };
+        children[1] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = content };
+        root.children = children;
+        return root;
+    }
+
+    fn drawSettingsMembers(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        self.syncSettingsMemberWidgets();
+
+        const list_w: u16 = if (size.width > 100) size.width -| 32 else size.width;
+        const detail_w: u16 = if (size.width > 100) 31 else 0;
+
+        // Member list
+        self.settings_member_scroll.scroll_view.draw_cursor = false;
+        defer self.settings_member_scroll.scroll_view.draw_cursor = true;
+
+        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Org Members", .subtitle = "maintainer: invite/remove", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.settings_member_scroll.widget() };
+        var list_surface = try panel.draw(list_ctx);
+        list_surface = try w.applyCursorOverlay(list_ctx, &list_surface, &self.settings_member_scroll.scroll_view);
+
+        if (detail_w > 0) {
+            const sel_idx = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
+            const m = &data.MEMBERS[sel_idx];
+            const detail_text = try std.fmt.allocPrint(ctx.arena,
+                \\User
+                \\{s}
+                \\
+                \\Role
+                \\{s}
+                \\
+                \\Joined
+                \\{s}
+                \\
+                \\Actions
+                \\PATCH role (maintainer only)
+                \\DELETE remove (maintainer only)
+            , .{ m.username, m.role, m.joined });
+            const text_widget: vxfw.Text = .{ .text = detail_text, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
+            const wrapper = try ctx.arena.create(w.WidgetBox);
+            wrapper.* = .{ .widget_ref = text_widget.widget() };
+            const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
+            const detail_panel: w.Panel = .{ .owner = self.widget(), .title = m.username, .subtitle = m.role, .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+
+            const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+            children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
+            children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try detail_panel.draw(detail_ctx) };
+            root.children = children;
+        } else {
+            const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+            children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
+            root.children = children;
+        }
+        return root;
+    }
+
+    fn drawSettingsBundles(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.appendSlice(ctx.arena, "Bundle management (maintainer only)\n\n");
+        for (data.BUNDLES) |bundle| {
+            const line = try std.fmt.allocPrint(ctx.arena, "{s:<16} {d} prompts\n", .{ bundle.name, bundle.count });
+            try buf.appendSlice(ctx.arena, line);
+        }
+        try buf.appendSlice(ctx.arena, "\nActions\nPOST create  PUT update  DELETE remove");
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Bundles", .subtitle = "org-level groups", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawSettingsWorkspaces(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.appendSlice(ctx.arena, "Workspace management\n\n");
+        for (data.WORKSPACES) |ws| {
+            const line = try std.fmt.allocPrint(ctx.arena, "{s:<16} {d}p {d}c {d}o  {s}\n", .{ ws.name, ws.prompts, ws.contexts, ws.overrides, data.syncStateLabel(&ws) });
+            try buf.appendSlice(ctx.arena, line);
+        }
+        try buf.appendSlice(ctx.arena, "\nActions\nPATCH rename  DELETE remove (maintainer)\nMembers: list / add / remove");
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspaces", .subtitle = "project-level", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawSettingsToken(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const t = data.CURRENT_TOKEN;
+        const text = try std.fmt.allocPrint(ctx.arena,
+            \\Current Token
+            \\
+            \\Scopes
+            \\{s}
+            \\
+            \\Expires
+            \\{s}
+            \\
+            \\Note
+            \\Token scopes limit what this session can do.
+            \\Actual permissions = min(role, scopes).
+            \\Use DELETE /api/auth/token to revoke.
+        , .{ t.scope, t.expires });
+        const text_widget: vxfw.Text = .{ .text = text, .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Token", .subtitle = "current session", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    fn syncSettingsMemberWidgets(self: *Dashboard) void {
+        self.settings_member_scroll.scroll_view.cursor = @min(self.settings_member_scroll.scroll_view.cursor, data.MEMBERS.len - 1);
+        const sel_idx = @as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor));
+        for (data.MEMBERS, 0..) |m, idx| {
+            const sel = idx == sel_idx;
+            self.settings_member_cols[idx] = .{
+                .{ .text = m.username, .flex = 1 },
+                .{ .text = m.role, .flex = 0 },
+                .{ .text = m.joined, .flex = 0, .alignment = .right },
+            };
+            self.settings_member_rows[idx] = .{
+                .columns = &self.settings_member_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 2,
+            };
+            self.settings_member_widgets[idx] = self.settings_member_rows[idx].widget();
+        }
+        self.settings_member_scroll.scroll_view.children = .{ .slice = self.settings_member_widgets[0..] };
+        self.settings_member_scroll.estimated_content_height = data.MEMBERS.len;
+    }
+
+    fn shiftSettingsTab(self: *Dashboard, delta: i8) void {
+        const current: i8 = @intCast(@intFromEnum(self.settings_tab));
+        const count: i8 = @intCast(settings_tabs.len);
+        const next = @mod(current + delta + count, count);
+        self.settings_tab = @enumFromInt(@as(u8, @intCast(next)));
+    }
+
     fn drawHelpOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
@@ -1074,6 +1394,60 @@ pub const Dashboard = struct {
         for (lines, 0..) |line, i| {
             w.writeText(&surface, ctx, start_col + 2, @intCast(start_row + 2 + i), line, theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT));
         }
+
+        return surface;
+    }
+
+    fn drawConfirmOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.CANVAS);
+
+        const box_w: u16 = 44;
+        const box_h: u16 = 7;
+        const start_col = (size.width -| box_w) / 2;
+        const start_row = (size.height -| box_h) / 2;
+
+        // Box background
+        var row: u16 = 0;
+        while (row < box_h) : (row += 1) {
+            var col: u16 = 0;
+            while (col < box_w) : (col += 1) {
+                surface.writeCell(start_col + col, start_row + row, .{
+                    .char = .{ .grapheme = " ", .width = 1 },
+                    .style = .{ .fg = theme.TEXT, .bg = theme.PANEL_ALT },
+                });
+            }
+        }
+
+        // Border
+        const s = vaxis.Style{ .fg = theme.DANGER, .bg = theme.PANEL_ALT };
+        surface.writeCell(start_col, start_row, .{ .char = .{ .grapheme = "\xe2\x95\xad", .width = 1 }, .style = s });
+        surface.writeCell(start_col + box_w - 1, start_row, .{ .char = .{ .grapheme = "\xe2\x95\xae", .width = 1 }, .style = s });
+        surface.writeCell(start_col, start_row + box_h - 1, .{ .char = .{ .grapheme = "\xe2\x95\xb0", .width = 1 }, .style = s });
+        surface.writeCell(start_col + box_w - 1, start_row + box_h - 1, .{ .char = .{ .grapheme = "\xe2\x95\xaf", .width = 1 }, .style = s });
+        var c: u16 = 1;
+        while (c < box_w - 1) : (c += 1) {
+            surface.writeCell(start_col + c, start_row, .{ .char = .{ .grapheme = "\xe2\x94\x80", .width = 1 }, .style = s });
+            surface.writeCell(start_col + c, start_row + box_h - 1, .{ .char = .{ .grapheme = "\xe2\x94\x80", .width = 1 }, .style = s });
+        }
+        var r: u16 = 1;
+        while (r < box_h - 1) : (r += 1) {
+            surface.writeCell(start_col, start_row + r, .{ .char = .{ .grapheme = "\xe2\x94\x82", .width = 1 }, .style = s });
+            surface.writeCell(start_col + box_w - 1, start_row + r, .{ .char = .{ .grapheme = "\xe2\x94\x82", .width = 1 }, .style = s });
+        }
+
+        w.writeText(&surface, ctx, start_col + 2, start_row, " Confirm ", theme.boldOn(theme.PANEL_ALT, theme.DANGER));
+
+        const action_label: []const u8 = switch (self.confirm_action) {
+            .remove_member => "Remove member:",
+            .delete_bundle => "Delete bundle:",
+            .delete_workspace => "Delete workspace:",
+            .none => "Confirm:",
+        };
+        w.writeText(&surface, ctx, start_col + 2, start_row + 2, action_label, theme.textOn(theme.PANEL_ALT, theme.TEXT));
+        w.writeText(&surface, ctx, start_col + 2, start_row + 3, self.confirm_message, theme.boldOn(theme.PANEL_ALT, theme.ACCENT));
+        w.writeText(&surface, ctx, start_col + 2, start_row + 5, "y confirm    n / Esc cancel", theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT));
 
         return surface;
     }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -120,8 +120,8 @@ const DetailTab = enum(u8) {
 
 const top_tabs = [_]TopModule{ .insights, .workspace, .library };
 
-// 12 prompts + up to 12 group headers = 24 max rows
-const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
+const MAX_LIBRARY_ROWS = 128;
+const MAX_PR_ROWS = 64;
 const detail_tabs = [_]DetailTab{ .content, .pull_requests };
 
 pub const Dashboard = struct {
@@ -159,11 +159,11 @@ pub const Dashboard = struct {
     // PR list within Prompt Detail
     pr_filter: PrFilter = .open,
     pr_scroll_bars: vxfw.ScrollBars,
-    pr_widgets: [data.PULL_REQUESTS.len * 2]vxfw.Widget = undefined,
-    pr_table_rows: [data.PULL_REQUESTS.len]TableRow = undefined,
-    pr_table_cols: [data.PULL_REQUESTS.len][4]Column = undefined,
-    pr_text_rows: [data.PULL_REQUESTS.len]vxfw.Text = undefined,
-    pr_indices: [data.PULL_REQUESTS.len * 2]?usize = .{null} ** (data.PULL_REQUESTS.len * 2),
+    pr_widgets: [MAX_PR_ROWS * 2]vxfw.Widget = undefined,
+    pr_table_rows: [MAX_PR_ROWS]TableRow = undefined,
+    pr_table_cols: [MAX_PR_ROWS][4]Column = undefined,
+    pr_text_rows: [MAX_PR_ROWS]vxfw.Text = undefined,
+    pr_indices: [MAX_PR_ROWS * 2]?usize = .{null} ** (MAX_PR_ROWS * 2),
     pr_row_count: usize = 0,
     // PR drill-down state
     show_pr_diff: bool = false,
@@ -595,7 +595,13 @@ pub const Dashboard = struct {
                 switch (self.selected_module) {
                     .library => {
                         if (key.matches('b', .{})) {
-                            self.library_bundle_filter = (self.library_bundle_filter + 1) % (data.BUNDLES.len + 1);
+                            const bundle_count = blk: {
+                                self.api_state.mutex.lock();
+                                defer self.api_state.mutex.unlock();
+                                if (self.api_state.bundles) |lb| break :blk lb.len;
+                                break :blk data.BUNDLES.len;
+                            };
+                            self.library_bundle_filter = (self.library_bundle_filter + 1) % (bundle_count + 1);
                             self.library_scroll_bars.scroll_view.cursor = 0;
                             ctx.consumeAndRedraw();
                             return;
@@ -1171,7 +1177,17 @@ pub const Dashboard = struct {
 
         const list_w: u16 = size.width / 3;
         const detail_w: u16 = size.width - list_w - 1;
-        const p = &data.PROMPTS[self.selected_prompt];
+        const prompts: []const data.PromptEntry = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.prompts) |lp| {
+                const alloc = self.api_state.arena.allocator();
+                break :blk api.toPromptEntries(alloc, lp);
+            }
+            break :blk &data.PROMPTS;
+        };
+        const sel_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
+        const p = if (prompts.len > 0) &prompts[sel_idx] else &data.PROMPTS[0];
 
         const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
         const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
@@ -1189,11 +1205,28 @@ pub const Dashboard = struct {
         self.library_scroll_bars.scroll_view.draw_cursor = false;
         defer self.library_scroll_bars.scroll_view.draw_cursor = true;
 
+        const bundles_list: []const data.BundleEntry = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.bundles) |lb| {
+                const a = self.api_state.arena.allocator();
+                break :blk api.toBundleEntries(a, lb);
+            }
+            break :blk &data.BUNDLES;
+        };
         const bundle_label: []const u8 = if (self.library_bundle_filter == 0)
             "All"
+        else if (self.library_bundle_filter - 1 < bundles_list.len)
+            bundles_list[self.library_bundle_filter - 1].name
         else
-            data.BUNDLES[self.library_bundle_filter - 1].name;
-        const subtitle = try std.fmt.allocPrint(ctx.arena, "{d} prompts  bundle: {s}  / search  b filter", .{ data.PROMPTS.len, bundle_label });
+            "All";
+        const prompt_count: usize = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.prompts) |p| break :blk p.len;
+            break :blk data.PROMPTS.len;
+        };
+        const subtitle = try std.fmt.allocPrint(ctx.arena, "{d} prompts  bundle: {s}  / search  b filter", .{ prompt_count, bundle_label });
         const list_border = if (!self.detail_focus_content) theme.ACCENT else theme.BORDER;
         const panel: w.Panel = .{
             .owner = self.widget(),
@@ -1305,7 +1338,9 @@ pub const Dashboard = struct {
     // Old Prompt Detail (kept for non-Library drill-down from other modules)
     fn drawPromptDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
-        const p = &data.PROMPTS[self.selected_prompt];
+        const prompts = self.getPrompts();
+        const sel_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
+        const p = if (prompts.len > 0) &prompts[sel_idx] else &data.PROMPTS[0];
 
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
@@ -1727,7 +1762,14 @@ pub const Dashboard = struct {
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.CANVAS);
 
-        const ins = &data.INSIGHTS;
+        // Use live stats for chart header if available, mock for everything else
+        var live_insights: ?data.InsightsData = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(stats);
+            break :blk null;
+        };
+        const ins: *const data.InsightsData = if (live_insights) |*li| li else &data.INSIGHTS;
 
         // Layout: chart(top, full width) + prompts|team (bottom, side by side)
         const chart_h: u16 = if (size.height > 40) 10 else 8;
@@ -2410,6 +2452,16 @@ pub const Dashboard = struct {
         return surface;
     }
 
+    fn getPrompts(self: *Dashboard) []const data.PromptEntry {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.prompts) |lp| {
+            const alloc = self.api_state.arena.allocator();
+            return api.toPromptEntries(alloc, lp);
+        }
+        return &data.PROMPTS;
+    }
+
     fn orgMemberCount(self: *Dashboard) usize {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
@@ -2552,7 +2604,9 @@ pub const Dashboard = struct {
         w.drawBorder(&surface, theme.ACCENT, bg);
 
         // Title: show reply context or "New Comment"
-        const p = &data.PROMPTS[self.selected_prompt];
+        const all_prompts = self.getPrompts();
+        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
+        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
         const prs = data.prsForPrompt(p.canonical_name);
         const title = if (prs.len > 0 and self.selected_pr_idx < prs.len)
             try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
@@ -2588,16 +2642,38 @@ pub const Dashboard = struct {
     // library_prompt_indices maps each row index to the PROMPTS array index
     // (null for group header rows, so cursor can skip them).
     fn syncLibraryWidgets(self: *Dashboard) void {
+        // Use live prompts if available, else mock
+        const prompts: []const data.PromptEntry = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.prompts) |lp| {
+                const alloc = self.api_state.arena.allocator();
+                break :blk api.toPromptEntries(alloc, lp);
+            }
+            break :blk &data.PROMPTS;
+        };
+
+        const bundles: []const data.BundleEntry = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.bundles) |lb| {
+                const alloc = self.api_state.arena.allocator();
+                break :blk api.toBundleEntries(alloc, lb);
+            }
+            break :blk &data.BUNDLES;
+        };
+
         const filter_name: ?[]const u8 = if (self.library_bundle_filter == 0)
             null
+        else if (self.library_bundle_filter - 1 < bundles.len)
+            bundles[self.library_bundle_filter - 1].name
         else
-            data.BUNDLES[self.library_bundle_filter - 1].name;
+            null;
 
         var row_idx: usize = 0;
         var last_prefix: []const u8 = "";
 
-        for (data.PROMPTS, 0..) |p, pidx| {
-            // Apply bundle filter
+        for (prompts, 0..) |p, pidx| {
             if (filter_name) |fname| {
                 if (std.mem.indexOf(u8, p.bundle_names, fname) == null) continue;
             }
@@ -2605,11 +2681,8 @@ pub const Dashboard = struct {
             const prefix = data.pathPrefix(p.canonical_name);
             const name = data.promptName(p.canonical_name);
 
-            // Insert group header when prefix changes
             if (!std.mem.eql(u8, prefix, last_prefix)) {
                 if (row_idx < MAX_LIBRARY_ROWS) {
-                    // Prefix headers use static padded strings to avoid
-                    // needing an allocator in sync functions.
                     self.library_text_rows[row_idx] = .{
                         .text = prefixWithPad(prefix),
                         .style = theme.boldOn(theme.PANEL, theme.ACCENT),
@@ -2621,7 +2694,6 @@ pub const Dashboard = struct {
                 last_prefix = prefix;
             }
 
-            // Insert prompt row (name + stats)
             if (row_idx < MAX_LIBRARY_ROWS) {
                 const sel = pidx == self.selected_prompt;
                 const pr_label: []const u8 = switch (p.open_pr_count) {
@@ -2650,7 +2722,6 @@ pub const Dashboard = struct {
         self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..row_idx] };
         self.library_scroll_bars.estimated_content_height = @intCast(row_idx);
 
-        // Ensure cursor is on a prompt row, not a group header or summary
         var cur = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
         while (cur < row_idx and self.library_prompt_indices[cur] == null) {
             cur += 1;
@@ -2674,7 +2745,9 @@ pub const Dashboard = struct {
     }
 
     fn syncPrWidgets(self: *Dashboard) void {
-        const p = &data.PROMPTS[self.selected_prompt];
+        const all_prompts = self.getPrompts();
+        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
+        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
         const prs = data.prsForPrompt(p.canonical_name);
         var row_idx: usize = 0;
         for (prs, 0..) |pr, pi| {
@@ -2723,7 +2796,9 @@ pub const Dashboard = struct {
     }
 
     fn syncPrDiffAndComments(self: *Dashboard, allocator: std.mem.Allocator) void {
-        const p = &data.PROMPTS[self.selected_prompt];
+        const all_prompts = self.getPrompts();
+        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
+        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
         const prs = data.prsForPrompt(p.canonical_name);
         if (prs.len == 0) {
             self.pr_diff_count = 0;
@@ -2821,7 +2896,11 @@ pub const Dashboard = struct {
     }
 
     fn openDetail(self: *Dashboard, ctx: *vxfw.EventContext, prompt_idx: usize, origin: TopModule, initial_tab: DetailTab) void {
-        self.selected_prompt = @min(prompt_idx, data.PROMPTS.len - 1);
+        const max_prompt = blk: {
+            const p = self.getPrompts();
+            break :blk if (p.len > 0) p.len - 1 else 0;
+        };
+        self.selected_prompt = @min(prompt_idx, max_prompt);
         self.library_scroll_bars.scroll_view.cursor = @intCast(self.selected_prompt);
         self.pr_filter = .open;
         self.detail_origin = origin;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -196,6 +196,7 @@ pub const Dashboard = struct {
     insights_show_member_detail: bool = false,
     insights_show_input_detail: bool = false,
     dashboard_input_capacity: usize = 1,
+    view_arena: std.heap.ArenaAllocator,
 
     pub fn init(api_state: *api.ApiState) Dashboard {
         return .{
@@ -204,7 +205,15 @@ pub const Dashboard = struct {
             .content_scroll_bars = w.initPlainScrollBars(theme.PANEL, 3),
             .pr_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .pr_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
+            .view_arena = std.heap.ArenaAllocator.init(api_state.backing_allocator),
         };
+    }
+
+    pub fn deinit(self: *Dashboard) void {
+        self.view_arena.deinit();
+        self.library_expanded.deinit(self.api_state.allocator());
+        self.ws_context_expanded.deinit(self.api_state.allocator());
+        self.ws_prompts_expanded.deinit(self.api_state.allocator());
     }
 
     pub fn widget(self: *Dashboard) vxfw.Widget {
@@ -225,7 +234,12 @@ pub const Dashboard = struct {
         return self.draw(ctx);
     }
 
+    fn viewAllocator(self: *Dashboard) std.mem.Allocator {
+        return self.view_arena.allocator();
+    }
+
     fn handleEvent(self: *Dashboard, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        _ = self.view_arena.reset(.retain_capacity);
         switch (event) {
             .key_press => |key| {
                 // Confirm overlay absorbs all keys
@@ -1103,6 +1117,7 @@ pub const Dashboard = struct {
     }
 
     fn draw(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        _ = self.view_arena.reset(.retain_capacity);
         const size = ctx.max.size();
         if (size.width < 96 or size.height < 24) {
             return self.drawTooSmall(ctx, size);
@@ -1354,15 +1369,7 @@ pub const Dashboard = struct {
         self.library_scroll_bars.scroll_view.draw_cursor = false;
         defer self.library_scroll_bars.scroll_view.draw_cursor = true;
 
-        const bundles_list: []const data.BundleEntry = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            if (self.api_state.bundles) |lb| {
-                const a = self.api_state.allocator();
-                break :blk api.toBundleEntries(a, lb);
-            }
-            break :blk &.{};
-        };
+        const bundles_list = self.getBundles();
         const bundle_label: []const u8 = if (self.library_bundle_filter == 0)
             "All"
         else if (self.library_bundle_filter - 1 < bundles_list.len)
@@ -1402,7 +1409,7 @@ pub const Dashboard = struct {
             w.writeText(&surface, ctx, 2, 2, empty_msg, theme.fg(theme.MUTED));
             return surface;
         }
-        return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view);
+        return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view, theme.PANEL);
     }
 
     // Library right pane: detail for selected prompt with Overview/Content/Pull Requests tabs.
@@ -3077,8 +3084,7 @@ pub const Dashboard = struct {
             } else {
                 return &.{};
             }
-            const alloc = self.api_state.allocator();
-            return api.toPrEntries(alloc, prs, prompt_path, self.api_state);
+            return api.toPrEntries(self.viewAllocator(), prs, prompt_path, self.api_state);
         }
         return &.{};
     }
@@ -3087,8 +3093,16 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         if (self.api_state.prompts) |lp| {
-            const alloc = self.api_state.allocator();
-            return api.toPromptEntries(alloc, lp);
+            return api.toPromptEntries(self.viewAllocator(), lp);
+        }
+        return &.{};
+    }
+
+    fn getBundles(self: *Dashboard) []const data.BundleEntry {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.bundles) |lb| {
+            return api.toBundleEntries(self.viewAllocator(), lb);
         }
         return &.{};
     }
@@ -3106,11 +3120,13 @@ pub const Dashboard = struct {
             self.status_line = "Failed to submit comment";
             return;
         };
+        defer alloc.free(path);
         const comment_text = self.comment_input_buf[0..self.comment_input_len];
         const body = std.fmt.allocPrint(alloc, "{{\"body\":\"{s}\"}}", .{comment_text}) catch {
             self.status_line = "Failed to submit comment";
             return;
         };
+        defer alloc.free(body);
         _ = api.postAction(self.api_state, alloc, .POST, path, body) catch {
             self.status_line = "Comment submission failed";
             return;
@@ -3132,10 +3148,12 @@ pub const Dashboard = struct {
             self.status_line = "Failed to build request";
             return;
         };
+        defer alloc.free(path);
         const body = std.fmt.allocPrint(alloc, "{{\"action\":\"{s}\"}}", .{action}) catch {
             self.status_line = "Failed to build request";
             return;
         };
+        defer alloc.free(body);
         _ = api.postAction(self.api_state, alloc, .PUT, path, body) catch {
             self.status_line = if (std.mem.eql(u8, action, "accept")) "Accept failed" else "Reject failed";
             return;
@@ -3612,15 +3630,7 @@ pub const Dashboard = struct {
     fn syncLibraryWidgets(self: *Dashboard) void {
         const prompts = self.getPrompts();
 
-        const bundles: []const data.BundleEntry = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            if (self.api_state.bundles) |lb| {
-                const alloc = self.api_state.allocator();
-                break :blk api.toBundleEntries(alloc, lb);
-            }
-            break :blk &.{};
-        };
+        const bundles = self.getBundles();
 
         const filter_name: ?[]const u8 = if (self.library_bundle_filter == 0)
             null

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1726,7 +1726,7 @@ pub const Dashboard = struct {
         var live_insights: ?data.InsightsData = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
-            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(stats);
+            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts);
             break :blk null;
         };
         const ins: *const data.InsightsData = if (live_insights) |*li| li else &data.INSIGHTS;
@@ -2309,6 +2309,12 @@ pub const Dashboard = struct {
             w.writeText(&surface, ctx, 2, row, "Effective permissions = min(org role, token scopes)", theme.fg(theme.MUTED));
         }
         return surface;
+    }
+
+    // Get PRs for a prompt. Uses mock data (API PRs have different shape for diff/comments).
+    fn getPrsForPrompt(self: *Dashboard, canonical_name: []const u8) []const data.PullRequestEntry {
+        _ = self;
+        return data.prsForPrompt(canonical_name);
     }
 
     fn getPrompts(self: *Dashboard) []const data.PromptEntry {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -105,13 +105,11 @@ const PrFilter = enum {
 };
 
 const DetailTab = enum(u8) {
-    overview,
     content,
     pull_requests,
 
     fn label(self: DetailTab) []const u8 {
         return switch (self) {
-            .overview => "Overview",
             .content => "Content",
             .pull_requests => "Pull Requests",
         };
@@ -122,7 +120,7 @@ const top_tabs = [_]TopModule{ .insights, .workspace, .library };
 
 // 12 prompts + up to 12 group headers = 24 max rows
 const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
-const detail_tabs = [_]DetailTab{ .overview, .content, .pull_requests };
+const detail_tabs = [_]DetailTab{ .content, .pull_requests };
 
 pub const Dashboard = struct {
     selected_module: TopModule = .insights,
@@ -134,7 +132,7 @@ pub const Dashboard = struct {
     confirm_message: []const u8 = "",
     confirm_action: ConfirmAction = .none,
     detail_origin: TopModule = .library,
-    detail_tab: DetailTab = .overview,
+    detail_tab: DetailTab = .content,
     detail_focus_content: bool = false,
     settings_tab: SettingsTab = .account,
     settings_focus: enum { sidebar, content } = .sidebar,
@@ -149,7 +147,7 @@ pub const Dashboard = struct {
     library_widgets: [MAX_LIBRARY_ROWS]vxfw.Widget = undefined,
     library_text_rows: [MAX_LIBRARY_ROWS]vxfw.Text = undefined,
     library_table_rows: [MAX_LIBRARY_ROWS]TableRow = undefined,
-    library_table_cols: [MAX_LIBRARY_ROWS][4]Column = undefined,
+    library_table_cols: [MAX_LIBRARY_ROWS][2]Column = undefined,
 
     content_scroll_bars: vxfw.ScrollBars,
     content_widget: [1]vxfw.Widget = undefined,
@@ -182,6 +180,7 @@ pub const Dashboard = struct {
     ws_sel: usize = 0,
     ws_list_sel: usize = 0,
     ws_grid_cols: u16 = 3,
+    ws_show_diff: bool = false,
     // Workspace uses manual grid + list rendering, no ScrollBars
 
     // Insights
@@ -782,6 +781,7 @@ pub const Dashboard = struct {
                                     };
                                     if (self.ws_list_sel + 1 < max_items) {
                                         self.ws_list_sel += 1;
+                                        self.ws_show_diff = false;
                                         ctx.consumeAndRedraw();
                                     }
                                     return;
@@ -789,6 +789,7 @@ pub const Dashboard = struct {
                                 if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
                                     if (self.ws_list_sel > 0) {
                                         self.ws_list_sel -= 1;
+                                        self.ws_show_diff = false;
                                         ctx.consumeAndRedraw();
                                     }
                                     return;
@@ -807,6 +808,11 @@ pub const Dashboard = struct {
                             .content => {
                                 if (key.matches(vaxis.Key.escape, .{})) {
                                     self.ws_focus = .list;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('d', .{})) {
+                                    self.ws_show_diff = !self.ws_show_diff;
                                     ctx.consumeAndRedraw();
                                     return;
                                 }
@@ -1071,7 +1077,7 @@ pub const Dashboard = struct {
             .workspace => switch (self.ws_focus) {
                 .bar => "j/k select workspace  Tab list  r sync  ? help  q quit",
                 .list => "h/l tab  j/k move  Enter content  Esc bar  ? help",
-                .content => "j/k scroll  Esc list  ? help",
+                .content => "j/k scroll  d toggle diff  Esc list  ? help",
             },
             .insights => switch (self.insights_focus) {
                 .chart => "h/l scroll  Tab focus  t period  ? help  q quit",
@@ -1090,6 +1096,29 @@ pub const Dashboard = struct {
                 }
             }
         }
+
+        // Right-aligned contextual hint for workspace items
+        if (!self.show_help and !self.show_confirm and !self.show_settings and
+            !self.show_comment_editor and !self.show_detail and
+            self.selected_module == .workspace)
+        {
+            const hint: []const u8 = if (self.ws_focus == .content)
+                (if (self.ws_show_diff) "d content" else "d diff")
+            else if (self.ws_focus == .bar) blk: {
+                const ws_idx = @min(self.ws_sel, data.WORKSPACES.len - 1);
+                const wsi = &data.WORKSPACES[ws_idx];
+                break :blk if (wsi.local_rev != wsi.remote_rev) "New version available, press r to sync" else "Up to date";
+            } else blk: {
+                const ws_sel = self.ws_list_sel;
+                const is_modified = switch (self.ws_tab) {
+                    .context => ws_sel < data.WS_CONTEXT.len and data.WS_CONTEXT[ws_sel].modified,
+                    .prompts => ws_sel < data.WS_PROMPTS.len and data.WS_PROMPTS[ws_sel].has_override,
+                };
+                break :blk if (is_modified) "New version available, press r to sync" else "Up to date";
+            };
+            w.writeRightText(&surface, ctx, 0, hint, theme.fg(theme.TEXT_SOFT));
+        }
+
         return surface;
     }
 
@@ -1163,33 +1192,27 @@ pub const Dashboard = struct {
         const inner_w = ctx.max.width.? -| 4;
 
         switch (self.detail_tab) {
-            .overview => {
-                const kv_col: u16 = 2;
-                var kv_row: u16 = 2;
-                w.writeText(&surface, ctx, kv_col, kv_row, p.summary, theme.fg(theme.TEXT_SOFT));
-                kv_row += 2;
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "local edit", "yes (payments-api)", 8);
-                kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
-                const top_n = @min(p.constraint_count, 3);
-                var ci: u8 = 0;
-                while (ci < top_n) : (ci += 1) {
-                    const cid = try std.fmt.allocPrint(ctx.arena, "c-{d}", .{ci + 1});
-                    kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, cid, "(mock refer data)", 5);
-                }
-                if (p.constraint_count > 3) {
-                    w.writeText(&surface, ctx, kv_col, kv_row, try std.fmt.allocPrint(ctx.arena, "... +{d} more", .{p.constraint_count - 3}), theme.fg(theme.MUTED));
-                }
-            },
             .content => {
+                // Meta header row
+                var header_rows: u16 = 1;
+                const meta_line = try std.fmt.allocPrint(ctx.arena, "rev.{d}  \xc2\xb7{d} PR  {d} constraints  {s}", .{ p.revision, p.open_pr_count, p.constraint_count, p.updated });
+                w.writeText(&surface, ctx, 2, 2, meta_line, theme.fg(theme.MUTED));
+
+                // Workspace names (if present)
+                if (p.workspace_names.len > 0) {
+                    header_rows += 1;
+                    w.writeText(&surface, ctx, 2, 3, p.workspace_names, theme.fg(theme.TEXT_SOFT));
+                }
+
+                // Spacing row
+                header_rows += 1;
+                const content_origin_row: u16 = 2 + header_rows;
+                const content_h = inner_h -| header_rows;
+
                 self.syncContentWidget();
-                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = content_h }, .{ .width = inner_w, .height = content_h });
                 const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+                children[0] = .{ .origin = .{ .row = content_origin_row, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
             .pull_requests => {
@@ -1282,40 +1305,27 @@ pub const Dashboard = struct {
         const inner_w = ctx.max.width.? -| 2;
 
         switch (self.detail_tab) {
-            .overview => {
-                const kv_col: u16 = 2;
-                var kv_row: u16 = 2;
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "local edit", "yes (payments-api)", 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
-                kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
-                // Mock: show constraint count, real data from GET /api/stats/prompt/{id}
-                const ccount = p.constraint_count;
-                const top_n = @min(ccount, 3);
-                var ci: u8 = 0;
-                while (ci < top_n) : (ci += 1) {
-                    const cid = try std.fmt.allocPrint(ctx.arena, "c-{d}", .{ci + 1});
-                    const cval = try std.fmt.allocPrint(ctx.arena, "(mock refer data)", .{});
-                    kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, cid, cval, 5);
-                }
-                if (ccount > 3) {
-                    w.writeText(&surface, ctx, kv_col, kv_row, try std.fmt.allocPrint(ctx.arena, "... +{d} more", .{ccount - 3}), theme.fg(theme.MUTED));
-                    kv_row += 1;
-                }
-                kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Edit");
-                w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api", theme.fg(theme.TEXT_SOFT));
-                kv_row += 1;
-                w.writeText(&surface, ctx, kv_col, kv_row, "Press p to create PR from this edit", theme.fg(theme.MUTED));
-            },
             .content => {
+                // Meta header row
+                var header_rows2: u16 = 1;
+                const meta_line2 = try std.fmt.allocPrint(ctx.arena, "rev.{d}  \xc2\xb7{d} PR  {d} constraints  {s}", .{ p.revision, p.open_pr_count, p.constraint_count, p.updated });
+                w.writeText(&surface, ctx, 2, 2, meta_line2, theme.fg(theme.MUTED));
+
+                // Workspace names (if present)
+                if (p.workspace_names.len > 0) {
+                    header_rows2 += 1;
+                    w.writeText(&surface, ctx, 2, 3, p.workspace_names, theme.fg(theme.TEXT_SOFT));
+                }
+
+                // Spacing row
+                header_rows2 += 1;
+                const content_origin_row2: u16 = 2 + header_rows2;
+                const content_h2 = inner_h -| header_rows2;
+
                 self.syncContentWidget();
-                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = content_h2 }, .{ .width = inner_w, .height = content_h2 });
                 const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+                children[0] = .{ .origin = .{ .row = content_origin_row2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
             .pull_requests => {
@@ -1441,7 +1451,7 @@ pub const Dashboard = struct {
                 });
             }
 
-            const name_x = x + 2;
+            const name_x = x + 1;
             const needs_sync = wsi.local_rev != wsi.remote_rev;
             const label = if (needs_sync)
                 try std.fmt.allocPrint(ctx.arena, "{s} *", .{wsi.name})
@@ -1497,7 +1507,16 @@ pub const Dashboard = struct {
         switch (self.ws_tab) {
             .context => {
                 var kv_row: u16 = 2;
+                var last_prefix: []const u8 = "";
                 for (data.WS_CONTEXT, 0..) |f, i| {
+                    if (kv_row >= inner_h + 2) break;
+                    const prefix = data.pathPrefix(f.path);
+                    if (!std.mem.eql(u8, prefix, last_prefix)) {
+                        w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                        kv_row += 1;
+                        last_prefix = prefix;
+                        if (kv_row >= inner_h + 2) break;
+                    }
                     const sel = i == self.ws_list_sel;
                     const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
                     if (sel) {
@@ -1506,29 +1525,27 @@ pub const Dashboard = struct {
                             .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
                         });
                     }
-                    // Name + (modified) inline marker
-                    const label = if (f.modified)
-                        try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{f.path})
-                    else
-                        f.path;
-                    w.writeText(&surface, ctx, 3, kv_row, label, name_style);
+                    const fname = data.promptName(f.path);
+                    w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
                     if (f.modified) {
-                        // Color just the "(modified)" part
-                        const path_w: u16 = @intCast(ctx.stringWidth(f.path));
-                        w.writeText(&surface, ctx, 3 + path_w + 1, kv_row, "(modified)", theme.fg(theme.WARN));
-                    }
-                    // Right side: always show size
-                    if (ctx.max.width) |max_w| {
-                        const sw: u16 = @intCast(ctx.stringWidth(f.size));
-                        if (sw + 3 < max_w) w.writeText(&surface, ctx, max_w - sw - 2, kv_row, f.size, theme.fg(theme.MUTED));
+                        const nw: u16 = @intCast(ctx.stringWidth(fname));
+                        w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
                     }
                     kv_row += 1;
-                    if (kv_row >= inner_h + 2) break;
                 }
             },
             .prompts => {
                 var kv_row: u16 = 2;
+                var last_prefix: []const u8 = "";
                 for (data.WS_PROMPTS, 0..) |p, i| {
+                    if (kv_row >= inner_h + 2) break;
+                    const prefix = data.pathPrefix(p.name);
+                    if (!std.mem.eql(u8, prefix, last_prefix)) {
+                        w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                        kv_row += 1;
+                        last_prefix = prefix;
+                        if (kv_row >= inner_h + 2) break;
+                    }
                     const sel = i == self.ws_list_sel;
                     const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
                     if (sel) {
@@ -1537,23 +1554,13 @@ pub const Dashboard = struct {
                             .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
                         });
                     }
-                    // Name + (modified) inline marker
-                    const label = if (p.has_override)
-                        try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{p.name})
-                    else
-                        p.name;
-                    w.writeText(&surface, ctx, 3, kv_row, label, name_style);
+                    const fname = data.promptName(p.name);
+                    w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
                     if (p.has_override) {
-                        const name_w: u16 = @intCast(ctx.stringWidth(p.name));
-                        w.writeText(&surface, ctx, 3 + name_w + 1, kv_row, "(modified)", theme.fg(theme.WARN));
-                    }
-                    // Right side: always show state
-                    if (ctx.max.width) |max_w| {
-                        const sw: u16 = @intCast(ctx.stringWidth(p.state));
-                        if (sw + 3 < max_w) w.writeText(&surface, ctx, max_w - sw - 2, kv_row, p.state, theme.fg(theme.MUTED));
+                        const nw: u16 = @intCast(ctx.stringWidth(fname));
+                        w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
                     }
                     kv_row += 1;
-                    if (kv_row >= inner_h + 2) break;
                 }
             },
         }
@@ -1580,11 +1587,18 @@ pub const Dashboard = struct {
             .context => sel < data.WS_CONTEXT.len and data.WS_CONTEXT[sel].modified,
             .prompts => sel < data.WS_PROMPTS.len and data.WS_PROMPTS[sel].has_override,
         };
-        if (has_diff) {
-            const marker = try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{title});
-            w.writeText(&surface, ctx, 2, 0, marker, theme.boldOn(theme.PANEL, theme.WARN));
-        } else {
-            w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(theme.PANEL, if (has_diff) theme.WARN else theme.TEXT));
+        {
+            var marker_col: u16 = 2 + @as(u16, @intCast(ctx.stringWidth(title)));
+            if (has_diff) {
+                marker_col += 1;
+                w.writeText(&surface, ctx, marker_col, 0, "*", theme.boldOn(theme.PANEL, theme.WARN));
+                marker_col += 1;
+            }
+            if (self.ws_show_diff) {
+                marker_col += 1;
+                w.writeText(&surface, ctx, marker_col, 0, "diff", theme.boldOn(theme.PANEL, theme.ACCENT));
+            }
         }
 
         var kv_row: u16 = 2;
@@ -1594,27 +1608,31 @@ pub const Dashboard = struct {
             .context => {
                 if (sel < data.WS_CONTEXT.len) {
                     const f = &data.WS_CONTEXT[sel];
-                    if (f.modified and f.branch_diff.len > 0) {
-                        // Show branch diff (same GitHub-style as prompts)
-                        for (f.branch_diff) |line| {
-                            if (kv_row >= max_row) break;
-                            const line_color = if (std.mem.startsWith(u8, line, "+"))
-                                theme.OK
-                            else if (std.mem.startsWith(u8, line, "-"))
-                                theme.DANGER
-                            else
-                                theme.TEXT_SOFT;
-                            const line_bg = if (std.mem.startsWith(u8, line, "+"))
-                                theme.rgb(0x1d2617)
-                            else if (std.mem.startsWith(u8, line, "-"))
-                                theme.rgb(0x2a1b18)
-                            else
-                                theme.PANEL;
-                            w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
-                            kv_row += 1;
+                    if (self.ws_show_diff) {
+                        if (f.branch_diff.len > 0) {
+                            // Show branch diff (GitHub-style colored lines)
+                            for (f.branch_diff) |line| {
+                                if (kv_row >= max_row) break;
+                                const line_color = if (std.mem.startsWith(u8, line, "+"))
+                                    theme.OK
+                                else if (std.mem.startsWith(u8, line, "-"))
+                                    theme.DANGER
+                                else
+                                    theme.TEXT_SOFT;
+                                const line_bg = if (std.mem.startsWith(u8, line, "+"))
+                                    theme.rgb(0x1d2617)
+                                else if (std.mem.startsWith(u8, line, "-"))
+                                    theme.rgb(0x2a1b18)
+                                else
+                                    theme.PANEL;
+                                w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
+                                kv_row += 1;
+                            }
+                        } else {
+                            w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
                         }
                     } else {
-                        // No branch changes - show file content
+                        // Show file content
                         var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
                         while (line_iter.next()) |line| {
                             if (kv_row >= max_row) break;
@@ -1627,27 +1645,31 @@ pub const Dashboard = struct {
             .prompts => {
                 if (sel < data.WS_PROMPTS.len) {
                     const p = &data.WS_PROMPTS[sel];
-                    if (p.has_override and p.override_diff.len > 0) {
-                        // Show diff (GitHub-style colored lines)
-                        for (p.override_diff) |line| {
-                            if (kv_row >= max_row) break;
-                            const line_color = if (std.mem.startsWith(u8, line, "+"))
-                                theme.OK
-                            else if (std.mem.startsWith(u8, line, "-"))
-                                theme.DANGER
-                            else
-                                theme.TEXT_SOFT;
-                            const line_bg = if (std.mem.startsWith(u8, line, "+"))
-                                theme.rgb(0x1d2617)
-                            else if (std.mem.startsWith(u8, line, "-"))
-                                theme.rgb(0x2a1b18)
-                            else
-                                theme.PANEL;
-                            w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
-                            kv_row += 1;
+                    if (self.ws_show_diff) {
+                        if (p.override_diff.len > 0) {
+                            // Show diff (GitHub-style colored lines)
+                            for (p.override_diff) |line| {
+                                if (kv_row >= max_row) break;
+                                const line_color = if (std.mem.startsWith(u8, line, "+"))
+                                    theme.OK
+                                else if (std.mem.startsWith(u8, line, "-"))
+                                    theme.DANGER
+                                else
+                                    theme.TEXT_SOFT;
+                                const line_bg = if (std.mem.startsWith(u8, line, "+"))
+                                    theme.rgb(0x1d2617)
+                                else if (std.mem.startsWith(u8, line, "-"))
+                                    theme.rgb(0x2a1b18)
+                                else
+                                    theme.PANEL;
+                                w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
+                                kv_row += 1;
+                            }
+                        } else {
+                            w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
                         }
                     } else {
-                        // Show prompt body (no override)
+                        // Show prompt body
                         var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
                         while (line_iter.next()) |line| {
                             if (kv_row >= max_row) break;
@@ -2462,9 +2484,7 @@ pub const Dashboard = struct {
                 };
                 self.library_table_cols[row_idx] = .{
                     .{ .text = name, .flex = 1 },
-                    .{ .text = pr_label, .flex = 0, .min_width = 2 },
-                    .{ .text = p.refer_count, .flex = 0, .min_width = 4, .alignment = .right },
-                    .{ .text = p.age, .flex = 0, .min_width = 3, .alignment = .right },
+                    .{ .text = pr_label, .flex = 0, .min_width = 2, .alignment = .right },
                 };
                 self.library_table_rows[row_idx] = .{
                     .columns = &self.library_table_cols[row_idx],
@@ -2634,7 +2654,6 @@ pub const Dashboard = struct {
     fn contextHint(self: *const Dashboard) []const u8 {
         if (self.show_help) return "Keyboard reference overlay.";
         if (self.show_detail) return switch (self.detail_tab) {
-            .overview => "Prompt metadata, usage summary, and local edit status.",
             .content => "Full prompt body. j/k to scroll.",
             .pull_requests => if (self.show_pr_diff) "PR diff view. j/k scroll, a/x/c actions." else "j/k move  f filter  Enter view  c comment  Esc back",
         };

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -745,6 +745,16 @@ pub const Dashboard = struct {
                                 }
                                 if (key.matches(vaxis.Key.enter, .{})) {
                                     self.ws_focus = .list;
+                                    // Trigger workspace detail fetch
+                                    self.api_state.mutex.lock();
+                                    const ws_list = if (self.api_state.current_user) |u| u.workspaces else &.{};
+                                    if (self.ws_sel < ws_list.len) {
+                                        const ws_id = ws_list[self.ws_sel].ws_id;
+                                        self.api_state.mutex.unlock();
+                                        api.fetchWorkspaceAsync(self.api_state, ws_id);
+                                    } else {
+                                        self.api_state.mutex.unlock();
+                                    }
                                     ctx.consumeAndRedraw();
                                 }
                             },
@@ -1537,63 +1547,119 @@ pub const Dashboard = struct {
 
         const inner_h = ctx.max.height.? -| 2;
 
+        // Check for live workspace detail
+        self.api_state.mutex.lock();
+        const live_ws = self.api_state.ws_detail;
+        self.api_state.mutex.unlock();
+
         switch (self.ws_tab) {
             .context => {
                 var kv_row: u16 = 2;
                 var last_prefix: []const u8 = "";
-                for (data.WS_CONTEXT, 0..) |f, i| {
-                    if (kv_row >= inner_h + 2) break;
-                    const prefix = data.pathPrefix(f.path);
-                    if (!std.mem.eql(u8, prefix, last_prefix)) {
-                        w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
-                        kv_row += 1;
-                        last_prefix = prefix;
+                if (live_ws) |ws_d| {
+                    for (ws_d.context_files, 0..) |f, i| {
                         if (kv_row >= inner_h + 2) break;
+                        const prefix = data.pathPrefix(f.path);
+                        if (!std.mem.eql(u8, prefix, last_prefix)) {
+                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                            kv_row += 1;
+                            last_prefix = prefix;
+                            if (kv_row >= inner_h + 2) break;
+                        }
+                        const sel = i == self.ws_list_sel;
+                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                        if (sel) {
+                            surface.writeCell(1, kv_row, .{
+                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                            });
+                        }
+                        w.writeText(&surface, ctx, 2, kv_row, data.promptName(f.path), name_style);
+                        kv_row += 1;
                     }
-                    const sel = i == self.ws_list_sel;
-                    const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                    if (sel) {
-                        surface.writeCell(1, kv_row, .{
-                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                        });
+                } else {
+                    for (data.WS_CONTEXT, 0..) |f, i| {
+                        if (kv_row >= inner_h + 2) break;
+                        const prefix = data.pathPrefix(f.path);
+                        if (!std.mem.eql(u8, prefix, last_prefix)) {
+                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                            kv_row += 1;
+                            last_prefix = prefix;
+                            if (kv_row >= inner_h + 2) break;
+                        }
+                        const sel = i == self.ws_list_sel;
+                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                        if (sel) {
+                            surface.writeCell(1, kv_row, .{
+                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                            });
+                        }
+                        const fname = data.promptName(f.path);
+                        w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
+                        if (f.modified) {
+                            const nw: u16 = @intCast(ctx.stringWidth(fname));
+                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
+                        }
+                        kv_row += 1;
                     }
-                    const fname = data.promptName(f.path);
-                    w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
-                    if (f.modified) {
-                        const nw: u16 = @intCast(ctx.stringWidth(fname));
-                        w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                    }
-                    kv_row += 1;
                 }
             },
             .prompts => {
                 var kv_row: u16 = 2;
                 var last_prefix: []const u8 = "";
-                for (data.WS_PROMPTS, 0..) |p, i| {
-                    if (kv_row >= inner_h + 2) break;
-                    const prefix = data.pathPrefix(p.name);
-                    if (!std.mem.eql(u8, prefix, last_prefix)) {
-                        w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
-                        kv_row += 1;
-                        last_prefix = prefix;
+                if (live_ws) |ws_d| {
+                    // Live: cross-ref prompt_id with library for canonical_name
+                    const lib_prompts = self.getPrompts();
+                    for (ws_d.ws_prompts, 0..) |wp, i| {
                         if (kv_row >= inner_h + 2) break;
+                        const name = for (lib_prompts) |lp| {
+                            if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.canonical_name;
+                        } else wp.prompt_id;
+                        const prefix = data.pathPrefix(name);
+                        if (!std.mem.eql(u8, prefix, last_prefix)) {
+                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                            kv_row += 1;
+                            last_prefix = prefix;
+                            if (kv_row >= inner_h + 2) break;
+                        }
+                        const sel = i == self.ws_list_sel;
+                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                        if (sel) {
+                            surface.writeCell(1, kv_row, .{
+                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                            });
+                        }
+                        w.writeText(&surface, ctx, 2, kv_row, data.promptName(name), name_style);
+                        kv_row += 1;
                     }
-                    const sel = i == self.ws_list_sel;
-                    const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                    if (sel) {
-                        surface.writeCell(1, kv_row, .{
-                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                        });
+                } else {
+                    for (data.WS_PROMPTS, 0..) |p, i| {
+                        if (kv_row >= inner_h + 2) break;
+                        const prefix = data.pathPrefix(p.name);
+                        if (!std.mem.eql(u8, prefix, last_prefix)) {
+                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                            kv_row += 1;
+                            last_prefix = prefix;
+                            if (kv_row >= inner_h + 2) break;
+                        }
+                        const sel = i == self.ws_list_sel;
+                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                        if (sel) {
+                            surface.writeCell(1, kv_row, .{
+                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                            });
+                        }
+                        const fname = data.promptName(p.name);
+                        w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
+                        if (p.has_override) {
+                            const nw: u16 = @intCast(ctx.stringWidth(fname));
+                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
+                        }
+                        kv_row += 1;
                     }
-                    const fname = data.promptName(p.name);
-                    w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
-                    if (p.has_override) {
-                        const nw: u16 = @intCast(ctx.stringWidth(fname));
-                        w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                    }
-                    kv_row += 1;
                 }
             },
         }
@@ -2600,13 +2666,26 @@ pub const Dashboard = struct {
     }
 
     fn syncContentWidget(self: *Dashboard) void {
+        // Use live prompt content if available, else mock
+        const content: []const u8 = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.prompt_content) |c| break :blk c;
+            break :blk data.SAMPLE_CONTENT;
+        };
         self.content_text = .{
-            .text = data.SAMPLE_CONTENT,
+            .text = content,
             .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
         };
         self.content_widget[0] = self.content_text.widget();
         self.content_scroll_bars.scroll_view.children = .{ .slice = self.content_widget[0..1] };
-        self.content_scroll_bars.estimated_content_height = @intCast(@max(w.countLines(data.SAMPLE_CONTENT), 24));
+        self.content_scroll_bars.estimated_content_height = @intCast(@max(w.countLines(content), 24));
+
+        // Trigger fetch for the selected prompt content
+        const prompts = self.getPrompts();
+        if (self.selected_prompt < prompts.len) {
+            api.fetchPromptContentAsync(self.api_state, prompts[self.selected_prompt].canonical_name);
+        }
     }
 
     fn syncPrWidgets(self: *Dashboard) void {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -69,17 +69,37 @@ const ConfirmAction = enum {
 };
 
 const TopModule = enum(u8) {
-    library,
-    workspace,
-    proposals,
     insights,
+    workspace,
+    library,
 
     fn label(self: TopModule) []const u8 {
         return switch (self) {
-            .library => "Library",
-            .workspace => "Workspace",
-            .proposals => "Proposals",
             .insights => "Insights",
+            .workspace => "Workspace",
+            .library => "Library",
+        };
+    }
+};
+
+const PrFilter = enum {
+    open,
+    all,
+    closed,
+
+    fn label(self: PrFilter) []const u8 {
+        return switch (self) {
+            .open => "open",
+            .all => "all",
+            .closed => "closed",
+        };
+    }
+
+    fn next(self: PrFilter) PrFilter {
+        return switch (self) {
+            .open => .all,
+            .all => .closed,
+            .closed => .open,
         };
     }
 };
@@ -87,25 +107,25 @@ const TopModule = enum(u8) {
 const DetailTab = enum(u8) {
     overview,
     content,
-    history,
+    pull_requests,
 
     fn label(self: DetailTab) []const u8 {
         return switch (self) {
             .overview => "Overview",
             .content => "Content",
-            .history => "History",
+            .pull_requests => "Pull Requests",
         };
     }
 };
 
-const top_tabs = [_]TopModule{ .library, .workspace, .proposals, .insights };
+const top_tabs = [_]TopModule{ .insights, .workspace, .library };
 
 // 12 prompts + up to 12 group headers = 24 max rows
 const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
-const detail_tabs = [_]DetailTab{ .overview, .content, .history };
+const detail_tabs = [_]DetailTab{ .overview, .content, .pull_requests };
 
 pub const Dashboard = struct {
-    selected_module: TopModule = .library,
+    selected_module: TopModule = .insights,
     selected_prompt: usize = 0,
     show_help: bool = false,
     show_detail: bool = false,
@@ -129,26 +149,32 @@ pub const Dashboard = struct {
     library_widgets: [MAX_LIBRARY_ROWS]vxfw.Widget = undefined,
     library_text_rows: [MAX_LIBRARY_ROWS]vxfw.Text = undefined,
     library_table_rows: [MAX_LIBRARY_ROWS]TableRow = undefined,
-    library_table_cols: [MAX_LIBRARY_ROWS][3]Column = undefined,
+    library_table_cols: [MAX_LIBRARY_ROWS][4]Column = undefined,
 
     content_scroll_bars: vxfw.ScrollBars,
     content_widget: [1]vxfw.Widget = undefined,
     content_text: vxfw.Text = .{ .text = "" },
 
-    history_scroll_bars: vxfw.ScrollBars,
-    history_widgets: [data.HISTORY.len]vxfw.Widget = undefined,
-    history_rows: [data.HISTORY.len]TableRow = undefined,
-    history_cols: [data.HISTORY.len][3]Column = undefined,
-
-    review_scroll_bars: vxfw.ScrollBars,
-    review_widgets: [data.PROPOSALS.len]vxfw.Widget = undefined,
-    review_rows: [data.PROPOSALS.len]TableRow = undefined,
-    review_cols: [data.PROPOSALS.len][2]Column = undefined,
-
-    review_diff_scroll_bars: vxfw.ScrollBars,
-    review_diff_widgets: [8]vxfw.Widget = undefined,
-    review_diff_rows: [8]vxfw.Text = undefined,
-    review_diff_count: usize = 0,
+    // PR list within Prompt Detail
+    pr_filter: PrFilter = .open,
+    pr_scroll_bars: vxfw.ScrollBars,
+    pr_widgets: [data.PULL_REQUESTS.len * 2]vxfw.Widget = undefined,
+    pr_table_rows: [data.PULL_REQUESTS.len]TableRow = undefined,
+    pr_table_cols: [data.PULL_REQUESTS.len][4]Column = undefined,
+    pr_text_rows: [data.PULL_REQUESTS.len]vxfw.Text = undefined,
+    pr_indices: [data.PULL_REQUESTS.len * 2]?usize = .{null} ** (data.PULL_REQUESTS.len * 2),
+    pr_row_count: usize = 0,
+    // PR drill-down state
+    show_pr_diff: bool = false,
+    selected_pr_idx: usize = 0,
+    pr_diff_scroll_bars: vxfw.ScrollBars,
+    pr_diff_widgets: [32]vxfw.Widget = undefined,
+    pr_diff_rows: [32]vxfw.Text = undefined,
+    pr_diff_count: usize = 0,
+    // Comment editor state
+    show_comment_editor: bool = false,
+    comment_input_buf: [256]u8 = .{0} ** 256,
+    comment_input_len: usize = 0,
 
     // Workspace Status
     ws_tab: WsTab = .context,
@@ -172,9 +198,8 @@ pub const Dashboard = struct {
         return .{
             .library_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .content_scroll_bars = w.initPlainScrollBars(theme.PANEL, 3),
-            .history_scroll_bars = w.initCursorScrollBars(theme.PANEL),
-            .review_scroll_bars = w.initCursorScrollBars(theme.PANEL),
-            .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
+            .pr_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .pr_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
             // workspace uses manual grid, no ScrollBars
         };
     }
@@ -233,6 +258,33 @@ pub const Dashboard = struct {
                     if (key.matches(vaxis.Key.escape, .{}) or key.matches('?', .{}) or key.matches('q', .{})) {
                         self.show_help = false;
                         ctx.consumeAndRedraw();
+                    }
+                    return;
+                }
+
+                // Comment editor absorbs all keys
+                if (self.show_comment_editor) {
+                    if (key.matches(vaxis.Key.escape, .{})) {
+                        self.show_comment_editor = false;
+                        self.comment_input_len = 0;
+                        ctx.consumeAndRedraw();
+                    } else if (key.matches(vaxis.Key.enter, .{})) {
+                        self.status_line = if (self.comment_input_len > 0) "Comment submitted." else "Empty comment discarded.";
+                        self.show_comment_editor = false;
+                        self.comment_input_len = 0;
+                        ctx.consumeAndRedraw();
+                    } else if (key.matches(vaxis.Key.backspace, .{})) {
+                        if (self.comment_input_len > 0) {
+                            self.comment_input_len -= 1;
+                            ctx.consumeAndRedraw();
+                        }
+                    } else if (key.text) |text| {
+                        const remaining = self.comment_input_buf.len - self.comment_input_len;
+                        if (text.len > 0 and text.len <= remaining) {
+                            @memcpy(self.comment_input_buf[self.comment_input_len .. self.comment_input_len + text.len], text);
+                            self.comment_input_len += text.len;
+                            ctx.consumeAndRedraw();
+                        }
                     }
                     return;
                 }
@@ -426,7 +478,7 @@ pub const Dashboard = struct {
                         return;
                     }
                     if (key.matches('p', .{})) {
-                        self.status_line = "Propose (not yet implemented)";
+                        self.status_line = "Create PR (not yet implemented)";
                         ctx.consumeAndRedraw();
                         return;
                     }
@@ -434,7 +486,35 @@ pub const Dashboard = struct {
                         // Content pane has focus: j/k scrolls content
                         try self.content_scroll_bars.scroll_view.handleEvent(ctx, event);
                     } else {
-                        // Info pane has focus: h/l switches tabs, j/k for history
+                        // Info pane has focus: h/l switches tabs, j/k for PRs
+                        if (self.detail_tab == .pull_requests and self.show_pr_diff) {
+                            // PR diff drill-down: Esc goes back, j/k scrolls diff
+                            if (key.matches(vaxis.Key.escape, .{})) {
+                                self.show_pr_diff = false;
+                                self.show_comment_editor = false;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('a', .{})) {
+                                self.status_line = "Accept PR (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('x', .{})) {
+                                self.status_line = "Reject PR (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('c', .{})) {
+                                self.show_comment_editor = true;
+                                self.comment_input_len = 0;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (self.pr_diff_count == 0) return;
+                            try self.pr_diff_scroll_bars.scroll_view.handleEvent(ctx, event);
+                            return;
+                        }
                         if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
                             self.shiftDetailTab(-1);
                             ctx.consumeAndRedraw();
@@ -445,18 +525,53 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        if (self.detail_tab == .history) {
-                            try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        if (self.detail_tab == .pull_requests) {
+                            if (key.matches('f', .{})) {
+                                self.pr_filter = self.pr_filter.next();
+                                self.pr_scroll_bars.scroll_view.cursor = 0;
+                                self.selected_pr_idx = 0;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches(vaxis.Key.enter, .{})) {
+                                self.show_pr_diff = true;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            self.syncPrWidgets();
+                            if (self.pr_row_count == 0) return;
+
+                            const prev = self.pr_scroll_bars.scroll_view.cursor;
+                            try self.pr_scroll_bars.scroll_view.handleEvent(ctx, event);
+
+                            var pos = @as(usize, @intCast(self.pr_scroll_bars.scroll_view.cursor));
+                            if (pos >= self.pr_row_count) pos = if (self.pr_row_count > 0) self.pr_row_count - 1 else 0;
+
+                            // Skip description rows (null index). Try next row, if still null revert.
+                            if (pos < self.pr_row_count and self.pr_indices[pos] == null) {
+                                const moving_down = self.pr_scroll_bars.scroll_view.cursor > prev;
+                                if (moving_down and pos + 1 < self.pr_row_count and self.pr_indices[pos + 1] != null) {
+                                    pos += 1;
+                                } else {
+                                    // Can't skip forward, revert to prev
+                                    pos = @intCast(prev);
+                                }
+                            }
+                            self.pr_scroll_bars.scroll_view.cursor = @intCast(pos);
+                            if (pos < self.pr_row_count) {
+                                if (self.pr_indices[pos]) |pi| {
+                                    self.selected_pr_idx = pi;
+                                }
+                            }
                         }
                     }
                     return;
                 }
 
                 // Top-level tab switching
-                if (key.matches('1', .{})) return self.selectTab(ctx, .library);
+                if (key.matches('1', .{})) return self.selectTab(ctx, .insights);
                 if (key.matches('2', .{})) return self.selectTab(ctx, .workspace);
-                if (key.matches('3', .{})) return self.selectTab(ctx, .proposals);
-                if (key.matches('4', .{})) return self.selectTab(ctx, .insights);
+                if (key.matches('3', .{})) return self.selectTab(ctx, .library);
 
                 // Module-specific input
                 switch (self.selected_module) {
@@ -481,6 +596,33 @@ pub const Dashboard = struct {
                         }
                         if (self.detail_focus_content) {
                             // Detail pane has focus
+                            if (self.detail_tab == .pull_requests and self.show_pr_diff) {
+                                if (key.matches(vaxis.Key.escape, .{})) {
+                                    self.show_pr_diff = false;
+                                    self.show_comment_editor = false;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('a', .{})) {
+                                    self.status_line = "Accept PR (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('x', .{})) {
+                                    self.status_line = "Reject PR (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('c', .{})) {
+                                    self.show_comment_editor = true;
+                                    self.comment_input_len = 0;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (self.pr_diff_count == 0) return;
+                                try self.pr_diff_scroll_bars.scroll_view.handleEvent(ctx, event);
+                                return;
+                            }
                             if (key.matches(vaxis.Key.escape, .{})) {
                                 self.detail_focus_content = false;
                                 ctx.consumeAndRedraw();
@@ -499,8 +641,46 @@ pub const Dashboard = struct {
                             if (self.detail_tab == .content) {
                                 try self.content_scroll_bars.scroll_view.handleEvent(ctx, event);
                             }
-                            if (self.detail_tab == .history) {
-                                try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
+                            if (self.detail_tab == .pull_requests) {
+                                if (key.matches('f', .{})) {
+                                    self.pr_filter = self.pr_filter.next();
+                                    self.pr_scroll_bars.scroll_view.cursor = 0;
+                                    self.selected_pr_idx = 0;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.enter, .{})) {
+                                    self.show_pr_diff = true;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                self.syncPrWidgets();
+                                if (self.pr_row_count == 0) return;
+
+                                const prev = self.pr_scroll_bars.scroll_view.cursor;
+                                try self.pr_scroll_bars.scroll_view.handleEvent(ctx, event);
+
+                                var pos = @as(usize, @intCast(self.pr_scroll_bars.scroll_view.cursor));
+                                if (pos >= self.pr_row_count) pos = if (self.pr_row_count > 0) self.pr_row_count - 1 else 0;
+
+                                // Skip description rows (null index). Try next row, if still null revert.
+                                if (pos < self.pr_row_count and self.pr_indices[pos] == null) {
+                                    const moving_down = self.pr_scroll_bars.scroll_view.cursor > prev;
+                                    if (moving_down and pos + 1 < self.pr_row_count and self.pr_indices[pos + 1] != null) {
+                                        pos += 1;
+                                    } else {
+                                        pos = @intCast(prev);
+                                    }
+                                }
+                                self.pr_scroll_bars.scroll_view.cursor = @intCast(pos);
+                                if (pos < self.pr_row_count) {
+                                    if (self.pr_indices[pos]) |pi| {
+                                        self.selected_pr_idx = pi;
+                                    }
+                                }
+                                if (self.pr_indices[pos]) |pi| {
+                                    self.selected_pr_idx = pi;
+                                }
                             }
                             return;
                         }
@@ -524,22 +704,14 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                         }
                         if (self.library_prompt_indices[pos]) |pi| {
-                            self.selected_prompt = pi;
-                        }
-                    },
-                    .proposals => {
-                        const prev = self.review_scroll_bars.scroll_view.cursor;
-                        try self.review_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        if (self.review_scroll_bars.scroll_view.cursor != prev) {
-                            self.status_line = "Proposal selected.";
-                        }
-                        if (key.matches('a', .{})) {
-                            self.status_line = "Accept proposal (not yet implemented)";
-                            ctx.consumeAndRedraw();
-                        }
-                        if (key.matches('x', .{})) {
-                            self.status_line = "Reject proposal (not yet implemented)";
-                            ctx.consumeAndRedraw();
+                            if (self.selected_prompt != pi) {
+                                self.selected_prompt = pi;
+                                self.show_pr_diff = false;
+                                self.show_comment_editor = false;
+                                self.selected_pr_idx = 0;
+                                self.pr_scroll_bars.scroll_view.cursor = 0;
+                                self.pr_filter = .open;
+                            }
                         }
                     },
                     .workspace => {
@@ -781,7 +953,7 @@ pub const Dashboard = struct {
         );
 
         var child_count: usize = 3;
-        if (self.show_help or self.show_confirm) child_count = 4;
+        if (self.show_help or self.show_confirm or self.show_comment_editor) child_count = 4;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
@@ -801,6 +973,17 @@ pub const Dashboard = struct {
                 .{ .width = size.width, .height = size.height },
             );
             children[3] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawConfirmOverlay(confirm_ctx) };
+        }
+        if (self.show_comment_editor) {
+            const box_w: u16 = 42;
+            const box_h: u16 = 8;
+            const box_col = size.width -| (box_w + 2);
+            const box_row = size.height -| (box_h + 2);
+            const comment_ctx = ctx.withConstraints(
+                .{ .width = box_w, .height = box_h },
+                .{ .width = box_w, .height = box_h },
+            );
+            children[3] = .{ .origin = .{ .row = box_row, .col = box_col }, .surface = try self.drawCommentEditorOverlay(comment_ctx) };
         }
 
         root.children = children;
@@ -841,7 +1024,6 @@ pub const Dashboard = struct {
         if (self.show_detail) return self.drawPromptDetail(ctx);
         return switch (self.selected_module) {
             .library => self.drawLibrary(ctx),
-            .proposals => self.drawProposalReview(ctx),
             .workspace => self.drawWorkspaceStatus(ctx),
             .insights => self.drawInsights(ctx),
         };
@@ -867,13 +1049,25 @@ pub const Dashboard = struct {
             "j/k move  r refresh  x revoke  h back  q close"
         else if (self.show_settings)
             "j/k move  h back  q close"
+        else if (self.show_comment_editor)
+            "Enter send  Esc cancel"
+        else if (self.show_detail and self.detail_tab == .pull_requests and self.show_pr_diff)
+            "j/k scroll  a accept  x reject  c comment  Esc back"
+        else if (self.show_detail and self.detail_tab == .pull_requests)
+            "j/k move  Enter view diff  h/l tab  Esc back  ? help"
         else if (self.show_detail and self.detail_focus_content)
             "j/k scroll  g/G jump  Tab info pane  Esc back  ? help"
         else if (self.show_detail)
-            "h/l tab  j/k move  Tab content pane  p propose  Esc back  ? help"
+            "h/l tab  j/k move  Tab content pane  p create PR  Esc back  ? help"
         else switch (self.selected_module) {
-            .library => if (self.detail_focus_content) "h/l tab  j/k scroll  Esc list  ? help" else "j/k move  Enter detail  b bundle  S settings  ? help  q quit",
-            .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
+            .library => if (self.detail_focus_content and self.detail_tab == .pull_requests and self.show_pr_diff)
+                "j/k scroll  a accept  x reject  c comment  Esc back"
+            else if (self.detail_focus_content and self.detail_tab == .pull_requests)
+                "j/k move  Enter view diff  Esc back  ? help"
+            else if (self.detail_focus_content)
+                "h/l tab  j/k scroll  Esc list  ? help"
+            else
+                "j/k move  Enter detail  b bundle  S settings  ? help  q quit",
             .workspace => switch (self.ws_focus) {
                 .bar => "j/k select workspace  Tab list  r sync  ? help  q quit",
                 .list => "h/l tab  j/k move  Enter content  Esc bar  ? help",
@@ -946,7 +1140,7 @@ pub const Dashboard = struct {
         return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view);
     }
 
-    // Library right pane: detail for selected prompt with Overview/Content/History tabs.
+    // Library right pane: detail for selected prompt with Overview/Content/Pull Requests tabs.
     fn drawLibraryDetail(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         const border_color = if (self.detail_focus_content) theme.ACCENT else theme.BORDER;
@@ -959,7 +1153,11 @@ pub const Dashboard = struct {
             tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, tab.label(), tab == self.detail_tab);
             tab_col +|= 1;
         }
-        w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
+        if (self.detail_tab == .pull_requests) {
+            w.writeRightText(&surface, ctx, 0, "f filter", theme.textOn(theme.PANEL, theme.MUTED));
+        } else {
+            w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
+        }
 
         const inner_h = ctx.max.height.? -| 2;
         const inner_w = ctx.max.width.? -| 4;
@@ -974,7 +1172,7 @@ pub const Dashboard = struct {
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "override", "local (payments-api)", 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "local edit", "yes (payments-api)", 8);
                 kv_row += 1;
                 kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
                 const top_n = @min(p.constraint_count, 3);
@@ -994,31 +1192,50 @@ pub const Dashboard = struct {
                 children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
-            .history => {
-                self.syncHistoryWidgets();
-                const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
-                self.history_scroll_bars.scroll_view.draw_cursor = false;
-                defer self.history_scroll_bars.scroll_view.draw_cursor = true;
+            .pull_requests => {
+                const prs = data.prsForPrompt(p.canonical_name);
+                if (prs.len == 0) {
+                    w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
+                } else if (self.show_pr_diff) {
+                    // Diff drill-down view
+                    const pr_idx = @min(self.selected_pr_idx, prs.len - 1);
+                    const pr = &prs[pr_idx];
+                    const title = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 refer:{d}", .{ pr.id, pr.prompt_name, pr.author, pr.status, pr.trace_refers });
+                    w.writeText(&surface, ctx, 2, 2, title, theme.boldOn(theme.PANEL, theme.TEXT));
 
-                var list_surface = try self.history_scroll_bars.widget().draw(list_ctx);
-                const sv = &self.history_scroll_bars.scroll_view;
-                if (sv.cursor >= sv.scroll.top) {
-                    const vis_row = sv.cursor - sv.scroll.top;
-                    const crow: i17 = @intCast(vis_row);
-                    if (crow < list_surface.size.height) {
-                        const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
-                        cbuf[0] = .{ .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 }, .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL } };
-                        const csurface: vxfw.Surface = .{ .size = .{ .width = 1, .height = 1 }, .widget = list_surface.widget, .buffer = cbuf, .children = &.{} };
-                        const old = list_surface.children;
-                        const new_ch = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
-                        @memcpy(new_ch[0..old.len], old);
-                        new_ch[old.len] = .{ .origin = .{ .col = 0, .row = crow }, .surface = csurface, .z_index = 1 };
-                        list_surface.children = new_ch;
+                    self.syncPrDiffAndComments(ctx.arena);
+                    const diff_h = inner_h -| 2;
+                    const diff_ctx = ctx.withConstraints(.{ .width = inner_w, .height = diff_h }, .{ .width = inner_w, .height = diff_h });
+                    const diff_children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                    diff_children[0] = .{ .origin = .{ .row = 4, .col = 2 }, .surface = try self.pr_diff_scroll_bars.widget().draw(diff_ctx) };
+                    surface.children = diff_children;
+                } else {
+                    // PR list view
+                    self.syncPrWidgets();
+                    const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                    self.pr_scroll_bars.scroll_view.draw_cursor = false;
+                    defer self.pr_scroll_bars.scroll_view.draw_cursor = true;
+
+                    var list_surface = try self.pr_scroll_bars.widget().draw(list_ctx);
+                    const sv = &self.pr_scroll_bars.scroll_view;
+                    if (sv.cursor >= sv.scroll.top) {
+                        const vis_row = sv.cursor - sv.scroll.top;
+                        const crow: i17 = @intCast(vis_row);
+                        if (crow < list_surface.size.height) {
+                            const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
+                            cbuf[0] = .{ .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 }, .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL } };
+                            const csurface: vxfw.Surface = .{ .size = .{ .width = 1, .height = 1 }, .widget = list_surface.widget, .buffer = cbuf, .children = &.{} };
+                            const old = list_surface.children;
+                            const new_ch = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
+                            @memcpy(new_ch[0..old.len], old);
+                            new_ch[old.len] = .{ .origin = .{ .col = 0, .row = crow }, .surface = csurface, .z_index = 1 };
+                            list_surface.children = new_ch;
+                        }
                     }
+                    const pr_children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                    pr_children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
+                    surface.children = pr_children;
                 }
-                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
-                surface.children = children;
             },
         }
         return surface;
@@ -1051,11 +1268,14 @@ pub const Dashboard = struct {
         const info_border = if (!self.detail_focus_content) theme.ACCENT else theme.BORDER;
         w.drawBorder(&surface, info_border, theme.PANEL);
 
-        // Row 0: inner tabs
+        // Row 0: inner tabs + right hint
         var col: u16 = 2;
         for (detail_tabs) |tab| {
             col = w.drawInnerTabBadge(&surface, ctx, 0, col, tab.label(), tab == self.detail_tab);
             col +|= 1;
+        }
+        if (self.detail_tab == .pull_requests) {
+            w.writeRightText(&surface, ctx, 0, "f filter", theme.textOn(theme.PANEL, theme.MUTED));
         }
 
         const inner_h = ctx.max.height.? -| 3;
@@ -1068,7 +1288,7 @@ pub const Dashboard = struct {
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "override", "local (payments-api)", 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "local edit", "yes (payments-api)", 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
                 kv_row += 1;
                 kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
@@ -1086,10 +1306,10 @@ pub const Dashboard = struct {
                     kv_row += 1;
                 }
                 kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Override");
+                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Edit");
                 w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api", theme.fg(theme.TEXT_SOFT));
                 kv_row += 1;
-                w.writeText(&surface, ctx, kv_col, kv_row, "Press p to propose this override", theme.fg(theme.MUTED));
+                w.writeText(&surface, ctx, kv_col, kv_row, "Press p to create PR from this edit", theme.fg(theme.MUTED));
             },
             .content => {
                 self.syncContentWidget();
@@ -1098,45 +1318,60 @@ pub const Dashboard = struct {
                 children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
-            .history => {
-                self.syncHistoryWidgets();
-                const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+            .pull_requests => {
+                const prs = data.prsForPrompt(p.canonical_name);
+                if (prs.len == 0) {
+                    w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
+                } else if (self.show_pr_diff) {
+                    const pr_idx = @min(self.selected_pr_idx, prs.len - 1);
+                    const pr = &prs[pr_idx];
+                    const title = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 refer:{d}", .{ pr.id, pr.prompt_name, pr.author, pr.status, pr.trace_refers });
+                    w.writeText(&surface, ctx, 2, 2, title, theme.boldOn(theme.PANEL, theme.TEXT));
 
-                self.history_scroll_bars.scroll_view.draw_cursor = false;
-                defer self.history_scroll_bars.scroll_view.draw_cursor = true;
+                    self.syncPrDiffAndComments(ctx.arena);
+                    const diff_h = inner_h -| 2;
+                    const diff_ctx = ctx.withConstraints(.{ .width = inner_w, .height = diff_h }, .{ .width = inner_w, .height = diff_h });
+                    const diff_children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                    diff_children[0] = .{ .origin = .{ .row = 4, .col = 2 }, .surface = try self.pr_diff_scroll_bars.widget().draw(diff_ctx) };
+                    surface.children = diff_children;
+                } else {
+                    self.syncPrWidgets();
+                    const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                    self.pr_scroll_bars.scroll_view.draw_cursor = false;
+                    defer self.pr_scroll_bars.scroll_view.draw_cursor = true;
 
-                var list_surface = try self.history_scroll_bars.widget().draw(list_ctx);
-                const sv = &self.history_scroll_bars.scroll_view;
-                if (sv.cursor >= sv.scroll.top) {
-                    const vis_row = sv.cursor - sv.scroll.top;
-                    const crow: i17 = @intCast(vis_row);
-                    if (crow < list_surface.size.height) {
-                        const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
-                        cbuf[0] = .{
-                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                        };
-                        const csurface: vxfw.Surface = .{
-                            .size = .{ .width = 1, .height = 1 },
-                            .widget = list_surface.widget,
-                            .buffer = cbuf,
-                            .children = &.{},
-                        };
-                        const old = list_surface.children;
-                        const new_children = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
-                        @memcpy(new_children[0..old.len], old);
-                        new_children[old.len] = .{
-                            .origin = .{ .col = 0, .row = crow },
-                            .surface = csurface,
-                            .z_index = 1,
-                        };
-                        list_surface.children = new_children;
+                    var list_surface = try self.pr_scroll_bars.widget().draw(list_ctx);
+                    const sv = &self.pr_scroll_bars.scroll_view;
+                    if (sv.cursor >= sv.scroll.top) {
+                        const vis_row = sv.cursor - sv.scroll.top;
+                        const crow: i17 = @intCast(vis_row);
+                        if (crow < list_surface.size.height) {
+                            const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
+                            cbuf[0] = .{
+                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                            };
+                            const csurface: vxfw.Surface = .{
+                                .size = .{ .width = 1, .height = 1 },
+                                .widget = list_surface.widget,
+                                .buffer = cbuf,
+                                .children = &.{},
+                            };
+                            const old = list_surface.children;
+                            const new_ch = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
+                            @memcpy(new_ch[0..old.len], old);
+                            new_ch[old.len] = .{
+                                .origin = .{ .col = 0, .row = crow },
+                                .surface = csurface,
+                                .z_index = 1,
+                            };
+                            list_surface.children = new_ch;
+                        }
                     }
+                    const pr_children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                    pr_children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
+                    surface.children = pr_children;
                 }
-
-                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
-                surface.children = children;
             },
         }
 
@@ -1163,76 +1398,6 @@ pub const Dashboard = struct {
         children[0] = .{ .origin = .{ .row = 1, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
         surface.children = children;
         return surface;
-    }
-
-    // Proposal Review: queue + diff + sidebar (three-column)
-    fn drawProposalReview(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const size = ctx.max.size();
-        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.PANEL);
-
-        self.syncReviewWidgets();
-        const proposal = &data.PROPOSALS[self.selectedProposalIdx()];
-        self.syncDiffWidgets(proposal);
-
-        const queue_w: u16 = if (size.width > 112) 28 else 24;
-        const side_w: u16 = if (size.width > 112) 28 else 24;
-        const diff_w: u16 = size.width - queue_w - side_w - 2;
-
-        const q_ctx = ctx.withConstraints(.{ .width = queue_w, .height = size.height }, .{ .width = queue_w, .height = size.height });
-        const d_ctx = ctx.withConstraints(.{ .width = diff_w, .height = size.height }, .{ .width = diff_w, .height = size.height });
-        const s_ctx = ctx.withConstraints(.{ .width = side_w, .height = size.height }, .{ .width = side_w, .height = size.height });
-
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawReviewQueue(q_ctx) };
-        children[1] = .{ .origin = .{ .row = 0, .col = queue_w + 1 }, .surface = try self.drawReviewDiff(d_ctx, proposal) };
-        children[2] = .{ .origin = .{ .row = 0, .col = queue_w + diff_w + 2 }, .surface = try self.drawReviewSidebar(s_ctx, proposal) };
-        root.children = children;
-        return root;
-    }
-
-    fn drawReviewQueue(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        self.review_scroll_bars.scroll_view.draw_cursor = false;
-        defer self.review_scroll_bars.scroll_view.draw_cursor = true;
-
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Proposal Queue", .subtitle = "status: open", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.review_scroll_bars.widget() };
-        var surface = try panel.draw(ctx);
-        return w.applyCursorOverlay(ctx, &surface, &self.review_scroll_bars.scroll_view);
-    }
-
-    fn drawReviewDiff(self: *Dashboard, ctx: vxfw.DrawContext, proposal: *const data.ProposalEntry) std.mem.Allocator.Error!vxfw.Surface {
-        const panel: w.Panel = .{ .owner = self.widget(), .title = proposal.prompt_name, .subtitle = proposal.id, .background = theme.PANEL, .border_color = theme.BORDER, .child = self.review_diff_scroll_bars.widget() };
-        return panel.draw(ctx);
-    }
-
-    fn drawReviewSidebar(self: *Dashboard, ctx: vxfw.DrawContext, proposal: *const data.ProposalEntry) std.mem.Allocator.Error!vxfw.Surface {
-        const sidebar = try std.fmt.allocPrint(ctx.arena,
-            \\Status
-            \\{s}
-            \\
-            \\Author
-            \\{s}
-            \\
-            \\Created
-            \\{s}
-            \\
-            \\Base Hash
-            \\{s}
-            \\
-            \\Trace Summary
-            \\refer {d}   sessions {d}
-            \\
-            \\Actions
-            \\a  accept (maintainer only)
-            \\x  reject (maintainer only)
-            \\c  comment (Phase 2)
-        , .{ proposal.status, proposal.author, proposal.created, proposal.base_hash, proposal.trace_refers, proposal.trace_sessions });
-
-        const text_widget: vxfw.Text = .{ .text = sidebar, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Review Lens", .subtitle = proposal.author, .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
     }
 
     // Workspace: top workspace bar + bottom master-detail (list | content).
@@ -1314,7 +1479,7 @@ pub const Dashboard = struct {
     }
 
     fn drawWsList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        // Context/Prompts/Overrides item list with inner tabs
+        // Context/Prompts/Local Edits item list with inner tabs
         const list_border = if (self.ws_focus == .list) theme.ACCENT else theme.BORDER;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
@@ -1410,7 +1575,7 @@ pub const Dashboard = struct {
             .context => if (sel < data.WS_CONTEXT.len) data.WS_CONTEXT[sel].path else "no files",
             .prompts => if (sel < data.WS_PROMPTS.len) data.WS_PROMPTS[sel].name else "no prompts",
         };
-        // Title with diff marker (context branch or prompt override)
+        // Title with diff marker (context branch or prompt local edit)
         const has_diff = switch (self.ws_tab) {
             .context => sel < data.WS_CONTEXT.len and data.WS_CONTEXT[sel].modified,
             .prompts => sel < data.WS_PROMPTS.len and data.WS_PROMPTS[sel].has_override,
@@ -2133,7 +2298,7 @@ pub const Dashboard = struct {
         w.writeText(&surface, ctx, start_col + 2, start_row, " Keyboard Reference ", theme.boldOn(theme.PANEL_ALT, theme.ACCENT));
 
         const lines = [_][]const u8{
-            "1-4            Switch top-level module",
+            "1-3            Switch top-level module",
             "j / \xe2\x86\x93           Move down / next row",
             "k / \xe2\x86\x91           Move up / previous row",
             "h / \xe2\x86\x90           Previous tab / region",
@@ -2142,11 +2307,8 @@ pub const Dashboard = struct {
             "Esc            Back / close overlay",
             "g              Jump to first row",
             "G              Jump to last row",
-            "a              Accept proposal (maintainer)",
-            "x              Reject proposal (maintainer)",
             "r              Refresh / sync",
             "w              Workspace switcher (future)",
-            "p              Propose from override",
             "?              Toggle this help",
             "q / Ctrl+C     Quit",
         };
@@ -2211,6 +2373,36 @@ pub const Dashboard = struct {
         return surface;
     }
 
+    fn drawCommentEditorOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        const bg = theme.PANEL_ALT;
+        w.fillSurface(&surface, bg);
+        w.drawBorder(&surface, theme.ACCENT, bg);
+
+        // Title: show reply context or "New Comment"
+        const p = &data.PROMPTS[self.selected_prompt];
+        const prs = data.prsForPrompt(p.canonical_name);
+        const title = if (prs.len > 0 and self.selected_pr_idx < prs.len)
+            try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
+        else
+            " New Comment ";
+        w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(bg, theme.ACCENT));
+
+        // Input text with cursor
+        const input_text = self.comment_input_buf[0..self.comment_input_len];
+        const max_visible: usize = @as(usize, size.width -| 4);
+        const visible_start = if (input_text.len > max_visible) input_text.len - max_visible else 0;
+        const visible = input_text[visible_start..];
+        const display = try std.fmt.allocPrint(ctx.arena, "{s}_", .{visible});
+        w.writeText(&surface, ctx, 2, 2, display, theme.textOn(bg, theme.TEXT));
+
+        // Hint
+        w.writeText(&surface, ctx, 2, size.height -| 2, "Enter send  Esc cancel", theme.textOn(bg, theme.TEXT_SOFT));
+
+        return surface;
+    }
+
     fn drawTooSmall(self: *Dashboard, ctx: vxfw.DrawContext, size: vxfw.Size) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
@@ -2261,8 +2453,16 @@ pub const Dashboard = struct {
             // Insert prompt row (name + stats)
             if (row_idx < MAX_LIBRARY_ROWS) {
                 const sel = pidx == self.selected_prompt;
+                const pr_label: []const u8 = switch (p.open_pr_count) {
+                    0 => "",
+                    1 => "\xe2\x80\xa21",
+                    2 => "\xe2\x80\xa22",
+                    3 => "\xe2\x80\xa23",
+                    else => "\xe2\x80\xa2+",
+                };
                 self.library_table_cols[row_idx] = .{
                     .{ .text = name, .flex = 1 },
+                    .{ .text = pr_label, .flex = 0, .min_width = 2 },
                     .{ .text = p.refer_count, .flex = 0, .min_width = 4, .alignment = .right },
                     .{ .text = p.age, .flex = 0, .min_width = 3, .alignment = .right },
                 };
@@ -2304,79 +2504,142 @@ pub const Dashboard = struct {
         self.content_scroll_bars.estimated_content_height = @intCast(@max(w.countLines(data.SAMPLE_CONTENT), 24));
     }
 
-    fn syncHistoryWidgets(self: *Dashboard) void {
-        for (data.HISTORY, 0..) |h, idx| {
-            const sel = idx == @as(usize, @intCast(self.history_scroll_bars.scroll_view.cursor));
-            self.history_cols[idx] = .{
-                .{ .text = h.date, .flex = 0 },
-                .{ .text = h.hash, .flex = 0 },
-                .{ .text = h.label, .flex = 1 },
+    fn syncPrWidgets(self: *Dashboard) void {
+        const p = &data.PROMPTS[self.selected_prompt];
+        const prs = data.prsForPrompt(p.canonical_name);
+        var row_idx: usize = 0;
+        for (prs, 0..) |pr, pi| {
+            if (row_idx + 1 >= self.pr_widgets.len) break;
+            const show = switch (self.pr_filter) {
+                .open => std.mem.eql(u8, pr.status, "open"),
+                .closed => !std.mem.eql(u8, pr.status, "open"),
+                .all => true,
             };
-            self.history_rows[idx] = .{
-                .columns = &self.history_cols[idx],
+            if (!show) continue;
+            const sel = pi == self.selected_pr_idx;
+            // Row 1: id, status, author, created
+            self.pr_table_cols[pi] = .{
+                .{ .text = pr.id, .flex = 0 },
+                .{ .text = pr.status, .flex = 0 },
+                .{ .text = pr.author, .flex = 0 },
+                .{ .text = pr.created, .flex = 1, .alignment = .right },
+            };
+            self.pr_table_rows[pi] = .{
+                .columns = &self.pr_table_cols[pi],
                 .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
                 .gap = 2,
             };
-            self.history_widgets[idx] = self.history_rows[idx].widget();
+            self.pr_widgets[row_idx] = self.pr_table_rows[pi].widget();
+            self.pr_indices[row_idx] = pi;
+            row_idx += 1;
+            // Row 2: description (muted)
+            self.pr_text_rows[pi] = .{
+                .text = pr.description,
+                .style = theme.textOn(theme.PANEL, theme.MUTED),
+            };
+            self.pr_widgets[row_idx] = self.pr_text_rows[pi].widget();
+            self.pr_indices[row_idx] = null; // skip on cursor
+            row_idx += 1;
         }
-        self.history_scroll_bars.scroll_view.children = .{ .slice = self.history_widgets[0..data.HISTORY.len] };
-        self.history_scroll_bars.estimated_content_height = data.HISTORY.len;
+        self.pr_row_count = row_idx;
+        self.pr_scroll_bars.scroll_view.children = .{ .slice = self.pr_widgets[0..row_idx] };
+        self.pr_scroll_bars.estimated_content_height = @intCast(row_idx);
+        // Ensure cursor is on a TableRow, not a description
+        var cur = @as(usize, @intCast(self.pr_scroll_bars.scroll_view.cursor));
+        while (cur < row_idx and self.pr_indices[cur] == null) cur += 1;
+        self.pr_scroll_bars.scroll_view.cursor = @intCast(cur);
+        if (cur < row_idx) {
+            if (self.pr_indices[cur]) |pi| self.selected_pr_idx = pi;
+        }
     }
 
-    // Inner width budget: panel=24min → border=2 → inner=22.
-    // Row format: 1 + 9 id + 1 + 6 status + 1 = 18 fixed + truncated name. Fits.
-    fn syncReviewWidgets(self: *Dashboard) void {
-        self.review_scroll_bars.scroll_view.cursor = @min(self.review_scroll_bars.scroll_view.cursor, data.PROPOSALS.len - 1);
-        const sel_idx = self.selectedProposalIdx();
-        for (data.PROPOSALS, 0..) |p, idx| {
-            const sel = idx == sel_idx;
-            self.review_cols[idx] = .{
-                .{ .text = p.id, .flex = 0 },
-                .{ .text = p.status, .flex = 1 },
-            };
-            self.review_rows[idx] = .{
-                .columns = &self.review_cols[idx],
-                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
-                .gap = 2,
-            };
-            self.review_widgets[idx] = self.review_rows[idx].widget();
+    fn syncPrDiffAndComments(self: *Dashboard, allocator: std.mem.Allocator) void {
+        const p = &data.PROMPTS[self.selected_prompt];
+        const prs = data.prsForPrompt(p.canonical_name);
+        if (prs.len == 0) {
+            self.pr_diff_count = 0;
+            return;
         }
-        self.review_scroll_bars.scroll_view.children = .{ .slice = self.review_widgets[0..] };
-        self.review_scroll_bars.estimated_content_height = data.PROPOSALS.len;
-    }
-
-    fn syncDiffWidgets(self: *Dashboard, proposal: *const data.ProposalEntry) void {
-        self.review_diff_count = @min(proposal.diff.len, self.review_diff_widgets.len);
-        for (0..self.review_diff_count) |idx| {
-            const line = proposal.diff[idx];
-            self.review_diff_rows[idx] = .{
+        const pr_idx = @min(self.selected_pr_idx, prs.len - 1);
+        const pr = &prs[pr_idx];
+        var count: usize = 0;
+        for (pr.diff) |line| {
+            if (count >= self.pr_diff_rows.len) break;
+            self.pr_diff_rows[count] = .{
                 .text = line,
-                .style = theme.textOn(diffBg(line), diffFg(line)),
-                .softwrap = false,
+                .style = .{ .fg = diffFg(line), .bg = diffBg(line) },
             };
-            self.review_diff_widgets[idx] = self.review_diff_rows[idx].widget();
+            self.pr_diff_widgets[count] = self.pr_diff_rows[count].widget();
+            count += 1;
         }
-        self.review_diff_scroll_bars.scroll_view.children = .{ .slice = self.review_diff_widgets[0..self.review_diff_count] };
-        self.review_diff_scroll_bars.estimated_content_height = @intCast(self.review_diff_count);
+        // Comment section
+        if (pr.comments.len > 0) {
+            if (count < self.pr_diff_rows.len) {
+                self.pr_diff_rows[count] = .{
+                    .text = "\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80 Comments \xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80",
+                    .style = theme.fg(theme.MUTED),
+                };
+                self.pr_diff_widgets[count] = self.pr_diff_rows[count].widget();
+                count += 1;
+            }
+            for (pr.comments) |comment| {
+                // Header: "author · created"
+                if (count < self.pr_diff_rows.len) {
+                    const header = std.fmt.allocPrint(allocator, "{s} \xc2\xb7 {s}", .{ comment.author, comment.created }) catch "??";
+                    self.pr_diff_rows[count] = .{
+                        .text = header,
+                        .style = theme.fgBold(theme.TEXT_SOFT),
+                    };
+                    self.pr_diff_widgets[count] = self.pr_diff_rows[count].widget();
+                    count += 1;
+                }
+                // Body
+                if (count < self.pr_diff_rows.len) {
+                    self.pr_diff_rows[count] = .{
+                        .text = comment.body,
+                        .style = theme.fg(theme.TEXT_SOFT),
+                    };
+                    self.pr_diff_widgets[count] = self.pr_diff_rows[count].widget();
+                    count += 1;
+                }
+                // Blank line for spacing
+                if (count < self.pr_diff_rows.len) {
+                    self.pr_diff_rows[count] = .{
+                        .text = " ",
+                        .style = theme.fg(theme.MUTED),
+                    };
+                    self.pr_diff_widgets[count] = self.pr_diff_rows[count].widget();
+                    count += 1;
+                }
+            }
+        }
+        self.pr_diff_count = count;
+        self.pr_diff_scroll_bars.scroll_view.children = .{ .slice = self.pr_diff_widgets[0..count] };
+        self.pr_diff_scroll_bars.estimated_content_height = @intCast(count);
     }
 
-    // Workspace grid uses manual rendering, no sync function needed
+    fn diffBg(line: []const u8) vaxis.Color {
+        if (std.mem.startsWith(u8, line, "+")) return theme.rgb(0x1d2617);
+        if (std.mem.startsWith(u8, line, "-")) return theme.rgb(0x2a1b18);
+        return theme.PANEL;
+    }
 
-
-    fn selectedProposalIdx(self: *const Dashboard) usize {
-        return @min(@as(usize, @intCast(self.review_scroll_bars.scroll_view.cursor)), data.PROPOSALS.len - 1);
+    fn diffFg(line: []const u8) vaxis.Color {
+        if (std.mem.startsWith(u8, line, "+")) return theme.OK;
+        if (std.mem.startsWith(u8, line, "-")) return theme.DANGER;
+        if (std.mem.startsWith(u8, line, "@@")) return theme.INFO;
+        return theme.TEXT_SOFT;
     }
 
     fn contextHint(self: *const Dashboard) []const u8 {
         if (self.show_help) return "Keyboard reference overlay.";
         if (self.show_detail) return switch (self.detail_tab) {
-            .overview => "Prompt metadata, usage summary, and override status.",
+            .overview => "Prompt metadata, usage summary, and local edit status.",
             .content => "Full prompt body. j/k to scroll.",
-            .history => "Revision list left, version detail right.",
+            .pull_requests => if (self.show_pr_diff) "PR diff view. j/k scroll, a/x/c actions." else "j/k move  f filter  Enter view  c comment  Esc back",
         };
         return switch (self.selected_module) {
             .library => "Bundle facet, prompt list, and passive preview.",
-            .proposals => "Proposal queue left, diff center, review lens right.",
             .workspace => "Workspace list and sync status detail.",
             .insights => "Refer coverage analysis (Phase 3, API pending).",
         };
@@ -2392,7 +2655,7 @@ pub const Dashboard = struct {
     fn openDetail(self: *Dashboard, ctx: *vxfw.EventContext, prompt_idx: usize, origin: TopModule, initial_tab: DetailTab) void {
         self.selected_prompt = @min(prompt_idx, data.PROMPTS.len - 1);
         self.library_scroll_bars.scroll_view.cursor = @intCast(self.selected_prompt);
-        self.history_scroll_bars.scroll_view.cursor = 0;
+        self.pr_filter = .open;
         self.detail_origin = origin;
         self.detail_tab = initial_tab;
         self.show_detail = true;
@@ -2405,6 +2668,10 @@ pub const Dashboard = struct {
         const count: i8 = @intCast(detail_tabs.len);
         const next = @mod(current + delta + count, count);
         self.detail_tab = @enumFromInt(@as(u8, @intCast(next)));
+        // Reset PR drill-down state when leaving PR tab
+        self.show_pr_diff = false;
+        self.show_comment_editor = false;
+        self.pr_filter = .open;
     }
 
     fn shiftWsTab(self: *Dashboard, delta: i8) void {
@@ -2432,16 +2699,3 @@ fn prefixWithPad(prefix: []const u8) []const u8 {
 
 // workspace_buf removed: workspace uses manual grid rendering
 
-fn diffFg(line: []const u8) vaxis.Color {
-    if (std.mem.startsWith(u8, line, "+")) return theme.OK;
-    if (std.mem.startsWith(u8, line, "-")) return theme.DANGER;
-    if (std.mem.startsWith(u8, line, "@@")) return theme.GOLD;
-    return theme.TEXT_SOFT;
-}
-
-fn diffBg(line: []const u8) vaxis.Color {
-    if (std.mem.startsWith(u8, line, "+")) return theme.rgb(0x1d2617);
-    if (std.mem.startsWith(u8, line, "-")) return theme.rgb(0x2a1b18);
-    if (std.mem.startsWith(u8, line, "@@")) return theme.PANEL_ALT;
-    return theme.PANEL;
-}

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1532,13 +1532,15 @@ pub const Dashboard = struct {
         const size = ctx.max.size();
         const focused = self.settings_focus == .content;
         const user = data.CURRENT_USER;
+        const cfg = data.CLIENT_CONFIG;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
         w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
         w.writeText(&surface, ctx, 2, 0, "Account", theme.boldOn(theme.PANEL, theme.TEXT));
 
         var row: u16 = 2;
-        // Profile section
+
+        // Profile
         row = w.writeSectionHeader(&surface, ctx, 2, row, "Profile");
         row = w.writeKv(&surface, ctx, 4, row, "Username", user.username, 14);
         row = w.writeKv(&surface, ctx, 4, row, "User ID", user.user_id, 14);
@@ -1547,7 +1549,17 @@ pub const Dashboard = struct {
         w.writeText(&surface, ctx, 19, row, user.role, theme.fg(role_color));
         row += 2;
 
-        // Security section
+        // Connection
+        row = w.writeSectionHeader(&surface, ctx, 2, row, "Connection");
+        row = w.writeKv(&surface, ctx, 4, row, "Server", cfg.server_url, 14);
+        row = w.writeKv(&surface, ctx, 4, row, "Sync", cfg.sync_strategy, 14);
+        w.writeText(&surface, ctx, 4, row, "Token", theme.fg(theme.MUTED));
+        const token_color = if (std.mem.eql(u8, cfg.token_status, "active")) theme.OK else theme.DANGER;
+        const token_info = try std.fmt.allocPrint(ctx.arena, "{s}, expires {s}", .{ cfg.token_status, cfg.token_expires });
+        w.writeText(&surface, ctx, 19, row, token_info, theme.fg(token_color));
+        row += 2;
+
+        // Security
         row = w.writeSectionHeader(&surface, ctx, 2, row, "Security");
         w.writeText(&surface, ctx, 4, row, "Password", theme.fg(theme.MUTED));
         w.writeText(&surface, ctx, 19, row, "********", theme.fg(theme.TEXT_SOFT));
@@ -1557,10 +1569,11 @@ pub const Dashboard = struct {
         w.writeText(&surface, ctx, 19, row, "1 active", theme.fg(theme.OK));
         row += 2;
 
-        // My Workspaces
+        // My Workspaces with tree-expanded paths
         row = w.writeSectionHeader(&surface, ctx, 2, row, try std.fmt.allocPrint(ctx.arena, "My Workspaces ({d})", .{user.workspaces.len}));
         const sel = @min(self.settings_content_sel, user.workspaces.len - 1);
         for (user.workspaces, 0..) |ws_access, i| {
+            if (row >= size.height -| 4) break;
             const is_sel = i == sel and focused;
             if (is_sel) {
                 surface.writeCell(1, row, .{
@@ -1582,7 +1595,22 @@ pub const Dashboard = struct {
             };
             w.writeText(&surface, ctx, 24, row, level_label, theme.fg(badge_fg));
             row += 1;
-            if (row >= size.height -| 3) break;
+
+            // Expand paths for selected workspace
+            if (is_sel and ws_access.paths.len > 0) {
+                for (ws_access.paths, 0..) |path, pi| {
+                    if (row >= size.height -| 4) break;
+                    const is_last = pi + 1 == ws_access.paths.len;
+                    const connector = if (is_last) "\xe2\x94\x94" else "\xe2\x94\x9c"; // └ or ├
+                    w.writeText(&surface, ctx, 6, row, connector, theme.fg(theme.BORDER));
+                    w.writeText(&surface, ctx, 8, row, path, theme.fg(theme.MUTED));
+                    row += 1;
+                }
+            } else if (is_sel and ws_access.paths.len == 0) {
+                w.writeText(&surface, ctx, 6, row, "\xe2\x94\x94", theme.fg(theme.BORDER)); // └
+                w.writeText(&surface, ctx, 8, row, "(no local paths)", theme.fg(theme.MUTED));
+                row += 1;
+            }
         }
         row += 1;
 

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -67,6 +67,7 @@ const ConfirmAction = enum {
     remove_member,
     delete_bundle,
     delete_workspace,
+    revoke_token,
     quit,
 };
 
@@ -240,6 +241,17 @@ pub const Dashboard = struct {
                             .delete_workspace => {
                                 self.status_line = "Workspace deleted (not yet implemented)";
                             },
+                            .revoke_token => {
+                                const alloc = self.api_state.arena.allocator();
+                                _ = api.postAction(self.api_state, alloc, .DELETE, "/api/auth/token", null) catch {
+                                    self.status_line = "Token revoke failed";
+                                    self.show_confirm = false;
+                                    self.confirm_action = .none;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                };
+                                self.status_line = "Token revoked. Please re-login.";
+                            },
                             .quit => {
                                 ctx.consumeEvent();
                                 ctx.quit = true;
@@ -276,7 +288,11 @@ pub const Dashboard = struct {
                         self.comment_input_len = 0;
                         ctx.consumeAndRedraw();
                     } else if (key.matches(vaxis.Key.enter, .{})) {
-                        self.status_line = if (self.comment_input_len > 0) "Comment submitted." else "Empty comment discarded.";
+                        if (self.comment_input_len > 0) {
+                            self.submitComment();
+                        } else {
+                            self.status_line = "Empty comment discarded.";
+                        }
                         self.show_comment_editor = false;
                         self.comment_input_len = 0;
                         ctx.consumeAndRedraw();
@@ -401,7 +417,7 @@ pub const Dashboard = struct {
                         }
                         if (self.settings_tab == .organization) {
                             if (key.matches('r', .{})) {
-                                self.status_line = "Role change (not yet implemented)";
+                                self.status_line = "Role change (requires input dialog)";
                                 ctx.consumeAndRedraw();
                                 return;
                             }
@@ -413,7 +429,7 @@ pub const Dashboard = struct {
                                 return;
                             }
                             if (key.matches('a', .{})) {
-                                self.status_line = "Invite member (not yet implemented)";
+                                self.status_line = "Invite member (requires input dialog)";
                                 ctx.consumeAndRedraw();
                                 return;
                             }
@@ -426,7 +442,7 @@ pub const Dashboard = struct {
                             }
                             if (key.matches('x', .{})) {
                                 self.confirm_message = "current token";
-                                self.confirm_action = .remove_member; // reuse for revoke
+                                self.confirm_action = .revoke_token;
                                 self.show_confirm = true;
                                 ctx.consumeAndRedraw();
                                 return;
@@ -476,12 +492,12 @@ pub const Dashboard = struct {
                                 return;
                             }
                             if (key.matches('a', .{})) {
-                                self.status_line = "Accept PR (not yet implemented)";
+                                self.doPrAction("accept");
                                 ctx.consumeAndRedraw();
                                 return;
                             }
                             if (key.matches('x', .{})) {
-                                self.status_line = "Reject PR (not yet implemented)";
+                                self.doPrAction("reject");
                                 ctx.consumeAndRedraw();
                                 return;
                             }
@@ -515,6 +531,14 @@ pub const Dashboard = struct {
                             }
                             if (key.matches(vaxis.Key.enter, .{})) {
                                 self.show_pr_diff = true;
+                                // Trigger PR detail fetch for diff/comments
+                                const all_p = self.getPrompts();
+                                const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
+                                if (all_p.len > 0) {
+                                    const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+                                    const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
+                                    if (prs_for.len > 0) api.fetchPrDetailAsync(self.api_state, prs_for[pri].id);
+                                }
                                 ctx.consumeAndRedraw();
                                 return;
                             }
@@ -590,12 +614,12 @@ pub const Dashboard = struct {
                                     return;
                                 }
                                 if (key.matches('a', .{})) {
-                                    self.status_line = "Accept PR (not yet implemented)";
+                                    self.doPrAction("accept");
                                     ctx.consumeAndRedraw();
                                     return;
                                 }
                                 if (key.matches('x', .{})) {
-                                    self.status_line = "Reject PR (not yet implemented)";
+                                    self.doPrAction("reject");
                                     ctx.consumeAndRedraw();
                                     return;
                                 }
@@ -2379,12 +2403,12 @@ pub const Dashboard = struct {
 
     fn getPrsForPrompt(self: *Dashboard, canonical_name: []const u8) []const data.PullRequestEntry {
         self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
         const live_prs = self.api_state.prompt_prs;
         const lib = self.api_state.prompts;
-        self.api_state.mutex.unlock();
         if (live_prs) |prs| {
             const alloc = self.api_state.arena.allocator();
-            return api.toPrEntries(alloc, prs, canonical_name, lib);
+            return api.toPrEntries(alloc, prs, canonical_name, lib, self.api_state);
         }
         return data.prsForPrompt(canonical_name);
     }
@@ -2397,6 +2421,57 @@ pub const Dashboard = struct {
             return api.toPromptEntries(alloc, lp);
         }
         return &data.PROMPTS;
+    }
+
+    fn submitComment(self: *Dashboard) void {
+        const all_p = self.getPrompts();
+        const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
+        if (all_p.len == 0) return;
+        const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+        const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
+        if (prs_for.len == 0) return;
+
+        const alloc = self.api_state.arena.allocator();
+        const path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{prs_for[pri].id}) catch {
+            self.status_line = "Failed to submit comment";
+            return;
+        };
+        const comment_text = self.comment_input_buf[0..self.comment_input_len];
+        const body = std.fmt.allocPrint(alloc, "{{\"body\":\"{s}\"}}", .{comment_text}) catch {
+            self.status_line = "Failed to submit comment";
+            return;
+        };
+        _ = api.postAction(self.api_state, alloc, .POST, path, body) catch {
+            self.status_line = "Comment submission failed";
+            return;
+        };
+        self.status_line = "Comment submitted.";
+    }
+
+    fn doPrAction(self: *Dashboard, action: []const u8) void {
+        const all_p = self.getPrompts();
+        const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
+        if (all_p.len == 0) return;
+        const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+        const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
+        if (prs_for.len == 0) return;
+        const pr_id = prs_for[pri].id;
+
+        const alloc = self.api_state.arena.allocator();
+        const path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}", .{pr_id}) catch {
+            self.status_line = "Failed to build request";
+            return;
+        };
+        const body = std.fmt.allocPrint(alloc, "{{\"action\":\"{s}\"}}", .{action}) catch {
+            self.status_line = "Failed to build request";
+            return;
+        };
+        _ = api.postAction(self.api_state, alloc, .PUT, path, body) catch {
+            self.status_line = if (std.mem.eql(u8, action, "accept")) "Accept failed" else "Reject failed";
+            return;
+        };
+        self.status_line = if (std.mem.eql(u8, action, "accept")) "PR accepted" else "PR rejected";
+        self.show_pr_diff = false;
     }
 
     fn orgMemberCount(self: *Dashboard) usize {
@@ -2523,6 +2598,7 @@ pub const Dashboard = struct {
             .remove_member => "Remove member:",
             .delete_bundle => "Delete bundle:",
             .delete_workspace => "Delete workspace:",
+            .revoke_token => "Revoke token?",
             .quit => "Quit clumsies?",
             .none => "Confirm:",
         };

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -6,6 +6,7 @@ const w = @import("widgets.zig");
 const data = @import("mock_data.zig");
 const api = @import("api.zig");
 const tree = @import("tree.zig");
+const trace_reader = @import("trace_reader.zig");
 const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 
@@ -24,28 +25,6 @@ const WsTab = enum(u8) {
 const ws_tabs = [_]WsTab{ .context, .prompts };
 
 const WsFocus = enum { bar, list, content };
-
-const Period = enum(u8) {
-    daily,
-    weekly,
-    monthly,
-
-    fn label(self: Period) []const u8 {
-        return switch (self) {
-            .daily => "daily",
-            .weekly => "weekly",
-            .monthly => "monthly",
-        };
-    }
-
-    fn next(self: Period) Period {
-        return switch (self) {
-            .daily => .weekly,
-            .weekly => .monthly,
-            .monthly => .daily,
-        };
-    }
-};
 
 const SettingsTab = enum(u8) {
     account,
@@ -73,15 +52,17 @@ const ConfirmAction = enum {
 };
 
 const TopModule = enum(u8) {
-    insights,
+    dashboard,
     workspace,
     library,
+    analysis,
 
     fn label(self: TopModule) []const u8 {
         return switch (self) {
-            .insights => "Insights",
+            .dashboard => "Dashboard",
             .workspace => "Workspace",
             .library => "Library",
+            .analysis => "Analysis",
         };
     }
 };
@@ -120,7 +101,7 @@ const DetailTab = enum(u8) {
     }
 };
 
-const top_tabs = [_]TopModule{ .insights, .workspace, .library };
+const top_tabs = [_]TopModule{ .dashboard, .workspace, .library, .analysis };
 
 const MAX_LIBRARY_ROWS = 128;
 const MAX_PR_ROWS = 64;
@@ -128,7 +109,7 @@ const detail_tabs = [_]DetailTab{ .content, .pull_requests };
 
 pub const Dashboard = struct {
     api_state: *api.ApiState,
-    selected_module: TopModule = .insights,
+    selected_module: TopModule = .dashboard,
     selected_prompt: usize = 0,
     show_help: bool = false,
     show_detail: bool = false,
@@ -192,10 +173,20 @@ pub const Dashboard = struct {
     ws_list_sel: usize = 0,
     ws_grid_cols: u16 = 3,
     ws_show_diff: bool = false,
-    // Workspace uses manual grid + list rendering, no ScrollBars
+    ws_row_count: usize = 0,
+    ws_row_leaf_index: [MAX_LIBRARY_ROWS]?usize = .{null} ** MAX_LIBRARY_ROWS,
+    ws_row_dir_path: [MAX_LIBRARY_ROWS]?[]const u8 = .{null} ** MAX_LIBRARY_ROWS,
+    ws_row_depth: [MAX_LIBRARY_ROWS]u8 = .{0} ** MAX_LIBRARY_ROWS,
+    ws_row_text_len: [MAX_LIBRARY_ROWS]usize = .{0} ** MAX_LIBRARY_ROWS,
+    ws_row_text_bufs: [MAX_LIBRARY_ROWS][96]u8 = undefined,
+    ws_context_expanded: std.StringHashMapUnmanaged(void) = .empty,
+    ws_prompts_expanded: std.StringHashMapUnmanaged(void) = .empty,
+    ws_context_tree_initialized: bool = false,
+    ws_prompts_tree_initialized: bool = false,
+    // Workspace uses manual grid + cached visible rows, no ScrollBars
 
-    // Insights
-    insights_period: Period = .daily,
+    // Dashboard / Analysis shared state
+    insights_scope_idx: usize = 0,
     breathing_phase: u8 = 0, // 0-20 for breathing animation cycle
     insights_focus: enum { chart, prompts, team, inputs } = .chart,
     insights_prompt_cursor: usize = 0,
@@ -204,7 +195,7 @@ pub const Dashboard = struct {
     insights_expanded_prompt: ?usize = null,
     insights_show_member_detail: bool = false,
     insights_show_input_detail: bool = false,
-    chart_offset: u16 = 0,
+    dashboard_input_capacity: usize = 1,
 
     pub fn init(api_state: *api.ApiState) Dashboard {
         return .{
@@ -251,7 +242,7 @@ pub const Dashboard = struct {
                                 self.status_line = "Workspace deleted (not yet implemented)";
                             },
                             .revoke_token => {
-                                const alloc = self.api_state.arena.allocator();
+                                const alloc = self.api_state.allocator();
                                 _ = api.postAction(self.api_state, alloc, .DELETE, "/api/auth/token", null) catch {
                                     self.status_line = "Token revoke failed";
                                     self.show_confirm = false;
@@ -584,13 +575,20 @@ pub const Dashboard = struct {
                 }
 
                 // Top-level tab switching
-                if (key.matches('1', .{})) return self.selectTab(ctx, .insights);
+                if (key.matches('1', .{})) return self.selectTab(ctx, .dashboard);
                 if (key.matches('2', .{})) return self.selectTab(ctx, .workspace);
                 if (key.matches('3', .{})) return self.selectTab(ctx, .library);
+                if (key.matches('4', .{})) return self.selectTab(ctx, .analysis);
 
                 // Module-specific input
                 switch (self.selected_module) {
                     .library => {
+                        if (key.matches('r', .{})) {
+                            api.refetchAllAsync(self.api_state);
+                            self.status_line = "Refreshing data...";
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
                         if (key.matches('b', .{})) {
                             const bundle_count = blk: {
                                 self.api_state.mutex.lock();
@@ -630,7 +628,7 @@ pub const Dashboard = struct {
                             const pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
                             if (pos < self.library_row_count) {
                                 if (self.library_row_dir_path[pos]) |dir| {
-                                    const alloc = self.api_state.arena.allocator();
+                                    const alloc = self.api_state.allocator();
                                     if (!self.library_expanded.contains(dir)) {
                                         _ = self.library_expanded.put(alloc, dir, {}) catch {};
                                         ctx.consumeAndRedraw();
@@ -759,8 +757,11 @@ pub const Dashboard = struct {
                         // List pane: j/k moves through rows. Cursor can land on
                         // dir nodes (which allows Enter to toggle them) as well
                         // as leaf prompts.
+                        if (self.library_row_count == 0) {
+                            ctx.consumeEvent();
+                            return;
+                        }
                         try self.library_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        if (self.library_row_count == 0) return;
 
                         var pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
                         if (pos >= self.library_row_count) pos = self.library_row_count - 1;
@@ -822,6 +823,9 @@ pub const Dashboard = struct {
                                 }
                                 if (key.matches(vaxis.Key.enter, .{})) {
                                     self.ws_focus = .list;
+                                    self.ws_list_sel = 0;
+                                    self.ws_show_diff = false;
+                                    self.resetWorkspaceTrees();
                                     // Trigger workspace detail fetch
                                     self.api_state.mutex.lock();
                                     const ws_list = if (self.api_state.current_user) |u| u.workspaces else &.{};
@@ -836,24 +840,63 @@ pub const Dashboard = struct {
                                 }
                             },
                             .list => {
-                                if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                                self.syncWsRows();
+                                if (key.matches('h', .{})) {
                                     self.shiftWsTab(-1);
                                     self.ws_list_sel = 0;
+                                    self.ws_show_diff = false;
                                     ctx.consumeAndRedraw();
                                     return;
                                 }
-                                if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                                if (key.matches('l', .{})) {
                                     self.shiftWsTab(1);
                                     self.ws_list_sel = 0;
+                                    self.ws_show_diff = false;
                                     ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.left, .{})) {
+                                    if (self.ws_list_sel < self.ws_row_count) {
+                                        if (self.ws_row_dir_path[self.ws_list_sel]) |dir| {
+                                            if (self.wsExpandedSet().contains(dir)) {
+                                                _ = self.wsExpandedSet().remove(dir);
+                                                self.ws_show_diff = false;
+                                                ctx.consumeAndRedraw();
+                                                return;
+                                            }
+                                        }
+                                        const cur_depth = self.ws_row_depth[self.ws_list_sel];
+                                        if (cur_depth > 0 and self.ws_list_sel > 0) {
+                                            var p = self.ws_list_sel;
+                                            while (p > 0) {
+                                                p -= 1;
+                                                if (self.ws_row_depth[p] < cur_depth) {
+                                                    self.ws_list_sel = p;
+                                                    self.ws_show_diff = false;
+                                                    ctx.consumeAndRedraw();
+                                                    return;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.right, .{})) {
+                                    if (self.ws_list_sel < self.ws_row_count) {
+                                        if (self.ws_row_dir_path[self.ws_list_sel]) |dir| {
+                                            if (!self.wsExpandedSet().contains(dir)) {
+                                                const alloc = self.api_state.allocator();
+                                                _ = self.wsExpandedSet().put(alloc, dir, {}) catch {};
+                                                self.ws_show_diff = false;
+                                                ctx.consumeAndRedraw();
+                                                return;
+                                            }
+                                        }
+                                    }
                                     return;
                                 }
                                 if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
-                                    const max_items: usize = switch (self.ws_tab) {
-                                        .context => self.wsContextCount(),
-                                        .prompts => self.wsPromptsCount(),
-                                    };
-                                    if (self.ws_list_sel + 1 < max_items) {
+                                    if (self.ws_list_sel + 1 < self.ws_row_count) {
                                         self.ws_list_sel += 1;
                                         self.ws_show_diff = false;
                                         ctx.consumeAndRedraw();
@@ -869,7 +912,16 @@ pub const Dashboard = struct {
                                     return;
                                 }
                                 if (key.matches(vaxis.Key.enter, .{})) {
+                                    if (self.ws_list_sel < self.ws_row_count) {
+                                        if (self.ws_row_dir_path[self.ws_list_sel]) |dir| {
+                                            self.toggleWsDir(dir);
+                                            self.ws_show_diff = false;
+                                            ctx.consumeAndRedraw();
+                                            return;
+                                        }
+                                    }
                                     self.ws_focus = .content;
+                                    self.ws_show_diff = false;
                                     ctx.consumeAndRedraw();
                                     return;
                                 }
@@ -894,36 +946,79 @@ pub const Dashboard = struct {
                             },
                         }
                         if (key.matches('r', .{})) {
-                            self.status_line = "Sync (not yet implemented)";
+                            api.refetchAllAsync(self.api_state);
+                            self.status_line = "Refreshing data...";
                             ctx.consumeAndRedraw();
                         }
                     },
-                    .insights => {
+                    .dashboard => {
                         const ins_counts = self.getInsightsCounts();
-                        if (key.matches('t', .{})) {
-                            self.insights_period = self.insights_period.next();
-                            self.status_line = switch (self.insights_period) {
-                                .daily => "Period: daily (30d).",
-                                .weekly => "Period: weekly (8w).",
-                                .monthly => "Period: monthly (12m).",
-                            };
+                        if (key.matches('w', .{})) {
+                            const scope = self.cycleInsightsScope();
+                            const alloc = self.api_state.allocator();
+                            self.insights_input_cursor = 0;
+                            self.insights_show_input_detail = false;
+                            self.status_line = std.fmt.allocPrint(alloc, "Dashboard scope: {s}", .{scope.label}) catch "Dashboard scope updated.";
                             ctx.consumeAndRedraw();
+                            return;
                         }
                         if (key.matches('F', .{ .shift = true })) {
                             self.flushTrace();
                             ctx.consumeAndRedraw();
+                            return;
                         }
                         if (key.matches(vaxis.Key.tab, .{})) {
                             self.insights_focus = switch (self.insights_focus) {
-                                .chart => .prompts,
+                                .chart => .inputs,
+                                else => .chart,
+                            };
+                            self.insights_show_input_detail = false;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                            if (self.insights_focus == .inputs) {
+                                if (ins_counts.input_count > 0 and self.insights_input_cursor < ins_counts.input_count - 1)
+                                    self.insights_input_cursor += 1;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                        }
+                        if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                            if (self.insights_focus == .inputs) {
+                                self.insights_input_cursor -|= 1;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                        }
+                        if (key.matches(vaxis.Key.enter, .{})) {
+                            if (self.insights_focus == .inputs) {
+                                self.insights_show_input_detail = !self.insights_show_input_detail;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                        }
+                        if (key.matches(vaxis.Key.escape, .{})) {
+                            if (self.insights_show_input_detail) {
+                                self.insights_show_input_detail = false;
+                            } else {
+                                self.insights_focus = .chart;
+                            }
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                    },
+                    .analysis => {
+                        const ins_counts = self.getInsightsCounts();
+                        if (key.matches(vaxis.Key.tab, .{})) {
+                            self.insights_focus = switch (self.insights_focus) {
                                 .prompts => .team,
-                                .team => .inputs,
-                                .inputs => .chart,
+                                else => .prompts,
                             };
                             self.insights_expanded_prompt = null;
                             self.insights_show_member_detail = false;
-                            self.insights_show_input_detail = false;
                             ctx.consumeAndRedraw();
+                            return;
                         }
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
                             switch (self.insights_focus) {
@@ -931,16 +1026,13 @@ pub const Dashboard = struct {
                                     if (ins_counts.prompt_count > 0 and self.insights_prompt_cursor < ins_counts.prompt_count - 1)
                                         self.insights_prompt_cursor += 1;
                                     ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 .team => {
                                     if (ins_counts.member_count > 0 and self.insights_member_cursor < ins_counts.member_count - 1)
                                         self.insights_member_cursor += 1;
                                     ctx.consumeAndRedraw();
-                                },
-                                .inputs => {
-                                    if (ins_counts.input_count > 0 and self.insights_input_cursor < ins_counts.input_count - 1)
-                                        self.insights_input_cursor += 1;
-                                    ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 else => {},
                             }
@@ -950,48 +1042,31 @@ pub const Dashboard = struct {
                                 .prompts => {
                                     self.insights_prompt_cursor -|= 1;
                                     ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 .team => {
                                     self.insights_member_cursor -|= 1;
                                     ctx.consumeAndRedraw();
-                                },
-                                .inputs => {
-                                    self.insights_input_cursor -|= 1;
-                                    ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 else => {},
-                            }
-                        }
-                        if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
-                            if (self.insights_focus == .chart) {
-                                self.status_line = "Chart scroll requires Hub API (mock: fixed 30d window).";
-                                ctx.consumeAndRedraw();
-                            }
-                        }
-                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
-                            if (self.insights_focus == .chart) {
-                                self.status_line = "Chart scroll requires Hub API (mock: fixed 30d window).";
-                                ctx.consumeAndRedraw();
                             }
                         }
                         if (key.matches(vaxis.Key.enter, .{})) {
                             switch (self.insights_focus) {
                                 .prompts => {
-                                    // Toggle per-constraint detail expansion
                                     if (self.insights_expanded_prompt == self.insights_prompt_cursor) {
                                         self.insights_expanded_prompt = null;
                                     } else {
                                         self.insights_expanded_prompt = self.insights_prompt_cursor;
                                     }
                                     ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 .team => {
                                     self.insights_show_member_detail = !self.insights_show_member_detail;
                                     ctx.consumeAndRedraw();
-                                },
-                                .inputs => {
-                                    self.insights_show_input_detail = !self.insights_show_input_detail;
-                                    ctx.consumeAndRedraw();
+                                    return;
                                 },
                                 else => {},
                             }
@@ -999,17 +1074,13 @@ pub const Dashboard = struct {
                         if (key.matches(vaxis.Key.escape, .{})) {
                             if (self.insights_expanded_prompt != null) {
                                 self.insights_expanded_prompt = null;
-                                ctx.consumeAndRedraw();
                             } else if (self.insights_show_member_detail) {
                                 self.insights_show_member_detail = false;
-                                ctx.consumeAndRedraw();
-                            } else if (self.insights_show_input_detail) {
-                                self.insights_show_input_detail = false;
-                                ctx.consumeAndRedraw();
                             } else {
                                 self.insights_focus = .prompts;
-                                ctx.consumeAndRedraw();
                             }
+                            ctx.consumeAndRedraw();
+                            return;
                         }
                     },
                 }
@@ -1021,6 +1092,9 @@ pub const Dashboard = struct {
             .tick => {
                 // Advance breathing cycle: 0→20→0 (2 seconds at 100ms intervals)
                 self.breathing_phase = (self.breathing_phase + 1) % 21;
+                if ((self.selected_module == .dashboard or self.selected_module == .analysis) and (self.breathing_phase == 0 or self.breathing_phase == 10)) {
+                    api.refreshLocalState(self.api_state);
+                }
                 ctx.redraw = true;
                 try ctx.tick(100, self.widget());
             },
@@ -1054,15 +1128,16 @@ pub const Dashboard = struct {
             .{ .width = size.width, .height = footer_h },
         );
 
+        const show_input_overlay = self.insights_show_input_detail and self.selected_module == .dashboard;
         var child_count: usize = 3;
-        if (self.show_help or self.show_confirm or self.show_comment_editor or self.insights_show_input_detail) child_count = 4;
+        if (self.show_help or self.show_confirm or self.show_comment_editor or show_input_overlay) child_count = 4;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
         children[1] = .{ .origin = .{ .row = header_h, .col = 0 }, .surface = try self.drawBody(body_ctx) };
         children[2] = .{ .origin = .{ .row = header_h + body_h, .col = 0 }, .surface = try self.drawFooter(footer_ctx) };
 
-        if (self.insights_show_input_detail and self.selected_module == .insights) {
+        if (show_input_overlay) {
             const input_ctx = ctx.withConstraints(
                 .{ .width = size.width, .height = size.height },
                 .{ .width = size.width, .height = size.height },
@@ -1151,9 +1226,10 @@ pub const Dashboard = struct {
         if (self.show_settings) return self.drawSettings(ctx);
         if (self.show_detail) return self.drawPromptDetail(ctx);
         return switch (self.selected_module) {
+            .dashboard => self.drawDashboard(ctx),
             .library => self.drawLibrary(ctx),
             .workspace => self.drawWorkspaceStatus(ctx),
-            .insights => self.drawInsights(ctx),
+            .analysis => self.drawAnalysis(ctx),
         };
     }
 
@@ -1186,6 +1262,11 @@ pub const Dashboard = struct {
         else if (self.show_detail)
             "h/l tab  j/k move  Tab content pane  p create PR  Esc back  ? help"
         else switch (self.selected_module) {
+            .dashboard => switch (self.insights_focus) {
+                .chart => "Tab focus  w scope  Shift-F flush  ? help  q quit",
+                .inputs => "j/k move  Enter detail  Tab focus  w scope  Shift-F flush  ? help  q quit",
+                else => "Tab focus  w scope  Shift-F flush  ? help  q quit",
+            },
             .library => if (self.detail_focus_content and self.detail_tab == .pull_requests and self.show_pr_diff)
                 "j/k scroll  a accept  x reject  c comment  Esc back"
             else if (self.detail_focus_content and self.detail_tab == .pull_requests)
@@ -1193,17 +1274,16 @@ pub const Dashboard = struct {
             else if (self.detail_focus_content)
                 "h/l tab  j/k scroll  Esc list  ? help"
             else
-                "j/k move  Enter detail  b bundle  S settings  ? help  q quit",
+                "j/k move  Enter detail  r refresh  b bundle  S settings  ? help  q quit",
             .workspace => switch (self.ws_focus) {
-                .bar => "j/k select workspace  Tab list  r sync  ? help  q quit",
-                .list => "h/l tab  j/k move  Enter content  Esc bar  ? help",
+                .bar => "j/k select workspace  Tab list  r refresh  ? help  q quit",
+                .list => "h/l tab  j/k move  ←/→ tree  Enter open  Esc bar  ? help",
                 .content => "j/k scroll  d toggle diff  Esc list  ? help",
             },
-            .insights => switch (self.insights_focus) {
-                .chart => "h/l scroll  Tab focus  t period  Shift-F flush  ? help  q quit",
-                .prompts => "j/k move  Enter expand  Tab focus  t period  Shift-F flush  ? help  q quit",
-                .team => "j/k move  Enter detail  Tab focus  t period  Shift-F flush  ? help  q quit",
-                .inputs => "j/k move  Enter detail  Tab focus  t period  Shift-F flush  ? help  q quit",
+            .analysis => switch (self.insights_focus) {
+                .prompts => "j/k move  Enter expand  Tab focus  ? help  q quit",
+                .team => "j/k move  Enter detail  Tab focus  ? help  q quit",
+                else => "Tab focus  ? help  q quit",
             },
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
@@ -1278,7 +1358,7 @@ pub const Dashboard = struct {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
             if (self.api_state.bundles) |lb| {
-                const a = self.api_state.arena.allocator();
+                const a = self.api_state.allocator();
                 break :blk api.toBundleEntries(a, lb);
             }
             break :blk &.{};
@@ -1304,8 +1384,24 @@ pub const Dashboard = struct {
             .background = theme.PANEL,
             .border_color = list_border,
             .child = self.library_scroll_bars.widget(),
+            .padding = .{ .left = 1 },
         };
         var surface = try panel.draw(ctx);
+        if (self.library_row_count == 0) {
+            const empty_msg: []const u8 = blk: {
+                self.api_state.mutex.lock();
+                defer self.api_state.mutex.unlock();
+                break :blk switch (self.api_state.status) {
+                    .connecting => "Loading prompts...",
+                    .error_auth => "Not authenticated. Run clumsies login.",
+                    .error_network => "Hub unavailable. Check clumsies-hub.",
+                    .disconnected => "Not connected to hub.",
+                    .connected => "No prompts loaded.",
+                };
+            };
+            w.writeText(&surface, ctx, 2, 2, empty_msg, theme.fg(theme.MUTED));
+            return surface;
+        }
         return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view);
     }
 
@@ -1590,7 +1686,18 @@ pub const Dashboard = struct {
         w.writeText(&bar, ctx, 2, 0, "Workspaces", theme.boldOn(theme.PANEL, theme.TEXT));
 
         if (wss.len == 0) {
-            w.writeText(&bar, ctx, 2, 1, "No workspaces loaded.", theme.fg(theme.MUTED));
+            const empty_msg: []const u8 = blk: {
+                self.api_state.mutex.lock();
+                defer self.api_state.mutex.unlock();
+                break :blk switch (self.api_state.status) {
+                    .connecting => "Loading workspaces...",
+                    .error_auth => "Not authenticated. Run clumsies login.",
+                    .error_network => "Hub unavailable. Check clumsies-hub.",
+                    .disconnected => "Not connected to hub.",
+                    .connected => "No workspaces loaded.",
+                };
+            };
+            w.writeText(&bar, ctx, 2, 1, empty_msg, theme.fg(theme.MUTED));
         }
 
         const ws_idx = if (wss.len > 0) @min(self.ws_sel, wss.len - 1) else 0;
@@ -1653,6 +1760,8 @@ pub const Dashboard = struct {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
         w.drawBorder(&surface, list_border, theme.PANEL);
+        const row_col: u16 = 2;
+        const cursor_col: u16 = 1;
 
         // Row 0: inner tabs
         var tab_col: u16 = 2;
@@ -1662,149 +1771,254 @@ pub const Dashboard = struct {
         }
 
         const inner_h = ctx.max.height.? -| 2;
+        self.syncWsRows();
 
-        // Check for live workspace detail
+        if (self.ws_row_count == 0) {
+            const empty_msg = switch (self.ws_tab) {
+                .context => "No context files.",
+                .prompts => "No workspace prompts.",
+            };
+            w.writeText(&surface, ctx, row_col, 1, empty_msg, theme.fg(theme.MUTED));
+            return surface;
+        }
+
         self.api_state.mutex.lock();
         const live_ws = self.api_state.ws_detail;
         self.api_state.mutex.unlock();
+        const lib_prompts: []const data.PromptEntry = if (self.ws_tab == .prompts) self.getPrompts() else &.{};
 
-        switch (self.ws_tab) {
-            .context => {
-                var kv_row: u16 = 2;
-                if (live_ws) |ws_d| {
-                    if (ws_d.context_files.len == 0) {
-                        w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
-                    } else {
-                        const MAX_ROWS = 128;
-                        var paths_buf: [MAX_ROWS][]const u8 = undefined;
-                        var orig_idx: [MAX_ROWS]usize = undefined;
-                        const n = @min(ws_d.context_files.len, MAX_ROWS);
-                        for (0..n) |i| {
-                            paths_buf[i] = ws_d.context_files[i].path;
-                            orig_idx[i] = i;
-                        }
-                        const SortCtx = struct {
-                            paths: [*]const []const u8,
-                            fn lt(cx: @This(), a: usize, b: usize) bool {
-                                return std.mem.lessThan(u8, cx.paths[a], cx.paths[b]);
-                            }
-                        };
-                        std.mem.sort(usize, orig_idx[0..n], SortCtx{ .paths = &paths_buf }, SortCtx.lt);
-                        var sorted_paths: [MAX_ROWS][]const u8 = undefined;
-                        for (0..n) |i| sorted_paths[i] = paths_buf[orig_idx[i]];
+        var kv_row: u16 = 1;
+        var r: usize = 0;
+        while (r < self.ws_row_count and kv_row < inner_h + 1) : (r += 1) {
+            const sel = r == self.ws_list_sel;
+            if (sel) {
+                surface.writeCell(cursor_col, kv_row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
 
-                        var rows_buf: [MAX_ROWS]tree.Row = undefined;
-                        const row_count = tree.flatten(sorted_paths[0..n], null, &rows_buf);
+            const rendered = self.ws_row_text_bufs[r][0..self.ws_row_text_len[r]];
+            if (self.ws_row_dir_path[r] != null) {
+                const style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.boldOn(theme.PANEL, theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, row_col, kv_row, rendered, style);
+            } else {
+                const style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, row_col, kv_row, rendered, style);
 
-                        var text_buf: [96]u8 = undefined;
-                        var r: usize = 0;
-                        while (r < row_count and kv_row < inner_h + 2) : (r += 1) {
-                            const tr = rows_buf[r];
-                            var len = tree.renderPrefix(&text_buf, tr.depth, tr.is_last, null);
-                            len = tree.appendText(&text_buf, len, tr.label);
-                            if (tr.kind == .dir and len < text_buf.len) {
-                                text_buf[len] = '/';
-                                len += 1;
-                            }
-                            // Copy to draw arena so cell grapheme pointers remain valid
-                            const rendered = ctx.arena.dupe(u8, text_buf[0..len]) catch continue;
-                            if (tr.kind == .dir) {
-                                w.writeText(&surface, ctx, 2, kv_row, rendered, theme.boldOn(theme.PANEL, theme.ACCENT));
-                            } else {
-                                const file_i = orig_idx[tr.leaf_idx];
-                                const sel = file_i == self.ws_list_sel;
-                                if (sel) {
-                                    surface.writeCell(1, kv_row, .{
-                                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                                    });
-                                }
-                                const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                                w.writeText(&surface, ctx, 2, kv_row, rendered, name_style);
-                            }
-                            kv_row += 1;
-                        }
-                    }
-                } else {
-                    w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
-                }
-            },
-            .prompts => {
-                var kv_row: u16 = 2;
-                if (live_ws) |ws_d| {
-                    if (ws_d.ws_prompts.len == 0) {
-                        w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
-                    } else {
-                        const MAX_ROWS = 128;
-                        const lib_prompts = self.getPrompts();
-                        var paths_buf: [MAX_ROWS][]const u8 = undefined;
-                        var orig_idx: [MAX_ROWS]usize = undefined;
-                        const n = @min(ws_d.ws_prompts.len, MAX_ROWS);
-                        for (0..n) |i| {
-                            const wp = ws_d.ws_prompts[i];
-                            // Prefer the manifest-supplied path (new schema); fall
-                            // back to a library lookup for the legacy string-valued
-                            // manifest, and finally to the raw prompt_id.
-                            paths_buf[i] = if (wp.path.len > 0)
+                if (self.ws_tab == .prompts) {
+                    if (live_ws) |ws_d| {
+                        if (self.ws_row_leaf_index[r]) |idx| {
+                            const wp = ws_d.ws_prompts[idx];
+                            const prompt_path = if (wp.path.len > 0)
                                 wp.path
                             else for (lib_prompts) |lp| {
                                 if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
                             } else wp.prompt_id;
-                            orig_idx[i] = i;
-                        }
-                        const SortCtx = struct {
-                            paths: [*]const []const u8,
-                            fn lt(cx: @This(), a: usize, b: usize) bool {
-                                return std.mem.lessThan(u8, cx.paths[a], cx.paths[b]);
-                            }
-                        };
-                        std.mem.sort(usize, orig_idx[0..n], SortCtx{ .paths = &paths_buf }, SortCtx.lt);
-                        var sorted_paths: [MAX_ROWS][]const u8 = undefined;
-                        for (0..n) |i| sorted_paths[i] = paths_buf[orig_idx[i]];
 
-                        var rows_buf: [MAX_ROWS]tree.Row = undefined;
-                        const row_count = tree.flatten(sorted_paths[0..n], null, &rows_buf);
-
-                        var text_buf: [96]u8 = undefined;
-                        var r: usize = 0;
-                        while (r < row_count and kv_row < inner_h + 2) : (r += 1) {
-                            const tr = rows_buf[r];
-                            var len = tree.renderPrefix(&text_buf, tr.depth, tr.is_last, null);
-                            len = tree.appendText(&text_buf, len, tr.label);
-                            if (tr.kind == .dir and len < text_buf.len) {
-                                text_buf[len] = '/';
-                                len += 1;
+                            if (self.hasDraftFor(prompt_path)) {
+                                const nw: u16 = @intCast(ctx.stringWidth(rendered));
+                                w.writeText(&surface, ctx, row_col + nw + 1, kv_row, "*", theme.fg(theme.WARN));
                             }
-                            // Copy to draw arena so cell grapheme pointers remain valid
-                            const rendered = ctx.arena.dupe(u8, text_buf[0..len]) catch continue;
-                            if (tr.kind == .dir) {
-                                w.writeText(&surface, ctx, 2, kv_row, rendered, theme.boldOn(theme.PANEL, theme.ACCENT));
-                            } else {
-                                const wp_i = orig_idx[tr.leaf_idx];
-                                const sel = wp_i == self.ws_list_sel;
-                                if (sel) {
-                                    surface.writeCell(1, kv_row, .{
-                                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                                    });
-                                }
-                                const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                                w.writeText(&surface, ctx, 2, kv_row, rendered, name_style);
-                                // Draft marker: the full prompt path lives in sorted_paths[r]; hasDraftFor matches on path.
-                                if (self.hasDraftFor(sorted_paths[tr.leaf_idx])) {
-                                    const nw: u16 = @intCast(ctx.stringWidth(rendered));
-                                    w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                                }
-                            }
-                            kv_row += 1;
                         }
                     }
-                } else {
-                    w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
+                }
+            }
+            kv_row += 1;
+        }
+        return surface;
+    }
+
+    fn sortPathIndices(paths: []const []const u8, out: []usize) void {
+        for (0..paths.len) |i| out[i] = i;
+        const SortCtx = struct {
+            paths: []const []const u8,
+
+            fn lt(cx: @This(), a: usize, b: usize) bool {
+                return std.mem.lessThan(u8, cx.paths[a], cx.paths[b]);
+            }
+        };
+        std.mem.sort(usize, out[0..paths.len], SortCtx{ .paths = paths }, SortCtx.lt);
+    }
+
+    fn clearWsRows(self: *Dashboard) void {
+        self.ws_row_count = 0;
+        var i: usize = 0;
+        while (i < MAX_LIBRARY_ROWS) : (i += 1) {
+            self.ws_row_leaf_index[i] = null;
+            self.ws_row_dir_path[i] = null;
+            self.ws_row_depth[i] = 0;
+            self.ws_row_text_len[i] = 0;
+        }
+        self.ws_list_sel = 0;
+    }
+
+    fn wsExpandedSet(self: *Dashboard) *std.StringHashMapUnmanaged(void) {
+        return switch (self.ws_tab) {
+            .context => &self.ws_context_expanded,
+            .prompts => &self.ws_prompts_expanded,
+        };
+    }
+
+    fn wsTreeInitializedFlag(self: *Dashboard) *bool {
+        return switch (self.ws_tab) {
+            .context => &self.ws_context_tree_initialized,
+            .prompts => &self.ws_prompts_tree_initialized,
+        };
+    }
+
+    fn resetWorkspaceTrees(self: *Dashboard) void {
+        self.ws_context_expanded.clearRetainingCapacity();
+        self.ws_prompts_expanded.clearRetainingCapacity();
+        self.ws_context_tree_initialized = false;
+        self.ws_prompts_tree_initialized = false;
+        self.clearWsRows();
+    }
+
+    fn syncWsRows(self: *Dashboard) void {
+        self.api_state.mutex.lock();
+        const live_ws = self.api_state.ws_detail;
+        self.api_state.mutex.unlock();
+
+        if (live_ws == null) {
+            self.clearWsRows();
+            return;
+        }
+        const ws_d = live_ws.?;
+
+        var paths_buf: [MAX_LIBRARY_ROWS][]const u8 = undefined;
+        var orig_idx: [MAX_LIBRARY_ROWS]usize = undefined;
+        var item_count: usize = 0;
+
+        switch (self.ws_tab) {
+            .context => {
+                item_count = @min(ws_d.context_files.len, MAX_LIBRARY_ROWS);
+                for (0..item_count) |i| {
+                    paths_buf[i] = ws_d.context_files[i].path;
+                    orig_idx[i] = i;
+                }
+            },
+            .prompts => {
+                const lib_prompts = self.getPrompts();
+                item_count = @min(ws_d.ws_prompts.len, MAX_LIBRARY_ROWS);
+                for (0..item_count) |i| {
+                    const wp = ws_d.ws_prompts[i];
+                    paths_buf[i] = if (wp.path.len > 0)
+                        wp.path
+                    else for (lib_prompts) |lp| {
+                        if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
+                    } else wp.prompt_id;
+                    orig_idx[i] = i;
                 }
             },
         }
-        return surface;
+
+        if (item_count == 0) {
+            self.clearWsRows();
+            return;
+        }
+
+        const expanded = self.wsExpandedSet();
+        const initialized = self.wsTreeInitializedFlag();
+        if (!initialized.*) {
+            const alloc = self.api_state.allocator();
+            for (paths_buf[0..item_count]) |path| {
+                if (std.mem.indexOfScalar(u8, path, '/')) |slash| {
+                    const top = path[0 .. slash + 1];
+                    if (!expanded.contains(top)) {
+                        _ = expanded.put(alloc, top, {}) catch {};
+                    }
+                }
+            }
+            initialized.* = true;
+        }
+
+        var sort_idx: [MAX_LIBRARY_ROWS]usize = undefined;
+        sortPathIndices(paths_buf[0..item_count], sort_idx[0..item_count]);
+
+        var sorted_paths: [MAX_LIBRARY_ROWS][]const u8 = undefined;
+        var sorted_orig: [MAX_LIBRARY_ROWS]usize = undefined;
+        for (0..item_count) |i| {
+            sorted_paths[i] = paths_buf[sort_idx[i]];
+            sorted_orig[i] = orig_idx[sort_idx[i]];
+        }
+
+        var rows_buf: [MAX_LIBRARY_ROWS]tree.Row = undefined;
+        const row_count = tree.flatten(sorted_paths[0..item_count], expanded, &rows_buf);
+
+        var i: usize = 0;
+        while (i < row_count) : (i += 1) {
+            const tr = rows_buf[i];
+            const buf = &self.ws_row_text_bufs[i];
+
+            self.ws_row_leaf_index[i] = null;
+            self.ws_row_dir_path[i] = null;
+            self.ws_row_depth[i] = tr.depth;
+
+            var len = tree.renderPrefix(buf, tr.depth, tr.ancestor_mask, tr.is_last, null);
+            len = tree.appendText(buf, len, tr.label);
+            if (tr.kind == .dir and len < buf.len) {
+                buf[len] = '/';
+                len += 1;
+            }
+            self.ws_row_text_len[i] = len;
+
+            switch (tr.kind) {
+                .dir => self.ws_row_dir_path[i] = tr.dir_prefix,
+                .leaf => self.ws_row_leaf_index[i] = sorted_orig[tr.leaf_idx],
+            }
+        }
+
+        var clear_idx: usize = row_count;
+        while (clear_idx < MAX_LIBRARY_ROWS) : (clear_idx += 1) {
+            self.ws_row_leaf_index[clear_idx] = null;
+            self.ws_row_dir_path[clear_idx] = null;
+            self.ws_row_depth[clear_idx] = 0;
+            self.ws_row_text_len[clear_idx] = 0;
+        }
+
+        self.ws_row_count = row_count;
+        if (row_count == 0) {
+            self.ws_list_sel = 0;
+        } else if (self.ws_list_sel >= row_count) {
+            self.ws_list_sel = row_count - 1;
+        }
+    }
+
+    fn toggleWsDir(self: *Dashboard, prefix: []const u8) void {
+        const expanded = self.wsExpandedSet();
+        const alloc = self.api_state.allocator();
+        if (expanded.fetchRemove(prefix)) |_| return;
+        _ = expanded.put(alloc, prefix, {}) catch {};
+    }
+
+    fn currentWsDirSelection(self: *Dashboard) ?[]const u8 {
+        if (self.ws_list_sel >= self.ws_row_count) return null;
+        return self.ws_row_dir_path[self.ws_list_sel];
+    }
+
+    fn resolveWsContextSelection(self: *Dashboard, ws_d: *const api.WsDetail) ?usize {
+        _ = ws_d;
+        if (self.ws_list_sel >= self.ws_row_count) return null;
+        return self.ws_row_leaf_index[self.ws_list_sel];
+    }
+
+    const ResolvedWsPrompt = struct {
+        idx: usize,
+        path: []const u8,
+    };
+
+    fn resolveWsPromptSelection(self: *Dashboard, ws_d: *const api.WsDetail) ?ResolvedWsPrompt {
+        if (self.ws_list_sel >= self.ws_row_count) return null;
+        const idx = self.ws_row_leaf_index[self.ws_list_sel] orelse return null;
+        const lib_prompts = self.getPrompts();
+        const wp = ws_d.ws_prompts[idx];
+        const path = if (wp.path.len > 0)
+            wp.path
+        else for (lib_prompts) |lp| {
+            if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
+        } else wp.prompt_id;
+        return .{ .idx = idx, .path = path };
     }
 
     // Workspace content pane: shows selected item's content
@@ -1826,12 +2040,15 @@ pub const Dashboard = struct {
             return surface;
         }
         const ws_d = live_ws.?;
-        const sel = self.ws_list_sel;
+        self.syncWsRows();
+        const dir_sel = self.currentWsDirSelection();
+        const context_sel = self.resolveWsContextSelection(&ws_d);
+        const prompt_sel = self.resolveWsPromptSelection(&ws_d);
 
         // Title: selected item name
         const title: []const u8 = switch (self.ws_tab) {
-            .context => if (sel < ws_d.context_files.len) ws_d.context_files[sel].path else "no files",
-            .prompts => if (sel < ws_d.ws_prompts.len) ws_d.ws_prompts[sel].prompt_id else "no prompts",
+            .context => if (dir_sel) |dir| dir else if (context_sel) |sel| ws_d.context_files[sel].path else "no files",
+            .prompts => if (dir_sel) |dir| dir else if (prompt_sel) |sel| sel.path else "no prompts",
         };
         // Title with diff marker
         const has_diff: bool = false; // Live data does not yet track diff state
@@ -1846,7 +2063,13 @@ pub const Dashboard = struct {
 
         switch (self.ws_tab) {
             .context => {
-                if (sel < ws_d.context_files.len) {
+                if (dir_sel != null) {
+                    w.writeText(&surface, ctx, 2, kv_row, "Directory selected.", theme.fg(theme.TEXT_SOFT));
+                    kv_row += 1;
+                    if (kv_row < max_row) {
+                        w.writeText(&surface, ctx, 2, kv_row, "Enter toggles expansion. Left collapses or jumps to parent. Right expands.", theme.fg(theme.MUTED));
+                    }
+                } else if (context_sel) |sel| {
                     const f = &ws_d.context_files[sel];
                     if (self.ws_show_diff) {
                         w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
@@ -1863,12 +2086,18 @@ pub const Dashboard = struct {
                 }
             },
             .prompts => {
-                if (sel < ws_d.ws_prompts.len) {
-                    const p = &ws_d.ws_prompts[sel];
+                if (dir_sel != null) {
+                    w.writeText(&surface, ctx, 2, kv_row, "Directory selected.", theme.fg(theme.TEXT_SOFT));
+                    kv_row += 1;
+                    if (kv_row < max_row) {
+                        w.writeText(&surface, ctx, 2, kv_row, "Enter toggles expansion. Left collapses or jumps to parent. Right expands.", theme.fg(theme.MUTED));
+                    }
+                } else if (prompt_sel) |sel| {
+                    const p = &ws_d.ws_prompts[sel.idx];
                     if (self.ws_show_diff) {
                         w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
                     } else {
-                        w.writeText(&surface, ctx, 2, kv_row, p.prompt_id, theme.fg(theme.TEXT_SOFT));
+                        w.writeText(&surface, ctx, 2, kv_row, sel.path, theme.fg(theme.TEXT_SOFT));
                         kv_row += 1;
                         if (kv_row < max_row) {
                             const hash_label = try std.fmt.allocPrint(ctx.arena, "hash: {s}", .{p.content_hash});
@@ -1883,36 +2112,66 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    // Insights: multi-panel signal-ratio dashboard
-    fn drawInsights(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+    fn loadInsightsData(self: *Dashboard, arena: std.mem.Allocator) ?data.InsightsData {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.org_stats) |stats| {
+            return api.insightsFromStats(arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models, null);
+        }
+        return null;
+    }
+
+    // Dashboard: live scope-aware signal and recent input feed.
+    fn drawDashboard(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+        const scope = self.currentInsightsScope();
+        const server_signal_ratio = self.serverSignalRatio();
+
+        const scoped_trace = self.scopedTraceData();
+        const signal_value_text: []const u8 = blk: {
+            if (scoped_trace) |st| {
+                if (st.constraint_count > 0) {
+                    break :blk std.fmt.allocPrint(ctx.arena, "{d}%", .{st.signal_ratio}) catch "n/a";
+                }
+            }
+            if (scope.ws_id == null) {
+                if (server_signal_ratio) |sig| {
+                    break :blk std.fmt.allocPrint(ctx.arena, "{d}%", .{sig}) catch "n/a";
+                }
+            }
+            break :blk "n/a";
+        };
+        const chart_series: ChartSeries = if (scoped_trace) |st|
+            self.buildLocalChartSeries(ctx.arena, st.refers)
+        else
+            .{ .values = &.{}, .left_label = "60s ago", .right_label = "now" };
+
+        const inputs: []const trace_reader.InputEvent = if (scoped_trace) |st| st.inputs else &.{};
+
+        const chart_h: u16 = if (size.height > 40) 10 else 8;
+        const inputs_h: u16 = size.height -| chart_h;
+        const usable_input_rows: u16 = inputs_h -| 2;
+        self.dashboard_input_capacity = @max(@as(usize, 1), @as(usize, @intCast((usable_input_rows + 1) / 3)));
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawInsightsChart(ctx, size.width, chart_h, signal_value_text, chart_series, scope.label, scope.ws_id) };
+        children[1] = .{ .origin = .{ .row = chart_h, .col = 0 }, .surface = try self.drawInsightsInputs(ctx, size.width, inputs_h, inputs, scope.label) };
+
+        root.children = children;
+        return root;
+    }
+
+    // Analysis: aggregate prompt/team views and drill-downs.
+    fn drawAnalysis(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.CANVAS);
 
-        // Use live stats if available, otherwise zero-initialized defaults
-        var live_insights: ?data.InsightsData = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            if (self.api_state.org_stats) |stats|
-                break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models, self.api_state.local_stats);
-            // No server stats, but local trace available — show personal data
-            if (self.api_state.local_stats) |local| {
-                var inputs_list: std.ArrayList(data.InputItem) = .empty;
-                for (local.inputs) |iv| {
-                    inputs_list.append(ctx.arena, .{ .timestamp = iv.timestamp, .content = iv.content }) catch break;
-                }
-                break :blk data.InsightsData{
-                    .constraint_count = local.constraint_count,
-                    .active_constraint_count = local.active_constraint_count,
-                    .idle_constraint_count = if (local.constraint_count > local.active_constraint_count) local.constraint_count - local.active_constraint_count else 0,
-                    .signal_ratio = local.signal_ratio,
-                    .refer_trend = local.refer_trend,
-                    .prompts = local.prompts,
-                    .inputs = inputs_list.items,
-                };
-            }
-            break :blk null;
-        };
+        var live_insights = self.loadInsightsData(ctx.arena);
+        const analysis_available = live_insights != null;
         var empty_insights: data.InsightsData = .{
             .constraint_count = 0,
             .active_constraint_count = 0,
@@ -1929,42 +2188,29 @@ pub const Dashboard = struct {
         };
         const ins: *const data.InsightsData = if (live_insights) |*li| li else &empty_insights;
 
-        // Layout:
-        //   row 0: chart (full width)
-        //   row 1: prompts | team (side by side)
-        //   row 2: recent inputs (full width)
-        const chart_h: u16 = if (size.height > 40) 10 else 8;
-        const inputs_h: u16 = if (size.height > 40) 10 else 7;
-        const middle_h: u16 = size.height -| chart_h -| inputs_h;
         const team_w: u16 = 18;
         const prompts_w: u16 = size.width -| team_w;
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
 
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 4);
-
-        // Panel 1: Signal Trend chart (hero, full width)
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawInsightsChart(ctx, size.width, chart_h, ins) };
-        // Panel 2: Prompts Rank (or Member Detail if active)
         const main_surface = if (self.insights_show_member_detail)
-            try self.drawMemberDetail(ctx, prompts_w, middle_h, ins)
+            try self.drawMemberDetail(ctx, prompts_w, size.height, ins)
         else
-            try self.drawInsightsPrompts(ctx, prompts_w, middle_h, ins);
-        children[1] = .{ .origin = .{ .row = chart_h, .col = 0 }, .surface = main_surface };
-        // Panel 3: Team Activity sidebar (narrow, right side)
-        children[2] = .{ .origin = .{ .row = chart_h, .col = prompts_w }, .surface = try self.drawInsightsTeam(ctx, team_w, middle_h, ins) };
-        // Panel 4: Recent Inputs (full width, bottom)
-        children[3] = .{ .origin = .{ .row = chart_h + middle_h, .col = 0 }, .surface = try self.drawInsightsInputs(ctx, size.width, inputs_h, ins) };
+            try self.drawInsightsPrompts(ctx, prompts_w, size.height, ins, analysis_available);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = main_surface };
+        children[1] = .{ .origin = .{ .row = 0, .col = prompts_w }, .surface = try self.drawInsightsTeam(ctx, team_w, size.height, ins, analysis_available) };
 
         root.children = children;
         return root;
     }
 
-    fn drawInsightsChart(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawInsightsChart(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, signal_value_text: []const u8, series: ChartSeries, scope_label: []const u8, scope_ws_id: ?[]const u8) std.mem.Allocator.Error!vxfw.Surface {
         const border_color = if (self.insights_focus == .chart) theme.ACCENT else theme.BORDER;
         var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
         w.fillSurface(&s, theme.PANEL);
         w.drawBorder(&s, border_color, theme.PANEL);
 
-        // Title bar: ● Signal Trend ── key metrics
+        // Title bar: continuous bullet-separated fields, no border dashes
+        // bleeding through between segments.
         // Breathing ● : phase 0-10 = dim→bright, 10-20 = bright→dim
         const breath_t: f32 = blk: {
             const p = self.breathing_phase;
@@ -1974,31 +2220,78 @@ pub const Dashboard = struct {
         const dark_green = theme.rgb(0x2d4a1f);
         const dot_color = theme.lerpColor(dark_green, theme.OK, breath_t);
         w.writeText(&s, ctx, 2, 0, "\u{25cf}", .{ .fg = dot_color, .bg = theme.PANEL });
-        w.writeText(&s, ctx, 4, 0, "Signal Trend", theme.boldOn(theme.PANEL, theme.TEXT));
-        const metrics_txt = try std.fmt.allocPrint(ctx.arena, "signal {d}%", .{ins.signal_ratio});
-        w.writeText(&s, ctx, 18, 0, metrics_txt, theme.fg(theme.ACCENT_SOFT));
+        const right_hint = "w scope  Shift-F flush";
+        const right_hint_w: u16 = @intCast(ctx.stringWidth(right_hint));
+        const right_limit: u16 = width -| right_hint_w -| 2;
 
-        const active = self.activeSessionCount();
-        if (active > 0) {
-            const sess_txt = try std.fmt.allocPrint(ctx.arena, "\u{25cf} {d} live", .{active});
-            w.writeText(&s, ctx, 32, 0, sess_txt, .{ .fg = theme.OK, .bg = theme.PANEL });
+        var header_col: u16 = 3;
+        const lead_gap = " ";
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, lead_gap, theme.textOn(theme.PANEL, theme.TEXT));
+            header_col +|= @intCast(ctx.stringWidth(lead_gap));
+        }
+        const title_txt = "Signal Trend";
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, title_txt, theme.boldOn(theme.PANEL, theme.TEXT));
+            header_col +|= @intCast(ctx.stringWidth(title_txt));
+        }
+        const sep_txt = "  \xc2\xb7 ";
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, sep_txt, theme.fg(theme.MUTED));
+            header_col +|= @intCast(ctx.stringWidth(sep_txt));
+        }
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, scope_label, theme.boldOn(theme.PANEL, theme.TEXT));
+            header_col +|= @intCast(ctx.stringWidth(scope_label));
+        }
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, sep_txt, theme.fg(theme.MUTED));
+            header_col +|= @intCast(ctx.stringWidth(sep_txt));
+        }
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, "signal", theme.boldOn(theme.PANEL, theme.TEXT));
+            header_col +|= @intCast(ctx.stringWidth("signal"));
+        }
+        if (header_col < right_limit) {
+            w.writeText(&s, ctx, header_col, 0, " ", theme.fg(theme.MUTED));
+            header_col +|= 1;
+        }
+        if (header_col < right_limit) {
+            const signal_style = if (std.mem.eql(u8, signal_value_text, "n/a"))
+                theme.fg(theme.MUTED)
+            else
+                theme.fg(theme.TEXT_SOFT);
+            w.writeText(&s, ctx, header_col, 0, signal_value_text, signal_style);
+            header_col +|= @intCast(ctx.stringWidth(signal_value_text));
         }
 
-        w.writeRightText(&s, ctx, 0, "t period", theme.fg(theme.MUTED));
+        const active = self.activeSessionCount(scope_ws_id);
+        if (active > 0) {
+            const sess_txt = try std.fmt.allocPrint(ctx.arena, "{d} live", .{active});
+            if (header_col < right_limit) {
+                w.writeText(&s, ctx, header_col, 0, sep_txt, theme.fg(theme.MUTED));
+                header_col +|= @intCast(ctx.stringWidth(sep_txt));
+            }
+            if (header_col < right_limit) {
+                w.writeText(&s, ctx, header_col, 0, sess_txt, .{ .fg = theme.OK, .bg = theme.PANEL });
+            }
+        }
+
+        w.writeRightText(&s, ctx, 0, right_hint, theme.fg(theme.MUTED));
 
         const chart_x: u16 = 1;
         const chart_w: u16 = width -| 2;
         const chart_rows: u16 = height -| 3;
-        w.drawBrailleAreaChart(&s, ctx.arena, &ins.refer_trend, chart_x, 1, chart_w, chart_rows);
+        w.drawBrailleAreaChart(&s, ctx.arena, series.values, chart_x, 1, chart_w, chart_rows);
 
         // X-axis: minimal endpoints
-        w.writeText(&s, ctx, chart_x, height -| 2, "30d ago", theme.fg(theme.DIM));
-        w.writeRightText(&s, ctx, height -| 2, "today", theme.fg(theme.DIM));
+        w.writeText(&s, ctx, chart_x, height -| 2, series.left_label, theme.fg(theme.DIM));
+        w.writeRightText(&s, ctx, height -| 2, series.right_label, theme.fg(theme.DIM));
 
         return s;
     }
 
-    fn drawInsightsPrompts(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawInsightsPrompts(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData, available: bool) std.mem.Allocator.Error!vxfw.Surface {
         const border_color = if (self.insights_focus == .prompts) theme.ACCENT else theme.BORDER;
         var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
         w.fillSurface(&s, theme.PANEL);
@@ -2006,12 +2299,23 @@ pub const Dashboard = struct {
 
         w.writeText(&s, ctx, 3, 0, "Prompts Rank", theme.boldOn(theme.PANEL, theme.TEXT));
         // Right-aligned column headers (with right padding)
-        const col_rate: u16 = width -| 24;
-        const col_delta: u16 = width -| 16;
-        const col_sig: u16 = width -| 9;
-        w.writeText(&s, ctx, col_rate, 0, "rate", theme.fg(theme.MUTED));
-        w.writeText(&s, ctx, col_delta, 0, "\u{0394}7d", theme.fg(theme.MUTED));
-        w.writeText(&s, ctx, col_sig, 0, "signal", theme.fg(theme.MUTED));
+        const col_reach: u16 = width -| 24;
+        const col_trend: u16 = width -| 16;
+        const col_last: u16 = width -| 8;
+        w.writeText(&s, ctx, col_reach, 0, "reach", theme.fg(theme.MUTED));
+        w.writeText(&s, ctx, col_trend, 0, "trend", theme.fg(theme.MUTED));
+        w.writeText(&s, ctx, col_last, 0, "last", theme.fg(theme.MUTED));
+
+        if (!available) {
+            w.writeText(&s, ctx, 2, 2, "Remote analysis unavailable.", theme.fg(theme.MUTED));
+            w.writeText(&s, ctx, 2, 3, "Analysis now uses hub stats only. Press r to refresh after /api/stats loads.", theme.fg(theme.DIM));
+            return s;
+        }
+
+        if (ins.prompts.len == 0) {
+            w.writeText(&s, ctx, 2, 2, "No prompt analysis data returned by the hub.", theme.fg(theme.MUTED));
+            return s;
+        }
 
         // Find max refer count for bar scaling
         var max_refer: u32 = 1;
@@ -2019,9 +2323,17 @@ pub const Dashboard = struct {
             if (p.refer_count > max_refer) max_refer = p.refer_count;
         }
 
-        const name_w: u16 = 21;
-        const bar_start: u16 = name_w + 1;
-        const bar_end: u16 = col_rate -| 2;
+        const name_col: u16 = 2;
+        const min_name_w: u16 = 18;
+        const max_name_w: u16 = @max(min_name_w, @min(@as(u16, 40), col_reach -| name_col -| 24));
+        var measured_name_w: u16 = min_name_w;
+        for (ins.prompts) |p| {
+            const candidate = @as(u16, @intCast(ctx.stringWidth(firstLineTrimmed(p.name, max_name_w))));
+            if (candidate > measured_name_w) measured_name_w = candidate;
+        }
+        const name_w: u16 = @min(max_name_w, measured_name_w);
+        const bar_start: u16 = name_col + name_w + 1;
+        const bar_end: u16 = col_reach -| 2;
         const bar_max_w: u16 = bar_end -| bar_start;
 
         const focused = self.insights_focus == .prompts;
@@ -2039,19 +2351,17 @@ pub const Dashboard = struct {
                 });
             }
 
-            if (is_idle) {
-                // Same layout as active prompts, just name in red
-                const name_style: vaxis.Style = if (is_sel) theme.boldOn(theme.PANEL, theme.DANGER) else .{ .fg = theme.DANGER, .bg = theme.PANEL };
-                w.writeText(&s, ctx, 2, row, p.name, name_style);
-                w.writeText(&s, ctx, col_rate, row, "0/d", theme.fg(theme.MUTED));
-                w.writeText(&s, ctx, col_delta, row, " 0%", theme.fg(theme.MUTED));
-                const sig_txt = try std.fmt.allocPrint(ctx.arena, "0/{d}", .{p.constraint_count});
-                w.writeText(&s, ctx, col_sig, row, sig_txt, theme.fg(theme.MUTED));
-            } else {
-                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&s, ctx, 2, row, p.name, name_style);
+            const name_style: vaxis.Style = if (is_idle)
+                (if (is_sel) theme.boldOn(theme.PANEL, theme.DANGER) else .{ .fg = theme.DANGER, .bg = theme.PANEL })
+            else if (is_sel)
+                theme.boldOn(theme.PANEL, theme.TEXT)
+            else
+                theme.fg(theme.TEXT_SOFT);
+            w.writeText(&s, ctx, name_col, row, firstLineTrimmed(p.name, name_w), name_style);
 
-                const bar_w: u16 = @intCast(@as(u32, bar_max_w) * p.refer_count / max_refer);
+            if (!is_idle) {
+                const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * p.refer_count / max_refer);
+                const bar_w: u16 = if (p.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
                 for (0..bar_w) |offset| {
                     const bc: u16 = bar_start + @as(u16, @intCast(offset));
                     if (bc >= bar_end) break;
@@ -2063,15 +2373,19 @@ pub const Dashboard = struct {
                 }
                 const ref_text = try std.fmt.allocPrint(ctx.arena, " {d}", .{p.refer_count});
                 const ref_col: u16 = bar_start + bar_w;
-                if (ref_col + @as(u16, @intCast(ctx.stringWidth(ref_text))) < col_rate) {
+                if (ref_col + @as(u16, @intCast(ctx.stringWidth(ref_text))) < col_reach) {
                     w.writeText(&s, ctx, ref_col, row, ref_text, theme.fg(theme.TEXT));
                 }
-                const rate = try std.fmt.allocPrint(ctx.arena, "{d}/d", .{p.rate_per_day});
-                w.writeText(&s, ctx, col_rate, row, rate, theme.fg(theme.MUTED));
-                w.writeDelta(&s, ctx, col_delta, row, p.delta_pct);
-                const sig_txt = try std.fmt.allocPrint(ctx.arena, "{d}/{d}", .{ p.active_constraint_count, p.constraint_count });
-                w.writeText(&s, ctx, col_sig, row, sig_txt, theme.fg(theme.MUTED));
             }
+
+            const reach_txt = try std.fmt.allocPrint(ctx.arena, "{d}", .{p.workspace_count});
+            w.writeText(&s, ctx, col_reach, row, reach_txt, theme.fg(theme.MUTED));
+            w.writeText(&s, ctx, col_trend, row, "\xe2\x80\x94", theme.fg(theme.DIM));
+            const last_txt = if (p.last_referred_days_ago) |days|
+                (try std.fmt.allocPrint(ctx.arena, "{d}d", .{days}))
+            else
+                "\xe2\x80\x94";
+            w.writeText(&s, ctx, col_last, row, last_txt, theme.fg(theme.MUTED));
             row += 1;
 
             // Expanded per-constraint detail
@@ -2084,15 +2398,23 @@ pub const Dashboard = struct {
                     if (row >= height -| 1) break;
                     const is_c_idle = c.refer_count == 0;
                     const is_last = ci + 1 == p.constraints.len;
+                    const show_child_id = !std.mem.eql(u8, c.id, c.label);
+                    const child_label_col: u16 = if (show_child_id) 12 else 9;
+                    const child_label = firstLineTrimmed(c.label, bar_start -| child_label_col -| 2);
+                    const child_bar_start: u16 = bar_start + 2;
                     const tree_char: []const u8 = if (is_last) "\xe2\x94\x94" else "\xe2\x94\x9c"; // └ or ├
                     w.writeText(&s, ctx, 5, row, tree_char, theme.fg(theme.DIM));
-                    w.writeText(&s, ctx, 7, row, c.id, theme.fg(theme.MUTED));
-                    w.writeText(&s, ctx, 12, row, c.label, if (is_c_idle) theme.fg(theme.DANGER) else theme.fg(theme.TEXT_SOFT));
+                    if (show_child_id) {
+                        w.writeText(&s, ctx, 7, row, firstLineTrimmed(c.id, 4), theme.fg(theme.MUTED));
+                    }
+                    w.writeText(&s, ctx, child_label_col, row, child_label, if (is_c_idle) theme.fg(theme.DANGER) else theme.fg(theme.TEXT_SOFT));
                     if (!is_c_idle) {
-                        const c_bar_w: u16 = @intCast(@min(@as(u32, bar_max_w / 2) * c.refer_count / c_max, bar_max_w / 2));
+                        const child_bar_max_w: u16 = bar_max_w / 2;
+                        const c_bar_w_raw: u16 = @intCast(@min(@as(u32, child_bar_max_w) * c.refer_count / c_max, child_bar_max_w));
+                        const c_bar_w: u16 = if (c.refer_count > 0 and c_bar_w_raw == 0 and child_bar_max_w > 0) 1 else c_bar_w_raw;
                         for (0..c_bar_w) |offset| {
-                            const bc: u16 = 32 + @as(u16, @intCast(offset));
-                            if (bc >= col_rate -| 2) break;
+                            const bc: u16 = child_bar_start + @as(u16, @intCast(offset));
+                            if (bc >= col_reach -| 2) break;
                             const t: f32 = if (c_bar_w > 1) @as(f32, @floatFromInt(offset)) / @as(f32, @floatFromInt(c_bar_w - 1)) else 0.5;
                             s.writeCell(bc, row, .{
                                 .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
@@ -2100,13 +2422,13 @@ pub const Dashboard = struct {
                             });
                         }
                         const c_ref = try std.fmt.allocPrint(ctx.arena, " {d}", .{c.refer_count});
-                        w.writeText(&s, ctx, col_rate, row, c_ref, theme.fg(theme.MUTED));
+                        w.writeText(&s, ctx, col_reach, row, c_ref, theme.fg(theme.MUTED));
                     } else {
                         const idle_txt = if (c.idle_days) |d|
                             try std.fmt.allocPrint(ctx.arena, "idle {d}d \xe2\x9a\xa0", .{d})
                         else
                             "idle \xe2\x9a\xa0";
-                        w.writeText(&s, ctx, col_rate, row, idle_txt, .{ .fg = theme.DANGER, .bg = theme.PANEL });
+                        w.writeText(&s, ctx, col_reach, row, idle_txt, .{ .fg = theme.DANGER, .bg = theme.PANEL });
                     }
                     row += 1;
                 }
@@ -2116,13 +2438,25 @@ pub const Dashboard = struct {
         return s;
     }
 
-    fn drawInsightsTeam(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawInsightsTeam(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData, available: bool) std.mem.Allocator.Error!vxfw.Surface {
         const border_color = if (self.insights_focus == .team) theme.ACCENT else theme.BORDER;
         var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
         w.fillSurface(&s, theme.PANEL);
         w.drawBorder(&s, border_color, theme.PANEL);
 
         w.writeText(&s, ctx, 2, 0, "Team Activity", theme.boldOn(theme.PANEL, theme.TEXT));
+
+        if (!available) {
+            w.writeText(&s, ctx, 2, 2, "No", theme.fg(theme.MUTED));
+            w.writeText(&s, ctx, 2, 3, "stats", theme.fg(theme.MUTED));
+            return s;
+        }
+
+        if (ins.members.len == 0) {
+            w.writeText(&s, ctx, 2, 2, "No", theme.fg(theme.MUTED));
+            w.writeText(&s, ctx, 2, 3, "team", theme.fg(theme.MUTED));
+            return s;
+        }
 
         // Find team max for color scaling
         var team_max: u16 = 1;
@@ -2180,64 +2514,78 @@ pub const Dashboard = struct {
         return s;
     }
 
-    // Returns the cutoff timestamp (ms since epoch) for the current
-    // insights_period window. Events older than this are filtered out.
-    fn inputsCutoffMs(self: *const Dashboard) i64 {
-        const now_ms = std.time.milliTimestamp();
-        const day_ms: i64 = 86400 * 1000;
-        const window_days: i64 = switch (self.insights_period) {
-            .daily => 1,
-            .weekly => 7,
-            .monthly => 30,
-        };
-        return now_ms - window_days * day_ms;
+    fn latestInputs(inputs: anytype, limit: usize) @TypeOf(inputs) {
+        return inputs[0..@min(inputs.len, limit)];
     }
 
-    fn visibleInputs(ins: *const data.InsightsData, cutoff_ms: i64) []const data.InputItem {
-        var last: usize = 0;
-        for (ins.inputs, 0..) |iv, i| {
-            if (iv.timestamp >= cutoff_ms) last = i + 1 else break;
+    fn workspaceNameForId(self: *const Dashboard, ws_id: []const u8) []const u8 {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const user = self.api_state.current_user orelse return ws_id;
+        for (user.workspaces) |ws| {
+            if (std.mem.eql(u8, ws.ws_id, ws_id)) return ws.name;
         }
-        return ins.inputs[0..last];
+        return ws_id;
     }
 
-    fn drawInsightsInputs(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+    fn compactSessionId(session_id: []const u8) []const u8 {
+        if (session_id.len <= 12) return session_id;
+        if (std.mem.startsWith(u8, session_id, "ses-") and session_id.len >= 10) {
+            return session_id[0..10];
+        }
+        return session_id[0..@min(session_id.len, 12)];
+    }
+
+    fn drawInsightsInputs(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, inputs: []const trace_reader.InputEvent, scope_label: []const u8) std.mem.Allocator.Error!vxfw.Surface {
         const border_color = if (self.insights_focus == .inputs) theme.ACCENT else theme.BORDER;
         var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
         w.fillSurface(&s, theme.PANEL);
         w.drawBorder(&s, border_color, theme.PANEL);
 
-        const cutoff = self.inputsCutoffMs();
-        const visible = visibleInputs(ins, cutoff);
+        const visible = latestInputs(inputs, self.dashboard_input_capacity);
 
-        const title_txt = try std.fmt.allocPrint(ctx.arena, "Recent Inputs  \xc2\xb7 {d} in {s}", .{ visible.len, self.insights_period.label() });
+        const title_txt = try std.fmt.allocPrint(ctx.arena, "Recent Inputs  \xc2\xb7 {s}  \xc2\xb7 live feed", .{scope_label});
         w.writeText(&s, ctx, 2, 0, title_txt, theme.boldOn(theme.PANEL, theme.TEXT));
 
         if (visible.len == 0) {
-            w.writeText(&s, ctx, 2, 2, "No user prompts captured in this window.", theme.fg(theme.MUTED));
+            w.writeText(&s, ctx, 2, 2, "No recent user prompts captured.", theme.fg(theme.MUTED));
             return s;
         }
 
         const focused = self.insights_focus == .inputs;
-        const max_rows: u16 = height -| 2;
-        const content_w: u16 = width -| 14; // leave room for timestamp column
+        const inner_w: u16 = width -| 4;
+        const body_col: u16 = 3;
+        const content_w: u16 = inner_w -| 4;
         var row: u16 = 1;
         var i: usize = 0;
-        while (i < visible.len and row < max_rows) : (i += 1) {
+        while (i < visible.len and row + 1 < height -| 1) : (i += 1) {
             const iv = visible[i];
             const is_sel = focused and i == self.insights_input_cursor;
-            if (is_sel) {
-                s.writeCell(1, row, .{
-                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                });
-            }
+            const ws_label = self.workspaceNameForId(iv.ws_id);
+            const session_label = compactSessionId(iv.session_id);
             const time_txt = try formatHm(ctx.arena, iv.timestamp);
-            w.writeText(&s, ctx, 2, row, time_txt, theme.fg(theme.MUTED));
+            const meta_label = if (std.mem.eql(u8, scope_label, "All Workspaces"))
+                try std.fmt.allocPrint(ctx.arena, "{s}  \xc2\xb7 {s}  \xc2\xb7 input", .{ ws_label, session_label })
+            else
+                try std.fmt.allocPrint(ctx.arena, "{s}  \xc2\xb7 input", .{session_label});
+            const meta_style: vaxis.Style = if (is_sel) theme.boldOn(theme.PANEL, theme.ACCENT_SOFT) else .{ .fg = theme.MUTED, .bg = theme.PANEL };
+            w.writeText(&s, ctx, body_col, row, firstLineTrimmed(meta_label, content_w), meta_style);
+            w.writeRightText(&s, ctx, row, time_txt, .{ .fg = if (is_sel) theme.ACCENT_SOFT else theme.MUTED, .bg = theme.PANEL });
+
             const snippet = firstLineTrimmed(iv.content, content_w);
-            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-            w.writeText(&s, ctx, 10, row, snippet, name_style);
-            row += 1;
+            const body_style: vaxis.Style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else .{ .fg = theme.TEXT_SOFT, .bg = theme.PANEL };
+            w.writeText(&s, ctx, body_col, row + 1, snippet, body_style);
+
+            if (i + 1 < visible.len and row + 2 < height -| 1) {
+                var sep_col: u16 = 2;
+                while (sep_col < width -| 2) : (sep_col += 1) {
+                    s.writeCell(sep_col, row + 2, .{
+                        .char = .{ .grapheme = "\xe2\x94\x80", .width = 1 },
+                        .style = .{ .fg = if (is_sel) theme.ACCENT_SOFT else theme.BORDER, .bg = theme.PANEL },
+                    });
+                }
+            }
+            row += 3;
         }
 
         return s;
@@ -2280,7 +2628,8 @@ pub const Dashboard = struct {
         for (member.top_prompts) |tp| {
             if (row >= height -| 5) break;
             w.writeText(&s, ctx, 5, row, tp.name, theme.fg(theme.TEXT_SOFT));
-            const bar_w: u16 = @intCast(@as(u32, bar_max_w) * tp.refer_count / max_ref);
+            const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * tp.refer_count / max_ref);
+            const bar_w: u16 = if (tp.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
             for (0..bar_w) |offset| {
                 const bc: u16 = bar_start + @as(u16, @intCast(offset));
                 if (bc >= bar_end) break;
@@ -2622,7 +2971,7 @@ pub const Dashboard = struct {
     // short-lived CLI that flushes buffered trace events and exits.
     fn flushTrace(self: *Dashboard) void {
         self.status_line = "Flushing trace...";
-        const alloc = self.api_state.arena.allocator();
+        const alloc = self.api_state.allocator();
         var child = std.process.Child.init(&.{ "clumsies", "trace", "flush" }, alloc);
         child.stdout_behavior = .Pipe;
         child.stderr_behavior = .Pipe;
@@ -2640,6 +2989,7 @@ pub const Dashboard = struct {
         switch (term) {
             .Exited => |code| {
                 if (code == 0) {
+                    api.refreshLocalState(self.api_state);
                     const trimmed = std.mem.trim(u8, stdout.items, " \n\r\t");
                     if (trimmed.len > 0) {
                         self.status_line = std.fmt.allocPrint(alloc, "Flush: {s}", .{trimmed}) catch "Flush: ok";
@@ -2655,10 +3005,18 @@ pub const Dashboard = struct {
         }
     }
 
-    fn activeSessionCount(self: *Dashboard) usize {
+    fn activeSessionCount(self: *Dashboard, scope_ws_id: ?[]const u8) usize {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        return if (self.api_state.active_sessions) |s| s.len else 0;
+        const sessions = self.api_state.active_sessions orelse return 0;
+        if (scope_ws_id) |ws_id| {
+            var count: usize = 0;
+            for (sessions) |sess| {
+                if (std.mem.eql(u8, sess.ws_id, ws_id)) count += 1;
+            }
+            return count;
+        }
+        return sessions.len;
     }
 
     // Build display-ready session rows with a human-readable age string.
@@ -2719,7 +3077,7 @@ pub const Dashboard = struct {
             } else {
                 return &.{};
             }
-            const alloc = self.api_state.arena.allocator();
+            const alloc = self.api_state.allocator();
             return api.toPrEntries(alloc, prs, prompt_path, self.api_state);
         }
         return &.{};
@@ -2729,7 +3087,7 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         if (self.api_state.prompts) |lp| {
-            const alloc = self.api_state.arena.allocator();
+            const alloc = self.api_state.allocator();
             return api.toPromptEntries(alloc, lp);
         }
         return &.{};
@@ -2743,7 +3101,7 @@ pub const Dashboard = struct {
         const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
         if (prs_for.len == 0) return;
 
-        const alloc = self.api_state.arena.allocator();
+        const alloc = self.api_state.allocator();
         const path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{prs_for[pri].id}) catch {
             self.status_line = "Failed to submit comment";
             return;
@@ -2769,7 +3127,7 @@ pub const Dashboard = struct {
         if (prs_for.len == 0) return;
         const pr_id = prs_for[pri].id;
 
-        const alloc = self.api_state.arena.allocator();
+        const alloc = self.api_state.allocator();
         const path = std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}", .{pr_id}) catch {
             self.status_line = "Failed to build request";
             return;
@@ -2808,7 +3166,7 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         if (self.api_state.current_user) |u| {
-            const alloc = self.api_state.arena.allocator();
+            const alloc = self.api_state.allocator();
             var list: std.ArrayList(data.WorkspaceEntry) = .empty;
             for (u.workspaces) |ws| {
                 const al: data.AccessLevel = if (std.mem.eql(u8, ws.role, "admin")) .admin else .member;
@@ -2846,28 +3204,145 @@ pub const Dashboard = struct {
 
     const InsightsCounts = struct { prompt_count: usize, member_count: usize, input_count: usize };
 
-    fn getInsightsCounts(self: *Dashboard) InsightsCounts {
-        // Returns counts of prompts, members, and inputs for bounds checking
-        // in the event handler. Inputs are filtered by the current period
-        // window to match what drawInsightsInputs actually renders.
+    const InsightsScopeInfo = struct {
+        label: []const u8,
+        ws_id: ?[]const u8,
+    };
+
+    const ScopedTraceData = struct {
+        label: []const u8,
+        signal_ratio: u8,
+        constraint_count: u32,
+        refers: []const trace_reader.ReferEvent,
+        inputs: []const trace_reader.InputEvent,
+    };
+
+    const ChartSeries = struct {
+        values: []const u16,
+        left_label: []const u8,
+        right_label: []const u8,
+    };
+
+    fn currentInsightsScopeLocked(self: *const Dashboard) InsightsScopeInfo {
+        const workspaces = if (self.api_state.current_user) |u| u.workspaces else &.{};
+        if (workspaces.len == 0 or self.insights_scope_idx == 0) {
+            return .{ .label = "All Workspaces", .ws_id = null };
+        }
+
+        const scope_idx = @min(self.insights_scope_idx, workspaces.len);
+        const ws = workspaces[scope_idx - 1];
+        return .{ .label = ws.name, .ws_id = ws.ws_id };
+    }
+
+    fn currentInsightsScope(self: *const Dashboard) InsightsScopeInfo {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        const input_count: usize = if (self.api_state.local_stats) |local| blk: {
-            const cutoff_ms = self.inputsCutoffMs();
-            var n: usize = 0;
-            for (local.inputs) |iv| {
-                if (iv.timestamp >= cutoff_ms) n += 1 else break;
+        return self.currentInsightsScopeLocked();
+    }
+
+    fn cycleInsightsScope(self: *Dashboard) InsightsScopeInfo {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const workspaces = if (self.api_state.current_user) |u| u.workspaces else &.{};
+        const scope_count = workspaces.len + 1;
+        self.insights_scope_idx = (self.insights_scope_idx + 1) % scope_count;
+        return self.currentInsightsScopeLocked();
+    }
+
+    fn serverSignalRatio(self: *const Dashboard) ?u8 {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const stats = self.api_state.org_stats orelse return null;
+        return @intCast(@min(@as(u64, @intFromFloat(stats.signal_ratio * 100)), 100));
+    }
+
+    fn scopedTraceData(self: *const Dashboard) ?ScopedTraceData {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+
+        const local = self.api_state.local_stats orelse return null;
+        const scope = self.currentInsightsScopeLocked();
+        if (scope.ws_id) |ws_id| {
+            if (local.workspace(ws_id)) |ws| {
+                return .{
+                    .label = scope.label,
+                    .signal_ratio = ws.signal_ratio,
+                    .constraint_count = ws.constraint_count,
+                    .refers = ws.refers,
+                    .inputs = ws.inputs,
+                };
             }
-            break :blk n;
-        } else 0;
-        if (self.api_state.org_stats) |stats| {
             return .{
-                .prompt_count = stats.prompts.len,
-                .member_count = if (self.api_state.ws_stats_members) |m| m.len else 0,
-                .input_count = input_count,
+                .label = scope.label,
+                .signal_ratio = 0,
+                .constraint_count = 0,
+                .refers = &.{},
+                .inputs = &.{},
             };
         }
-        return .{ .prompt_count = 0, .member_count = 0, .input_count = input_count };
+        return .{
+            .label = scope.label,
+            .signal_ratio = local.signal_ratio,
+            .constraint_count = local.constraint_count,
+            .refers = local.refers,
+            .inputs = local.inputs,
+        };
+    }
+
+    fn buildLocalChartSeries(self: *const Dashboard, arena: std.mem.Allocator, refers: []const trace_reader.ReferEvent) ChartSeries {
+        _ = self;
+        const bucket_ms: i64 = std.time.ms_per_s;
+        const bucket_count: usize = 60;
+        const span_ms: i64 = bucket_ms * bucket_count;
+
+        const values = arena.alloc(u16, bucket_count) catch {
+            return .{ .values = &.{}, .left_label = "60s ago", .right_label = "now" };
+        };
+        @memset(values, 0);
+
+        const now_ms = std.time.milliTimestamp();
+        const current_bucket_start_ms = now_ms - @mod(now_ms, bucket_ms);
+        const end_ms = current_bucket_start_ms + bucket_ms;
+        const start_ms = end_ms - span_ms;
+        for (refers) |rv| {
+            if (rv.timestamp < start_ms or rv.timestamp >= end_ms) continue;
+            const idx: usize = @intCast(@divFloor(rv.timestamp - start_ms, bucket_ms));
+            if (idx >= bucket_count) continue;
+            values[idx] +|= 1;
+        }
+
+        return .{
+            .values = values,
+            .left_label = "60s ago",
+            .right_label = "now",
+        };
+    }
+
+    fn getInsightsCounts(self: *Dashboard) InsightsCounts {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+
+        const scope = self.currentInsightsScopeLocked();
+        const input_count: usize = if (self.api_state.local_stats) |local| blk: {
+            const inputs = if (scope.ws_id) |ws_id|
+                (if (local.workspace(ws_id)) |ws| ws.inputs else &.{})
+            else
+                local.inputs;
+            break :blk latestInputs(inputs, self.dashboard_input_capacity).len;
+        } else 0;
+
+        const prompt_count: usize = if (self.api_state.local_stats) |local|
+            local.prompts.len
+        else if (self.api_state.org_stats) |stats|
+            stats.prompts.len
+        else
+            0;
+
+        return .{
+            .prompt_count = prompt_count,
+            .member_count = if (self.api_state.ws_stats_members) |m| m.len else 0,
+            .input_count = input_count,
+        };
     }
 
     fn drawEmptyDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -2927,19 +3402,13 @@ pub const Dashboard = struct {
             surface.writeCell(start_col + box_w - 1, start_row + r, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = border });
         }
 
-        // Resolve the selected input via the same filter drawInsightsInputs uses.
+        // Resolve the selected input via the same latest-N slice drawInsightsInputs uses.
         const content_and_ts: struct { content: []const u8, ts: i64 } = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            const local = self.api_state.local_stats orelse break :blk .{ .content = "", .ts = 0 };
-            const cutoff = self.inputsCutoffMs();
-            var vlen: usize = 0;
-            for (local.inputs) |iv| {
-                if (iv.timestamp >= cutoff) vlen += 1 else break;
-            }
-            if (vlen == 0) break :blk .{ .content = "", .ts = 0 };
-            const idx = @min(self.insights_input_cursor, vlen - 1);
-            break :blk .{ .content = local.inputs[idx].content, .ts = local.inputs[idx].timestamp };
+            const scoped = self.scopedTraceData() orelse break :blk .{ .content = "", .ts = 0 };
+            const visible = latestInputs(scoped.inputs, self.dashboard_input_capacity);
+            if (visible.len == 0) break :blk .{ .content = "", .ts = 0 };
+            const idx = @min(self.insights_input_cursor, visible.len - 1);
+            break :blk .{ .content = visible[idx].content, .ts = visible[idx].timestamp };
         };
 
         const time_txt = try formatHm(ctx.arena, content_and_ts.ts);
@@ -3016,7 +3485,7 @@ pub const Dashboard = struct {
         w.writeText(&surface, ctx, start_col + 2, start_row, " Keyboard Reference ", theme.boldOn(theme.PANEL_ALT, theme.ACCENT));
 
         const lines = [_][]const u8{
-            "1-3            Switch top-level module",
+            "1-4            Switch top-level module",
             "j / \xe2\x86\x93           Move down / next row",
             "k / \xe2\x86\x91           Move up / previous row",
             "h / \xe2\x86\x90           Previous tab / region",
@@ -3026,7 +3495,7 @@ pub const Dashboard = struct {
             "g              Jump to first row",
             "G              Jump to last row",
             "r              Refresh / sync",
-            "w              Workspace switcher (future)",
+            "w              Dashboard scope",
             "?              Toggle this help",
             "q / Ctrl+C     Quit",
         };
@@ -3147,7 +3616,7 @@ pub const Dashboard = struct {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
             if (self.api_state.bundles) |lb| {
-                const alloc = self.api_state.arena.allocator();
+                const alloc = self.api_state.allocator();
                 break :blk api.toBundleEntries(alloc, lb);
             }
             break :blk &.{};
@@ -3162,7 +3631,7 @@ pub const Dashboard = struct {
 
         // Default-expand every depth-0 prefix the first time we see prompts.
         if (!self.library_tree_initialized and prompts.len > 0) {
-            const alloc = self.api_state.arena.allocator();
+            const alloc = self.api_state.allocator();
             for (prompts) |p| {
                 if (std.mem.indexOfScalar(u8, p.path, '/')) |i| {
                     const top = p.path[0 .. i + 1];
@@ -3210,6 +3679,10 @@ pub const Dashboard = struct {
 
         var rows_buf: [MAX_LIBRARY_ROWS]tree.Row = undefined;
         const row_count = tree.flatten(sorted_paths[0..filtered_len], &self.library_expanded, &rows_buf);
+        const selected_row: usize = if (row_count > 0)
+            @min(@as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor)), row_count - 1)
+        else
+            0;
 
         var i: usize = 0;
         while (i < row_count) : (i += 1) {
@@ -3217,11 +3690,7 @@ pub const Dashboard = struct {
             const buf = &self.library_row_text_bufs[i];
             self.library_row_depth[i] = tr.depth;
 
-            const chevron: ?tree.Chevron = if (tr.kind == .dir)
-                (if (self.library_expanded.contains(tr.dir_prefix)) .expanded else .collapsed)
-            else
-                null;
-            var len = tree.renderPrefix(buf, tr.depth, tr.is_last, chevron);
+            var len = tree.renderPrefix(buf, tr.depth, tr.ancestor_mask, tr.is_last, null);
             len = tree.appendText(buf, len, tr.label);
             if (tr.kind == .dir and len < buf.len) {
                 buf[len] = '/';
@@ -3229,9 +3698,10 @@ pub const Dashboard = struct {
             }
 
             if (tr.kind == .dir) {
+                const row_sel = i == selected_row;
                 self.library_text_rows[i] = .{
                     .text = buf[0..len],
-                    .style = theme.boldOn(theme.PANEL, theme.ACCENT),
+                    .style = theme.boldOn(theme.PANEL, if (row_sel) theme.TEXT else theme.TEXT_SOFT),
                 };
                 self.library_widgets[i] = self.library_text_rows[i].widget();
                 self.library_prompt_indices[i] = null;
@@ -3246,15 +3716,16 @@ pub const Dashboard = struct {
                     3 => "\xe2\x80\xa23",
                     else => "\xe2\x80\xa2+",
                 };
-                const sel = orig_pidx == self.selected_prompt;
+                const row_sel = i == selected_row;
                 self.library_table_cols[i] = .{
                     .{ .text = buf[0..len], .flex = 1 },
                     .{ .text = pr_label, .flex = 0, .min_width = 2, .alignment = .right },
                 };
                 self.library_table_rows[i] = .{
                     .columns = &self.library_table_cols[i],
-                    .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                    .style = theme.textOn(theme.PANEL, if (row_sel) theme.TEXT else theme.TEXT_SOFT),
                     .gap = 2,
+                    .padding_left = 0,
                 };
                 self.library_widgets[i] = self.library_table_rows[i].widget();
                 self.library_prompt_indices[i] = orig_pidx;
@@ -3283,7 +3754,7 @@ pub const Dashboard = struct {
     }
 
     fn toggleLibraryDir(self: *Dashboard, prefix: []const u8) void {
-        const alloc = self.api_state.arena.allocator();
+        const alloc = self.api_state.allocator();
         if (self.library_expanded.fetchRemove(prefix)) |_| {
             return;
         }
@@ -3515,15 +3986,32 @@ pub const Dashboard = struct {
             .pull_requests => if (self.show_pr_diff) "PR diff view. j/k scroll, a/x/c actions." else "j/k move  f filter  Enter view  c comment  Esc back",
         };
         return switch (self.selected_module) {
+            .dashboard => "Live signal and recent input feed.",
             .library => "Bundle facet, prompt list, and passive preview.",
             .workspace => "Workspace list and sync status detail.",
-            .insights => "Refer coverage analysis (Phase 3, API pending).",
+            .analysis => "Prompt and team aggregates.",
         };
     }
 
     fn selectTab(self: *Dashboard, ctx: *vxfw.EventContext, tab: TopModule) void {
         self.show_detail = false;
         self.selected_module = tab;
+        self.insights_show_input_detail = false;
+        self.insights_show_member_detail = false;
+        self.insights_expanded_prompt = null;
+        switch (tab) {
+            .dashboard => {
+                if (self.insights_focus != .chart and self.insights_focus != .inputs) {
+                    self.insights_focus = .chart;
+                }
+            },
+            .analysis => {
+                if (self.insights_focus != .prompts and self.insights_focus != .team) {
+                    self.insights_focus = .prompts;
+                }
+            },
+            else => {},
+        }
         self.status_line = tab.label();
         ctx.consumeAndRedraw();
     }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1991,6 +1991,13 @@ pub const Dashboard = struct {
     }
 
     fn drawMemberDetail(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        if (ins.members.len == 0) {
+            var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+            w.fillSurface(&s, theme.PANEL);
+            w.drawBorder(&s, theme.BORDER, theme.PANEL);
+            w.writeText(&s, ctx, 2, 2, "No member data available.", theme.fg(theme.MUTED));
+            return s;
+        }
         const member_idx = @min(self.insights_member_cursor, ins.members.len - 1);
         const member = &ins.members[member_idx];
         var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
@@ -2154,6 +2161,10 @@ pub const Dashboard = struct {
 
         // My Workspaces with tree-expanded paths
         row = w.writeSectionHeader(&surface, ctx, 2, row, try std.fmt.allocPrint(ctx.arena, "My Workspaces ({d})", .{user.workspaces.len}));
+        if (user.workspaces.len == 0) {
+            w.writeText(&surface, ctx, 4, row, "No workspaces", theme.fg(theme.MUTED));
+            return surface;
+        }
         const sel = @min(self.settings_content_sel, user.workspaces.len - 1);
         for (user.workspaces, 0..) |ws_access, i| {
             if (row >= size.height -| 4) break;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1705,7 +1705,11 @@ pub const Dashboard = struct {
                             if (tr.kind == .dir and len < text_buf.len) {
                                 text_buf[len] = '/';
                                 len += 1;
-                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], theme.boldOn(theme.PANEL, theme.ACCENT));
+                            }
+                            // Copy to draw arena so cell grapheme pointers remain valid
+                            const rendered = ctx.arena.dupe(u8, text_buf[0..len]) catch continue;
+                            if (tr.kind == .dir) {
+                                w.writeText(&surface, ctx, 2, kv_row, rendered, theme.boldOn(theme.PANEL, theme.ACCENT));
                             } else {
                                 const file_i = orig_idx[tr.leaf_idx];
                                 const sel = file_i == self.ws_list_sel;
@@ -1716,7 +1720,7 @@ pub const Dashboard = struct {
                                     });
                                 }
                                 const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], name_style);
+                                w.writeText(&surface, ctx, 2, kv_row, rendered, name_style);
                             }
                             kv_row += 1;
                         }
@@ -1770,7 +1774,11 @@ pub const Dashboard = struct {
                             if (tr.kind == .dir and len < text_buf.len) {
                                 text_buf[len] = '/';
                                 len += 1;
-                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], theme.boldOn(theme.PANEL, theme.ACCENT));
+                            }
+                            // Copy to draw arena so cell grapheme pointers remain valid
+                            const rendered = ctx.arena.dupe(u8, text_buf[0..len]) catch continue;
+                            if (tr.kind == .dir) {
+                                w.writeText(&surface, ctx, 2, kv_row, rendered, theme.boldOn(theme.PANEL, theme.ACCENT));
                             } else {
                                 const wp_i = orig_idx[tr.leaf_idx];
                                 const sel = wp_i == self.ws_list_sel;
@@ -1781,10 +1789,10 @@ pub const Dashboard = struct {
                                     });
                                 }
                                 const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], name_style);
+                                w.writeText(&surface, ctx, 2, kv_row, rendered, name_style);
                                 // Draft marker: the full prompt path lives in sorted_paths[r]; hasDraftFor matches on path.
                                 if (self.hasDraftFor(sorted_paths[tr.leaf_idx])) {
-                                    const nw: u16 = @intCast(ctx.stringWidth(text_buf[0..len]));
+                                    const nw: u16 = @intCast(ctx.stringWidth(rendered));
                                     w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
                                 }
                             }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -46,22 +46,20 @@ const Period = enum(u8) {
 };
 
 const SettingsTab = enum(u8) {
-    members,
-    bundles,
-    workspaces,
+    account,
+    organization,
     token,
 
     fn label(self: SettingsTab) []const u8 {
         return switch (self) {
-            .members => "Members",
-            .bundles => "Bundles",
-            .workspaces => "Workspaces",
+            .account => "Account",
+            .organization => "Organization",
             .token => "Token",
         };
     }
 };
 
-const settings_tabs = [_]SettingsTab{ .members, .bundles, .workspaces, .token };
+const settings_tabs = [_]SettingsTab{ .account, .organization, .token };
 
 const ConfirmAction = enum {
     none,
@@ -118,14 +116,10 @@ pub const Dashboard = struct {
     detail_origin: TopModule = .library,
     detail_tab: DetailTab = .overview,
     detail_focus_content: bool = false,
-    settings_tab: SettingsTab = .members,
+    settings_tab: SettingsTab = .account,
+    settings_focus: enum { sidebar, content } = .sidebar,
+    settings_content_sel: usize = 0, // cursor within content (members/teams/workspaces list)
     status_line: []const u8 = "Ready.",
-
-    // Settings
-    settings_member_scroll: vxfw.ScrollBars,
-    settings_member_widgets: [data.MEMBERS.len]vxfw.Widget = undefined,
-    settings_member_rows: [data.MEMBERS.len]TableRow = undefined,
-    settings_member_cols: [data.MEMBERS.len][3]Column = undefined,
 
     // Library: grouped display with bundle filter
     library_bundle_filter: usize = 0,
@@ -180,7 +174,6 @@ pub const Dashboard = struct {
             .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
             // workspace uses manual grid, no ScrollBars
             .insights_scroll_bars = w.initCursorScrollBars(theme.PANEL),
-            .settings_member_scroll = w.initCursorScrollBars(theme.PANEL),
         };
     }
 
@@ -210,13 +203,13 @@ pub const Dashboard = struct {
                     if (key.matches('y', .{})) {
                         switch (self.confirm_action) {
                             .remove_member => {
-                                self.status_line = "Member removed (mock).";
+                                self.status_line = "Member removed (not yet implemented)";
                             },
                             .delete_bundle => {
-                                self.status_line = "Bundle deleted (mock).";
+                                self.status_line = "Bundle deleted (not yet implemented)";
                             },
                             .delete_workspace => {
-                                self.status_line = "Workspace deleted (mock).";
+                                self.status_line = "Workspace deleted (not yet implemented)";
                             },
                             .none => {},
                         }
@@ -263,65 +256,147 @@ pub const Dashboard = struct {
 
                 // Settings mode
                 if (self.show_settings) {
-                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('q', .{})) {
+                    if (key.matches('q', .{})) {
                         self.show_settings = false;
+                        self.settings_focus = .sidebar;
                         ctx.consumeAndRedraw();
                         return;
                     }
-                    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
-                        self.shiftSettingsTab(-1);
-                        ctx.consumeAndRedraw();
-                        return;
-                    }
-                    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
-                        self.shiftSettingsTab(1);
-                        ctx.consumeAndRedraw();
-                        return;
-                    }
-                    if (self.settings_tab == .members) {
-                        // r: toggle role of selected member
-                        if (key.matches('r', .{})) {
-                            const sel = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
-                            const m = &data.MEMBERS[sel];
-                            const new_role: []const u8 = if (std.mem.eql(u8, m.role, "member")) "maintainer" else "member";
-                            _ = new_role;
-                            self.status_line = "Role change requires Hub API (mock).";
+                    if (self.settings_focus == .sidebar) {
+                        if (key.matches(vaxis.Key.escape, .{})) {
+                            self.show_settings = false;
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        // x: remove selected member (confirm)
-                        if (key.matches('x', .{})) {
-                            const sel = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
-                            self.confirm_message = data.MEMBERS[sel].username;
-                            self.confirm_action = .remove_member;
-                            self.show_confirm = true;
+                        if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                            self.shiftSettingsTab(1);
+                            self.settings_content_sel = 0;
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        // a: invite (placeholder)
-                        if (key.matches('a', .{})) {
-                            self.status_line = "Invite requires TextField input (next iteration).";
+                        if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                            self.shiftSettingsTab(-1);
+                            self.settings_content_sel = 0;
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        try self.settings_member_scroll.scroll_view.handleEvent(ctx, event);
-                    }
-                    if (self.settings_tab == .bundles) {
-                        if (key.matches('x', .{})) {
-                            self.confirm_message = "selected bundle";
-                            self.confirm_action = .delete_bundle;
-                            self.show_confirm = true;
+                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{}) or key.matches(vaxis.Key.enter, .{})) {
+                            self.settings_focus = .content;
+                            self.settings_content_sel = 0;
                             ctx.consumeAndRedraw();
                             return;
                         }
-                    }
-                    if (self.settings_tab == .workspaces) {
-                        if (key.matches('x', .{})) {
-                            self.confirm_message = "selected workspace";
-                            self.confirm_action = .delete_workspace;
-                            self.show_confirm = true;
+                    } else {
+                        // Content focus
+                        if (key.matches(vaxis.Key.escape, .{}) or key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                            self.settings_focus = .sidebar;
                             ctx.consumeAndRedraw();
                             return;
+                        }
+                        const max_items: usize = switch (self.settings_tab) {
+                            .account => data.CURRENT_USER.workspaces.len,
+                            .organization => data.MEMBERS.len + data.TEAMS.len,
+                            .token => data.ALL_SCOPES.len,
+                        };
+                        if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                            if (self.settings_content_sel + 1 < max_items)
+                                self.settings_content_sel += 1;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                            if (self.settings_content_sel > 0)
+                                self.settings_content_sel -= 1;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        // Action keys per section
+                        if (self.settings_tab == .account) {
+                            if (key.matches('c', .{})) {
+                                self.status_line = "Password change (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches(vaxis.Key.enter, .{})) {
+                                const sel = @min(self.settings_content_sel, data.CURRENT_USER.workspaces.len - 1);
+                                self.ws_sel = sel;
+                                self.show_settings = false;
+                                self.settings_focus = .sidebar;
+                                self.selected_module = .workspace;
+                                self.ws_focus = .list;
+                                self.ws_list_sel = 0;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('x', .{})) {
+                                self.confirm_message = "sign out";
+                                self.confirm_action = .remove_member; // reuse for sign out
+                                self.show_confirm = true;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                        }
+                        if (self.settings_tab == .organization) {
+                            const on_member = self.settings_content_sel < data.MEMBERS.len;
+                            if (on_member) {
+                                if (key.matches('r', .{})) {
+                                    self.status_line = "Role change (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('x', .{})) {
+                                    const sel = @min(self.settings_content_sel, data.MEMBERS.len - 1);
+                                    self.confirm_message = data.MEMBERS[sel].username;
+                                    self.confirm_action = .remove_member;
+                                    self.show_confirm = true;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('a', .{})) {
+                                    self.status_line = "Invite member (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                            } else {
+                                if (key.matches('a', .{})) {
+                                    self.status_line = "Create team (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('=', .{})) {
+                                    self.status_line = "Add member to team (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('-', .{})) {
+                                    self.status_line = "Remove member from team (not yet implemented)";
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('x', .{})) {
+                                    const team_idx = self.settings_content_sel - data.MEMBERS.len;
+                                    const team_sel = @min(team_idx, data.TEAMS.len - 1);
+                                    self.confirm_message = data.TEAMS[team_sel].name;
+                                    self.confirm_action = .delete_bundle;
+                                    self.show_confirm = true;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                            }
+                        }
+                        if (self.settings_tab == .token) {
+                            if (key.matches('r', .{})) {
+                                self.status_line = "Token refresh (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('x', .{})) {
+                                self.confirm_message = "current token";
+                                self.confirm_action = .remove_member; // reuse for revoke
+                                self.show_confirm = true;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
                         }
                     }
                     return;
@@ -349,7 +424,7 @@ pub const Dashboard = struct {
                         return;
                     }
                     if (key.matches('p', .{})) {
-                        self.status_line = "Propose: disabled until Hub contracts land (Phase 2).";
+                        self.status_line = "Propose (not yet implemented)";
                         ctx.consumeAndRedraw();
                         return;
                     }
@@ -457,11 +532,11 @@ pub const Dashboard = struct {
                             self.status_line = "Proposal selected.";
                         }
                         if (key.matches('a', .{})) {
-                            self.status_line = "Accept: maintainer-only, disabled until Hub API.";
+                            self.status_line = "Accept proposal (not yet implemented)";
                             ctx.consumeAndRedraw();
                         }
                         if (key.matches('x', .{})) {
-                            self.status_line = "Reject: maintainer-only, disabled until Hub API.";
+                            self.status_line = "Reject proposal (not yet implemented)";
                             ctx.consumeAndRedraw();
                         }
                     },
@@ -565,7 +640,7 @@ pub const Dashboard = struct {
                             },
                         }
                         if (key.matches('r', .{})) {
-                            self.status_line = "Sync: requires Hub client core.";
+                            self.status_line = "Sync (not yet implemented)";
                             ctx.consumeAndRedraw();
                         }
                     },
@@ -578,7 +653,7 @@ pub const Dashboard = struct {
                         if (key.matches(vaxis.Key.enter, .{})) {
                             const cidx = @min(@as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor)), data.INSIGHTS_WS.len - 1);
                             _ = cidx;
-                            self.status_line = "Drill-down to workspace detail (future).";
+                            self.status_line = "Workspace detail (not yet implemented)";
                             ctx.consumeAndRedraw();
                         }
                     },
@@ -689,8 +764,18 @@ pub const Dashboard = struct {
             "Esc close help"
         else if (self.show_confirm)
             "y confirm  n cancel  Esc cancel"
+        else if (self.show_settings and self.settings_focus == .sidebar)
+            "j/k section  l open  q close"
+        else if (self.show_settings and self.settings_tab == .account)
+            "j/k move  c change password  Enter go to workspace  x sign out  h back  q close"
+        else if (self.show_settings and self.settings_tab == .organization and self.settings_content_sel < data.MEMBERS.len)
+            "j/k move  a invite  r role  x remove  h back  q close"
+        else if (self.show_settings and self.settings_tab == .organization)
+            "j/k move  a create  = add member  - remove member  x delete  h back  q close"
+        else if (self.show_settings and self.settings_tab == .token)
+            "j/k move  r refresh  x revoke  h back  q close"
         else if (self.show_settings)
-            "h/l tab  j/k move  a add  r role  x remove  Esc back"
+            "j/k move  h back  q close"
         else if (self.show_detail and self.detail_focus_content)
             "j/k scroll  g/G jump  Tab info pane  Esc back  ? help"
         else if (self.show_detail)
@@ -706,6 +791,16 @@ pub const Dashboard = struct {
             .insights => "j/k move  t period  S settings  ? help  q quit",
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
+
+        // Status line on the right side of footer
+        if (!std.mem.eql(u8, self.status_line, "Ready.")) {
+            const sw: u16 = @intCast(ctx.stringWidth(self.status_line));
+            if (ctx.max.width) |max_w| {
+                if (sw + 2 < max_w) {
+                    w.writeText(&surface, ctx, max_w - sw - 1, 0, self.status_line, theme.fg(theme.ACCENT_SOFT));
+                }
+            }
+        }
         return surface;
     }
 
@@ -1087,12 +1182,20 @@ pub const Dashboard = struct {
             }
 
             const name_x = x + 2;
-            const label = try std.fmt.allocPrint(ctx.arena, "{s} ({s})", .{ wsi.name, data.syncStateLabel(&wsi) });
+            const needs_sync = wsi.local_rev != wsi.remote_rev;
+            const label = if (needs_sync)
+                try std.fmt.allocPrint(ctx.arena, "{s} *", .{wsi.name})
+            else
+                wsi.name;
 
             if (is_sel) {
                 w.writeText(&bar, ctx, name_x, y, label, theme.boldOn(theme.PANEL, theme.TEXT));
             } else {
-                w.writeText(&bar, ctx, name_x, y, label, theme.fg(theme.TEXT_SOFT));
+                w.writeText(&bar, ctx, name_x, y, wsi.name, theme.fg(theme.TEXT_SOFT));
+                if (needs_sync) {
+                    const nw: u16 = @intCast(ctx.stringWidth(wsi.name));
+                    w.writeText(&bar, ctx, name_x + nw + 1, y, "*", theme.fg(theme.WARN));
+                }
             }
         }
 
@@ -1378,167 +1481,256 @@ pub const Dashboard = struct {
         return panel.draw(ctx);
     }
 
-    // Settings: drill-down view with inner tabs (Members/Bundles/Workspaces/Token)
+    // Settings: vertical sidebar + content pane (web-style layout)
     fn drawSettings(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
 
-        // Inner tab strip
-        var tab_surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = 1 });
-        w.fillSurface(&tab_surface, theme.PANEL);
-        var tab_col: u16 = 1;
+        // Sidebar (fixed width)
+        const sidebar_w: u16 = 18;
+        const sidebar_border = if (self.settings_focus == .sidebar) theme.ACCENT else theme.BORDER;
+        var sidebar = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = sidebar_w, .height = size.height });
+        w.fillSurface(&sidebar, theme.PANEL);
+        w.drawBorder(&sidebar, sidebar_border, theme.PANEL);
+        w.writeText(&sidebar, ctx, 2, 0, "Settings", theme.boldOn(theme.PANEL, theme.TEXT));
+
+        var row: u16 = 2;
         for (settings_tabs) |tab| {
-            tab_col = w.drawInnerTabBadge(&tab_surface, ctx, 0, tab_col, tab.label(), tab == self.settings_tab);
-            tab_col +|= 1;
+            const is_sel = tab == self.settings_tab;
+            if (is_sel) {
+                sidebar.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&sidebar, ctx, 3, row, tab.label(), style);
+            row += 1;
         }
 
-        // Content area
-        const content_h = size.height -| 2;
+        // Content pane
+        const content_w = size.width -| sidebar_w -| 1;
         const content_ctx = ctx.withConstraints(
-            .{ .width = size.width, .height = content_h },
-            .{ .width = size.width, .height = content_h },
+            .{ .width = content_w, .height = size.height },
+            .{ .width = content_w, .height = size.height },
         );
         const content = switch (self.settings_tab) {
-            .members => try self.drawSettingsMembers(content_ctx),
-            .bundles => try self.drawSettingsBundles(content_ctx),
-            .workspaces => try self.drawSettingsWorkspaces(content_ctx),
+            .account => try self.drawSettingsAccount(content_ctx),
+            .organization => try self.drawSettingsOrg(content_ctx),
             .token => try self.drawSettingsToken(content_ctx),
         };
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = tab_surface };
-        children[1] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = content };
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = sidebar };
+        children[1] = .{ .origin = .{ .row = 0, .col = sidebar_w + 1 }, .surface = content };
         root.children = children;
         return root;
     }
 
-    fn drawSettingsMembers(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawSettingsAccount(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
-        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.PANEL);
+        const focused = self.settings_focus == .content;
+        const user = data.CURRENT_USER;
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
+        w.writeText(&surface, ctx, 2, 0, "Account", theme.boldOn(theme.PANEL, theme.TEXT));
 
-        self.syncSettingsMemberWidgets();
+        var row: u16 = 2;
+        // Profile section
+        row = w.writeSectionHeader(&surface, ctx, 2, row, "Profile");
+        row = w.writeKv(&surface, ctx, 4, row, "Username", user.username, 14);
+        row = w.writeKv(&surface, ctx, 4, row, "User ID", user.user_id, 14);
+        const role_color = if (std.mem.eql(u8, user.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
+        w.writeText(&surface, ctx, 4, row, "Role", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 19, row, user.role, theme.fg(role_color));
+        row += 2;
 
-        const list_w: u16 = if (size.width > 100) size.width -| 32 else size.width;
-        const detail_w: u16 = if (size.width > 100) 31 else 0;
+        // Security section
+        row = w.writeSectionHeader(&surface, ctx, 2, row, "Security");
+        w.writeText(&surface, ctx, 4, row, "Password", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 19, row, "********", theme.fg(theme.TEXT_SOFT));
+        w.writeText(&surface, ctx, 30, row, "[ Change ]", theme.fg(theme.ACCENT_SOFT));
+        row += 1;
+        w.writeText(&surface, ctx, 4, row, "Sessions", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 19, row, "1 active", theme.fg(theme.OK));
+        row += 2;
 
-        // Member list
-        self.settings_member_scroll.scroll_view.draw_cursor = false;
-        defer self.settings_member_scroll.scroll_view.draw_cursor = true;
-
-        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Org Members", .subtitle = "maintainer: invite/remove", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.settings_member_scroll.widget() };
-        var list_surface = try panel.draw(list_ctx);
-        list_surface = try w.applyCursorOverlay(list_ctx, &list_surface, &self.settings_member_scroll.scroll_view);
-
-        if (detail_w > 0) {
-            const sel_idx = @min(@as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor)), data.MEMBERS.len - 1);
-            const m = &data.MEMBERS[sel_idx];
-            const detail_text = try std.fmt.allocPrint(ctx.arena,
-                \\User
-                \\{s}
-                \\
-                \\Role
-                \\{s}
-                \\
-                \\Joined
-                \\{s}
-                \\
-                \\Actions
-                \\PATCH role (maintainer only)
-                \\DELETE remove (maintainer only)
-            , .{ m.username, m.role, m.joined });
-            const text_widget: vxfw.Text = .{ .text = detail_text, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
-            const wrapper = try ctx.arena.create(w.WidgetBox);
-            wrapper.* = .{ .widget_ref = text_widget.widget() };
-            const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
-            const detail_panel: w.Panel = .{ .owner = self.widget(), .title = m.username, .subtitle = m.role, .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-
-            const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-            children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
-            children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try detail_panel.draw(detail_ctx) };
-            root.children = children;
-        } else {
-            const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-            children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
-            root.children = children;
+        // My Workspaces
+        row = w.writeSectionHeader(&surface, ctx, 2, row, try std.fmt.allocPrint(ctx.arena, "My Workspaces ({d})", .{user.workspaces.len}));
+        const sel = @min(self.settings_content_sel, user.workspaces.len - 1);
+        for (user.workspaces, 0..) |ws_access, i| {
+            const is_sel = i == sel and focused;
+            if (is_sel) {
+                surface.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&surface, ctx, 4, row, ws_access.name, name_style);
+            const badge_fg = switch (ws_access.level) {
+                .read => theme.MUTED,
+                .write => theme.OK,
+                .admin => theme.ACCENT,
+            };
+            const level_label = switch (ws_access.level) {
+                .read => "read",
+                .write => "write",
+                .admin => "admin",
+            };
+            w.writeText(&surface, ctx, 24, row, level_label, theme.fg(badge_fg));
+            row += 1;
+            if (row >= size.height -| 3) break;
         }
-        return root;
+        row += 1;
+
+        // Danger zone
+        if (row + 2 < size.height) {
+            row = w.writeSectionHeader(&surface, ctx, 2, row, "Danger Zone");
+            w.writeText(&surface, ctx, 4, row, "[ Sign Out ]", theme.fg(theme.DANGER));
+            w.writeText(&surface, ctx, 19, row, "Revoke current token and exit", theme.fg(theme.MUTED));
+        }
+        return surface;
     }
 
-    fn drawSettingsBundles(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        var buf: std.ArrayList(u8) = .empty;
-        try buf.appendSlice(ctx.arena, "Bundle management (maintainer only)\n\n");
-        for (data.BUNDLES) |bundle| {
-            const line = try std.fmt.allocPrint(ctx.arena, "{s:<16} {d} prompts\n", .{ bundle.name, bundle.count });
-            try buf.appendSlice(ctx.arena, line);
-        }
-        try buf.appendSlice(ctx.arena, "\nActions\nPOST create  PUT update  DELETE remove");
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Bundles", .subtitle = "org-level groups", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
-    }
+    fn drawSettingsOrg(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        const focused = self.settings_focus == .content;
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
+        w.writeText(&surface, ctx, 2, 0, "Organization", theme.boldOn(theme.PANEL, theme.TEXT));
 
-    fn drawSettingsWorkspaces(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        var buf: std.ArrayList(u8) = .empty;
-        try buf.appendSlice(ctx.arena, "Workspace management\n\n");
-        for (data.WORKSPACES) |ws| {
-            const line = try std.fmt.allocPrint(ctx.arena, "{s:<16} {d}p {d}c {d}o  {s}\n", .{ ws.name, ws.prompts, ws.contexts, ws.overrides, data.syncStateLabel(&ws) });
-            try buf.appendSlice(ctx.arena, line);
+        var row: u16 = 2;
+        const sel = self.settings_content_sel;
+
+        // Members section
+        var maintainer_count: u16 = 0;
+        for (data.MEMBERS) |m| {
+            if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
         }
-        try buf.appendSlice(ctx.arena, "\nActions\nPATCH rename  DELETE remove (maintainer)\nMembers: list / add / remove");
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspaces", .subtitle = "project-level", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
+        const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ data.MEMBERS.len, maintainer_count, data.MEMBERS.len - maintainer_count });
+        row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
+
+        w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
+        row += 1;
+
+        for (data.MEMBERS, 0..) |m, i| {
+            const is_sel = i == sel and focused;
+            if (is_sel) {
+                surface.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&surface, ctx, 4, row, m.username, name_style);
+            const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
+            w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
+            w.writeText(&surface, ctx, 30, row, m.teams, theme.fg(theme.TEXT_SOFT));
+            w.writeText(&surface, ctx, 52, row, m.joined, theme.fg(theme.MUTED));
+            row += 1;
+            if (row >= size.height -| 10) break;
+        }
+        row += 1;
+
+        // Teams section
+        const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{data.TEAMS.len});
+        row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
+
+        w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
+        row += 1;
+
+        for (data.TEAMS, 0..) |team, i| {
+            const team_idx = data.MEMBERS.len + i;
+            const is_sel = team_idx == sel and focused;
+            if (is_sel) {
+                surface.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&surface, ctx, 4, row, team.name, name_style);
+            var names_buf: std.ArrayList(u8) = .empty;
+            for (team.member_usernames, 0..) |username, mi| {
+                try names_buf.appendSlice(ctx.arena, username);
+                if (mi + 1 < team.member_usernames.len) try names_buf.appendSlice(ctx.arena, ", ");
+            }
+            w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
+            row += 1;
+        }
+        row += 1;
+
+        return surface;
     }
 
     fn drawSettingsToken(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        const focused = self.settings_focus == .content;
         const t = data.CURRENT_TOKEN;
-        const text = try std.fmt.allocPrint(ctx.arena,
-            \\Current Token
-            \\
-            \\Scopes
-            \\{s}
-            \\
-            \\Expires
-            \\{s}
-            \\
-            \\Note
-            \\Token scopes limit what this session can do.
-            \\Actual permissions = min(role, scopes).
-            \\Use DELETE /api/auth/token to revoke.
-        , .{ t.scope, t.expires });
-        const text_widget: vxfw.Text = .{ .text = text, .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Token", .subtitle = "current session", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
-    }
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
+        w.writeText(&surface, ctx, 2, 0, "Token", theme.boldOn(theme.PANEL, theme.TEXT));
 
-    fn syncSettingsMemberWidgets(self: *Dashboard) void {
-        self.settings_member_scroll.scroll_view.cursor = @min(self.settings_member_scroll.scroll_view.cursor, data.MEMBERS.len - 1);
-        const sel_idx = @as(usize, @intCast(self.settings_member_scroll.scroll_view.cursor));
-        for (data.MEMBERS, 0..) |m, idx| {
-            const sel = idx == sel_idx;
-            self.settings_member_cols[idx] = .{
-                .{ .text = m.username, .flex = 1 },
-                .{ .text = m.role, .flex = 0 },
-                .{ .text = m.joined, .flex = 0, .alignment = .right },
-            };
-            self.settings_member_rows[idx] = .{
-                .columns = &self.settings_member_cols[idx],
-                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
-                .gap = 2,
-            };
-            self.settings_member_widgets[idx] = self.settings_member_rows[idx].widget();
+        var row: u16 = 2;
+        // Token info
+        var active_count: u16 = 0;
+        for (data.ALL_SCOPES) |scope_def| {
+            for (t.scopes) |active| {
+                if (std.mem.eql(u8, scope_def.name, active)) {
+                    active_count += 1;
+                    break;
+                }
+            }
         }
-        self.settings_member_scroll.scroll_view.children = .{ .slice = self.settings_member_widgets[0..] };
-        self.settings_member_scroll.estimated_content_height = data.MEMBERS.len;
+        row = w.writeKv(&surface, ctx, 2, row, "Expires", t.expires, 14);
+        const scope_summary = try std.fmt.allocPrint(ctx.arena, "{d} / {d} scopes active", .{ active_count, data.ALL_SCOPES.len });
+        row = w.writeKv(&surface, ctx, 2, row, "Permissions", scope_summary, 14);
+        row += 1;
+
+        // Scope permission matrix
+        row = w.writeSectionHeader(&surface, ctx, 2, row, "Scope Permissions");
+        const sel = @min(self.settings_content_sel, data.ALL_SCOPES.len - 1);
+        for (data.ALL_SCOPES, 0..) |scope_def, i| {
+            if (row >= size.height -| 5) break;
+            const is_sel = i == sel and focused;
+            if (is_sel) {
+                surface.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            // Check if this scope is active
+            var is_active = false;
+            for (t.scopes) |active| {
+                if (std.mem.eql(u8, scope_def.name, active)) {
+                    is_active = true;
+                    break;
+                }
+            }
+            const check = if (is_active) "\xe2\x9c\x93" else "\xe2\x94\x80";
+            const check_color = if (is_active) theme.OK else theme.MUTED;
+            w.writeText(&surface, ctx, 4, row, check, theme.fg(check_color));
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else if (is_active) theme.fg(theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&surface, ctx, 6, row, scope_def.name, name_style);
+            w.writeText(&surface, ctx, 24, row, scope_def.description, theme.fg(if (is_active) theme.TEXT_SOFT else theme.MUTED));
+            row += 1;
+        }
+        row += 1;
+
+        // Info note
+        if (row + 1 < size.height) {
+            w.writeText(&surface, ctx, 2, row, "Effective permissions = min(org role, token scopes)", theme.fg(theme.MUTED));
+        }
+        return surface;
     }
 
     fn shiftSettingsTab(self: *Dashboard, delta: i8) void {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -10,18 +10,18 @@ const Column = @import("table_row.zig").Column;
 const WsTab = enum(u8) {
     context,
     prompts,
-    overrides,
 
     fn label(self: WsTab) []const u8 {
         return switch (self) {
             .context => "Context",
             .prompts => "Prompts",
-            .overrides => "Overrides",
         };
     }
 };
 
-const ws_tabs = [_]WsTab{ .context, .prompts, .overrides };
+const ws_tabs = [_]WsTab{ .context, .prompts };
+
+const WsFocus = enum { bar, list, content };
 
 const Period = enum(u8) {
     daily,
@@ -158,10 +158,11 @@ pub const Dashboard = struct {
 
     // Workspace Status
     ws_tab: WsTab = .context,
-    workspace_scroll_bars: vxfw.ScrollBars,
-    workspace_widgets: [data.WORKSPACES.len]vxfw.Widget = undefined,
-    workspace_rows: [data.WORKSPACES.len]TableRow = undefined,
-    workspace_cols: [data.WORKSPACES.len][3]Column = undefined,
+    ws_focus: WsFocus = .bar,
+    ws_sel: usize = 0,
+    ws_list_sel: usize = 0,
+    ws_grid_cols: u16 = 3,
+    // Workspace uses manual grid + list rendering, no ScrollBars
 
     // Insights
     insights_period: Period = .daily,
@@ -177,7 +178,7 @@ pub const Dashboard = struct {
             .history_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .review_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
-            .workspace_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            // workspace uses manual grid, no ScrollBars
             .insights_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .settings_member_scroll = w.initCursorScrollBars(theme.PANEL),
         };
@@ -465,19 +466,106 @@ pub const Dashboard = struct {
                         }
                     },
                     .workspace => {
-                        if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
-                            self.shiftWsTab(-1);
+                        // Tab cycles focus: bar -> list -> content -> bar
+                        if (key.matches(vaxis.Key.tab, .{})) {
+                            self.ws_focus = switch (self.ws_focus) {
+                                .bar => .list,
+                                .list => .content,
+                                .content => .bar,
+                            };
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
-                            self.shiftWsTab(1);
-                            ctx.consumeAndRedraw();
-                            return;
+                        switch (self.ws_focus) {
+                            .bar => {
+                                const ws_count = data.WORKSPACES.len;
+                                const cols = self.ws_grid_cols;
+                                if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                                    if (self.ws_sel + 1 < ws_count) {
+                                        self.ws_sel += 1;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                                    if (self.ws_sel > 0) {
+                                        self.ws_sel -= 1;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                                    if (self.ws_sel + cols < ws_count) {
+                                        self.ws_sel += cols;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                                    if (self.ws_sel >= cols) {
+                                        self.ws_sel -= cols;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.enter, .{})) {
+                                    self.ws_focus = .list;
+                                    ctx.consumeAndRedraw();
+                                }
+                            },
+                            .list => {
+                                if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                                    self.shiftWsTab(-1);
+                                    self.ws_list_sel = 0;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                                    self.shiftWsTab(1);
+                                    self.ws_list_sel = 0;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                                    const max_items: usize = switch (self.ws_tab) {
+                                        .context => data.WS_CONTEXT.len,
+                                        .prompts => data.WS_PROMPTS.len,
+                                    };
+                                    if (self.ws_list_sel + 1 < max_items) {
+                                        self.ws_list_sel += 1;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                                    if (self.ws_list_sel > 0) {
+                                        self.ws_list_sel -= 1;
+                                        ctx.consumeAndRedraw();
+                                    }
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.enter, .{})) {
+                                    self.ws_focus = .content;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                if (key.matches(vaxis.Key.escape, .{})) {
+                                    self.ws_focus = .bar;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                            },
+                            .content => {
+                                if (key.matches(vaxis.Key.escape, .{})) {
+                                    self.ws_focus = .list;
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                                // j/k scrolls content (future: ScrollView)
+                            },
                         }
-                        try self.workspace_scroll_bars.scroll_view.handleEvent(ctx, event);
                         if (key.matches('r', .{})) {
-                            self.status_line = "Sync: requires Hub client core (Phase 2).";
+                            self.status_line = "Sync: requires Hub client core.";
                             ctx.consumeAndRedraw();
                         }
                     },
@@ -610,7 +698,11 @@ pub const Dashboard = struct {
         else switch (self.selected_module) {
             .library => if (self.detail_focus_content) "h/l tab  j/k scroll  Esc list  ? help" else "j/k move  Enter detail  b bundle  S settings  ? help  q quit",
             .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
-            .workspace => "h/l tab  j/k move  r sync  S settings  ? help  q quit",
+            .workspace => switch (self.ws_focus) {
+                .bar => "j/k select workspace  Tab list  r sync  ? help  q quit",
+                .list => "h/l tab  j/k move  Enter content  Esc bar  ? help",
+                .content => "j/k scroll  Esc list  ? help",
+            },
             .insights => "j/k move  t period  S settings  ? help  q quit",
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
@@ -953,116 +1045,256 @@ pub const Dashboard = struct {
         return panel.draw(ctx);
     }
 
-    // Workspace Status: list + detail (two-column)
-    // Workspace: master-detail. Left = workspace list, right = detail with inner tabs.
+    // Workspace: top workspace bar + bottom master-detail (list | content).
+    // Tab cycles focus: workspace bar -> list -> content -> bar.
     fn drawWorkspaceStatus(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
 
-        self.syncWorkspaceWidgets();
-        const ws_idx = @min(@as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor)), data.WORKSPACES.len - 1);
+        const ws_idx = @min(self.ws_sel, data.WORKSPACES.len - 1);
         const ws = &data.WORKSPACES[ws_idx];
 
+        // Top: workspace bar with grid layout (each card = 2 rows: name + status)
+        // Fixed height: border(1) + 2 content rows per grid row + border(1)
+        const inner_w = size.width -| 2;
+        const cols: u16 = if (inner_w >= 120) 4 else if (inner_w >= 80) 3 else 2;
+        self.ws_grid_cols = cols;
+        const card_w: u16 = inner_w / cols;
+        const ws_count: u16 = @intCast(data.WORKSPACES.len);
+        const grid_rows: u16 = (ws_count + cols - 1) / cols;
+        const bar_h: u16 = 1 + grid_rows + 1; // border + rows + border
+
+        const bar_border = if (self.ws_focus == .bar) theme.ACCENT else theme.BORDER;
+        var bar = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = bar_h });
+        w.fillSurface(&bar, theme.PANEL);
+        w.drawBorder(&bar, bar_border, theme.PANEL);
+        w.writeText(&bar, ctx, 2, 0, "Workspaces", theme.boldOn(theme.PANEL, theme.TEXT));
+
+        for (data.WORKSPACES, 0..) |wsi, i| {
+            const is_sel = i == ws_idx;
+            const grid_col: u16 = @intCast(i % cols);
+            const grid_row: u16 = @intCast(i / cols);
+            const x = 1 + grid_col * card_w;
+            const y = 1 + grid_row;
+
+            // Cursor indicator (same style as Library)
+            if (is_sel) {
+                bar.writeCell(x, y, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+
+            const name_x = x + 2;
+            const label = try std.fmt.allocPrint(ctx.arena, "{s} ({s})", .{ wsi.name, data.syncStateLabel(&wsi) });
+
+            if (is_sel) {
+                w.writeText(&bar, ctx, name_x, y, label, theme.boldOn(theme.PANEL, theme.TEXT));
+            } else {
+                w.writeText(&bar, ctx, name_x, y, label, theme.fg(theme.TEXT_SOFT));
+            }
+        }
+
+        // Bottom: master-detail (list | content)
+        const body_h = size.height - bar_h;
         const list_w: u16 = size.width / 3;
         const detail_w: u16 = size.width - list_w - 1;
 
-        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
-        const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
+        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = body_h }, .{ .width = list_w, .height = body_h });
+        const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = body_h }, .{ .width = detail_w, .height = body_h });
 
-        // Workspace list panel
-        self.workspace_scroll_bars.scroll_view.draw_cursor = false;
-        defer self.workspace_scroll_bars.scroll_view.draw_cursor = true;
-        const list_panel: w.Panel = .{
-            .owner = self.widget(),
-            .title = "Workspaces",
-            .subtitle = "r sync",
-            .background = theme.PANEL,
-            .border_color = theme.BORDER,
-            .child = self.workspace_scroll_bars.widget(),
-        };
-        var list_surface = try list_panel.draw(list_ctx);
-        list_surface = try w.applyCursorOverlay(list_ctx, &list_surface, &self.workspace_scroll_bars.scroll_view);
+        const list_surface = try self.drawWsList(list_ctx);
+        const detail_surface = try self.drawWsDetail(detail_ctx, ws);
 
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
-        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawWsDetail(detail_ctx, ws) };
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = bar };
+        children[1] = .{ .origin = .{ .row = bar_h, .col = 0 }, .surface = list_surface };
+        children[2] = .{ .origin = .{ .row = bar_h, .col = list_w + 1 }, .surface = detail_surface };
         root.children = children;
         return root;
     }
 
-    // Workspace right pane: summary KV + inner tabs (Prompts/Context/Overrides)
-    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawWsList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        // Context/Prompts/Overrides item list with inner tabs
+        const list_border = if (self.ws_focus == .list) theme.ACCENT else theme.BORDER;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
-        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
+        w.drawBorder(&surface, list_border, theme.PANEL);
 
-        // Row 0: inner tabs + workspace name
+        // Row 0: inner tabs
         var tab_col: u16 = 2;
         for (ws_tabs) |tab| {
             tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, tab.label(), tab == self.ws_tab);
             tab_col +|= 1;
         }
-        w.writeRightText(&surface, ctx, 0, ws.name, theme.textOn(theme.PANEL, theme.MUTED));
 
-        // Row 1: summary stats
-        const summary = try std.fmt.allocPrint(ctx.arena, " {d}p {d}c {d}o  rev {d}/{d}  {s}", .{ ws.prompts, ws.contexts, ws.overrides, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws) });
-        w.writeText(&surface, ctx, 2, 1, summary, theme.fg(theme.TEXT_SOFT));
-
-        const inner_h = ctx.max.height.? -| 3;
-        const inner_w = ctx.max.width.? -| 4;
+        const inner_h = ctx.max.height.? -| 2;
 
         switch (self.ws_tab) {
             .context => {
-                // Main branch files
-                var kv_row: u16 = 3;
-                kv_row = w.writeSectionHeader(&surface, ctx, 2, kv_row, try std.fmt.allocPrint(ctx.arena, "main ({d} files)", .{ws.contexts}));
-                for (data.WS_CONTEXT) |f| {
-                    kv_row = w.writeKv(&surface, ctx, 2, kv_row, f.path, f.state, 26);
-                    if (kv_row >= inner_h + 2) break;
-                }
-                // Member branches
-                kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, 2, kv_row, "Branches");
-                for (data.CONTEXT_BRANCHES) |br| {
-                    if (std.mem.eql(u8, br.name, "main")) continue;
-                    const br_info = try std.fmt.allocPrint(ctx.arena, "{d} ahead  {d} behind", .{ br.ahead, br.behind });
-                    kv_row = w.writeKv(&surface, ctx, 2, kv_row, br.name, br_info, 10);
-                    if (kv_row >= inner_h + 2) break;
-                }
-                // Open PRs
-                kv_row += 1;
-                const pr_text = try std.fmt.allocPrint(ctx.arena, "{d} open", .{ws.open_prs});
-                kv_row = w.writeKv(&surface, ctx, 2, kv_row, "Context PRs", pr_text, 12);
-                for (data.CONTEXT_PRS) |pr| {
-                    if (!std.mem.eql(u8, pr.status, "open")) continue;
-                    const pr_line = try std.fmt.allocPrint(ctx.arena, "{s}: {s}", .{ pr.author, pr.description });
-                    w.writeText(&surface, ctx, 4, kv_row, pr_line, theme.fg(theme.TEXT_SOFT));
+                var kv_row: u16 = 2;
+                for (data.WS_CONTEXT, 0..) |f, i| {
+                    const sel = i == self.ws_list_sel;
+                    const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                    if (sel) {
+                        surface.writeCell(1, kv_row, .{
+                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                        });
+                    }
+                    // Name + (modified) inline marker
+                    const label = if (f.modified)
+                        try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{f.path})
+                    else
+                        f.path;
+                    w.writeText(&surface, ctx, 3, kv_row, label, name_style);
+                    if (f.modified) {
+                        // Color just the "(modified)" part
+                        const path_w: u16 = @intCast(ctx.stringWidth(f.path));
+                        w.writeText(&surface, ctx, 3 + path_w + 1, kv_row, "(modified)", theme.fg(theme.WARN));
+                    }
+                    // Right side: always show size
+                    if (ctx.max.width) |max_w| {
+                        const sw: u16 = @intCast(ctx.stringWidth(f.size));
+                        if (sw + 3 < max_w) w.writeText(&surface, ctx, max_w - sw - 2, kv_row, f.size, theme.fg(theme.MUTED));
+                    }
                     kv_row += 1;
                     if (kv_row >= inner_h + 2) break;
                 }
             },
             .prompts => {
-                var kv_row: u16 = 3;
-                for (data.WS_PROMPTS) |p| {
-                    const ovr: []const u8 = if (p.has_override) "yes" else " no";
-                    const line = try std.fmt.allocPrint(ctx.arena, " {s:<18} {s:<4} {s} {s}", .{ p.name, p.kind, ovr, p.state });
-                    w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
+                var kv_row: u16 = 2;
+                for (data.WS_PROMPTS, 0..) |p, i| {
+                    const sel = i == self.ws_list_sel;
+                    const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                    if (sel) {
+                        surface.writeCell(1, kv_row, .{
+                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                        });
+                    }
+                    // Name + (modified) inline marker
+                    const label = if (p.has_override)
+                        try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{p.name})
+                    else
+                        p.name;
+                    w.writeText(&surface, ctx, 3, kv_row, label, name_style);
+                    if (p.has_override) {
+                        const name_w: u16 = @intCast(ctx.stringWidth(p.name));
+                        w.writeText(&surface, ctx, 3 + name_w + 1, kv_row, "(modified)", theme.fg(theme.WARN));
+                    }
+                    // Right side: always show state
+                    if (ctx.max.width) |max_w| {
+                        const sw: u16 = @intCast(ctx.stringWidth(p.state));
+                        if (sw + 3 < max_w) w.writeText(&surface, ctx, max_w - sw - 2, kv_row, p.state, theme.fg(theme.MUTED));
+                    }
                     kv_row += 1;
-                    if (kv_row >= inner_h + 3) break;
-                }
-            },
-            .overrides => {
-                var kv_row: u16 = 3;
-                for (data.WS_OVERRIDES) |o| {
-                    const line = try std.fmt.allocPrint(ctx.arena, " {s:<18} {s:<4} {s:<4} {s}", .{ o.prompt_name, o.base_hash, o.current_hash, o.status });
-                    w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
-                    kv_row += 1;
-                    if (kv_row >= inner_h + 3) break;
+                    if (kv_row >= inner_h + 2) break;
                 }
             },
         }
-        _ = inner_w;
+        return surface;
+    }
+
+    // Workspace content pane: shows selected item's content
+    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+        _ = ws;
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        const content_border = if (self.ws_focus == .content) theme.ACCENT else theme.BORDER;
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, content_border, theme.PANEL);
+
+        const sel = self.ws_list_sel;
+
+        // Title: selected item name
+        const title: []const u8 = switch (self.ws_tab) {
+            .context => if (sel < data.WS_CONTEXT.len) data.WS_CONTEXT[sel].path else "no files",
+            .prompts => if (sel < data.WS_PROMPTS.len) data.WS_PROMPTS[sel].name else "no prompts",
+        };
+        // Title with diff marker (context branch or prompt override)
+        const has_diff = switch (self.ws_tab) {
+            .context => sel < data.WS_CONTEXT.len and data.WS_CONTEXT[sel].modified,
+            .prompts => sel < data.WS_PROMPTS.len and data.WS_PROMPTS[sel].has_override,
+        };
+        if (has_diff) {
+            const marker = try std.fmt.allocPrint(ctx.arena, "{s} (modified)", .{title});
+            w.writeText(&surface, ctx, 2, 0, marker, theme.boldOn(theme.PANEL, theme.WARN));
+        } else {
+            w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
+        }
+
+        var kv_row: u16 = 2;
+        const max_row = ctx.max.height.? -| 1;
+
+        switch (self.ws_tab) {
+            .context => {
+                if (sel < data.WS_CONTEXT.len) {
+                    const f = &data.WS_CONTEXT[sel];
+                    if (f.modified and f.branch_diff.len > 0) {
+                        // Show branch diff (same GitHub-style as prompts)
+                        for (f.branch_diff) |line| {
+                            if (kv_row >= max_row) break;
+                            const line_color = if (std.mem.startsWith(u8, line, "+"))
+                                theme.OK
+                            else if (std.mem.startsWith(u8, line, "-"))
+                                theme.DANGER
+                            else
+                                theme.TEXT_SOFT;
+                            const line_bg = if (std.mem.startsWith(u8, line, "+"))
+                                theme.rgb(0x1d2617)
+                            else if (std.mem.startsWith(u8, line, "-"))
+                                theme.rgb(0x2a1b18)
+                            else
+                                theme.PANEL;
+                            w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
+                            kv_row += 1;
+                        }
+                    } else {
+                        // No branch changes - show file content
+                        var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
+                        while (line_iter.next()) |line| {
+                            if (kv_row >= max_row) break;
+                            w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
+                            kv_row += 1;
+                        }
+                    }
+                }
+            },
+            .prompts => {
+                if (sel < data.WS_PROMPTS.len) {
+                    const p = &data.WS_PROMPTS[sel];
+                    if (p.has_override and p.override_diff.len > 0) {
+                        // Show diff (GitHub-style colored lines)
+                        for (p.override_diff) |line| {
+                            if (kv_row >= max_row) break;
+                            const line_color = if (std.mem.startsWith(u8, line, "+"))
+                                theme.OK
+                            else if (std.mem.startsWith(u8, line, "-"))
+                                theme.DANGER
+                            else
+                                theme.TEXT_SOFT;
+                            const line_bg = if (std.mem.startsWith(u8, line, "+"))
+                                theme.rgb(0x1d2617)
+                            else if (std.mem.startsWith(u8, line, "-"))
+                                theme.rgb(0x2a1b18)
+                            else
+                                theme.PANEL;
+                            w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
+                            kv_row += 1;
+                        }
+                    } else {
+                        // Show prompt body (no override)
+                        var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
+                        while (line_iter.next()) |line| {
+                            if (kv_row >= max_row) break;
+                            w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
+                            kv_row += 1;
+                        }
+                    }
+                }
+            },
+        }
         return surface;
     }
 
@@ -1587,31 +1819,7 @@ pub const Dashboard = struct {
         self.review_diff_scroll_bars.estimated_content_height = @intCast(self.review_diff_count);
     }
 
-    fn syncWorkspaceWidgets(self: *Dashboard) void {
-        self.workspace_scroll_bars.scroll_view.cursor = @min(self.workspace_scroll_bars.scroll_view.cursor, data.WORKSPACES.len - 1);
-        const ws_sel = @as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor));
-        for (data.WORKSPACES, 0..) |ws, idx| {
-            const sel = idx == ws_sel;
-            const sync_label = data.syncStateLabel(&ws);
-            const counts = if (ws.open_prs > 0)
-                std.fmt.bufPrint(&workspace_buf[idx], "{d}pr {d}c {d}p", .{ ws.open_prs, ws.contexts, ws.prompts }) catch "?"
-            else
-                std.fmt.bufPrint(&workspace_buf[idx], "{d}c {d}p", .{ ws.contexts, ws.prompts }) catch "?";
-            self.workspace_cols[idx] = .{
-                .{ .text = ws.name, .flex = 1 },
-                .{ .text = sync_label, .flex = 0 },
-                .{ .text = counts, .flex = 0, .alignment = .right },
-            };
-            self.workspace_rows[idx] = .{
-                .columns = &self.workspace_cols[idx],
-                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
-                .gap = 1,
-            };
-            self.workspace_widgets[idx] = self.workspace_rows[idx].widget();
-        }
-        self.workspace_scroll_bars.scroll_view.children = .{ .slice = self.workspace_widgets[0..] };
-        self.workspace_scroll_bars.estimated_content_height = data.WORKSPACES.len;
-    }
+    // Workspace grid uses manual rendering, no sync function needed
 
     // Inner width budget: panel=36min → border=2 → inner=34.
     // Row format: 1 + 16 name + 1 + 3 pct + 1 + % + 2 + 4 count = ~29. Fits.
@@ -1703,7 +1911,7 @@ fn prefixWithPad(prefix: []const u8) []const u8 {
     return map.get(prefix) orelse prefix;
 }
 
-var workspace_buf: [data.WORKSPACES.len][32]u8 = undefined;
+// workspace_buf removed: workspace uses manual grid rendering
 var insights_buf: [data.INSIGHTS_WS.len][16]u8 = undefined;
 
 fn diffFg(line: []const u8) vaxis.Color {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1614,7 +1614,6 @@ pub const Dashboard = struct {
                 var kv_row: u16 = 2;
                 var last_prefix: []const u8 = "";
                 if (live_ws) |ws_d| {
-                    // Cross-ref content_hash with library to get display path
                     const lib_prompts = self.getPrompts();
                     for (ws_d.ws_prompts, 0..) |wp, i| {
                         if (kv_row >= inner_h + 2) break;
@@ -1636,7 +1635,12 @@ pub const Dashboard = struct {
                                 .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
                             });
                         }
-                        w.writeText(&surface, ctx, 2, kv_row, data.promptName(name), name_style);
+                        const display_name = data.promptName(name);
+                        w.writeText(&surface, ctx, 2, kv_row, display_name, name_style);
+                        if (self.hasDraftFor(name)) {
+                            const nw: u16 = @intCast(ctx.stringWidth(display_name));
+                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
+                        }
                         kv_row += 1;
                     }
                 } else {
@@ -2355,6 +2359,34 @@ pub const Dashboard = struct {
             w.writeText(&surface, ctx, 2, row, "Effective permissions = min(org role, token scopes)", theme.fg(theme.MUTED));
         }
         return surface;
+    }
+
+    // Count active drafts (status != "merged") across all categories.
+    fn draftCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const drafts = self.api_state.drafts orelse return 0;
+        var count: usize = 0;
+        for (drafts) |d| {
+            if (!std.mem.eql(u8, d.status, "merged")) count += 1;
+        }
+        return count;
+    }
+
+    // Returns true if any active draft targets the given prompt path.
+    fn hasDraftFor(self: *Dashboard, prompt_path: []const u8) bool {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const drafts = self.api_state.drafts orelse return false;
+        for (drafts) |d| {
+            if (!std.mem.eql(u8, d.category, "prompt")) continue;
+            if (std.mem.eql(u8, d.status, "merged")) continue;
+            if (d.current_path) |cp| {
+                if (std.mem.eql(u8, cp, prompt_path)) return true;
+            }
+            if (std.mem.eql(u8, d.draft_path, prompt_path)) return true;
+        }
+        return false;
     }
 
     fn getPrsForPrompt(self: *Dashboard, prompt_path: []const u8) []const data.PullRequestEntry {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -520,12 +520,20 @@ pub const Dashboard = struct {
 
     fn drawHeader(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, theme.PANEL);
+        w.fillSurface(&surface, theme.PANEL_ALT);
 
-        // Row 0: App title in accent, context in muted
-        w.writeText(&surface, ctx, 1, 0, "clumsies", theme.boldOn(theme.PANEL, theme.ACCENT));
-        w.writeText(&surface, ctx, 10, 0, "\xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", theme.fg(theme.MUTED));
-        _ = w.drawFilledBadge(&surface, ctx, 0, surface.size.width -| 8, "FRESH", theme.PANEL, theme.OK);
+        // Row 0: Accent band with org/ws/user context
+        w.paintBand(&surface, 0, theme.ACCENT, theme.PANEL);
+        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", .{
+            .fg = theme.PANEL,
+            .bg = theme.ACCENT,
+            .bold = true,
+        });
+        w.writeRightText(&surface, ctx, 0, "[FRESH]", .{
+            .fg = theme.PANEL,
+            .bg = theme.ACCENT,
+            .bold = true,
+        });
 
         // Row 2: Tab badges (row 1 and 3 are padding)
         var col: u16 = 1;
@@ -651,7 +659,7 @@ pub const Dashboard = struct {
         return panel.draw(ctx);
     }
 
-    // Prompt Detail: meta header + inner tabs + sidebar
+    // Prompt Detail: main panel (with identity in title) + sidebar
     fn drawPromptDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         const p = &data.PROMPTS[self.selected_prompt];
@@ -659,79 +667,54 @@ pub const Dashboard = struct {
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
 
-        const meta_h: u16 = 5;
         const sidebar_w: u16 = if (size.width > 118) 30 else 26;
         const main_w: u16 = size.width - sidebar_w - 1;
-        const lower_h: u16 = size.height - meta_h - 1;
 
-        const meta_ctx = ctx.withConstraints(.{ .width = size.width, .height = meta_h }, .{ .width = size.width, .height = meta_h });
-        const main_ctx = ctx.withConstraints(.{ .width = main_w, .height = lower_h }, .{ .width = main_w, .height = lower_h });
-        const side_ctx = ctx.withConstraints(.{ .width = sidebar_w, .height = lower_h }, .{ .width = sidebar_w, .height = lower_h });
+        const main_ctx = ctx.withConstraints(.{ .width = main_w, .height = size.height }, .{ .width = main_w, .height = size.height });
+        const side_ctx = ctx.withConstraints(.{ .width = sidebar_w, .height = size.height }, .{ .width = sidebar_w, .height = size.height });
 
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawDetailMeta(meta_ctx, p) };
-        children[1] = .{ .origin = .{ .row = meta_h + 1, .col = 0 }, .surface = try self.drawDetailMain(main_ctx, p) };
-        children[2] = .{ .origin = .{ .row = meta_h + 1, .col = main_w + 1 }, .surface = try self.drawDetailSidebar(side_ctx, p) };
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawDetailMain(main_ctx, p) };
+        children[1] = .{ .origin = .{ .row = 0, .col = main_w + 1 }, .surface = try self.drawDetailSidebar(side_ctx, p) };
         root.children = children;
         return root;
-    }
-
-    fn drawDetailMeta(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
-        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, theme.PANEL);
-        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
-
-        w.writeText(&surface, ctx, 2, 0, p.canonical_name, theme.boldOn(theme.PANEL, theme.TEXT));
-        w.writeRightText(&surface, ctx, 0, p.content_hash, theme.textOn(theme.PANEL, theme.MUTED));
-
-        var col: u16 = 2;
-        col = w.drawFilledBadge(&surface, ctx, 1, col, p.kind, theme.PANEL, theme.GOLD);
-        col +|= 1;
-        _ = w.drawFilledBadge(&surface, ctx, 1, col, p.bundle_names, theme.PANEL, theme.CYAN);
-
-        // Row 2: override / proposal status
-        var status_col: u16 = 2;
-        status_col = w.drawFilledBadge(&surface, ctx, 2, status_col, "LOCAL", theme.PANEL, theme.WARN);
-        status_col +|= 1;
-        _ = w.drawFilledBadge(&surface, ctx, 2, status_col, "NO PROPOSAL", theme.TEXT_SOFT, theme.PANEL_ALT);
-
-        const metrics = try std.fmt.allocPrint(ctx.arena, "refer {s}   constraints {d}   bundles {d}", .{ p.refer_count, p.constraint_count, p.bundle_count });
-        w.writeText(&surface, ctx, 2, 3, metrics, theme.boldOn(theme.PANEL, theme.TEXT));
-        return surface;
     }
 
     fn drawDetailMain(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
 
-        // Inner tab strip
-        var col: u16 = 0;
+        // Row 0: inner tabs (left) + canonical name (right)
+        var col: u16 = 2;
         for (detail_tabs) |tab| {
             col = w.drawInnerTabBadge(&surface, ctx, 0, col, tab.label(), tab == self.detail_tab);
             col +|= 1;
         }
+        w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
 
-        const inner_h = ctx.max.height.? -| 2;
-        const inner_w = ctx.max.width.?;
+        const inner_h = ctx.max.height.? -| 3;
+        const inner_w = ctx.max.width.? -| 2;
 
         switch (self.detail_tab) {
             .overview => {
-                const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-                const kw: u16 = 12;
                 const kv_col: u16 = 2;
-                var kv_row: u16 = 3;
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "canonical", p.canonical_name, kw);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "kind", p.kind, kw);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "bundles", p.bundle_names, kw);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, kw);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, kw);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
+                var kv_row: u16 = 2;
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "override", "local (payments-api)", 8);
                 kv_row += 1;
-                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Trend (last 7d)");
-                w.writeText(&surface, ctx, kv_col, kv_row, spark, theme.fg(theme.ACCENT));
-                kv_row += 2;
+                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
+                // Mock constraint ranking (real data from GET /api/stats/prompt/{id})
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-1", "naming clarity           3210", 5);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-3", "import grouping          2321", 5);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-5", "file ordering            1172", 5);
+                kv_row += 1;
                 kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Override");
-                w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api. Press p to propose.", theme.fg(theme.TEXT_SOFT));
+                w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api", theme.fg(theme.TEXT_SOFT));
+                kv_row += 1;
+                w.writeText(&surface, ctx, kv_col, kv_row, "Press p to propose this override", theme.fg(theme.MUTED));
             },
             .content => {
                 self.syncContentWidget();
@@ -740,7 +723,7 @@ pub const Dashboard = struct {
                     .{ .width = inner_w, .height = inner_h },
                 );
                 const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+                children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
             .history => {
@@ -785,101 +768,61 @@ pub const Dashboard = struct {
                 }
 
                 const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-                children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = list_surface };
-                children[1] = .{ .origin = .{ .row = 2, .col = list_w + 1 }, .surface = try self.drawHistoryDetail(det_ctx) };
+                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
+                children[1] = .{ .origin = .{ .row = 2, .col = 1 + list_w + 1 }, .surface = try self.drawHistoryDetail(det_ctx) };
                 surface.children = children;
             },
         }
 
-        // Wrap in panel
-        const sw = try ctx.arena.create(w.SurfaceWidget);
-        sw.* = .{ .surface = surface, .widget_ref = self.widget() };
-        const panel: w.Panel = .{
-            .owner = self.widget(),
-            .title = "Prompt Detail",
-            .subtitle = p.canonical_name,
-            .background = theme.PANEL,
-            .border_color = theme.BORDER,
-            .child = sw.widget(),
-            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
-        };
-        return panel.draw(ctx);
+        return surface;
     }
 
     fn drawDetailSidebar(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-        const size = ctx.max.size();
-        const inner_w = size.width -| 4;
-        _ = inner_w;
+        const bg = theme.PANEL_ALT;
 
-        // Build sidebar surface with structured KV
-        var sb = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = size.height });
-        w.fillSurface(&sb, theme.PANEL_ALT);
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, bg);
+        w.drawBorder(&surface, theme.BORDER, bg);
+        w.writeText(&surface, ctx, 2, 0, "Usage Summary", theme.boldOn(bg, theme.TEXT));
+
         const kw: u16 = 11;
-        const col: u16 = 1;
-        var row: u16 = 0;
-        row = w.writeKv(&sb, ctx, col, row, "refer", p.refer_count, kw);
-        row = w.writeKv(&sb, ctx, col, row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
-        row = w.writeKv(&sb, ctx, col, row, "workspaces", "API pending", kw);
+        const kv_col: u16 = 2;
+        var row: u16 = 2;
+        row = w.writeKv(&surface, ctx, kv_col, row, "refer", p.refer_count, kw);
+        row = w.writeKv(&surface, ctx, kv_col, row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
+        row = w.writeKv(&surface, ctx, kv_col, row, "workspaces", "API pending", kw);
         row += 1;
-        row = w.writeSectionHeader(&sb, ctx, col, row, "Trend");
-        w.writeText(&sb, ctx, col, row, spark, theme.fg(theme.ACCENT));
+        row = w.writeSectionHeader(&surface, ctx, kv_col, row, "Trend");
+        w.writeText(&surface, ctx, kv_col, row, spark, theme.fg(theme.ACCENT));
         row += 2;
-        row = w.writeSectionHeader(&sb, ctx, col, row, "Actions");
-        w.writeText(&sb, ctx, col, row, "p  propose", theme.fg(theme.TEXT_SOFT));
+        row = w.writeSectionHeader(&surface, ctx, kv_col, row, "Actions");
+        w.writeText(&surface, ctx, kv_col, row, "p  propose", theme.fg(theme.TEXT_SOFT));
         row += 1;
-        w.writeText(&sb, ctx, col, row, "Enter  diff", theme.fg(theme.TEXT_SOFT));
+        w.writeText(&surface, ctx, kv_col, row, "Enter  diff", theme.fg(theme.TEXT_SOFT));
         row += 1;
         const back_text = try std.fmt.allocPrint(ctx.arena, "Esc  back to {s}", .{self.detail_origin.label()});
-        w.writeText(&sb, ctx, col, row, back_text, theme.fg(theme.TEXT_SOFT));
-
-        const wrapper = try ctx.arena.create(w.SurfaceWidget);
-        wrapper.* = .{ .surface = sb, .widget_ref = self.widget() };
-        const panel: w.Panel = .{
-            .owner = self.widget(),
-            .title = "Usage Summary",
-            .subtitle = "",
-            .background = theme.PANEL_ALT,
-            .border_color = theme.BORDER,
-            .child = wrapper.widget(),
-        };
-        return panel.draw(ctx);
+        w.writeText(&surface, ctx, kv_col, row, back_text, theme.fg(theme.TEXT_SOFT));
+        return surface;
     }
 
     fn drawHistoryDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const idx = @min(@as(usize, @intCast(self.history_scroll_bars.scroll_view.cursor)), data.HISTORY.len - 1);
         const h = &data.HISTORY[idx];
-        const detail = try std.fmt.allocPrint(ctx.arena,
-            \\Date
-            \\{s}
-            \\
-            \\Hash
-            \\{s}
-            \\
-            \\Label
-            \\{s}
-            \\
-            \\Next
-            \\Enter opens a diff overlay vs current (Phase 2).
-        , .{ h.date, h.hash, h.label });
 
-        const text_widget: vxfw.Text = .{
-            .text = detail,
-            .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
-            .width_basis = .parent,
-        };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{
-            .owner = self.widget(),
-            .title = "Version Detail",
-            .subtitle = if (idx == 0) "current" else "history",
-            .background = theme.PANEL,
-            .border_color = theme.BORDER,
-            .child = wrapper.widget(),
-            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
-        };
-        return panel.draw(ctx);
+        // No border -- plain area within the main panel, avoids card-in-card
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, theme.PANEL);
+
+        const kv_col: u16 = 1;
+        var row: u16 = 0;
+        row = w.writeSectionHeader(&surface, ctx, kv_col, row, if (idx == 0) "current version" else "history version");
+        row = w.writeKv(&surface, ctx, kv_col, row, "date", h.date, 6);
+        row = w.writeKv(&surface, ctx, kv_col, row, "hash", h.hash, 6);
+        row = w.writeKv(&surface, ctx, kv_col, row, "label", h.label, 6);
+        row += 1;
+        w.writeText(&surface, ctx, kv_col, row, "Enter opens diff (Phase 2)", theme.fg(theme.MUTED));
+        return surface;
     }
 
     // Proposal Review: queue + diff + sidebar (three-column)

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -74,14 +74,14 @@ const TopModule = enum(u8) {
     library,
     proposals,
     workspace,
-    compliance,
+    insights,
 
     fn label(self: TopModule) []const u8 {
         return switch (self) {
             .library => "Library",
             .proposals => "Proposals",
             .workspace => "Workspace",
-            .compliance => "Compliance",
+            .insights => "Insights",
         };
     }
 };
@@ -100,7 +100,7 @@ const DetailTab = enum(u8) {
     }
 };
 
-const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .compliance };
+const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .insights };
 const detail_tabs = [_]DetailTab{ .overview, .content, .history };
 
 pub const Dashboard = struct {
@@ -155,12 +155,12 @@ pub const Dashboard = struct {
     workspace_rows: [data.WORKSPACES.len]TableRow = undefined,
     workspace_cols: [data.WORKSPACES.len][3]Column = undefined,
 
-    // Compliance
-    compliance_period: Period = .daily,
-    compliance_scroll_bars: vxfw.ScrollBars,
-    compliance_widgets: [data.COMPLIANCE_WS.len]vxfw.Widget = undefined,
-    compliance_rows: [data.COMPLIANCE_WS.len]TableRow = undefined,
-    compliance_cols: [data.COMPLIANCE_WS.len][3]Column = undefined,
+    // Insights
+    insights_period: Period = .daily,
+    insights_scroll_bars: vxfw.ScrollBars,
+    insights_widgets: [data.INSIGHTS_WS.len]vxfw.Widget = undefined,
+    insights_rows: [data.INSIGHTS_WS.len]TableRow = undefined,
+    insights_cols: [data.INSIGHTS_WS.len][3]Column = undefined,
 
     pub fn init() Dashboard {
         return .{
@@ -170,7 +170,7 @@ pub const Dashboard = struct {
             .review_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
             .workspace_scroll_bars = w.initCursorScrollBars(theme.PANEL),
-            .compliance_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .insights_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .settings_member_scroll = w.initCursorScrollBars(theme.PANEL),
         };
     }
@@ -364,7 +364,7 @@ pub const Dashboard = struct {
                 if (key.matches('1', .{})) return self.selectTab(ctx, .library);
                 if (key.matches('2', .{})) return self.selectTab(ctx, .proposals);
                 if (key.matches('3', .{})) return self.selectTab(ctx, .workspace);
-                if (key.matches('4', .{})) return self.selectTab(ctx, .compliance);
+                if (key.matches('4', .{})) return self.selectTab(ctx, .insights);
 
                 // Module-specific input
                 switch (self.selected_module) {
@@ -410,14 +410,14 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                         }
                     },
-                    .compliance => {
-                        try self.compliance_scroll_bars.scroll_view.handleEvent(ctx, event);
+                    .insights => {
+                        try self.insights_scroll_bars.scroll_view.handleEvent(ctx, event);
                         if (key.matches('t', .{})) {
-                            self.compliance_period = self.compliance_period.next();
+                            self.insights_period = self.insights_period.next();
                             ctx.consumeAndRedraw();
                         }
                         if (key.matches(vaxis.Key.enter, .{})) {
-                            const cidx = @min(@as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor)), data.COMPLIANCE_WS.len - 1);
+                            const cidx = @min(@as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor)), data.INSIGHTS_WS.len - 1);
                             _ = cidx;
                             self.status_line = "Drill-down to workspace detail (future).";
                             ctx.consumeAndRedraw();
@@ -518,7 +518,7 @@ pub const Dashboard = struct {
             .library => self.drawLibrary(ctx),
             .proposals => self.drawProposalReview(ctx),
             .workspace => self.drawWorkspaceStatus(ctx),
-            .compliance => self.drawCompliance(ctx),
+            .insights => self.drawInsights(ctx),
         };
     }
 
@@ -538,7 +538,7 @@ pub const Dashboard = struct {
             .library => "j/k move  Enter open  S settings  1-4 switch  ? help  q quit",
             .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
             .workspace => "h/l tab  j/k move  r sync  S settings  ? help  q quit",
-            .compliance => "j/k move  t period  S settings  ? help  q quit",
+            .insights => "j/k move  t period  S settings  ? help  q quit",
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.textOn(theme.RAIL, theme.TEXT_SOFT));
         return surface;
@@ -1080,26 +1080,26 @@ pub const Dashboard = struct {
         return panel.draw(ctx);
     }
 
-    // Compliance: workspace-first refer coverage analysis
-    fn drawCompliance(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+    // Insights: workspace-first refer coverage analysis
+    fn drawInsights(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.CANVAS);
 
-        self.syncComplianceWidgets();
+        self.syncInsightsWidgets();
 
         // Org summary bar (3 rows)
         const summary_h: u16 = 3;
         var summary = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = summary_h });
         w.fillSurface(&summary, theme.PANEL);
         w.drawBorder(&summary, theme.BORDER, theme.PANEL);
-        const title = try std.fmt.allocPrint(ctx.arena, "Compliance \xe2\x94\x80 org: acme \xe2\x94\x80 period: {s}", .{self.compliance_period.label()});
+        const title = try std.fmt.allocPrint(ctx.arena, "Insights \xe2\x94\x80 org: acme \xe2\x94\x80 period: {s}", .{self.insights_period.label()});
         w.writeText(&summary, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
         w.writeRightText(&summary, ctx, 0, "t cycle period", theme.textOn(theme.PANEL, theme.MUTED));
 
         // Compute org totals from mock data
         var total_refer: u32 = 0;
-        for (data.COMPLIANCE_WS) |cw| {
+        for (data.INSIGHTS_WS) |cw| {
             var val: u32 = 0;
             for (cw.refer_count) |c| {
                 if (c >= '0' and c <= '9') {
@@ -1108,8 +1108,8 @@ pub const Dashboard = struct {
             }
             total_refer += val;
         }
-        const org_spark = try w.sparkline(ctx.arena, &data.COMPLIANCE_WS[0].trend);
-        const org_line = try std.fmt.allocPrint(ctx.arena, " workspaces {d}   prompts {d}   total refer ~{d}   org trend {s}", .{ data.COMPLIANCE_WS.len, data.PROMPTS.len, total_refer, org_spark });
+        const org_spark = try w.sparkline(ctx.arena, &data.INSIGHTS_WS[0].trend);
+        const org_line = try std.fmt.allocPrint(ctx.arena, " workspaces {d}   prompts {d}   total refer ~{d}   org trend {s}", .{ data.INSIGHTS_WS.len, data.PROMPTS.len, total_refer, org_spark });
         w.writeText(&summary, ctx, 1, 1, org_line, theme.textOn(theme.PANEL, theme.TEXT_SOFT));
 
         // Two-column: workspace rank (left) + selected detail (right)
@@ -1122,24 +1122,24 @@ pub const Dashboard = struct {
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = summary };
-        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = try self.drawComplianceList(l_ctx) };
-        children[2] = .{ .origin = .{ .row = summary_h, .col = left_w + 1 }, .surface = try self.drawComplianceDetail(r_ctx) };
+        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = try self.drawInsightsList(l_ctx) };
+        children[2] = .{ .origin = .{ .row = summary_h, .col = left_w + 1 }, .surface = try self.drawInsightsDetail(r_ctx) };
         root.children = children;
         return root;
     }
 
-    fn drawComplianceList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        self.compliance_scroll_bars.scroll_view.draw_cursor = false;
-        defer self.compliance_scroll_bars.scroll_view.draw_cursor = true;
+    fn drawInsightsList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        self.insights_scroll_bars.scroll_view.draw_cursor = false;
+        defer self.insights_scroll_bars.scroll_view.draw_cursor = true;
 
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspace Coverage", .subtitle = "j/k select", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.compliance_scroll_bars.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspace Coverage", .subtitle = "j/k select", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.insights_scroll_bars.widget() };
         var surface = try panel.draw(ctx);
-        return w.applyCursorOverlay(ctx, &surface, &self.compliance_scroll_bars.scroll_view);
+        return w.applyCursorOverlay(ctx, &surface, &self.insights_scroll_bars.scroll_view);
     }
 
-    fn drawComplianceDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const cidx = @min(@as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor)), data.COMPLIANCE_WS.len - 1);
-        const cw = &data.COMPLIANCE_WS[cidx];
+    fn drawInsightsDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const cidx = @min(@as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor)), data.INSIGHTS_WS.len - 1);
+        const cw = &data.INSIGHTS_WS[cidx];
         const spark = try w.sparkline(ctx.arena, cw.trend[0..8]);
 
         var buf: std.ArrayList(u8) = .empty;
@@ -1574,25 +1574,25 @@ pub const Dashboard = struct {
 
     // Inner width budget: panel=36min → border=2 → inner=34.
     // Row format: 1 + 16 name + 1 + 3 pct + 1 + % + 2 + 4 count = ~29. Fits.
-    fn syncComplianceWidgets(self: *Dashboard) void {
-        self.compliance_scroll_bars.scroll_view.cursor = @min(self.compliance_scroll_bars.scroll_view.cursor, data.COMPLIANCE_WS.len - 1);
-        const sel_idx = @as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor));
-        for (data.COMPLIANCE_WS, 0..) |cw, idx| {
+    fn syncInsightsWidgets(self: *Dashboard) void {
+        self.insights_scroll_bars.scroll_view.cursor = @min(self.insights_scroll_bars.scroll_view.cursor, data.INSIGHTS_WS.len - 1);
+        const sel_idx = @as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor));
+        for (data.INSIGHTS_WS, 0..) |cw, idx| {
             const sel = idx == sel_idx;
-            self.compliance_cols[idx] = .{
+            self.insights_cols[idx] = .{
                 .{ .text = cw.name, .flex = 1 },
-                .{ .text = std.fmt.bufPrint(&compliance_buf[idx], "{d}%", .{cw.coverage}) catch "?", .flex = 0, .alignment = .right },
+                .{ .text = std.fmt.bufPrint(&insights_buf[idx], "{d}%", .{cw.coverage}) catch "?", .flex = 0, .alignment = .right },
                 .{ .text = cw.refer_count, .flex = 0, .alignment = .right },
             };
-            self.compliance_rows[idx] = .{
-                .columns = &self.compliance_cols[idx],
+            self.insights_rows[idx] = .{
+                .columns = &self.insights_cols[idx],
                 .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
                 .gap = 2,
             };
-            self.compliance_widgets[idx] = self.compliance_rows[idx].widget();
+            self.insights_widgets[idx] = self.insights_rows[idx].widget();
         }
-        self.compliance_scroll_bars.scroll_view.children = .{ .slice = self.compliance_widgets[0..] };
-        self.compliance_scroll_bars.estimated_content_height = data.COMPLIANCE_WS.len;
+        self.insights_scroll_bars.scroll_view.children = .{ .slice = self.insights_widgets[0..] };
+        self.insights_scroll_bars.estimated_content_height = data.INSIGHTS_WS.len;
     }
 
     fn selectedProposalIdx(self: *const Dashboard) usize {
@@ -1610,7 +1610,7 @@ pub const Dashboard = struct {
             .library => "Bundle facet, prompt list, and passive preview.",
             .proposals => "Proposal queue left, diff center, review lens right.",
             .workspace => "Workspace list and sync status detail.",
-            .compliance => "Refer coverage analysis (Phase 3, API pending).",
+            .insights => "Refer coverage analysis (Phase 3, API pending).",
         };
     }
 
@@ -1650,7 +1650,7 @@ pub const Dashboard = struct {
 // Static row buffers to avoid per-frame allocation
 // Small buffers for inline-formatted column values (counts, percentages)
 var workspace_buf: [data.WORKSPACES.len][32]u8 = undefined;
-var compliance_buf: [data.COMPLIANCE_WS.len][16]u8 = undefined;
+var insights_buf: [data.INSIGHTS_WS.len][16]u8 = undefined;
 
 fn diffFg(line: []const u8) vaxis.Color {
     if (std.mem.startsWith(u8, line, "+")) return theme.OK;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1257,7 +1257,7 @@ pub const Dashboard = struct {
                 surface.children = children;
             },
             .pull_requests => {
-                const prs = data.prsForPrompt(p.canonical_name);
+                const prs = self.getPrsForPrompt(p.canonical_name);
                 if (prs.len == 0) {
                     w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
                 } else if (self.show_pr_diff) {
@@ -1372,7 +1372,7 @@ pub const Dashboard = struct {
                 surface.children = children;
             },
             .pull_requests => {
-                const prs = data.prsForPrompt(p.canonical_name);
+                const prs = self.getPrsForPrompt(p.canonical_name);
                 if (prs.len == 0) {
                     w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
                 } else if (self.show_pr_diff) {
@@ -2377,9 +2377,15 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    // Get PRs for a prompt. Uses mock data (API PRs have different shape for diff/comments).
     fn getPrsForPrompt(self: *Dashboard, canonical_name: []const u8) []const data.PullRequestEntry {
-        _ = self;
+        self.api_state.mutex.lock();
+        const live_prs = self.api_state.prompt_prs;
+        const lib = self.api_state.prompts;
+        self.api_state.mutex.unlock();
+        if (live_prs) |prs| {
+            const alloc = self.api_state.arena.allocator();
+            return api.toPrEntries(alloc, prs, canonical_name, lib);
+        }
         return data.prsForPrompt(canonical_name);
     }
 
@@ -2538,7 +2544,7 @@ pub const Dashboard = struct {
         const all_prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
         const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
-        const prs = data.prsForPrompt(p.canonical_name);
+        const prs = self.getPrsForPrompt(p.canonical_name);
         const title = if (prs.len > 0 and self.selected_pr_idx < prs.len)
             try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
         else
@@ -2692,7 +2698,7 @@ pub const Dashboard = struct {
         const all_prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
         const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
-        const prs = data.prsForPrompt(p.canonical_name);
+        const prs = self.getPrsForPrompt(p.canonical_name);
         var row_idx: usize = 0;
         for (prs, 0..) |pr, pi| {
             if (row_idx + 1 >= self.pr_widgets.len) break;
@@ -2743,7 +2749,7 @@ pub const Dashboard = struct {
         const all_prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
         const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
-        const prs = data.prsForPrompt(p.canonical_name);
+        const prs = self.getPrsForPrompt(p.canonical_name);
         if (prs.len == 0) {
             self.pr_diff_count = 0;
             return;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1733,7 +1733,17 @@ pub const Dashboard = struct {
         var live_insights: ?data.InsightsData = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
-            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models);
+            if (self.api_state.org_stats) |stats|
+                break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models, self.api_state.local_stats);
+            // No server stats, but local trace available — show personal data
+            if (self.api_state.local_stats) |local| break :blk data.InsightsData{
+                .constraint_count = local.constraint_count,
+                .active_constraint_count = local.active_constraint_count,
+                .idle_constraint_count = if (local.constraint_count > local.active_constraint_count) local.constraint_count - local.active_constraint_count else 0,
+                .signal_ratio = local.signal_ratio,
+                .refer_trend = local.refer_trend,
+                .prompts = local.prompts,
+            };
             break :blk null;
         };
         var empty_insights: data.InsightsData = .{

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -101,6 +101,9 @@ const DetailTab = enum(u8) {
 };
 
 const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .insights };
+
+// 12 prompts + up to 12 group headers = 24 max rows in Library
+const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
 const detail_tabs = [_]DetailTab{ .overview, .content, .history };
 
 pub const Dashboard = struct {
@@ -123,11 +126,15 @@ pub const Dashboard = struct {
     settings_member_rows: [data.MEMBERS.len]TableRow = undefined,
     settings_member_cols: [data.MEMBERS.len][3]Column = undefined,
 
-    // ScrollBars for each module
+    // Library: grouped display with bundle filter
+    library_bundle_filter: usize = 0,
     library_scroll_bars: vxfw.ScrollBars,
-    library_widgets: [data.PROMPTS.len]vxfw.Widget = undefined,
-    library_rows: [data.PROMPTS.len]TableRow = undefined,
-    library_cols: [data.PROMPTS.len][4]Column = undefined,
+    library_row_count: usize = 0,
+    library_prompt_indices: [MAX_LIBRARY_ROWS]?usize = .{null} ** MAX_LIBRARY_ROWS,
+    library_widgets: [MAX_LIBRARY_ROWS]vxfw.Widget = undefined,
+    library_text_rows: [MAX_LIBRARY_ROWS]vxfw.Text = undefined,
+    library_table_rows: [MAX_LIBRARY_ROWS]TableRow = undefined,
+    library_table_cols: [MAX_LIBRARY_ROWS][3]Column = undefined,
 
     content_scroll_bars: vxfw.ScrollBars,
     content_widget: [1]vxfw.Widget = undefined,
@@ -369,10 +376,39 @@ pub const Dashboard = struct {
                 // Module-specific input
                 switch (self.selected_module) {
                     .library => {
+                        if (key.matches('b', .{})) {
+                            self.library_bundle_filter = (self.library_bundle_filter + 1) % (data.BUNDLES.len + 1);
+                            self.library_scroll_bars.scroll_view.cursor = 0;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
                         const prev = self.library_scroll_bars.scroll_view.cursor;
                         try self.library_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        if (self.library_scroll_bars.scroll_view.cursor != prev) {
-                            self.selected_prompt = @intCast(@min(self.library_scroll_bars.scroll_view.cursor, data.PROMPTS.len - 1));
+                        // If cursor landed on a group header, skip in the
+                        // direction of movement to the next prompt row.
+                        const cursor_pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+                        if (cursor_pos < self.library_row_count) {
+                            if (self.library_prompt_indices[cursor_pos]) |pi| {
+                                self.selected_prompt = pi;
+                            } else if (self.library_scroll_bars.scroll_view.cursor != prev) {
+                                const moving_down = self.library_scroll_bars.scroll_view.cursor > prev;
+                                if (moving_down) {
+                                    if (cursor_pos + 1 < self.library_row_count) {
+                                        self.library_scroll_bars.scroll_view.cursor += 1;
+                                        if (self.library_prompt_indices[cursor_pos + 1]) |pi| {
+                                            self.selected_prompt = pi;
+                                        }
+                                    }
+                                } else {
+                                    if (cursor_pos > 0) {
+                                        self.library_scroll_bars.scroll_view.cursor -= 1;
+                                        if (self.library_prompt_indices[cursor_pos - 1]) |pi| {
+                                            self.selected_prompt = pi;
+                                        }
+                                    }
+                                }
+                                ctx.consumeAndRedraw();
+                            }
                         }
                         if (key.matches(vaxis.Key.enter, .{})) {
                             self.openDetail(ctx, self.selected_prompt, .library, .overview);
@@ -436,7 +472,7 @@ pub const Dashboard = struct {
         }
 
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         const header_h: u16 = 4;
         const footer_h: u16 = 1;
@@ -484,26 +520,18 @@ pub const Dashboard = struct {
 
     fn drawHeader(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, theme.HEADER);
+        w.fillSurface(&surface, theme.PANEL);
 
-        // Row 0: Accent band with org/ws/user/role context
-        w.paintBand(&surface, 0, theme.ACCENT, theme.CANVAS);
-        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", .{
-            .fg = theme.CANVAS,
-            .bg = theme.ACCENT,
-            .bold = true,
-        });
-        w.writeRightText(&surface, ctx, 0, "[FRESH]", .{
-            .fg = theme.CANVAS,
-            .bg = theme.ACCENT,
-            .bold = true,
-        });
+        // Row 0: App title in accent, context in muted
+        w.writeText(&surface, ctx, 1, 0, "clumsies", theme.boldOn(theme.PANEL, theme.ACCENT));
+        w.writeText(&surface, ctx, 10, 0, "\xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", theme.fg(theme.MUTED));
+        _ = w.drawFilledBadge(&surface, ctx, 0, surface.size.width -| 8, "FRESH", theme.PANEL, theme.OK);
 
         // Row 2: Tab badges (row 1 and 3 are padding)
         var col: u16 = 1;
         for (top_tabs, 0..) |tab, idx| {
             const label = try std.fmt.allocPrint(ctx.arena, "{d} {s}", .{ idx + 1, tab.label() });
-            const is_active = if (self.show_detail) false else (tab == self.selected_module);
+            const is_active = if (self.show_detail or self.show_settings) false else (tab == self.selected_module);
             col = w.drawTabBadge(&surface, ctx, 2, col, label, is_active);
             col +|= 1;
         }
@@ -524,7 +552,7 @@ pub const Dashboard = struct {
 
     fn drawFooter(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, theme.RAIL);
+        w.fillSurface(&surface, theme.PANEL);
 
         const keys = if (self.show_help)
             "Esc close help"
@@ -535,12 +563,12 @@ pub const Dashboard = struct {
         else if (self.show_detail)
             "h/l tab  j/k move  Enter diff  p propose  Esc back  ? help"
         else switch (self.selected_module) {
-            .library => "j/k move  Enter open  S settings  1-4 switch  ? help  q quit",
+            .library => "j/k move  Enter open  b bundle  S settings  ? help  q quit",
             .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
             .workspace => "h/l tab  j/k move  r sync  S settings  ? help  q quit",
             .insights => "j/k move  t period  S settings  ? help  q quit",
         };
-        w.writeText(&surface, ctx, 1, 0, keys, theme.textOn(theme.RAIL, theme.TEXT_SOFT));
+        w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
         return surface;
     }
 
@@ -549,7 +577,7 @@ pub const Dashboard = struct {
     fn drawLibrary(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         self.syncLibraryWidgets();
 
@@ -572,10 +600,15 @@ pub const Dashboard = struct {
         self.library_scroll_bars.scroll_view.draw_cursor = false;
         defer self.library_scroll_bars.scroll_view.draw_cursor = true;
 
+        const bundle_label: []const u8 = if (self.library_bundle_filter == 0)
+            "All"
+        else
+            data.BUNDLES[self.library_bundle_filter - 1].name;
+        const subtitle = try std.fmt.allocPrint(ctx.arena, "bundle: {s}  b cycle", .{bundle_label});
         const panel: w.Panel = .{
             .owner = self.widget(),
             .title = "Library Prompts",
-            .subtitle = "bundle: All",
+            .subtitle = subtitle,
             .background = theme.PANEL,
             .border_color = theme.BORDER,
             .child = self.library_scroll_bars.widget(),
@@ -624,7 +657,7 @@ pub const Dashboard = struct {
         const p = &data.PROMPTS[self.selected_prompt];
 
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         const meta_h: u16 = 5;
         const sidebar_w: u16 = if (size.width > 118) 30 else 26;
@@ -652,13 +685,13 @@ pub const Dashboard = struct {
         w.writeRightText(&surface, ctx, 0, p.content_hash, theme.textOn(theme.PANEL, theme.MUTED));
 
         var col: u16 = 2;
-        col = w.drawFilledBadge(&surface, ctx, 1, col, p.kind, theme.CANVAS, theme.GOLD);
+        col = w.drawFilledBadge(&surface, ctx, 1, col, p.kind, theme.PANEL, theme.GOLD);
         col +|= 1;
-        _ = w.drawFilledBadge(&surface, ctx, 1, col, p.bundle_names, theme.CANVAS, theme.CYAN);
+        _ = w.drawFilledBadge(&surface, ctx, 1, col, p.bundle_names, theme.PANEL, theme.CYAN);
 
         // Row 2: override / proposal status
         var status_col: u16 = 2;
-        status_col = w.drawFilledBadge(&surface, ctx, 2, status_col, "LOCAL", theme.CANVAS, theme.WARN);
+        status_col = w.drawFilledBadge(&surface, ctx, 2, status_col, "LOCAL", theme.PANEL, theme.WARN);
         status_col +|= 1;
         _ = w.drawFilledBadge(&surface, ctx, 2, status_col, "NO PROPOSAL", theme.TEXT_SOFT, theme.PANEL_ALT);
 
@@ -684,41 +717,21 @@ pub const Dashboard = struct {
         switch (self.detail_tab) {
             .overview => {
                 const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-                const overview = try std.fmt.allocPrint(ctx.arena,
-                    \\Canonical Name
-                    \\{s}
-                    \\
-                    \\Kind
-                    \\{s}
-                    \\
-                    \\Bundles
-                    \\{s}
-                    \\
-                    \\Content Hash
-                    \\{s}
-                    \\
-                    \\Updated
-                    \\{s}
-                    \\
-                    \\Trend (last 7d)
-                    \\{s}
-                    \\
-                    \\Local Override
-                    \\Detected in ws: payments-api. Press p to propose.
-                , .{ p.canonical_name, p.kind, p.bundle_names, p.content_hash, p.updated, spark });
-
-                const text_widget: vxfw.Text = .{
-                    .text = overview,
-                    .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
-                    .width_basis = .parent,
-                };
-                const child_ctx = ctx.withConstraints(
-                    .{ .width = inner_w, .height = inner_h },
-                    .{ .width = inner_w, .height = inner_h },
-                );
-                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = try text_widget.widget().draw(child_ctx) };
-                surface.children = children;
+                const kw: u16 = 12;
+                const kv_col: u16 = 2;
+                var kv_row: u16 = 3;
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "canonical", p.canonical_name, kw);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "kind", p.kind, kw);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "bundles", p.bundle_names, kw);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, kw);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, kw);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
+                kv_row += 1;
+                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Trend (last 7d)");
+                w.writeText(&surface, ctx, kv_col, kv_row, spark, theme.fg(theme.ACCENT));
+                kv_row += 2;
+                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Override");
+                w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api. Press p to propose.", theme.fg(theme.TEXT_SOFT));
             },
             .content => {
                 self.syncContentWidget();
@@ -795,40 +808,40 @@ pub const Dashboard = struct {
 
     fn drawDetailSidebar(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-        const sidebar = try std.fmt.allocPrint(ctx.arena,
-            \\Refer Count
-            \\{s}
-            \\
-            \\Constraints
-            \\{d}
-            \\
-            \\Trend
-            \\{s}
-            \\
-            \\Workspaces
-            \\API pending
-            \\
-            \\Actions
-            \\p  propose from local override
-            \\Enter  open diff from history
-            \\Esc  back to {s}
-        , .{ p.refer_count, p.constraint_count, spark, self.detail_origin.label() });
+        const size = ctx.max.size();
+        const inner_w = size.width -| 4;
+        _ = inner_w;
 
-        const text_widget: vxfw.Text = .{
-            .text = sidebar,
-            .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT),
-            .width_basis = .parent,
-        };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        // Build sidebar surface with structured KV
+        var sb = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = size.height });
+        w.fillSurface(&sb, theme.PANEL_ALT);
+        const kw: u16 = 11;
+        const col: u16 = 1;
+        var row: u16 = 0;
+        row = w.writeKv(&sb, ctx, col, row, "refer", p.refer_count, kw);
+        row = w.writeKv(&sb, ctx, col, row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
+        row = w.writeKv(&sb, ctx, col, row, "workspaces", "API pending", kw);
+        row += 1;
+        row = w.writeSectionHeader(&sb, ctx, col, row, "Trend");
+        w.writeText(&sb, ctx, col, row, spark, theme.fg(theme.ACCENT));
+        row += 2;
+        row = w.writeSectionHeader(&sb, ctx, col, row, "Actions");
+        w.writeText(&sb, ctx, col, row, "p  propose", theme.fg(theme.TEXT_SOFT));
+        row += 1;
+        w.writeText(&sb, ctx, col, row, "Enter  diff", theme.fg(theme.TEXT_SOFT));
+        row += 1;
+        const back_text = try std.fmt.allocPrint(ctx.arena, "Esc  back to {s}", .{self.detail_origin.label()});
+        w.writeText(&sb, ctx, col, row, back_text, theme.fg(theme.TEXT_SOFT));
+
+        const wrapper = try ctx.arena.create(w.SurfaceWidget);
+        wrapper.* = .{ .surface = sb, .widget_ref = self.widget() };
         const panel: w.Panel = .{
             .owner = self.widget(),
             .title = "Usage Summary",
-            .subtitle = "API pending",
+            .subtitle = "",
             .background = theme.PANEL_ALT,
             .border_color = theme.BORDER,
             .child = wrapper.widget(),
-            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
         };
         return panel.draw(ctx);
     }
@@ -873,7 +886,7 @@ pub const Dashboard = struct {
     fn drawProposalReview(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         self.syncReviewWidgets();
         const proposal = &data.PROPOSALS[self.selectedProposalIdx()];
@@ -943,7 +956,7 @@ pub const Dashboard = struct {
     fn drawWorkspaceStatus(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         self.syncWorkspaceWidgets();
         const ws_idx = @min(@as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor)), data.WORKSPACES.len - 1);
@@ -974,7 +987,7 @@ pub const Dashboard = struct {
     fn drawWsBody(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&surface, theme.CANVAS);
+        w.fillSurface(&surface, theme.PANEL);
 
         // Inner tabs
         var tab_col: u16 = 1;
@@ -1084,7 +1097,7 @@ pub const Dashboard = struct {
     fn drawInsights(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         self.syncInsightsWidgets();
 
@@ -1164,11 +1177,11 @@ pub const Dashboard = struct {
     fn drawSettings(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         // Inner tab strip
         var tab_surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = 1 });
-        w.fillSurface(&tab_surface, theme.CANVAS);
+        w.fillSurface(&tab_surface, theme.PANEL);
         var tab_col: u16 = 1;
         for (settings_tabs) |tab| {
             tab_col = w.drawInnerTabBadge(&tab_surface, ctx, 0, tab_col, tab.label(), tab == self.settings_tab);
@@ -1198,7 +1211,7 @@ pub const Dashboard = struct {
     fn drawSettingsMembers(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.CANVAS);
+        w.fillSurface(&root, theme.PANEL);
 
         self.syncSettingsMemberWidgets();
 
@@ -1334,7 +1347,7 @@ pub const Dashboard = struct {
         const size = ctx.max.size();
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         // Semi-transparent overlay: paint dimmed background
-        w.fillSurface(&surface, theme.CANVAS);
+        w.fillSurface(&surface, theme.PANEL);
 
         const box_w: u16 = 52;
         const box_h: u16 = 19;
@@ -1401,7 +1414,7 @@ pub const Dashboard = struct {
     fn drawConfirmOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&surface, theme.CANVAS);
+        w.fillSurface(&surface, theme.PANEL);
 
         const box_w: u16 = 44;
         const box_h: u16 = 7;
@@ -1454,34 +1467,73 @@ pub const Dashboard = struct {
 
     fn drawTooSmall(self: *Dashboard, ctx: vxfw.DrawContext, size: vxfw.Size) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&surface, theme.CANVAS);
-        w.paintBand(&surface, 0, theme.ACCENT, theme.CANVAS);
-        w.writeText(&surface, ctx, 1, 0, "clumsies / prompt dashboard", .{ .fg = theme.CANVAS, .bg = theme.ACCENT, .bold = true });
-        w.writeText(&surface, ctx, 2, 2, "Terminal too small. Need at least 96x24.", theme.boldOn(theme.CANVAS, theme.TEXT));
-        w.writeText(&surface, ctx, 2, 4, "Resize the terminal, or press q / Ctrl-C to exit.", theme.textOn(theme.CANVAS, theme.TEXT_SOFT));
+        w.fillSurface(&surface, theme.PANEL);
+        w.writeText(&surface, ctx, 1, 0, "clumsies", theme.boldOn(theme.PANEL, theme.ACCENT));
+        w.writeText(&surface, ctx, 2, 2, "Terminal too small. Need at least 96x24.", theme.fgBold(theme.TEXT));
+        w.writeText(&surface, ctx, 2, 4, "Resize the terminal, or press q / Ctrl-C to exit.", theme.fg(theme.TEXT_SOFT));
         return surface;
     }
 
-    // Library rows: name (flex=1) | kind (auto) | refer (auto, right) | age (auto, right)
+    // Library: grouped by path prefix with optional bundle filter.
+    // Builds a mixed list of group headers (Text) and prompt rows (TableRow).
+    // library_prompt_indices maps each row index to the PROMPTS array index
+    // (null for group header rows, so cursor can skip them).
     fn syncLibraryWidgets(self: *Dashboard) void {
-        self.library_scroll_bars.scroll_view.cursor = @intCast(self.selected_prompt);
-        for (data.PROMPTS, 0..) |p, idx| {
-            const sel = idx == self.selected_prompt;
-            self.library_cols[idx] = .{
-                .{ .text = p.canonical_name, .flex = 1 },
-                .{ .text = p.kind, .flex = 0 },
-                .{ .text = p.refer_count, .flex = 0, .alignment = .right },
-                .{ .text = p.age, .flex = 0, .alignment = .right },
-            };
-            self.library_rows[idx] = .{
-                .columns = &self.library_cols[idx],
-                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
-                .gap = 2,
-            };
-            self.library_widgets[idx] = self.library_rows[idx].widget();
+        const filter_name: ?[]const u8 = if (self.library_bundle_filter == 0)
+            null
+        else
+            data.BUNDLES[self.library_bundle_filter - 1].name;
+
+        var row_idx: usize = 0;
+        var last_prefix: []const u8 = "";
+
+        for (data.PROMPTS, 0..) |p, pidx| {
+            // Apply bundle filter
+            if (filter_name) |fname| {
+                if (std.mem.indexOf(u8, p.bundle_names, fname) == null) continue;
+            }
+
+            const prefix = data.pathPrefix(p.canonical_name);
+            const name = data.promptName(p.canonical_name);
+
+            // Insert group header when prefix changes
+            if (!std.mem.eql(u8, prefix, last_prefix)) {
+                if (row_idx < MAX_LIBRARY_ROWS) {
+                    // Prefix headers use static padded strings to avoid
+                    // needing an allocator in sync functions.
+                    self.library_text_rows[row_idx] = .{
+                        .text = prefixWithPad(prefix),
+                        .style = theme.boldOn(theme.PANEL, theme.ACCENT),
+                    };
+                    self.library_widgets[row_idx] = self.library_text_rows[row_idx].widget();
+                    self.library_prompt_indices[row_idx] = null;
+                    row_idx += 1;
+                }
+                last_prefix = prefix;
+            }
+
+            // Insert prompt row
+            if (row_idx < MAX_LIBRARY_ROWS) {
+                const sel = pidx == self.selected_prompt;
+                self.library_table_cols[row_idx] = .{
+                    .{ .text = name, .flex = 1 },
+                    .{ .text = p.refer_count, .flex = 0, .min_width = 4, .alignment = .right },
+                    .{ .text = p.age, .flex = 0, .min_width = 3, .alignment = .right },
+                };
+                self.library_table_rows[row_idx] = .{
+                    .columns = &self.library_table_cols[row_idx],
+                    .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                    .gap = 2,
+                };
+                self.library_widgets[row_idx] = self.library_table_rows[row_idx].widget();
+                self.library_prompt_indices[row_idx] = pidx;
+                row_idx += 1;
+            }
         }
-        self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..] };
-        self.library_scroll_bars.estimated_content_height = data.PROMPTS.len;
+
+        self.library_row_count = row_idx;
+        self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..row_idx] };
+        self.library_scroll_bars.estimated_content_height = @intCast(row_idx);
     }
 
     fn syncContentWidget(self: *Dashboard) void {
@@ -1649,6 +1701,19 @@ pub const Dashboard = struct {
 
 // Static row buffers to avoid per-frame allocation
 // Small buffers for inline-formatted column values (counts, percentages)
+fn prefixWithPad(prefix: []const u8) []const u8 {
+    // Map known path prefixes to static padded strings
+    const map = std.StaticStringMap([]const u8).initComptime(.{
+        .{ "arch", " arch" },
+        .{ "cmd", " cmd" },
+        .{ "coding", " coding" },
+        .{ "style", " style" },
+        .{ "wf", " wf" },
+        .{ "zig", " zig" },
+    });
+    return map.get(prefix) orelse prefix;
+}
+
 var workspace_buf: [data.WORKSPACES.len][32]u8 = undefined;
 var insights_buf: [data.INSIGHTS_WS.len][16]u8 = undefined;
 

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -2496,10 +2496,15 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         const live_prs = self.api_state.prompt_prs;
-        const lib = self.api_state.prompts;
         if (live_prs) |prs| {
+            // Only trust the cached PR list when it was fetched for this path.
+            if (self.api_state.prompt_prs_for_path) |cached| {
+                if (!std.mem.eql(u8, cached, prompt_path)) return &.{};
+            } else {
+                return &.{};
+            }
             const alloc = self.api_state.arena.allocator();
-            return api.toPrEntries(alloc, prs, prompt_path, lib, self.api_state);
+            return api.toPrEntries(alloc, prs, prompt_path, self.api_state);
         }
         return &.{};
     }
@@ -2990,10 +2995,12 @@ pub const Dashboard = struct {
         self.content_scroll_bars.scroll_view.children = .{ .slice = self.content_widget[0..1] };
         self.content_scroll_bars.estimated_content_height = @intCast(@max(w.countLines(content), 24));
 
-        // Trigger fetch for the selected prompt content
+        // Trigger fetch for the selected prompt content and its PR list
         const prompts = self.getPrompts();
         if (self.selected_prompt < prompts.len) {
-            api.fetchPromptContentAsync(self.api_state, prompts[self.selected_prompt].path);
+            const sel_path = prompts[self.selected_prompt].path;
+            api.fetchPromptContentAsync(self.api_state, sel_path);
+            api.fetchPromptPrsAsync(self.api_state, sel_path);
         }
     }
 

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -315,6 +315,11 @@ pub const Dashboard = struct {
                         ctx.consumeAndRedraw();
                         return;
                     }
+                    if (key.matches(vaxis.Key.tab, .{})) {
+                        self.settings_focus = if (self.settings_focus == .sidebar) .content else .sidebar;
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
                     if (self.settings_focus == .sidebar) {
                         if (key.matches(vaxis.Key.escape, .{})) {
                             self.show_settings = false;
@@ -333,7 +338,7 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{}) or key.matches(vaxis.Key.enter, .{})) {
+                        if (key.matches(vaxis.Key.enter, .{})) {
                             self.settings_focus = .content;
                             self.settings_content_sel = 0;
                             ctx.consumeAndRedraw();
@@ -341,7 +346,7 @@ pub const Dashboard = struct {
                         }
                     } else {
                         // Content focus
-                        if (key.matches(vaxis.Key.escape, .{}) or key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                        if (key.matches(vaxis.Key.escape, .{})) {
                             self.settings_focus = .sidebar;
                             ctx.consumeAndRedraw();
                             return;
@@ -1769,7 +1774,7 @@ pub const Dashboard = struct {
         }
 
         const name_w: u16 = 21;
-        const bar_start: u16 = name_w + 2;
+        const bar_start: u16 = name_w + 1;
         const bar_end: u16 = col_rate -| 2;
         const bar_max_w: u16 = bar_end -| bar_start;
 
@@ -1791,14 +1796,14 @@ pub const Dashboard = struct {
             if (is_idle) {
                 // Same layout as active prompts, just name in red
                 const name_style: vaxis.Style = if (is_sel) theme.boldOn(theme.PANEL, theme.DANGER) else .{ .fg = theme.DANGER, .bg = theme.PANEL };
-                w.writeText(&s, ctx, 3, row, p.name, name_style);
+                w.writeText(&s, ctx, 2, row, p.name, name_style);
                 w.writeText(&s, ctx, col_rate, row, "0/d", theme.fg(theme.MUTED));
                 w.writeText(&s, ctx, col_delta, row, " 0%", theme.fg(theme.MUTED));
                 const sig_txt = try std.fmt.allocPrint(ctx.arena, "0/{d}", .{p.constraint_count});
                 w.writeText(&s, ctx, col_sig, row, sig_txt, theme.fg(theme.MUTED));
             } else {
                 const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&s, ctx, 3, row, p.name, name_style);
+                w.writeText(&s, ctx, 2, row, p.name, name_style);
 
                 const bar_w: u16 = @intCast(@as(u32, bar_max_w) * p.refer_count / max_refer);
                 for (0..bar_w) |offset| {
@@ -2013,7 +2018,7 @@ pub const Dashboard = struct {
                 });
             }
             const style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-            w.writeText(&sidebar, ctx, 3, row, tab.label(), style);
+            w.writeText(&sidebar, ctx, 2, row, tab.label(), style);
             row += 1;
         }
 

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -160,10 +160,13 @@ pub const Dashboard = struct {
 
     // Insights
     insights_period: Period = .daily,
-    insights_scroll_bars: vxfw.ScrollBars,
-    insights_widgets: [data.INSIGHTS_WS.len]vxfw.Widget = undefined,
-    insights_rows: [data.INSIGHTS_WS.len]TableRow = undefined,
-    insights_cols: [data.INSIGHTS_WS.len][3]Column = undefined,
+    breathing_phase: u8 = 0, // 0-20 for breathing animation cycle
+    insights_focus: enum { chart, prompts, team } = .chart,
+    insights_prompt_cursor: usize = 0,
+    insights_member_cursor: usize = 0,
+    insights_expanded_prompt: ?usize = null,
+    insights_show_member_detail: bool = false,
+    chart_offset: u16 = 0,
 
     pub fn init() Dashboard {
         return .{
@@ -173,7 +176,6 @@ pub const Dashboard = struct {
             .review_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
             // workspace uses manual grid, no ScrollBars
-            .insights_scroll_bars = w.initCursorScrollBars(theme.PANEL),
         };
     }
 
@@ -645,19 +647,108 @@ pub const Dashboard = struct {
                         }
                     },
                     .insights => {
-                        try self.insights_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        const ins = &data.INSIGHTS;
                         if (key.matches('t', .{})) {
                             self.insights_period = self.insights_period.next();
+                            self.status_line = switch (self.insights_period) {
+                                .daily => "Period: daily (30d).",
+                                .weekly => "Period: weekly (8w).",
+                                .monthly => "Period: monthly (12m).",
+                            };
                             ctx.consumeAndRedraw();
                         }
-                        if (key.matches(vaxis.Key.enter, .{})) {
-                            const cidx = @min(@as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor)), data.INSIGHTS_WS.len - 1);
-                            _ = cidx;
-                            self.status_line = "Workspace detail (not yet implemented)";
+                        if (key.matches(vaxis.Key.tab, .{})) {
+                            self.insights_focus = switch (self.insights_focus) {
+                                .chart => .prompts,
+                                .prompts => .team,
+                                .team => .chart,
+                            };
+                            self.insights_expanded_prompt = null;
+                            self.insights_show_member_detail = false;
                             ctx.consumeAndRedraw();
+                        }
+                        if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+                            switch (self.insights_focus) {
+                                .prompts => {
+                                    if (self.insights_prompt_cursor < ins.prompts.len - 1)
+                                        self.insights_prompt_cursor += 1;
+                                    ctx.consumeAndRedraw();
+                                },
+                                .team => {
+                                    if (self.insights_member_cursor < ins.members.len - 1)
+                                        self.insights_member_cursor += 1;
+                                    ctx.consumeAndRedraw();
+                                },
+                                else => {},
+                            }
+                        }
+                        if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+                            switch (self.insights_focus) {
+                                .prompts => {
+                                    self.insights_prompt_cursor -|= 1;
+                                    ctx.consumeAndRedraw();
+                                },
+                                .team => {
+                                    self.insights_member_cursor -|= 1;
+                                    ctx.consumeAndRedraw();
+                                },
+                                else => {},
+                            }
+                        }
+                        if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                            if (self.insights_focus == .chart) {
+                                self.status_line = "Chart scroll requires Hub API (mock: fixed 30d window).";
+                                ctx.consumeAndRedraw();
+                            }
+                        }
+                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                            if (self.insights_focus == .chart) {
+                                self.status_line = "Chart scroll requires Hub API (mock: fixed 30d window).";
+                                ctx.consumeAndRedraw();
+                            }
+                        }
+                        if (key.matches(vaxis.Key.enter, .{})) {
+                            switch (self.insights_focus) {
+                                .prompts => {
+                                    // Toggle per-constraint detail expansion
+                                    if (self.insights_expanded_prompt == self.insights_prompt_cursor) {
+                                        self.insights_expanded_prompt = null;
+                                    } else {
+                                        self.insights_expanded_prompt = self.insights_prompt_cursor;
+                                    }
+                                    ctx.consumeAndRedraw();
+                                },
+                                .team => {
+                                    self.insights_show_member_detail = !self.insights_show_member_detail;
+                                    ctx.consumeAndRedraw();
+                                },
+                                else => {},
+                            }
+                        }
+                        if (key.matches(vaxis.Key.escape, .{})) {
+                            if (self.insights_expanded_prompt != null) {
+                                self.insights_expanded_prompt = null;
+                                ctx.consumeAndRedraw();
+                            } else if (self.insights_show_member_detail) {
+                                self.insights_show_member_detail = false;
+                                ctx.consumeAndRedraw();
+                            } else {
+                                self.insights_focus = .prompts;
+                                ctx.consumeAndRedraw();
+                            }
                         }
                     },
                 }
+            },
+            .init => {
+                // Start breathing animation
+                try ctx.tick(100, self.widget());
+            },
+            .tick => {
+                // Advance breathing cycle: 0→20→0 (2 seconds at 100ms intervals)
+                self.breathing_phase = (self.breathing_phase + 1) % 21;
+                ctx.redraw = true;
+                try ctx.tick(100, self.widget());
             },
             else => {},
         }
@@ -788,7 +879,11 @@ pub const Dashboard = struct {
                 .list => "h/l tab  j/k move  Enter content  Esc bar  ? help",
                 .content => "j/k scroll  Esc list  ? help",
             },
-            .insights => "j/k move  t period  S settings  ? help  q quit",
+            .insights => switch (self.insights_focus) {
+                .chart => "h/l scroll  Tab focus  t period  ? help  q quit",
+                .prompts => "j/k move  Enter expand  Tab focus  t period  ? help  q quit",
+                .team => "j/k move  Enter detail  Tab focus  t period  ? help  q quit",
+            },
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
 
@@ -1401,85 +1496,311 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    // Insights: workspace-first refer coverage analysis
+    // Insights: multi-panel signal-ratio dashboard
     fn drawInsights(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-        w.fillSurface(&root, theme.PANEL);
+        w.fillSurface(&root, theme.CANVAS);
 
-        self.syncInsightsWidgets();
+        const ins = &data.INSIGHTS;
 
-        // Org summary bar (3 rows)
-        const summary_h: u16 = 3;
-        var summary = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = summary_h });
-        w.fillSurface(&summary, theme.PANEL);
-        w.drawBorder(&summary, theme.BORDER, theme.PANEL);
-        const title = try std.fmt.allocPrint(ctx.arena, "Insights \xe2\x94\x80 org: acme \xe2\x94\x80 period: {s}", .{self.insights_period.label()});
-        w.writeText(&summary, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
-        w.writeRightText(&summary, ctx, 0, "t cycle period", theme.textOn(theme.PANEL, theme.MUTED));
-
-        // Compute org totals from mock data
-        var total_refer: u32 = 0;
-        for (data.INSIGHTS_WS) |cw| {
-            var val: u32 = 0;
-            for (cw.refer_count) |c| {
-                if (c >= '0' and c <= '9') {
-                    val = val * 10 + (c - '0');
-                }
-            }
-            total_refer += val;
-        }
-        const org_spark = try w.sparkline(ctx.arena, &data.INSIGHTS_WS[0].trend);
-        const org_line = try std.fmt.allocPrint(ctx.arena, " workspaces {d}   prompts {d}   total refer ~{d}   org trend {s}", .{ data.INSIGHTS_WS.len, data.PROMPTS.len, total_refer, org_spark });
-        w.writeText(&summary, ctx, 1, 1, org_line, theme.textOn(theme.PANEL, theme.TEXT_SOFT));
-
-        // Two-column: workspace rank (left) + selected detail (right)
-        const body_h = size.height - summary_h;
-        const left_w: u16 = if (size.width > 108) 44 else 36;
-        const right_w: u16 = size.width - left_w - 1;
-
-        const l_ctx = ctx.withConstraints(.{ .width = left_w, .height = body_h }, .{ .width = left_w, .height = body_h });
-        const r_ctx = ctx.withConstraints(.{ .width = right_w, .height = body_h }, .{ .width = right_w, .height = body_h });
+        // Layout: chart(top, full width) + prompts|team (bottom, side by side)
+        const chart_h: u16 = if (size.height > 40) 10 else 8;
+        const body_h: u16 = size.height -| chart_h;
+        const team_w: u16 = 18; // narrow sidebar: border(2) + padding(2) + grid(5×2) + gaps
+        const prompts_w: u16 = size.width -| team_w;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = summary };
-        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = try self.drawInsightsList(l_ctx) };
-        children[2] = .{ .origin = .{ .row = summary_h, .col = left_w + 1 }, .surface = try self.drawInsightsDetail(r_ctx) };
+
+        // Panel 1: Signal Trend chart (hero, full width)
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawInsightsChart(ctx, size.width, chart_h, ins) };
+        // Panel 2: Prompts Rank (or Member Detail if active)
+        const main_surface = if (self.insights_show_member_detail)
+            try self.drawMemberDetail(ctx, prompts_w, body_h, ins)
+        else
+            try self.drawInsightsPrompts(ctx, prompts_w, body_h, ins);
+        children[1] = .{ .origin = .{ .row = chart_h, .col = 0 }, .surface = main_surface };
+        // Panel 3: Team Activity sidebar (narrow, right side)
+        children[2] = .{ .origin = .{ .row = chart_h, .col = prompts_w }, .surface = try self.drawInsightsTeam(ctx, team_w, body_h, ins) };
+
         root.children = children;
         return root;
     }
 
-    fn drawInsightsList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        self.insights_scroll_bars.scroll_view.draw_cursor = false;
-        defer self.insights_scroll_bars.scroll_view.draw_cursor = true;
+    fn drawInsightsChart(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        const border_color = if (self.insights_focus == .chart) theme.ACCENT else theme.BORDER;
+        var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+        w.fillSurface(&s, theme.PANEL);
+        w.drawBorder(&s, border_color, theme.PANEL);
 
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspace Coverage", .subtitle = "j/k select", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.insights_scroll_bars.widget() };
-        var surface = try panel.draw(ctx);
-        return w.applyCursorOverlay(ctx, &surface, &self.insights_scroll_bars.scroll_view);
+        // Title bar: ● Signal Trend ── key metrics
+        // Breathing ● : phase 0-10 = dim→bright, 10-20 = bright→dim
+        const breath_t: f32 = blk: {
+            const p = self.breathing_phase;
+            const half: f32 = if (p <= 10) @as(f32, @floatFromInt(p)) / 10.0 else @as(f32, @floatFromInt(20 - p)) / 10.0;
+            break :blk 0.3 + half * 0.7; // range 0.3 to 1.0
+        };
+        const dark_green = theme.rgb(0x2d4a1f);
+        const dot_color = theme.lerpColor(dark_green, theme.OK, breath_t);
+        w.writeText(&s, ctx, 2, 0, "\u{25cf}", .{ .fg = dot_color, .bg = theme.PANEL });
+        w.writeText(&s, ctx, 4, 0, "Signal Trend", theme.boldOn(theme.PANEL, theme.TEXT));
+        const metrics_txt = try std.fmt.allocPrint(ctx.arena, "signal {d}%", .{ins.signal_ratio});
+        w.writeText(&s, ctx, 18, 0, metrics_txt, theme.fg(theme.ACCENT_SOFT));
+        w.writeRightText(&s, ctx, 0, "t period", theme.fg(theme.MUTED));
+
+        const chart_x: u16 = 1;
+        const chart_w: u16 = width -| 2;
+        const chart_rows: u16 = height -| 3;
+        w.drawBrailleAreaChart(&s, ctx.arena, &ins.refer_trend, chart_x, 1, chart_w, chart_rows);
+
+        // X-axis: minimal endpoints
+        w.writeText(&s, ctx, chart_x, height -| 2, "30d ago", theme.fg(theme.DIM));
+        w.writeRightText(&s, ctx, height -| 2, "today", theme.fg(theme.DIM));
+
+        return s;
     }
 
-    fn drawInsightsDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const cidx = @min(@as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor)), data.INSIGHTS_WS.len - 1);
-        const cw = &data.INSIGHTS_WS[cidx];
-        const spark = try w.sparkline(ctx.arena, cw.trend[0..8]);
+    fn drawInsightsPrompts(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        const border_color = if (self.insights_focus == .prompts) theme.ACCENT else theme.BORDER;
+        var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+        w.fillSurface(&s, theme.PANEL);
+        w.drawBorder(&s, border_color, theme.PANEL);
 
-        var buf: std.ArrayList(u8) = .empty;
-        // Selected workspace detail
-        try buf.appendSlice(ctx.arena, try std.fmt.allocPrint(ctx.arena, "Workspace\n{s}\n\nCoverage\n{d}%\n\nRefer Count\n{s}\n\nTrend\n{s}\n\n", .{ cw.name, cw.coverage, cw.refer_count, spark }));
+        w.writeText(&s, ctx, 3, 0, "Prompts Rank", theme.boldOn(theme.PANEL, theme.TEXT));
+        // Right-aligned column headers (with right padding)
+        const col_rate: u16 = width -| 24;
+        const col_delta: u16 = width -| 16;
+        const col_sig: u16 = width -| 9;
+        w.writeText(&s, ctx, col_rate, 0, "rate", theme.fg(theme.MUTED));
+        w.writeText(&s, ctx, col_delta, 0, "\u{0394}7d", theme.fg(theme.MUTED));
+        w.writeText(&s, ctx, col_sig, 0, "signal", theme.fg(theme.MUTED));
 
-        // Hotspots section
-        try buf.appendSlice(ctx.arena, "Prompt Hotspots\n");
-        for (data.HOTSPOTS) |h| {
-            try buf.appendSlice(ctx.arena, try std.fmt.allocPrint(ctx.arena, " {s:<24} {s}\n", .{ h.name, h.refer_count }));
+        // Find max refer count for bar scaling
+        var max_refer: u32 = 1;
+        for (ins.prompts) |p| {
+            if (p.refer_count > max_refer) max_refer = p.refer_count;
         }
-        try buf.appendSlice(ctx.arena, "\nMember Grouping\nAPI pending (s1-4 expansion needed)");
 
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = cw.name, .subtitle = try std.fmt.allocPrint(ctx.arena, "coverage {d}%", .{cw.coverage}), .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
+        const name_w: u16 = 21;
+        const bar_start: u16 = name_w + 2;
+        const bar_end: u16 = col_rate -| 2;
+        const bar_max_w: u16 = bar_end -| bar_start;
+
+        const focused = self.insights_focus == .prompts;
+        var row: u16 = 1;
+        for (ins.prompts, 0..) |p, pi| {
+            if (row >= height -| 1) break;
+            const is_idle = p.refer_count == 0;
+            const is_sel = pi == self.insights_prompt_cursor and focused;
+
+            // Cursor indicator
+            if (is_sel) {
+                s.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+
+            if (is_idle) {
+                // Same layout as active prompts, just name in red
+                const name_style: vaxis.Style = if (is_sel) theme.boldOn(theme.PANEL, theme.DANGER) else .{ .fg = theme.DANGER, .bg = theme.PANEL };
+                w.writeText(&s, ctx, 3, row, p.name, name_style);
+                w.writeText(&s, ctx, col_rate, row, "0/d", theme.fg(theme.MUTED));
+                w.writeText(&s, ctx, col_delta, row, " 0%", theme.fg(theme.MUTED));
+                const sig_txt = try std.fmt.allocPrint(ctx.arena, "0/{d}", .{p.constraint_count});
+                w.writeText(&s, ctx, col_sig, row, sig_txt, theme.fg(theme.MUTED));
+            } else {
+                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&s, ctx, 3, row, p.name, name_style);
+
+                const bar_w: u16 = @intCast(@as(u32, bar_max_w) * p.refer_count / max_refer);
+                for (0..bar_w) |offset| {
+                    const bc: u16 = bar_start + @as(u16, @intCast(offset));
+                    if (bc >= bar_end) break;
+                    const t: f32 = if (bar_w > 1) @as(f32, @floatFromInt(offset)) / @as(f32, @floatFromInt(bar_w - 1)) else 0.5;
+                    s.writeCell(bc, row, .{
+                        .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
+                        .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
+                    });
+                }
+                const ref_text = try std.fmt.allocPrint(ctx.arena, " {d}", .{p.refer_count});
+                const ref_col: u16 = bar_start + bar_w;
+                if (ref_col + @as(u16, @intCast(ctx.stringWidth(ref_text))) < col_rate) {
+                    w.writeText(&s, ctx, ref_col, row, ref_text, theme.fg(theme.TEXT));
+                }
+                const rate = try std.fmt.allocPrint(ctx.arena, "{d}/d", .{p.rate_per_day});
+                w.writeText(&s, ctx, col_rate, row, rate, theme.fg(theme.MUTED));
+                w.writeDelta(&s, ctx, col_delta, row, p.delta_pct);
+                const sig_txt = try std.fmt.allocPrint(ctx.arena, "{d}/{d}", .{ p.active_constraint_count, p.constraint_count });
+                w.writeText(&s, ctx, col_sig, row, sig_txt, theme.fg(theme.MUTED));
+            }
+            row += 1;
+
+            // Expanded per-constraint detail
+            if (self.insights_expanded_prompt == pi) {
+                var c_max: u32 = 1;
+                for (p.constraints) |c| {
+                    if (c.refer_count > c_max) c_max = c.refer_count;
+                }
+                for (p.constraints, 0..) |c, ci| {
+                    if (row >= height -| 1) break;
+                    const is_c_idle = c.refer_count == 0;
+                    const is_last = ci + 1 == p.constraints.len;
+                    const tree_char: []const u8 = if (is_last) "\xe2\x94\x94" else "\xe2\x94\x9c"; // └ or ├
+                    w.writeText(&s, ctx, 5, row, tree_char, theme.fg(theme.DIM));
+                    w.writeText(&s, ctx, 7, row, c.id, theme.fg(theme.MUTED));
+                    w.writeText(&s, ctx, 12, row, c.label, if (is_c_idle) theme.fg(theme.DANGER) else theme.fg(theme.TEXT_SOFT));
+                    if (!is_c_idle) {
+                        const c_bar_w: u16 = @intCast(@min(@as(u32, bar_max_w / 2) * c.refer_count / c_max, bar_max_w / 2));
+                        for (0..c_bar_w) |offset| {
+                            const bc: u16 = 32 + @as(u16, @intCast(offset));
+                            if (bc >= col_rate -| 2) break;
+                            const t: f32 = if (c_bar_w > 1) @as(f32, @floatFromInt(offset)) / @as(f32, @floatFromInt(c_bar_w - 1)) else 0.5;
+                            s.writeCell(bc, row, .{
+                                .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
+                                .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
+                            });
+                        }
+                        const c_ref = try std.fmt.allocPrint(ctx.arena, " {d}", .{c.refer_count});
+                        w.writeText(&s, ctx, col_rate, row, c_ref, theme.fg(theme.MUTED));
+                    } else {
+                        const idle_txt = if (c.idle_days) |d|
+                            try std.fmt.allocPrint(ctx.arena, "idle {d}d \xe2\x9a\xa0", .{d})
+                        else
+                            "idle \xe2\x9a\xa0";
+                        w.writeText(&s, ctx, col_rate, row, idle_txt, .{ .fg = theme.DANGER, .bg = theme.PANEL });
+                    }
+                    row += 1;
+                }
+            }
+        }
+
+        return s;
     }
+
+    fn drawInsightsTeam(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        const border_color = if (self.insights_focus == .team) theme.ACCENT else theme.BORDER;
+        var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+        w.fillSurface(&s, theme.PANEL);
+        w.drawBorder(&s, border_color, theme.PANEL);
+
+        w.writeText(&s, ctx, 2, 0, "Team Activity", theme.boldOn(theme.PANEL, theme.TEXT));
+
+        // Find team max for color scaling
+        var team_max: u16 = 1;
+        for (ins.members) |member| {
+            for (member.trend) |v| {
+                if (v > team_max) team_max = v;
+            }
+        }
+
+        var row: u16 = 1;
+        const num_weeks: u16 = (30 + 6) / 7; // 5 weeks
+        const grid_col: u16 = 2;
+
+        for (ins.members, 0..) |member, mi| {
+            if (row + 8 >= height) break;
+            // Member name with cursor indicator
+            const is_sel = mi == self.insights_member_cursor and self.insights_focus == .team;
+            if (is_sel) {
+                s.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&s, ctx, 2, row, member.username, name_style);
+            row += 1;
+
+            // 5×7 grid: 5 rows (weeks) × 7 cols (days of week)
+            var week: u16 = 0;
+            while (week < num_weeks) : (week += 1) {
+                if (row >= height -| 1) break;
+                var day: u16 = 0;
+                while (day < 7) : (day += 1) {
+                    const data_idx = week * 7 + day;
+                    if (data_idx >= 30) break;
+                    const val = member.trend[data_idx];
+                    const max_f: f32 = @floatFromInt(@max(team_max, 1));
+                    const fg = if (val == 0)
+                        theme.rgb(0xffe8b8) // pale cream, lighter than ACCENT_SOFT
+                    else
+                        theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, @as(f32, @floatFromInt(val)) / max_f);
+                    const col = grid_col + day * 2; // 1 char cell + 1 gap
+                    if (col < width -| 1) {
+                        s.writeCell(col, row, .{
+                            .char = .{ .grapheme = "\xe2\x96\xa0", .width = 1 }, // ■
+                            .style = .{ .fg = fg, .bg = theme.PANEL },
+                        });
+                    }
+                }
+                row += 1;
+            }
+            row += 1; // gap between members
+        }
+
+        return s;
+    }
+
+    fn drawMemberDetail(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        const member_idx = @min(self.insights_member_cursor, ins.members.len - 1);
+        const member = &ins.members[member_idx];
+        var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+        w.fillSurface(&s, theme.PANEL);
+        w.drawBorder(&s, theme.ACCENT, theme.PANEL);
+
+        const title = try std.fmt.allocPrint(ctx.arena, "{s}'s Activity", .{member.username});
+        w.writeText(&s, ctx, 3, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeRightText(&s, ctx, 0, "Esc back", theme.fg(theme.MUTED));
+
+        var row: u16 = 2;
+        // Summary
+        const summary = try std.fmt.allocPrint(ctx.arena, "{d} refs  {d}d active", .{ member.refer_count, member.active_days });
+        w.writeText(&s, ctx, 3, row, summary, theme.fg(theme.TEXT));
+        row += 2;
+
+        // Top prompts with bars
+        w.writeText(&s, ctx, 3, row, "Top Prompts", theme.fgBold(theme.TEXT));
+        row += 1;
+        var max_ref: u32 = 1;
+        for (member.top_prompts) |tp| {
+            if (tp.refer_count > max_ref) max_ref = tp.refer_count;
+        }
+        const bar_start: u16 = 24;
+        const bar_end: u16 = width -| 12;
+        const bar_max_w: u16 = bar_end -| bar_start;
+        for (member.top_prompts) |tp| {
+            if (row >= height -| 5) break;
+            w.writeText(&s, ctx, 5, row, tp.name, theme.fg(theme.TEXT_SOFT));
+            const bar_w: u16 = @intCast(@as(u32, bar_max_w) * tp.refer_count / max_ref);
+            for (0..bar_w) |offset| {
+                const bc: u16 = bar_start + @as(u16, @intCast(offset));
+                if (bc >= bar_end) break;
+                const t: f32 = if (bar_w > 1) @as(f32, @floatFromInt(offset)) / @as(f32, @floatFromInt(bar_w - 1)) else 0.5;
+                s.writeCell(bc, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
+                    .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
+                });
+            }
+            const ref_txt = try std.fmt.allocPrint(ctx.arena, " {d}", .{tp.refer_count});
+            w.writeText(&s, ctx, bar_start + bar_w, row, ref_txt, theme.fg(theme.MUTED));
+            row += 1;
+        }
+
+        // Models
+        row += 1;
+        w.writeText(&s, ctx, 3, row, "Models", theme.fgBold(theme.TEXT));
+        row += 1;
+        for (member.models) |model| {
+            if (row >= height -| 1) break;
+            const mtxt = try std.fmt.allocPrint(ctx.arena, "{s}  \u{00d7}{d} ({d}%)", .{ model.model_id, model.refer_count, model.pct });
+            w.writeText(&s, ctx, 5, row, mtxt, theme.fg(theme.TEXT_SOFT));
+            row += 1;
+        }
+
+        return s;
+    }
+
 
     // Settings: vertical sidebar + content pane (web-style layout)
     fn drawSettings(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -2041,28 +2362,6 @@ pub const Dashboard = struct {
 
     // Workspace grid uses manual rendering, no sync function needed
 
-    // Inner width budget: panel=36min → border=2 → inner=34.
-    // Row format: 1 + 16 name + 1 + 3 pct + 1 + % + 2 + 4 count = ~29. Fits.
-    fn syncInsightsWidgets(self: *Dashboard) void {
-        self.insights_scroll_bars.scroll_view.cursor = @min(self.insights_scroll_bars.scroll_view.cursor, data.INSIGHTS_WS.len - 1);
-        const sel_idx = @as(usize, @intCast(self.insights_scroll_bars.scroll_view.cursor));
-        for (data.INSIGHTS_WS, 0..) |cw, idx| {
-            const sel = idx == sel_idx;
-            self.insights_cols[idx] = .{
-                .{ .text = cw.name, .flex = 1 },
-                .{ .text = std.fmt.bufPrint(&insights_buf[idx], "{d}%", .{cw.coverage}) catch "?", .flex = 0, .alignment = .right },
-                .{ .text = cw.refer_count, .flex = 0, .alignment = .right },
-            };
-            self.insights_rows[idx] = .{
-                .columns = &self.insights_cols[idx],
-                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
-                .gap = 2,
-            };
-            self.insights_widgets[idx] = self.insights_rows[idx].widget();
-        }
-        self.insights_scroll_bars.scroll_view.children = .{ .slice = self.insights_widgets[0..] };
-        self.insights_scroll_bars.estimated_content_height = data.INSIGHTS_WS.len;
-    }
 
     fn selectedProposalIdx(self: *const Dashboard) usize {
         return @min(@as(usize, @intCast(self.review_scroll_bars.scroll_view.cursor)), data.PROPOSALS.len - 1);
@@ -2132,7 +2431,6 @@ fn prefixWithPad(prefix: []const u8) []const u8 {
 }
 
 // workspace_buf removed: workspace uses manual grid rendering
-var insights_buf: [data.INSIGHTS_WS.len][16]u8 = undefined;
 
 fn diffFg(line: []const u8) vaxis.Color {
     if (std.mem.startsWith(u8, line, "+")) return theme.OK;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -171,6 +171,7 @@ pub const Dashboard = struct {
     pr_table_cols: [MAX_PR_ROWS][4]Column = undefined,
     pr_text_rows: [MAX_PR_ROWS]vxfw.Text = undefined,
     pr_indices: [MAX_PR_ROWS * 2]?usize = .{null} ** (MAX_PR_ROWS * 2),
+    pr_desc_bufs: [MAX_PR_ROWS][160]u8 = undefined,
     pr_row_count: usize = 0,
     // PR drill-down state
     show_pr_diff: bool = false,
@@ -1332,6 +1333,12 @@ pub const Dashboard = struct {
                     const pr = &prs[pr_idx];
                     const title = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 {s} \xe2\x94\x80 refer:{d}", .{ pr.id, pr.prompt_name, pr.author, pr.status, pr.trace_refers });
                     w.writeText(&surface, ctx, 2, 2, title, theme.boldOn(theme.PANEL, theme.TEXT));
+
+                    // Row 3: operation header (only once detail has been fetched).
+                    if (pr.operation_count > 0) {
+                        const op_line = try opHeaderLine(ctx.arena, pr);
+                        w.writeText(&surface, ctx, 2, 3, op_line, theme.fg(theme.TEXT_SOFT));
+                    }
 
                     self.syncPrDiffAndComments(ctx.arena);
                     const diff_h = inner_h -| 2;
@@ -3040,9 +3047,14 @@ pub const Dashboard = struct {
             self.pr_widgets[row_idx] = self.pr_table_rows[pi].widget();
             self.pr_indices[row_idx] = pi;
             row_idx += 1;
-            // Row 2: description (muted)
+            // Row 2: description + multi-op hint (muted)
+            const desc_text: []const u8 = if (pr.operation_count > 1) blk: {
+                const buf = &self.pr_desc_bufs[pi];
+                const written = std.fmt.bufPrint(buf, "{s}  \xc2\xb7 {d} ops", .{ pr.description, pr.operation_count }) catch break :blk pr.description;
+                break :blk written;
+            } else pr.description;
             self.pr_text_rows[pi] = .{
-                .text = pr.description,
+                .text = desc_text,
                 .style = theme.textOn(theme.PANEL, theme.MUTED),
             };
             self.pr_widgets[row_idx] = self.pr_text_rows[pi].widget();
@@ -3136,6 +3148,21 @@ pub const Dashboard = struct {
         if (std.mem.startsWith(u8, line, "+")) return theme.rgb(0x1d2617);
         if (std.mem.startsWith(u8, line, "-")) return theme.rgb(0x2a1b18);
         return theme.PANEL;
+    }
+
+    // Format the one-line operation header shown above the PR diff pane.
+    // Falls back gracefully when op detail has not yet been fetched.
+    fn opHeaderLine(arena: std.mem.Allocator, pr: *const data.PullRequestEntry) ![]const u8 {
+        const position = if (pr.operation_count > 1)
+            try std.fmt.allocPrint(arena, "op {d}/{d}", .{ pr.op_index + 1, pr.operation_count })
+        else
+            "op";
+        if (pr.op_type.len == 0) return position;
+        if (std.mem.eql(u8, pr.op_type, "rename")) {
+            return std.fmt.allocPrint(arena, "{s}: rename {s} \xe2\x86\x92 {s}", .{ position, pr.op_current_path, pr.op_new_path });
+        }
+        const target = if (pr.op_current_path.len > 0) pr.op_current_path else pr.op_new_path;
+        return std.fmt.allocPrint(arena, "{s}: {s} {s}", .{ position, pr.op_type, target });
     }
 
     fn diffFg(line: []const u8) vaxis.Color {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1706,7 +1706,12 @@ pub const Dashboard = struct {
                         const n = @min(ws_d.ws_prompts.len, MAX_ROWS);
                         for (0..n) |i| {
                             const wp = ws_d.ws_prompts[i];
-                            paths_buf[i] = for (lib_prompts) |lp| {
+                            // Prefer the manifest-supplied path (new schema); fall
+                            // back to a library lookup for the legacy string-valued
+                            // manifest, and finally to the raw prompt_id.
+                            paths_buf[i] = if (wp.path.len > 0)
+                                wp.path
+                            else for (lib_prompts) |lp| {
                                 if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
                             } else wp.prompt_id;
                             orig_idx[i] = i;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -197,11 +197,13 @@ pub const Dashboard = struct {
     // Insights
     insights_period: Period = .daily,
     breathing_phase: u8 = 0, // 0-20 for breathing animation cycle
-    insights_focus: enum { chart, prompts, team } = .chart,
+    insights_focus: enum { chart, prompts, team, inputs } = .chart,
     insights_prompt_cursor: usize = 0,
     insights_member_cursor: usize = 0,
+    insights_input_cursor: usize = 0,
     insights_expanded_prompt: ?usize = null,
     insights_show_member_detail: bool = false,
+    insights_show_input_detail: bool = false,
     chart_offset: u16 = 0,
 
     pub fn init(api_state: *api.ApiState) Dashboard {
@@ -915,10 +917,12 @@ pub const Dashboard = struct {
                             self.insights_focus = switch (self.insights_focus) {
                                 .chart => .prompts,
                                 .prompts => .team,
-                                .team => .chart,
+                                .team => .inputs,
+                                .inputs => .chart,
                             };
                             self.insights_expanded_prompt = null;
                             self.insights_show_member_detail = false;
+                            self.insights_show_input_detail = false;
                             ctx.consumeAndRedraw();
                         }
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
@@ -933,6 +937,11 @@ pub const Dashboard = struct {
                                         self.insights_member_cursor += 1;
                                     ctx.consumeAndRedraw();
                                 },
+                                .inputs => {
+                                    if (ins_counts.input_count > 0 and self.insights_input_cursor < ins_counts.input_count - 1)
+                                        self.insights_input_cursor += 1;
+                                    ctx.consumeAndRedraw();
+                                },
                                 else => {},
                             }
                         }
@@ -944,6 +953,10 @@ pub const Dashboard = struct {
                                 },
                                 .team => {
                                     self.insights_member_cursor -|= 1;
+                                    ctx.consumeAndRedraw();
+                                },
+                                .inputs => {
+                                    self.insights_input_cursor -|= 1;
                                     ctx.consumeAndRedraw();
                                 },
                                 else => {},
@@ -976,6 +989,10 @@ pub const Dashboard = struct {
                                     self.insights_show_member_detail = !self.insights_show_member_detail;
                                     ctx.consumeAndRedraw();
                                 },
+                                .inputs => {
+                                    self.insights_show_input_detail = !self.insights_show_input_detail;
+                                    ctx.consumeAndRedraw();
+                                },
                                 else => {},
                             }
                         }
@@ -985,6 +1002,9 @@ pub const Dashboard = struct {
                                 ctx.consumeAndRedraw();
                             } else if (self.insights_show_member_detail) {
                                 self.insights_show_member_detail = false;
+                                ctx.consumeAndRedraw();
+                            } else if (self.insights_show_input_detail) {
+                                self.insights_show_input_detail = false;
                                 ctx.consumeAndRedraw();
                             } else {
                                 self.insights_focus = .prompts;
@@ -1035,13 +1055,20 @@ pub const Dashboard = struct {
         );
 
         var child_count: usize = 3;
-        if (self.show_help or self.show_confirm or self.show_comment_editor) child_count = 4;
+        if (self.show_help or self.show_confirm or self.show_comment_editor or self.insights_show_input_detail) child_count = 4;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
         children[1] = .{ .origin = .{ .row = header_h, .col = 0 }, .surface = try self.drawBody(body_ctx) };
         children[2] = .{ .origin = .{ .row = header_h + body_h, .col = 0 }, .surface = try self.drawFooter(footer_ctx) };
 
+        if (self.insights_show_input_detail and self.selected_module == .insights) {
+            const input_ctx = ctx.withConstraints(
+                .{ .width = size.width, .height = size.height },
+                .{ .width = size.width, .height = size.height },
+            );
+            children[3] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawInputDetailOverlay(input_ctx) };
+        }
         if (self.show_help) {
             const help_ctx = ctx.withConstraints(
                 .{ .width = size.width, .height = size.height },
@@ -1173,9 +1200,10 @@ pub const Dashboard = struct {
                 .content => "j/k scroll  d toggle diff  Esc list  ? help",
             },
             .insights => switch (self.insights_focus) {
-                .chart => "h/l scroll  Tab focus  t period  ? help  q quit",
-                .prompts => "j/k move  Enter expand  Tab focus  t period  ? help  q quit",
-                .team => "j/k move  Enter detail  Tab focus  t period  ? help  q quit",
+                .chart => "h/l scroll  Tab focus  t period  Shift-F flush  ? help  q quit",
+                .prompts => "j/k move  Enter expand  Tab focus  t period  Shift-F flush  ? help  q quit",
+                .team => "j/k move  Enter detail  Tab focus  t period  Shift-F flush  ? help  q quit",
+                .inputs => "j/k move  Enter detail  Tab focus  t period  Shift-F flush  ? help  q quit",
             },
         };
         w.writeText(&surface, ctx, 1, 0, keys, theme.fg(theme.MUTED));
@@ -1860,14 +1888,21 @@ pub const Dashboard = struct {
             if (self.api_state.org_stats) |stats|
                 break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models, self.api_state.local_stats);
             // No server stats, but local trace available — show personal data
-            if (self.api_state.local_stats) |local| break :blk data.InsightsData{
-                .constraint_count = local.constraint_count,
-                .active_constraint_count = local.active_constraint_count,
-                .idle_constraint_count = if (local.constraint_count > local.active_constraint_count) local.constraint_count - local.active_constraint_count else 0,
-                .signal_ratio = local.signal_ratio,
-                .refer_trend = local.refer_trend,
-                .prompts = local.prompts,
-            };
+            if (self.api_state.local_stats) |local| {
+                var inputs_list: std.ArrayList(data.InputItem) = .empty;
+                for (local.inputs) |iv| {
+                    inputs_list.append(ctx.arena, .{ .timestamp = iv.timestamp, .content = iv.content }) catch break;
+                }
+                break :blk data.InsightsData{
+                    .constraint_count = local.constraint_count,
+                    .active_constraint_count = local.active_constraint_count,
+                    .idle_constraint_count = if (local.constraint_count > local.active_constraint_count) local.constraint_count - local.active_constraint_count else 0,
+                    .signal_ratio = local.signal_ratio,
+                    .refer_trend = local.refer_trend,
+                    .prompts = local.prompts,
+                    .inputs = inputs_list.items,
+                };
+            }
             break :blk null;
         };
         var empty_insights: data.InsightsData = .{
@@ -1886,24 +1921,30 @@ pub const Dashboard = struct {
         };
         const ins: *const data.InsightsData = if (live_insights) |*li| li else &empty_insights;
 
-        // Layout: chart(top, full width) + prompts|team (bottom, side by side)
+        // Layout:
+        //   row 0: chart (full width)
+        //   row 1: prompts | team (side by side)
+        //   row 2: recent inputs (full width)
         const chart_h: u16 = if (size.height > 40) 10 else 8;
-        const body_h: u16 = size.height -| chart_h;
-        const team_w: u16 = 18; // narrow sidebar: border(2) + padding(2) + grid(5×2) + gaps
+        const inputs_h: u16 = if (size.height > 40) 10 else 7;
+        const middle_h: u16 = size.height -| chart_h -| inputs_h;
+        const team_w: u16 = 18;
         const prompts_w: u16 = size.width -| team_w;
 
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 4);
 
         // Panel 1: Signal Trend chart (hero, full width)
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawInsightsChart(ctx, size.width, chart_h, ins) };
         // Panel 2: Prompts Rank (or Member Detail if active)
         const main_surface = if (self.insights_show_member_detail)
-            try self.drawMemberDetail(ctx, prompts_w, body_h, ins)
+            try self.drawMemberDetail(ctx, prompts_w, middle_h, ins)
         else
-            try self.drawInsightsPrompts(ctx, prompts_w, body_h, ins);
+            try self.drawInsightsPrompts(ctx, prompts_w, middle_h, ins);
         children[1] = .{ .origin = .{ .row = chart_h, .col = 0 }, .surface = main_surface };
         // Panel 3: Team Activity sidebar (narrow, right side)
-        children[2] = .{ .origin = .{ .row = chart_h, .col = prompts_w }, .surface = try self.drawInsightsTeam(ctx, team_w, body_h, ins) };
+        children[2] = .{ .origin = .{ .row = chart_h, .col = prompts_w }, .surface = try self.drawInsightsTeam(ctx, team_w, middle_h, ins) };
+        // Panel 4: Recent Inputs (full width, bottom)
+        children[3] = .{ .origin = .{ .row = chart_h + middle_h, .col = 0 }, .surface = try self.drawInsightsInputs(ctx, size.width, inputs_h, ins) };
 
         root.children = children;
         return root;
@@ -2126,6 +2167,69 @@ pub const Dashboard = struct {
                 row += 1;
             }
             row += 1; // gap between members
+        }
+
+        return s;
+    }
+
+    // Returns the cutoff timestamp (ms since epoch) for the current
+    // insights_period window. Events older than this are filtered out.
+    fn inputsCutoffMs(self: *const Dashboard) i64 {
+        const now_ms = std.time.milliTimestamp();
+        const day_ms: i64 = 86400 * 1000;
+        const window_days: i64 = switch (self.insights_period) {
+            .daily => 1,
+            .weekly => 7,
+            .monthly => 30,
+        };
+        return now_ms - window_days * day_ms;
+    }
+
+    fn visibleInputs(ins: *const data.InsightsData, cutoff_ms: i64) []const data.InputItem {
+        var last: usize = 0;
+        for (ins.inputs, 0..) |iv, i| {
+            if (iv.timestamp >= cutoff_ms) last = i + 1 else break;
+        }
+        return ins.inputs[0..last];
+    }
+
+    fn drawInsightsInputs(self: *Dashboard, ctx: vxfw.DrawContext, width: u16, height: u16, ins: *const data.InsightsData) std.mem.Allocator.Error!vxfw.Surface {
+        const border_color = if (self.insights_focus == .inputs) theme.ACCENT else theme.BORDER;
+        var s = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
+        w.fillSurface(&s, theme.PANEL);
+        w.drawBorder(&s, border_color, theme.PANEL);
+
+        const cutoff = self.inputsCutoffMs();
+        const visible = visibleInputs(ins, cutoff);
+
+        const title_txt = try std.fmt.allocPrint(ctx.arena, "Recent Inputs  \xc2\xb7 {d} in {s}", .{ visible.len, self.insights_period.label() });
+        w.writeText(&s, ctx, 2, 0, title_txt, theme.boldOn(theme.PANEL, theme.TEXT));
+
+        if (visible.len == 0) {
+            w.writeText(&s, ctx, 2, 2, "No user prompts captured in this window.", theme.fg(theme.MUTED));
+            return s;
+        }
+
+        const focused = self.insights_focus == .inputs;
+        const max_rows: u16 = height -| 2;
+        const content_w: u16 = width -| 14; // leave room for timestamp column
+        var row: u16 = 1;
+        var i: usize = 0;
+        while (i < visible.len and row < max_rows) : (i += 1) {
+            const iv = visible[i];
+            const is_sel = focused and i == self.insights_input_cursor;
+            if (is_sel) {
+                s.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const time_txt = try formatHm(ctx.arena, iv.timestamp);
+            w.writeText(&s, ctx, 2, row, time_txt, theme.fg(theme.MUTED));
+            const snippet = firstLineTrimmed(iv.content, content_w);
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&s, ctx, 10, row, snippet, name_style);
+            row += 1;
         }
 
         return s;
@@ -2733,20 +2837,30 @@ pub const Dashboard = struct {
         return 0;
     }
 
-    const InsightsCounts = struct { prompt_count: usize, member_count: usize };
+    const InsightsCounts = struct { prompt_count: usize, member_count: usize, input_count: usize };
 
     fn getInsightsCounts(self: *Dashboard) InsightsCounts {
-        // Returns counts of prompts and members for bounds checking in event handler.
-        // Uses live org_stats prompt/member counts if available, else 0.
+        // Returns counts of prompts, members, and inputs for bounds checking
+        // in the event handler. Inputs are filtered by the current period
+        // window to match what drawInsightsInputs actually renders.
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
+        const input_count: usize = if (self.api_state.local_stats) |local| blk: {
+            const cutoff_ms = self.inputsCutoffMs();
+            var n: usize = 0;
+            for (local.inputs) |iv| {
+                if (iv.timestamp >= cutoff_ms) n += 1 else break;
+            }
+            break :blk n;
+        } else 0;
         if (self.api_state.org_stats) |stats| {
             return .{
                 .prompt_count = stats.prompts.len,
                 .member_count = if (self.api_state.ws_stats_members) |m| m.len else 0,
+                .input_count = input_count,
             };
         }
-        return .{ .prompt_count = 0, .member_count = 0 };
+        return .{ .prompt_count = 0, .member_count = 0, .input_count = input_count };
     }
 
     fn drawEmptyDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -2764,6 +2878,91 @@ pub const Dashboard = struct {
         const count: i8 = @intCast(settings_tabs.len);
         const next = @mod(current + delta + count, count);
         self.settings_tab = @enumFromInt(@as(u8, @intCast(next)));
+    }
+
+    // Modal overlay showing the full text of the currently-selected user
+    // prompt from the Recent Inputs panel. Wraps at the box width and
+    // truncates if the prompt is longer than the box can display.
+    fn drawInputDetailOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.PANEL);
+
+        const box_w: u16 = @min(size.width -| 4, @as(u16, 100));
+        const box_h: u16 = @min(size.height -| 4, @as(u16, 24));
+        const start_col = (size.width -| box_w) / 2;
+        const start_row = (size.height -| box_h) / 2;
+
+        var row: u16 = 0;
+        while (row < box_h) : (row += 1) {
+            var col: u16 = 0;
+            while (col < box_w) : (col += 1) {
+                surface.writeCell(start_col + col, start_row + row, .{
+                    .char = .{ .grapheme = " ", .width = 1 },
+                    .style = .{ .fg = theme.TEXT, .bg = theme.PANEL_ALT },
+                });
+            }
+        }
+
+        const border = vaxis.Style{ .fg = theme.ACCENT, .bg = theme.PANEL_ALT };
+        surface.writeCell(start_col, start_row, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = border });
+        surface.writeCell(start_col + box_w - 1, start_row, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = border });
+        surface.writeCell(start_col, start_row + box_h - 1, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = border });
+        surface.writeCell(start_col + box_w - 1, start_row + box_h - 1, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = border });
+        var c: u16 = 1;
+        while (c < box_w - 1) : (c += 1) {
+            surface.writeCell(start_col + c, start_row, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = border });
+            surface.writeCell(start_col + c, start_row + box_h - 1, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = border });
+        }
+        var r: u16 = 1;
+        while (r < box_h - 1) : (r += 1) {
+            surface.writeCell(start_col, start_row + r, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = border });
+            surface.writeCell(start_col + box_w - 1, start_row + r, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = border });
+        }
+
+        // Resolve the selected input via the same filter drawInsightsInputs uses.
+        const content_and_ts: struct { content: []const u8, ts: i64 } = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            const local = self.api_state.local_stats orelse break :blk .{ .content = "", .ts = 0 };
+            const cutoff = self.inputsCutoffMs();
+            var vlen: usize = 0;
+            for (local.inputs) |iv| {
+                if (iv.timestamp >= cutoff) vlen += 1 else break;
+            }
+            if (vlen == 0) break :blk .{ .content = "", .ts = 0 };
+            const idx = @min(self.insights_input_cursor, vlen - 1);
+            break :blk .{ .content = local.inputs[idx].content, .ts = local.inputs[idx].timestamp };
+        };
+
+        const time_txt = try formatHm(ctx.arena, content_and_ts.ts);
+        const title = try std.fmt.allocPrint(ctx.arena, " User Input @ {s} ", .{time_txt});
+        w.writeText(&surface, ctx, start_col + 2, start_row, title, theme.boldOn(theme.PANEL_ALT, theme.ACCENT));
+
+        // Word-wrap the content into box_w - 4 columns.
+        const inner_w: u16 = box_w -| 4;
+        const inner_h: u16 = box_h -| 3;
+        var out_row: u16 = 0;
+        var remaining: []const u8 = content_and_ts.content;
+        while (remaining.len > 0 and out_row < inner_h) {
+            var line_end: usize = 0;
+            if (std.mem.indexOfScalar(u8, remaining, '\n')) |n| line_end = n else line_end = remaining.len;
+            var line = remaining[0..line_end];
+            while (line.len > 0 and out_row < inner_h) {
+                const take: usize = @min(line.len, @as(usize, @intCast(inner_w)));
+                w.writeText(&surface, ctx, start_col + 2, start_row + 2 + out_row, line[0..take], theme.textOn(theme.PANEL_ALT, theme.TEXT));
+                line = line[take..];
+                out_row += 1;
+            }
+            if (line_end < remaining.len) {
+                remaining = remaining[line_end + 1 ..];
+            } else {
+                remaining = &.{};
+            }
+        }
+
+        w.writeText(&surface, ctx, start_col + 2, start_row + box_h -| 1, " Esc close ", theme.textOn(theme.PANEL_ALT, theme.MUTED));
+        return surface;
     }
 
     fn drawHelpOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -3240,6 +3439,28 @@ pub const Dashboard = struct {
         self.pr_diff_count = count;
         self.pr_diff_scroll_bars.scroll_view.children = .{ .slice = self.pr_diff_widgets[0..count] };
         self.pr_diff_scroll_bars.estimated_content_height = @intCast(count);
+    }
+
+    // Format a unix-ms timestamp as local HH:MM. Uses epoch-seconds div to
+    // avoid pulling in timezone machinery; shows UTC time.
+    fn formatHm(arena: std.mem.Allocator, ts_ms: i64) ![]const u8 {
+        const secs = @divTrunc(ts_ms, 1000);
+        const day_secs: i64 = 86400;
+        const day_offset = @mod(secs, day_secs);
+        const hh = @divTrunc(day_offset, 3600);
+        const mm = @divTrunc(@mod(day_offset, 3600), 60);
+        return std.fmt.allocPrint(arena, "{d:0>2}:{d:0>2}", .{ @as(u32, @intCast(hh)), @as(u32, @intCast(mm)) });
+    }
+
+    // Return the first line of `text` truncated to `max_cells`. Multi-line
+    // inputs get a trailing ellipsis hint so the user knows there is more.
+    fn firstLineTrimmed(text: []const u8, max_cells: u16) []const u8 {
+        var end: usize = text.len;
+        if (std.mem.indexOfScalar(u8, text, '\n')) |n| end = n;
+        var slice = text[0..end];
+        const cap: usize = @intCast(max_cells);
+        if (slice.len > cap) slice = slice[0..cap];
+        return slice;
     }
 
     fn formatAge(arena: std.mem.Allocator, seconds: i64) ![]const u8 {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -66,6 +66,7 @@ const ConfirmAction = enum {
     remove_member,
     delete_bundle,
     delete_workspace,
+    quit,
 };
 
 const TopModule = enum(u8) {
@@ -237,6 +238,11 @@ pub const Dashboard = struct {
                             .delete_workspace => {
                                 self.status_line = "Workspace deleted (not yet implemented)";
                             },
+                            .quit => {
+                                ctx.consumeEvent();
+                                ctx.quit = true;
+                                return;
+                            },
                             .none => {},
                         }
                         self.show_confirm = false;
@@ -254,7 +260,7 @@ pub const Dashboard = struct {
 
                 // Help overlay absorbs all keys
                 if (self.show_help) {
-                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('?', .{}) or key.matches('q', .{})) {
+                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('?', .{})) {
                         self.show_help = false;
                         ctx.consumeAndRedraw();
                     }
@@ -294,9 +300,11 @@ pub const Dashboard = struct {
                     ctx.quit = true;
                     return;
                 }
-                if (key.matches('q', .{}) and !self.show_detail and !self.show_settings) {
-                    ctx.consumeEvent();
-                    ctx.quit = true;
+                if (key.matches('q', .{})) {
+                    self.confirm_message = "";
+                    self.confirm_action = .quit;
+                    self.show_confirm = true;
+                    ctx.consumeAndRedraw();
                     return;
                 }
 
@@ -309,7 +317,7 @@ pub const Dashboard = struct {
 
                 // Settings mode
                 if (self.show_settings) {
-                    if (key.matches('q', .{})) {
+                    if (key.matches(vaxis.Key.escape, .{})) {
                         self.show_settings = false;
                         self.settings_focus = .sidebar;
                         ctx.consumeAndRedraw();
@@ -321,11 +329,6 @@ pub const Dashboard = struct {
                         return;
                     }
                     if (self.settings_focus == .sidebar) {
-                        if (key.matches(vaxis.Key.escape, .{})) {
-                            self.show_settings = false;
-                            ctx.consumeAndRedraw();
-                            return;
-                        }
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
                             self.shiftSettingsTab(1);
                             self.settings_content_sel = 0;
@@ -469,7 +472,7 @@ pub const Dashboard = struct {
 
                 // Detail mode: two-pane with Tab focus switching
                 if (self.show_detail) {
-                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('q', .{})) {
+                    if (key.matches(vaxis.Key.escape, .{})) {
                         self.show_detail = false;
                         self.detail_focus_content = false;
                         self.selected_module = self.detail_origin;
@@ -1005,14 +1008,21 @@ pub const Dashboard = struct {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL_ALT);
 
-        // Row 0: Accent band with org/ws/user context
+        // Row 0: Accent band with org/user context
         w.paintBand(&surface, 0, theme.ACCENT, theme.PANEL);
-        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 acme \xe2\x94\x80 payments-api \xe2\x94\x80 alice (maintainer)", .{
+        const user = data.CURRENT_USER;
+        const header_left = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} ({s})", .{ "acme", user.username, user.role });
+        w.writeText(&surface, ctx, 1, 0, header_left, .{
             .fg = theme.PANEL,
             .bg = theme.ACCENT,
             .bold = true,
         });
-        w.writeRightText(&surface, ctx, 0, "[FRESH]", .{
+        const minutes = data.INSIGHTS.last_event_minutes_ago;
+        const sync_label = if (minutes == 0)
+            "\xe2\x9c\x93 Synced"
+        else
+            try std.fmt.allocPrint(ctx.arena, "\xe2\x9c\x93 Synced {d}m ago", .{minutes});
+        w.writeRightText(&surface, ctx, 0, sync_label, .{
             .fg = theme.PANEL,
             .bg = theme.ACCENT,
             .bold = true,
@@ -1049,17 +1059,17 @@ pub const Dashboard = struct {
         else if (self.show_confirm)
             "y confirm  n cancel  Esc cancel"
         else if (self.show_settings and self.settings_focus == .sidebar)
-            "j/k section  l open  q close"
+            "j/k section  Enter open  Tab focus  Esc close"
         else if (self.show_settings and self.settings_tab == .account)
-            "j/k move  c change password  Enter go to workspace  x sign out  h back  q close"
+            "j/k move  c change password  Enter go to workspace  x sign out  Esc back"
         else if (self.show_settings and self.settings_tab == .organization and self.settings_content_sel < data.MEMBERS.len)
-            "j/k move  a invite  r role  x remove  h back  q close"
+            "j/k move  a invite  r role  x remove  Esc back"
         else if (self.show_settings and self.settings_tab == .organization)
-            "j/k move  a create  = add member  - remove member  x delete  h back  q close"
+            "j/k move  a create  = add member  - remove member  x delete  Esc back"
         else if (self.show_settings and self.settings_tab == .token)
-            "j/k move  r refresh  x revoke  h back  q close"
+            "j/k move  r refresh  x revoke  Esc back"
         else if (self.show_settings)
-            "j/k move  h back  q close"
+            "j/k move  Esc back"
         else if (self.show_comment_editor)
             "Enter send  Esc cancel"
         else if (self.show_detail and self.detail_tab == .pull_requests and self.show_pr_diff)
@@ -2391,6 +2401,7 @@ pub const Dashboard = struct {
             .remove_member => "Remove member:",
             .delete_bundle => "Delete bundle:",
             .delete_workspace => "Delete workspace:",
+            .quit => "Quit clumsies?",
             .none => "Confirm:",
         };
         w.writeText(&surface, ctx, start_col + 2, start_row + 2, action_label, theme.textOn(theme.PANEL_ALT, theme.TEXT));

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -907,6 +907,10 @@ pub const Dashboard = struct {
                             };
                             ctx.consumeAndRedraw();
                         }
+                        if (key.matches('F', .{ .shift = true })) {
+                            self.flushTrace();
+                            ctx.consumeAndRedraw();
+                        }
                         if (key.matches(vaxis.Key.tab, .{})) {
                             self.insights_focus = switch (self.insights_focus) {
                                 .chart => .prompts,
@@ -1924,6 +1928,13 @@ pub const Dashboard = struct {
         w.writeText(&s, ctx, 4, 0, "Signal Trend", theme.boldOn(theme.PANEL, theme.TEXT));
         const metrics_txt = try std.fmt.allocPrint(ctx.arena, "signal {d}%", .{ins.signal_ratio});
         w.writeText(&s, ctx, 18, 0, metrics_txt, theme.fg(theme.ACCENT_SOFT));
+
+        const active = self.activeSessionCount();
+        if (active > 0) {
+            const sess_txt = try std.fmt.allocPrint(ctx.arena, "\u{25cf} {d} live", .{active});
+            w.writeText(&s, ctx, 32, 0, sess_txt, .{ .fg = theme.OK, .bg = theme.PANEL });
+        }
+
         w.writeRightText(&s, ctx, 0, "t period", theme.fg(theme.MUTED));
 
         const chart_x: u16 = 1;
@@ -2276,7 +2287,25 @@ pub const Dashboard = struct {
         const token_color = if (std.mem.eql(u8, cfg.token_status, "active")) theme.OK else theme.DANGER;
         const token_info = try std.fmt.allocPrint(ctx.arena, "{s}, expires {s}", .{ cfg.token_status, cfg.token_expires });
         w.writeText(&surface, ctx, 19, row, token_info, theme.fg(token_color));
-        row += 2;
+        row += 1;
+
+        // Active MCP sessions (current_session.json markers on disk).
+        const sessions_slice: []const data.ActiveSessionView = self.getActiveSessionViews(ctx.arena);
+        w.writeText(&surface, ctx, 4, row, "MCP", theme.fg(theme.MUTED));
+        const mcp_summary = try std.fmt.allocPrint(ctx.arena, "{d} live session(s)", .{sessions_slice.len});
+        const mcp_color = if (sessions_slice.len > 0) theme.OK else theme.MUTED;
+        w.writeText(&surface, ctx, 19, row, mcp_summary, theme.fg(mcp_color));
+        row += 1;
+        for (sessions_slice, 0..) |sess, i| {
+            if (row >= size.height -| 4) break;
+            const is_last = i + 1 == sessions_slice.len;
+            const connector = if (is_last) "\xe2\x94\x94" else "\xe2\x94\x9c";
+            w.writeText(&surface, ctx, 6, row, connector, theme.fg(theme.BORDER));
+            const line = try std.fmt.allocPrint(ctx.arena, "{s}  {s}  pid {d}  {s}", .{ sess.ws_id, sess.session_id, sess.pid, sess.age });
+            w.writeText(&surface, ctx, 8, row, line, theme.fg(theme.TEXT_SOFT));
+            row += 1;
+        }
+        row += 1;
 
         // Security
         row = w.writeSectionHeader(&surface, ctx, 2, row, "Security");
@@ -2474,6 +2503,70 @@ pub const Dashboard = struct {
             w.writeText(&surface, ctx, 2, row, "Effective permissions = min(org role, token scopes)", theme.fg(theme.MUTED));
         }
         return surface;
+    }
+
+    // Spawn `clumsies trace flush` synchronously and report the result in
+    // the status line. Synchronous is fine here: the upload worker is a
+    // short-lived CLI that flushes buffered trace events and exits.
+    fn flushTrace(self: *Dashboard) void {
+        self.status_line = "Flushing trace...";
+        const alloc = self.api_state.arena.allocator();
+        var child = std.process.Child.init(&.{ "clumsies", "trace", "flush" }, alloc);
+        child.stdout_behavior = .Pipe;
+        child.stderr_behavior = .Pipe;
+        child.spawn() catch {
+            self.status_line = "Flush failed: clumsies binary not found";
+            return;
+        };
+        var stdout: std.ArrayList(u8) = .empty;
+        var stderr: std.ArrayList(u8) = .empty;
+        child.collectOutput(alloc, &stdout, &stderr, 64 * 1024) catch {};
+        const term = child.wait() catch {
+            self.status_line = "Flush failed: child wait error";
+            return;
+        };
+        switch (term) {
+            .Exited => |code| {
+                if (code == 0) {
+                    const trimmed = std.mem.trim(u8, stdout.items, " \n\r\t");
+                    if (trimmed.len > 0) {
+                        self.status_line = std.fmt.allocPrint(alloc, "Flush: {s}", .{trimmed}) catch "Flush: ok";
+                    } else {
+                        self.status_line = "Flush: ok";
+                    }
+                } else {
+                    const trimmed = std.mem.trim(u8, stderr.items, " \n\r\t");
+                    self.status_line = std.fmt.allocPrint(alloc, "Flush exit {d}: {s}", .{ code, trimmed }) catch "Flush failed";
+                }
+            },
+            else => self.status_line = "Flush terminated abnormally",
+        }
+    }
+
+    fn activeSessionCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        return if (self.api_state.active_sessions) |s| s.len else 0;
+    }
+
+    // Build display-ready session rows with a human-readable age string.
+    fn getActiveSessionViews(self: *Dashboard, arena: std.mem.Allocator) []const data.ActiveSessionView {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        const sessions = self.api_state.active_sessions orelse return &.{};
+        const now_s = std.time.timestamp();
+        var list: std.ArrayList(data.ActiveSessionView) = .empty;
+        for (sessions) |sess| {
+            const age_seconds = @max(now_s - sess.started_at, 0);
+            const age = formatAge(arena, age_seconds) catch "?";
+            list.append(arena, .{
+                .ws_id = sess.ws_id,
+                .session_id = sess.session_id,
+                .pid = sess.pid,
+                .age = age,
+            }) catch continue;
+        }
+        return list.items;
     }
 
     // Count active drafts (status != "merged") across all categories.
@@ -3147,6 +3240,16 @@ pub const Dashboard = struct {
         self.pr_diff_count = count;
         self.pr_diff_scroll_bars.scroll_view.children = .{ .slice = self.pr_diff_widgets[0..count] };
         self.pr_diff_scroll_bars.estimated_content_height = @intCast(count);
+    }
+
+    fn formatAge(arena: std.mem.Allocator, seconds: i64) ![]const u8 {
+        if (seconds < 60) return std.fmt.allocPrint(arena, "{d}s", .{seconds});
+        const minutes = @divTrunc(seconds, 60);
+        if (minutes < 60) return std.fmt.allocPrint(arena, "{d}m", .{minutes});
+        const hours = @divTrunc(minutes, 60);
+        if (hours < 48) return std.fmt.allocPrint(arena, "{d}h", .{hours});
+        const days = @divTrunc(hours, 24);
+        return std.fmt.allocPrint(arena, "{d}d", .{days});
     }
 
     fn diffBg(line: []const u8) vaxis.Color {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -102,7 +102,7 @@ const DetailTab = enum(u8) {
 
 const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .insights };
 
-// 12 prompts + up to 12 group headers = 24 max rows in Library
+// 12 prompts + up to 12 group headers = 24 max rows
 const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
 const detail_tabs = [_]DetailTab{ .overview, .content, .history };
 
@@ -117,6 +117,7 @@ pub const Dashboard = struct {
     confirm_action: ConfirmAction = .none,
     detail_origin: TopModule = .library,
     detail_tab: DetailTab = .overview,
+    detail_focus_content: bool = false,
     settings_tab: SettingsTab = .members,
     status_line: []const u8 = "Ready.",
 
@@ -332,22 +333,17 @@ pub const Dashboard = struct {
                     return;
                 }
 
-                // Detail mode: Esc returns to origin
+                // Detail mode: two-pane with Tab focus switching
                 if (self.show_detail) {
                     if (key.matches(vaxis.Key.escape, .{}) or key.matches('q', .{})) {
                         self.show_detail = false;
+                        self.detail_focus_content = false;
                         self.selected_module = self.detail_origin;
-                        self.status_line = "Returned.";
                         ctx.consumeAndRedraw();
                         return;
                     }
-                    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
-                        self.shiftDetailTab(-1);
-                        ctx.consumeAndRedraw();
-                        return;
-                    }
-                    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
-                        self.shiftDetailTab(1);
+                    if (key.matches(vaxis.Key.tab, .{})) {
+                        self.detail_focus_content = !self.detail_focus_content;
                         ctx.consumeAndRedraw();
                         return;
                     }
@@ -356,13 +352,24 @@ pub const Dashboard = struct {
                         ctx.consumeAndRedraw();
                         return;
                     }
-                    if (self.detail_tab == .content) {
+                    if (self.detail_focus_content) {
+                        // Content pane has focus: j/k scrolls content
                         try self.content_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        return;
-                    }
-                    if (self.detail_tab == .history) {
-                        try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        return;
+                    } else {
+                        // Info pane has focus: h/l switches tabs, j/k for history
+                        if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                            self.shiftDetailTab(-1);
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                            self.shiftDetailTab(1);
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (self.detail_tab == .history) {
+                            try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        }
                     }
                     return;
                 }
@@ -382,36 +389,64 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                             return;
                         }
+                        // Tab toggles focus between list and detail pane
+                        if (key.matches(vaxis.Key.tab, .{})) {
+                            self.detail_focus_content = !self.detail_focus_content;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        // Enter from list: focus detail pane
+                        if (!self.detail_focus_content and key.matches(vaxis.Key.enter, .{})) {
+                            self.detail_focus_content = true;
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (self.detail_focus_content) {
+                            // Detail pane has focus
+                            if (key.matches(vaxis.Key.escape, .{})) {
+                                self.detail_focus_content = false;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                                self.shiftDetailTab(-1);
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                                self.shiftDetailTab(1);
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (self.detail_tab == .content) {
+                                try self.content_scroll_bars.scroll_view.handleEvent(ctx, event);
+                            }
+                            if (self.detail_tab == .history) {
+                                try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
+                            }
+                            return;
+                        }
+                        // List pane: j/k moves through prompts, skipping group headers.
                         const prev = self.library_scroll_bars.scroll_view.cursor;
                         try self.library_scroll_bars.scroll_view.handleEvent(ctx, event);
-                        // If cursor landed on a group header, skip in the
-                        // direction of movement to the next prompt row.
-                        const cursor_pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
-                        if (cursor_pos < self.library_row_count) {
-                            if (self.library_prompt_indices[cursor_pos]) |pi| {
-                                self.selected_prompt = pi;
-                            } else if (self.library_scroll_bars.scroll_view.cursor != prev) {
-                                const moving_down = self.library_scroll_bars.scroll_view.cursor > prev;
-                                if (moving_down) {
-                                    if (cursor_pos + 1 < self.library_row_count) {
-                                        self.library_scroll_bars.scroll_view.cursor += 1;
-                                        if (self.library_prompt_indices[cursor_pos + 1]) |pi| {
-                                            self.selected_prompt = pi;
-                                        }
-                                    }
-                                } else {
-                                    if (cursor_pos > 0) {
-                                        self.library_scroll_bars.scroll_view.cursor -= 1;
-                                        if (self.library_prompt_indices[cursor_pos - 1]) |pi| {
-                                            self.selected_prompt = pi;
-                                        }
-                                    }
-                                }
-                                ctx.consumeAndRedraw();
+                        if (self.library_row_count == 0) return;
+
+                        var pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+                        if (pos >= self.library_row_count) pos = self.library_row_count - 1;
+
+                        // If landed on a group header, skip one row in direction of movement
+                        if (self.library_prompt_indices[pos] == null and self.library_scroll_bars.scroll_view.cursor != prev) {
+                            const moving_down = self.library_scroll_bars.scroll_view.cursor > prev;
+                            if (moving_down and pos + 1 < self.library_row_count) {
+                                pos += 1;
+                            } else if (!moving_down and pos > 0) {
+                                pos -= 1;
                             }
+                            self.library_scroll_bars.scroll_view.cursor = @intCast(pos);
+                            ctx.consumeAndRedraw();
                         }
-                        if (key.matches(vaxis.Key.enter, .{})) {
-                            self.openDetail(ctx, self.selected_prompt, .library, .overview);
+                        if (self.library_prompt_indices[pos]) |pi| {
+                            self.selected_prompt = pi;
                         }
                     },
                     .proposals => {
@@ -568,10 +603,12 @@ pub const Dashboard = struct {
             "y confirm  n cancel  Esc cancel"
         else if (self.show_settings)
             "h/l tab  j/k move  a add  r role  x remove  Esc back"
+        else if (self.show_detail and self.detail_focus_content)
+            "j/k scroll  g/G jump  Tab info pane  Esc back  ? help"
         else if (self.show_detail)
-            "h/l tab  j/k move  Enter diff  p propose  Esc back  ? help"
+            "h/l tab  j/k move  Tab content pane  p propose  Esc back  ? help"
         else switch (self.selected_module) {
-            .library => "j/k move  Enter open  b bundle  S settings  ? help  q quit",
+            .library => if (self.detail_focus_content) "h/l tab  j/k scroll  Esc list  ? help" else "j/k move  Enter detail  b bundle  S settings  ? help  q quit",
             .proposals => "j/k move  a accept  x reject  S settings  ? help  q quit",
             .workspace => "h/l tab  j/k move  r sync  S settings  ? help  q quit",
             .insights => "j/k move  t period  S settings  ? help  q quit",
@@ -580,8 +617,8 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    // Library: two-column (prompt list + preview sidebar).
-    // Bundle facet deferred to Phase 2 when filter interaction is implemented.
+    // Library: master-detail. Left = grouped prompt list, right = selected prompt detail.
+    // Enter / Tab switches focus between list and detail pane.
     fn drawLibrary(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
@@ -589,15 +626,16 @@ pub const Dashboard = struct {
 
         self.syncLibraryWidgets();
 
-        const preview_w: u16 = if (size.width > 118) 30 else 26;
-        const list_w: u16 = size.width - preview_w - 1;
+        const list_w: u16 = size.width / 3;
+        const detail_w: u16 = size.width - list_w - 1;
+        const p = &data.PROMPTS[self.selected_prompt];
 
         const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
-        const preview_ctx = ctx.withConstraints(.{ .width = preview_w, .height = size.height }, .{ .width = preview_w, .height = size.height });
+        const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawPromptTable(list_ctx) };
-        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawPromptPreview(preview_ctx) };
+        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawLibraryDetail(detail_ctx, p) };
         root.children = children;
         return root;
     }
@@ -612,54 +650,99 @@ pub const Dashboard = struct {
             "All"
         else
             data.BUNDLES[self.library_bundle_filter - 1].name;
-        const subtitle = try std.fmt.allocPrint(ctx.arena, "bundle: {s}  b cycle", .{bundle_label});
+        const subtitle = try std.fmt.allocPrint(ctx.arena, "{d} prompts  bundle: {s}  / search  b filter", .{ data.PROMPTS.len, bundle_label });
+        const list_border = if (!self.detail_focus_content) theme.ACCENT else theme.BORDER;
         const panel: w.Panel = .{
             .owner = self.widget(),
-            .title = "Library Prompts",
+            .title = "Library",
             .subtitle = subtitle,
             .background = theme.PANEL,
-            .border_color = theme.BORDER,
+            .border_color = list_border,
             .child = self.library_scroll_bars.widget(),
         };
         var surface = try panel.draw(ctx);
         return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view);
     }
 
-    // Preview shows only info NOT in the main table:
-    // sparkline trend, constraint count, bundle membership, action hint.
-    fn drawPromptPreview(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const p = &data.PROMPTS[self.selected_prompt];
-        const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-        const preview = try std.fmt.allocPrint(ctx.arena,
-            \\last 7d
-            \\{s}
-            \\
-            \\constraints  {d}
-            \\bundles      {s}
-            \\
-            \\Enter  open detail
-        , .{ spark, p.constraint_count, p.bundle_names });
+    // Library right pane: detail for selected prompt with Overview/Content/History tabs.
+    fn drawLibraryDetail(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        const border_color = if (self.detail_focus_content) theme.ACCENT else theme.BORDER;
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, border_color, theme.PANEL);
 
-        const text_widget: vxfw.Text = .{
-            .text = preview,
-            .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
-            .width_basis = .parent,
-        };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{
-            .owner = self.widget(),
-            .title = "Selected",
-            .subtitle = "",
-            .background = theme.PANEL,
-            .border_color = theme.BORDER,
-            .child = wrapper.widget(),
-            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
-        };
-        return panel.draw(ctx);
+        // Row 0: inner tabs + prompt name
+        var tab_col: u16 = 2;
+        for (detail_tabs) |tab| {
+            tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, tab.label(), tab == self.detail_tab);
+            tab_col +|= 1;
+        }
+        w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
+
+        const inner_h = ctx.max.height.? -| 2;
+        const inner_w = ctx.max.width.? -| 4;
+
+        switch (self.detail_tab) {
+            .overview => {
+                const kv_col: u16 = 2;
+                var kv_row: u16 = 2;
+                w.writeText(&surface, ctx, kv_col, kv_row, p.summary, theme.fg(theme.TEXT_SOFT));
+                kv_row += 2;
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "hash", p.content_hash, 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "override", "local (payments-api)", 8);
+                kv_row += 1;
+                kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
+                const top_n = @min(p.constraint_count, 3);
+                var ci: u8 = 0;
+                while (ci < top_n) : (ci += 1) {
+                    const cid = try std.fmt.allocPrint(ctx.arena, "c-{d}", .{ci + 1});
+                    kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, cid, "(mock refer data)", 5);
+                }
+                if (p.constraint_count > 3) {
+                    w.writeText(&surface, ctx, kv_col, kv_row, try std.fmt.allocPrint(ctx.arena, "... +{d} more", .{p.constraint_count - 3}), theme.fg(theme.MUTED));
+                }
+            },
+            .content => {
+                self.syncContentWidget();
+                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+                surface.children = children;
+            },
+            .history => {
+                self.syncHistoryWidgets();
+                const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
+                self.history_scroll_bars.scroll_view.draw_cursor = false;
+                defer self.history_scroll_bars.scroll_view.draw_cursor = true;
+
+                var list_surface = try self.history_scroll_bars.widget().draw(list_ctx);
+                const sv = &self.history_scroll_bars.scroll_view;
+                if (sv.cursor >= sv.scroll.top) {
+                    const vis_row = sv.cursor - sv.scroll.top;
+                    const crow: i17 = @intCast(vis_row);
+                    if (crow < list_surface.size.height) {
+                        const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
+                        cbuf[0] = .{ .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 }, .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL } };
+                        const csurface: vxfw.Surface = .{ .size = .{ .width = 1, .height = 1 }, .widget = list_surface.widget, .buffer = cbuf, .children = &.{} };
+                        const old = list_surface.children;
+                        const new_ch = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
+                        @memcpy(new_ch[0..old.len], old);
+                        new_ch[old.len] = .{ .origin = .{ .col = 0, .row = crow }, .surface = csurface, .z_index = 1 };
+                        list_surface.children = new_ch;
+                    }
+                }
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
+                surface.children = children;
+            },
+        }
+        return surface;
     }
 
-    // Prompt Detail: main panel (with identity in title) + sidebar
+    // Old Prompt Detail (kept for non-Library drill-down from other modules)
     fn drawPromptDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         const p = &data.PROMPTS[self.selected_prompt];
@@ -667,31 +750,31 @@ pub const Dashboard = struct {
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
 
-        const sidebar_w: u16 = if (size.width > 118) 30 else 26;
-        const main_w: u16 = size.width - sidebar_w - 1;
+        const info_w: u16 = size.width / 3;
+        const content_w: u16 = size.width - info_w - 1;
 
-        const main_ctx = ctx.withConstraints(.{ .width = main_w, .height = size.height }, .{ .width = main_w, .height = size.height });
-        const side_ctx = ctx.withConstraints(.{ .width = sidebar_w, .height = size.height }, .{ .width = sidebar_w, .height = size.height });
+        const info_ctx = ctx.withConstraints(.{ .width = info_w, .height = size.height }, .{ .width = info_w, .height = size.height });
+        const content_ctx = ctx.withConstraints(.{ .width = content_w, .height = size.height }, .{ .width = content_w, .height = size.height });
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawDetailMain(main_ctx, p) };
-        children[1] = .{ .origin = .{ .row = 0, .col = main_w + 1 }, .surface = try self.drawDetailSidebar(side_ctx, p) };
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawDetailInfo(info_ctx, p) };
+        children[1] = .{ .origin = .{ .row = 0, .col = info_w + 1 }, .surface = try self.drawDetailContent(content_ctx, p) };
         root.children = children;
         return root;
     }
 
-    fn drawDetailMain(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawDetailInfo(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
-        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
+        const info_border = if (!self.detail_focus_content) theme.ACCENT else theme.BORDER;
+        w.drawBorder(&surface, info_border, theme.PANEL);
 
-        // Row 0: inner tabs (left) + canonical name (right)
+        // Row 0: inner tabs
         var col: u16 = 2;
         for (detail_tabs) |tab| {
             col = w.drawInnerTabBadge(&surface, ctx, 0, col, tab.label(), tab == self.detail_tab);
             col +|= 1;
         }
-        w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
 
         const inner_h = ctx.max.height.? -| 3;
         const inner_w = ctx.max.width.? -| 2;
@@ -704,12 +787,22 @@ pub const Dashboard = struct {
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "updated", p.updated, 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "source", "acme", 8);
                 kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "override", "local (payments-api)", 8);
+                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "refer", p.refer_count, 8);
                 kv_row += 1;
                 kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Top Constraints");
-                // Mock constraint ranking (real data from GET /api/stats/prompt/{id})
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-1", "naming clarity           3210", 5);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-3", "import grouping          2321", 5);
-                kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, "c-5", "file ordering            1172", 5);
+                // Mock: show constraint count, real data from GET /api/stats/prompt/{id}
+                const ccount = p.constraint_count;
+                const top_n = @min(ccount, 3);
+                var ci: u8 = 0;
+                while (ci < top_n) : (ci += 1) {
+                    const cid = try std.fmt.allocPrint(ctx.arena, "c-{d}", .{ci + 1});
+                    const cval = try std.fmt.allocPrint(ctx.arena, "(mock refer data)", .{});
+                    kv_row = w.writeKv(&surface, ctx, kv_col, kv_row, cid, cval, 5);
+                }
+                if (ccount > 3) {
+                    w.writeText(&surface, ctx, kv_col, kv_row, try std.fmt.allocPrint(ctx.arena, "... +{d} more", .{ccount - 3}), theme.fg(theme.MUTED));
+                    kv_row += 1;
+                }
                 kv_row += 1;
                 kv_row = w.writeSectionHeader(&surface, ctx, kv_col, kv_row, "Local Override");
                 w.writeText(&surface, ctx, kv_col, kv_row, "Detected in ws: payments-api", theme.fg(theme.TEXT_SOFT));
@@ -718,27 +811,19 @@ pub const Dashboard = struct {
             },
             .content => {
                 self.syncContentWidget();
-                const child_ctx = ctx.withConstraints(
-                    .{ .width = inner_w, .height = inner_h },
-                    .{ .width = inner_w, .height = inner_h },
-                );
+                const child_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
                 const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
                 children[0] = .{ .origin = .{ .row = 2, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
                 surface.children = children;
             },
             .history => {
                 self.syncHistoryWidgets();
-                const list_w: u16 = if (inner_w > 76) 34 else inner_w / 2;
-                const detail_w = inner_w - list_w - 1;
-
-                const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = inner_h }, .{ .width = list_w, .height = inner_h });
-                const det_ctx = ctx.withConstraints(.{ .width = detail_w, .height = inner_h }, .{ .width = detail_w, .height = inner_h });
+                const list_ctx = ctx.withConstraints(.{ .width = inner_w, .height = inner_h }, .{ .width = inner_w, .height = inner_h });
 
                 self.history_scroll_bars.scroll_view.draw_cursor = false;
                 defer self.history_scroll_bars.scroll_view.draw_cursor = true;
 
                 var list_surface = try self.history_scroll_bars.widget().draw(list_ctx);
-                // No Panel border here, so cursor overlay targets row directly
                 const sv = &self.history_scroll_bars.scroll_view;
                 if (sv.cursor >= sv.scroll.top) {
                     const vis_row = sv.cursor - sv.scroll.top;
@@ -746,7 +831,7 @@ pub const Dashboard = struct {
                     if (crow < list_surface.size.height) {
                         const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
                         cbuf[0] = .{
-                            .char = .{ .grapheme = "▌", .width = 1 },
+                            .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
                             .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
                         };
                         const csurface: vxfw.Surface = .{
@@ -756,20 +841,19 @@ pub const Dashboard = struct {
                             .children = &.{},
                         };
                         const old = list_surface.children;
-                        const new = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
-                        @memcpy(new[0..old.len], old);
-                        new[old.len] = .{
+                        const new_children = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
+                        @memcpy(new_children[0..old.len], old);
+                        new_children[old.len] = .{
                             .origin = .{ .col = 0, .row = crow },
                             .surface = csurface,
                             .z_index = 1,
                         };
-                        list_surface.children = new;
+                        list_surface.children = new_children;
                     }
                 }
 
-                const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
                 children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = list_surface };
-                children[1] = .{ .origin = .{ .row = 2, .col = 1 + list_w + 1 }, .surface = try self.drawHistoryDetail(det_ctx) };
                 surface.children = children;
             },
         }
@@ -777,51 +861,25 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    fn drawDetailSidebar(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
-        const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
-        const bg = theme.PANEL_ALT;
-
-        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, bg);
-        w.drawBorder(&surface, theme.BORDER, bg);
-        w.writeText(&surface, ctx, 2, 0, "Usage Summary", theme.boldOn(bg, theme.TEXT));
-
-        const kw: u16 = 11;
-        const kv_col: u16 = 2;
-        var row: u16 = 2;
-        row = w.writeKv(&surface, ctx, kv_col, row, "refer", p.refer_count, kw);
-        row = w.writeKv(&surface, ctx, kv_col, row, "constraints", try std.fmt.allocPrint(ctx.arena, "{d}", .{p.constraint_count}), kw);
-        row = w.writeKv(&surface, ctx, kv_col, row, "workspaces", "API pending", kw);
-        row += 1;
-        row = w.writeSectionHeader(&surface, ctx, kv_col, row, "Trend");
-        w.writeText(&surface, ctx, kv_col, row, spark, theme.fg(theme.ACCENT));
-        row += 2;
-        row = w.writeSectionHeader(&surface, ctx, kv_col, row, "Actions");
-        w.writeText(&surface, ctx, kv_col, row, "p  propose", theme.fg(theme.TEXT_SOFT));
-        row += 1;
-        w.writeText(&surface, ctx, kv_col, row, "Enter  diff", theme.fg(theme.TEXT_SOFT));
-        row += 1;
-        const back_text = try std.fmt.allocPrint(ctx.arena, "Esc  back to {s}", .{self.detail_origin.label()});
-        w.writeText(&surface, ctx, kv_col, row, back_text, theme.fg(theme.TEXT_SOFT));
-        return surface;
-    }
-
-    fn drawHistoryDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const idx = @min(@as(usize, @intCast(self.history_scroll_bars.scroll_view.cursor)), data.HISTORY.len - 1);
-        const h = &data.HISTORY[idx];
-
-        // No border -- plain area within the main panel, avoids card-in-card
+    // Right pane: always-visible prompt content with border.
+    // Border highlight indicates focus state.
+    fn drawDetailContent(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
+        const border_color = if (self.detail_focus_content) theme.ACCENT else theme.BORDER;
+        w.drawBorder(&surface, border_color, theme.PANEL);
+        w.writeText(&surface, ctx, 2, 0, p.canonical_name, theme.boldOn(theme.PANEL, theme.TEXT));
 
-        const kv_col: u16 = 1;
-        var row: u16 = 0;
-        row = w.writeSectionHeader(&surface, ctx, kv_col, row, if (idx == 0) "current version" else "history version");
-        row = w.writeKv(&surface, ctx, kv_col, row, "date", h.date, 6);
-        row = w.writeKv(&surface, ctx, kv_col, row, "hash", h.hash, 6);
-        row = w.writeKv(&surface, ctx, kv_col, row, "label", h.label, 6);
-        row += 1;
-        w.writeText(&surface, ctx, kv_col, row, "Enter opens diff (Phase 2)", theme.fg(theme.MUTED));
+        self.syncContentWidget();
+        const inner_w = ctx.max.width.? -| 4;
+        const inner_h = ctx.max.height.? -| 2;
+        const child_ctx = ctx.withConstraints(
+            .{ .width = inner_w, .height = inner_h },
+            .{ .width = inner_w, .height = inner_h },
+        );
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        children[0] = .{ .origin = .{ .row = 1, .col = 2 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+        surface.children = children;
         return surface;
     }
 
@@ -1455,7 +1513,7 @@ pub const Dashboard = struct {
                 last_prefix = prefix;
             }
 
-            // Insert prompt row
+            // Insert prompt row (name + stats)
             if (row_idx < MAX_LIBRARY_ROWS) {
                 const sel = pidx == self.selected_prompt;
                 self.library_table_cols[row_idx] = .{
@@ -1477,6 +1535,18 @@ pub const Dashboard = struct {
         self.library_row_count = row_idx;
         self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..row_idx] };
         self.library_scroll_bars.estimated_content_height = @intCast(row_idx);
+
+        // Ensure cursor is on a prompt row, not a group header or summary
+        var cur = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+        while (cur < row_idx and self.library_prompt_indices[cur] == null) {
+            cur += 1;
+        }
+        self.library_scroll_bars.scroll_view.cursor = @intCast(cur);
+        if (cur < row_idx) {
+            if (self.library_prompt_indices[cur]) |pi| {
+                self.selected_prompt = pi;
+            }
+        }
     }
 
     fn syncContentWidget(self: *Dashboard) void {

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -358,13 +358,7 @@ pub const Dashboard = struct {
                         }
                         const max_items: usize = switch (self.settings_tab) {
                             .account => data.CURRENT_USER.workspaces.len,
-                            .organization => blk: {
-                                self.api_state.mutex.lock();
-                                defer self.api_state.mutex.unlock();
-                                if (self.api_state.directory) |dir|
-                                    break :blk dir.members.len + dir.teams.len;
-                                break :blk data.MEMBERS.len + data.TEAMS.len;
-                            },
+                            .organization => self.orgMemberCount(),
                             .token => data.ALL_SCOPES.len,
                         };
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
@@ -406,54 +400,22 @@ pub const Dashboard = struct {
                             }
                         }
                         if (self.settings_tab == .organization) {
-                            const member_count = blk: {
-                                self.api_state.mutex.lock();
-                                defer self.api_state.mutex.unlock();
-                                if (self.api_state.directory) |dir| break :blk dir.members.len;
-                                break :blk data.MEMBERS.len;
-                            };
-                            const on_member = self.settings_content_sel < member_count;
-                            if (on_member) {
-                                if (key.matches('r', .{})) {
-                                    self.status_line = "Role change (not yet implemented)";
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                                if (key.matches('x', .{})) {
-                                    self.confirm_message = "selected member";
-                                    self.confirm_action = .remove_member;
-                                    self.show_confirm = true;
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                                if (key.matches('a', .{})) {
-                                    self.status_line = "Invite member (not yet implemented)";
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                            } else {
-                                if (key.matches('a', .{})) {
-                                    self.status_line = "Create team (not yet implemented)";
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                                if (key.matches('=', .{})) {
-                                    self.status_line = "Add member to team (not yet implemented)";
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                                if (key.matches('-', .{})) {
-                                    self.status_line = "Remove member from team (not yet implemented)";
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
-                                if (key.matches('x', .{})) {
-                                    self.confirm_message = "selected team";
-                                    self.confirm_action = .delete_bundle;
-                                    self.show_confirm = true;
-                                    ctx.consumeAndRedraw();
-                                    return;
-                                }
+                            if (key.matches('r', .{})) {
+                                self.status_line = "Role change (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('x', .{})) {
+                                self.confirm_message = "selected member";
+                                self.confirm_action = .remove_member;
+                                self.show_confirm = true;
+                                ctx.consumeAndRedraw();
+                                return;
+                            }
+                            if (key.matches('a', .{})) {
+                                self.status_line = "Invite member (not yet implemented)";
+                                ctx.consumeAndRedraw();
+                                return;
                             }
                         }
                         if (self.settings_tab == .token) {
@@ -1091,10 +1053,8 @@ pub const Dashboard = struct {
             "j/k section  Enter open  Tab focus  Esc close"
         else if (self.show_settings and self.settings_tab == .account)
             "j/k move  c change password  Enter go to workspace  x sign out  Esc back"
-        else if (self.show_settings and self.settings_tab == .organization and self.settings_content_sel < self.orgMemberCount())
-            "j/k move  a invite  r role  x remove  Esc back"
         else if (self.show_settings and self.settings_tab == .organization)
-            "j/k move  a create  = add member  - remove member  x delete  Esc back"
+            "j/k move  a invite  r role  x remove  Esc back"
         else if (self.show_settings and self.settings_tab == .token)
             "j/k move  r refresh  x revoke  Esc back"
         else if (self.show_settings)
@@ -2178,14 +2138,12 @@ pub const Dashboard = struct {
             }
             const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
             w.writeText(&surface, ctx, 4, row, ws_access.name, name_style);
-            const badge_fg = switch (ws_access.level) {
-                .read => theme.MUTED,
-                .write => theme.OK,
+            const badge_fg = switch (ws_access.role) {
+                .member => theme.OK,
                 .admin => theme.ACCENT,
             };
-            const level_label = switch (ws_access.level) {
-                .read => "read",
-                .write => "write",
+            const level_label = switch (ws_access.role) {
+                .member => "member",
                 .admin => "admin",
             };
             w.writeText(&surface, ctx, 24, row, level_label, theme.fg(badge_fg));
@@ -2229,151 +2187,52 @@ pub const Dashboard = struct {
         var row: u16 = 2;
         const sel = self.settings_content_sel;
 
-        // Check for live directory data
+        // Use live directory or mock members
         self.api_state.mutex.lock();
         const live_dir = self.api_state.directory;
         self.api_state.mutex.unlock();
 
+        const MemberView = struct { username: []const u8, role: []const u8, joined: []const u8 };
+        var member_views: std.ArrayList(MemberView) = .empty;
+
         if (live_dir) |dir| {
-            // Live data path
-            var maintainer_count: u16 = 0;
             for (dir.members) |m| {
-                if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
-            }
-            const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ dir.members.len, maintainer_count, dir.members.len - maintainer_count });
-            row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
-
-            w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
-            row += 1;
-
-            for (dir.members, 0..) |m, i| {
-                const is_sel = i == sel and focused;
-                if (is_sel) {
-                    surface.writeCell(1, row, .{
-                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                    });
-                }
-                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&surface, ctx, 4, row, m.username, name_style);
-                const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
-                w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
-                // Resolve team_ids to team names
-                var teams_buf: std.ArrayList(u8) = .empty;
-                for (m.team_ids, 0..) |tid, ti| {
-                    for (dir.teams) |t| {
-                        if (std.mem.eql(u8, t.team_id, tid)) {
-                            try teams_buf.appendSlice(ctx.arena, t.name);
-                            break;
-                        }
-                    }
-                    if (ti + 1 < m.team_ids.len) try teams_buf.appendSlice(ctx.arena, ", ");
-                }
-                w.writeText(&surface, ctx, 30, row, try ctx.arena.dupe(u8, teams_buf.items), theme.fg(theme.TEXT_SOFT));
-                w.writeText(&surface, ctx, 52, row, m.joined_at, theme.fg(theme.MUTED));
-                row += 1;
-                if (row >= size.height -| 10) break;
-            }
-            row += 1;
-
-            // Teams section
-            const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{dir.teams.len});
-            row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
-
-            w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
-            row += 1;
-
-            for (dir.teams, 0..) |team, i| {
-                const team_idx = dir.members.len + i;
-                const is_sel = team_idx == sel and focused;
-                if (is_sel) {
-                    surface.writeCell(1, row, .{
-                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                    });
-                }
-                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&surface, ctx, 4, row, team.name, name_style);
-                // Resolve member_ids to usernames
-                var names_buf: std.ArrayList(u8) = .empty;
-                for (team.member_ids, 0..) |mid, mi| {
-                    for (dir.members) |m| {
-                        if (std.mem.eql(u8, m.user_id, mid)) {
-                            try names_buf.appendSlice(ctx.arena, m.username);
-                            break;
-                        }
-                    }
-                    if (mi + 1 < team.member_ids.len) try names_buf.appendSlice(ctx.arena, ", ");
-                }
-                w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
-                row += 1;
+                try member_views.append(ctx.arena, .{ .username = m.username, .role = m.role, .joined = m.joined_at });
             }
         } else {
-            // Fallback to mock data
-            var maintainer_count: u16 = 0;
             for (data.MEMBERS) |m| {
-                if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
-            }
-            const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ data.MEMBERS.len, maintainer_count, data.MEMBERS.len - maintainer_count });
-            row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
-
-            w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
-            row += 1;
-
-            for (data.MEMBERS, 0..) |m, i| {
-                const is_sel = i == sel and focused;
-                if (is_sel) {
-                    surface.writeCell(1, row, .{
-                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                    });
-                }
-                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&surface, ctx, 4, row, m.username, name_style);
-                const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
-                w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
-                w.writeText(&surface, ctx, 30, row, m.teams, theme.fg(theme.TEXT_SOFT));
-                w.writeText(&surface, ctx, 52, row, m.joined, theme.fg(theme.MUTED));
-                row += 1;
-                if (row >= size.height -| 10) break;
-            }
-            row += 1;
-
-            const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{data.TEAMS.len});
-            row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
-
-            w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
-            w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
-            row += 1;
-
-            for (data.TEAMS, 0..) |team, i| {
-                const team_idx = data.MEMBERS.len + i;
-                const is_sel = team_idx == sel and focused;
-                if (is_sel) {
-                    surface.writeCell(1, row, .{
-                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                    });
-                }
-                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                w.writeText(&surface, ctx, 4, row, team.name, name_style);
-                var names_buf: std.ArrayList(u8) = .empty;
-                for (team.member_usernames, 0..) |username, mi| {
-                    try names_buf.appendSlice(ctx.arena, username);
-                    if (mi + 1 < team.member_usernames.len) try names_buf.appendSlice(ctx.arena, ", ");
-                }
-                w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
-                row += 1;
+                try member_views.append(ctx.arena, .{ .username = m.username, .role = m.role, .joined = m.joined });
             }
         }
+
+        var maintainer_count: u16 = 0;
+        for (member_views.items) |m| {
+            if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
+        }
+        const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ member_views.items.len, maintainer_count, member_views.items.len - maintainer_count });
+        row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
+
+        w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 30, row, "JOINED", theme.fg(theme.MUTED));
         row += 1;
+
+        for (member_views.items, 0..) |m, i| {
+            const is_sel = i == sel and focused;
+            if (is_sel) {
+                surface.writeCell(1, row, .{
+                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                });
+            }
+            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+            w.writeText(&surface, ctx, 4, row, m.username, name_style);
+            const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
+            w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
+            w.writeText(&surface, ctx, 30, row, m.joined, theme.fg(theme.MUTED));
+            row += 1;
+            if (row >= size.height -| 4) break;
+        }
 
         return surface;
     }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1,0 +1,1293 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("theme.zig");
+const w = @import("widgets.zig");
+const data = @import("mock_data.zig");
+const TableRow = @import("table_row.zig").TableRow;
+const Column = @import("table_row.zig").Column;
+
+const WsTab = enum(u8) {
+    prompts,
+    context,
+    overrides,
+
+    fn label(self: WsTab) []const u8 {
+        return switch (self) {
+            .prompts => "Prompts",
+            .context => "Context",
+            .overrides => "Overrides",
+        };
+    }
+};
+
+const ws_tabs = [_]WsTab{ .prompts, .context, .overrides };
+
+const Period = enum(u8) {
+    daily,
+    weekly,
+    monthly,
+
+    fn label(self: Period) []const u8 {
+        return switch (self) {
+            .daily => "daily",
+            .weekly => "weekly",
+            .monthly => "monthly",
+        };
+    }
+
+    fn next(self: Period) Period {
+        return switch (self) {
+            .daily => .weekly,
+            .weekly => .monthly,
+            .monthly => .daily,
+        };
+    }
+};
+
+const TopModule = enum(u8) {
+    library,
+    proposals,
+    workspace,
+    compliance,
+
+    fn label(self: TopModule) []const u8 {
+        return switch (self) {
+            .library => "Library",
+            .proposals => "Proposals",
+            .workspace => "Workspace",
+            .compliance => "Compliance",
+        };
+    }
+};
+
+const DetailTab = enum(u8) {
+    overview,
+    content,
+    history,
+
+    fn label(self: DetailTab) []const u8 {
+        return switch (self) {
+            .overview => "Overview",
+            .content => "Content",
+            .history => "History",
+        };
+    }
+};
+
+const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .compliance };
+const detail_tabs = [_]DetailTab{ .overview, .content, .history };
+
+pub const Dashboard = struct {
+    selected_module: TopModule = .library,
+    selected_prompt: usize = 0,
+    show_help: bool = false,
+    show_detail: bool = false,
+    detail_origin: TopModule = .library,
+    detail_tab: DetailTab = .overview,
+    status_line: []const u8 = "Ready.",
+
+    // ScrollBars for each module
+    library_scroll_bars: vxfw.ScrollBars,
+    library_widgets: [data.PROMPTS.len]vxfw.Widget = undefined,
+    library_rows: [data.PROMPTS.len]TableRow = undefined,
+    library_cols: [data.PROMPTS.len][4]Column = undefined,
+
+    content_scroll_bars: vxfw.ScrollBars,
+    content_widget: [1]vxfw.Widget = undefined,
+    content_text: vxfw.Text = .{ .text = "" },
+
+    history_scroll_bars: vxfw.ScrollBars,
+    history_widgets: [data.HISTORY.len]vxfw.Widget = undefined,
+    history_rows: [data.HISTORY.len]TableRow = undefined,
+    history_cols: [data.HISTORY.len][3]Column = undefined,
+
+    review_scroll_bars: vxfw.ScrollBars,
+    review_widgets: [data.PROPOSALS.len]vxfw.Widget = undefined,
+    review_rows: [data.PROPOSALS.len]TableRow = undefined,
+    review_cols: [data.PROPOSALS.len][2]Column = undefined,
+
+    review_diff_scroll_bars: vxfw.ScrollBars,
+    review_diff_widgets: [8]vxfw.Widget = undefined,
+    review_diff_rows: [8]vxfw.Text = undefined,
+    review_diff_count: usize = 0,
+
+    // Workspace Status
+    ws_tab: WsTab = .prompts,
+    workspace_scroll_bars: vxfw.ScrollBars,
+    workspace_widgets: [data.WORKSPACES.len]vxfw.Widget = undefined,
+    workspace_rows: [data.WORKSPACES.len]TableRow = undefined,
+    workspace_cols: [data.WORKSPACES.len][3]Column = undefined,
+
+    // Compliance
+    compliance_period: Period = .daily,
+    compliance_scroll_bars: vxfw.ScrollBars,
+    compliance_widgets: [data.COMPLIANCE_WS.len]vxfw.Widget = undefined,
+    compliance_rows: [data.COMPLIANCE_WS.len]TableRow = undefined,
+    compliance_cols: [data.COMPLIANCE_WS.len][3]Column = undefined,
+
+    pub fn init() Dashboard {
+        return .{
+            .library_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .content_scroll_bars = w.initPlainScrollBars(theme.PANEL, 3),
+            .history_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .review_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .review_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
+            .workspace_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+            .compliance_scroll_bars = w.initCursorScrollBars(theme.PANEL),
+        };
+    }
+
+    pub fn widget(self: *Dashboard) vxfw.Widget {
+        return .{
+            .userdata = self,
+            .eventHandler = typeErasedEventHandler,
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        const self: *Dashboard = @ptrCast(@alignCast(ptr));
+        try self.handleEvent(ctx, event);
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *Dashboard = @ptrCast(@alignCast(ptr));
+        return self.draw(ctx);
+    }
+
+    fn handleEvent(self: *Dashboard, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        switch (event) {
+            .key_press => |key| {
+                // Help overlay absorbs all keys
+                if (self.show_help) {
+                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('?', .{}) or key.matches('q', .{})) {
+                        self.show_help = false;
+                        ctx.consumeAndRedraw();
+                    }
+                    return;
+                }
+
+                // Global quit
+                if (key.matches('c', .{ .ctrl = true })) {
+                    ctx.consumeEvent();
+                    ctx.quit = true;
+                    return;
+                }
+                if (key.matches('q', .{}) and !self.show_detail) {
+                    ctx.consumeEvent();
+                    ctx.quit = true;
+                    return;
+                }
+
+                // Help toggle
+                if (key.matches('?', .{})) {
+                    self.show_help = true;
+                    ctx.consumeAndRedraw();
+                    return;
+                }
+
+                // Detail mode: Esc returns to origin
+                if (self.show_detail) {
+                    if (key.matches(vaxis.Key.escape, .{}) or key.matches('q', .{})) {
+                        self.show_detail = false;
+                        self.selected_module = self.detail_origin;
+                        self.status_line = "Returned.";
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                        self.shiftDetailTab(-1);
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                        self.shiftDetailTab(1);
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (key.matches('p', .{})) {
+                        self.status_line = "Propose: disabled until Hub contracts land (Phase 2).";
+                        ctx.consumeAndRedraw();
+                        return;
+                    }
+                    if (self.detail_tab == .content) {
+                        try self.content_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        return;
+                    }
+                    if (self.detail_tab == .history) {
+                        try self.history_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        return;
+                    }
+                    return;
+                }
+
+                // Top-level tab switching
+                if (key.matches('1', .{})) return self.selectTab(ctx, .library);
+                if (key.matches('2', .{})) return self.selectTab(ctx, .proposals);
+                if (key.matches('3', .{})) return self.selectTab(ctx, .workspace);
+                if (key.matches('4', .{})) return self.selectTab(ctx, .compliance);
+
+                // Module-specific input
+                switch (self.selected_module) {
+                    .library => {
+                        const prev = self.library_scroll_bars.scroll_view.cursor;
+                        try self.library_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        if (self.library_scroll_bars.scroll_view.cursor != prev) {
+                            self.selected_prompt = @intCast(@min(self.library_scroll_bars.scroll_view.cursor, data.PROMPTS.len - 1));
+                        }
+                        if (key.matches(vaxis.Key.enter, .{})) {
+                            self.openDetail(ctx, self.selected_prompt, .library, .overview);
+                        }
+                    },
+                    .proposals => {
+                        const prev = self.review_scroll_bars.scroll_view.cursor;
+                        try self.review_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        if (self.review_scroll_bars.scroll_view.cursor != prev) {
+                            self.status_line = "Proposal selected.";
+                        }
+                        if (key.matches('a', .{})) {
+                            self.status_line = "Accept: maintainer-only, disabled until Hub API.";
+                            ctx.consumeAndRedraw();
+                        }
+                        if (key.matches('x', .{})) {
+                            self.status_line = "Reject: maintainer-only, disabled until Hub API.";
+                            ctx.consumeAndRedraw();
+                        }
+                    },
+                    .workspace => {
+                        if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+                            self.shiftWsTab(-1);
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+                            self.shiftWsTab(1);
+                            ctx.consumeAndRedraw();
+                            return;
+                        }
+                        try self.workspace_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        if (key.matches('r', .{})) {
+                            self.status_line = "Sync: requires Hub client core (Phase 2).";
+                            ctx.consumeAndRedraw();
+                        }
+                    },
+                    .compliance => {
+                        try self.compliance_scroll_bars.scroll_view.handleEvent(ctx, event);
+                        if (key.matches('t', .{})) {
+                            self.compliance_period = self.compliance_period.next();
+                            ctx.consumeAndRedraw();
+                        }
+                        if (key.matches(vaxis.Key.enter, .{})) {
+                            const cidx = @min(@as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor)), data.COMPLIANCE_WS.len - 1);
+                            _ = cidx;
+                            self.status_line = "Drill-down to workspace detail (future).";
+                            ctx.consumeAndRedraw();
+                        }
+                    },
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn draw(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        if (size.width < 96 or size.height < 24) {
+            return self.drawTooSmall(ctx, size);
+        }
+
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        const header_h: u16 = 4;
+        const footer_h: u16 = 1;
+        const body_h = size.height - header_h - footer_h;
+
+        const header_ctx = ctx.withConstraints(
+            .{ .width = size.width, .height = header_h },
+            .{ .width = size.width, .height = header_h },
+        );
+        const body_ctx = ctx.withConstraints(
+            .{ .width = size.width, .height = body_h },
+            .{ .width = size.width, .height = body_h },
+        );
+        const footer_ctx = ctx.withConstraints(
+            .{ .width = size.width, .height = footer_h },
+            .{ .width = size.width, .height = footer_h },
+        );
+
+        var child_count: usize = 3;
+        if (self.show_help) child_count = 4;
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
+        children[1] = .{ .origin = .{ .row = header_h, .col = 0 }, .surface = try self.drawBody(body_ctx) };
+        children[2] = .{ .origin = .{ .row = header_h + body_h, .col = 0 }, .surface = try self.drawFooter(footer_ctx) };
+
+        if (self.show_help) {
+            const help_ctx = ctx.withConstraints(
+                .{ .width = size.width, .height = size.height },
+                .{ .width = size.width, .height = size.height },
+            );
+            children[3] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHelpOverlay(help_ctx) };
+        }
+
+        root.children = children;
+        return root;
+    }
+
+    fn drawHeader(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, theme.HEADER);
+
+        // Row 0: Accent band with org/ws/user context
+        w.paintBand(&surface, 0, theme.ACCENT, theme.CANVAS);
+        w.writeText(&surface, ctx, 1, 0, "clumsies \xe2\x94\x80 org: acme \xe2\x94\x80 ws: payments-api \xe2\x94\x80 user: alice", .{
+            .fg = theme.CANVAS,
+            .bg = theme.ACCENT,
+            .bold = true,
+        });
+        w.writeRightText(&surface, ctx, 0, "[FRESH]", .{
+            .fg = theme.CANVAS,
+            .bg = theme.ACCENT,
+            .bold = true,
+        });
+
+        // Row 2: Tab badges (row 1 and 3 are padding)
+        var col: u16 = 1;
+        for (top_tabs, 0..) |tab, idx| {
+            const label = try std.fmt.allocPrint(ctx.arena, "{d} {s}", .{ idx + 1, tab.label() });
+            const is_active = if (self.show_detail) false else (tab == self.selected_module);
+            col = w.drawTabBadge(&surface, ctx, 2, col, label, is_active);
+            col +|= 1;
+        }
+
+        return surface;
+    }
+
+    fn drawBody(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        if (self.show_detail) return self.drawPromptDetail(ctx);
+        return switch (self.selected_module) {
+            .library => self.drawLibrary(ctx),
+            .proposals => self.drawProposalReview(ctx),
+            .workspace => self.drawWorkspaceStatus(ctx),
+            .compliance => self.drawCompliance(ctx),
+        };
+    }
+
+    fn drawFooter(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, theme.RAIL);
+
+        const keys = if (self.show_help)
+            "Esc close help"
+        else if (self.show_detail)
+            "h/l tab  j/k move  Enter diff  p propose  Esc back  ? help"
+        else switch (self.selected_module) {
+            .library => "j/k move  Enter open  1-4 switch  ? help  q quit",
+            .proposals => "j/k move  a accept  x reject  c comment  ? help  q quit",
+            .workspace => "h/l tab  j/k move  r sync  ? help  q quit",
+            .compliance => "j/k move  t period  ? help  q quit",
+        };
+        w.writeText(&surface, ctx, 1, 0, keys, theme.textOn(theme.RAIL, theme.TEXT_SOFT));
+        return surface;
+    }
+
+    // Library: two-column (prompt list + preview sidebar).
+    // Bundle facet deferred to Phase 2 when filter interaction is implemented.
+    fn drawLibrary(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        self.syncLibraryWidgets();
+
+        const preview_w: u16 = if (size.width > 118) 30 else 26;
+        const list_w: u16 = size.width - preview_w - 1;
+
+        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
+        const preview_ctx = ctx.withConstraints(.{ .width = preview_w, .height = size.height }, .{ .width = preview_w, .height = size.height });
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawPromptTable(list_ctx) };
+        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawPromptPreview(preview_ctx) };
+        root.children = children;
+        return root;
+    }
+
+    fn drawPromptTable(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        // Suppress draw_cursor during rendering to avoid libvaxis #256 clipping.
+        // Restored by defer so event handling still gets cursor movement.
+        self.library_scroll_bars.scroll_view.draw_cursor = false;
+        defer self.library_scroll_bars.scroll_view.draw_cursor = true;
+
+        const panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Library Prompts",
+            .subtitle = "bundle: All",
+            .background = theme.PANEL,
+            .border_color = theme.BORDER,
+            .child = self.library_scroll_bars.widget(),
+        };
+        var surface = try panel.draw(ctx);
+        return w.applyCursorOverlay(ctx, &surface, &self.library_scroll_bars.scroll_view);
+    }
+
+    // Preview shows only info NOT in the main table:
+    // sparkline trend, constraint count, bundle membership, action hint.
+    fn drawPromptPreview(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const p = &data.PROMPTS[self.selected_prompt];
+        const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
+        const preview = try std.fmt.allocPrint(ctx.arena,
+            \\last 7d
+            \\{s}
+            \\
+            \\constraints  {d}
+            \\bundles      {s}
+            \\
+            \\Enter  open detail
+        , .{ spark, p.constraint_count, p.bundle_names });
+
+        const text_widget: vxfw.Text = .{
+            .text = preview,
+            .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
+            .width_basis = .parent,
+        };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Selected",
+            .subtitle = "",
+            .background = theme.PANEL,
+            .border_color = theme.BORDER,
+            .child = wrapper.widget(),
+            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
+        };
+        return panel.draw(ctx);
+    }
+
+    // Prompt Detail: meta header + inner tabs + sidebar
+    fn drawPromptDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        const p = &data.PROMPTS[self.selected_prompt];
+
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        const meta_h: u16 = 5;
+        const sidebar_w: u16 = if (size.width > 118) 30 else 26;
+        const main_w: u16 = size.width - sidebar_w - 1;
+        const lower_h: u16 = size.height - meta_h - 1;
+
+        const meta_ctx = ctx.withConstraints(.{ .width = size.width, .height = meta_h }, .{ .width = size.width, .height = meta_h });
+        const main_ctx = ctx.withConstraints(.{ .width = main_w, .height = lower_h }, .{ .width = main_w, .height = lower_h });
+        const side_ctx = ctx.withConstraints(.{ .width = sidebar_w, .height = lower_h }, .{ .width = sidebar_w, .height = lower_h });
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawDetailMeta(meta_ctx, p) };
+        children[1] = .{ .origin = .{ .row = meta_h + 1, .col = 0 }, .surface = try self.drawDetailMain(main_ctx, p) };
+        children[2] = .{ .origin = .{ .row = meta_h + 1, .col = main_w + 1 }, .surface = try self.drawDetailSidebar(side_ctx, p) };
+        root.children = children;
+        return root;
+    }
+
+    fn drawDetailMeta(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
+
+        w.writeText(&surface, ctx, 2, 0, p.canonical_name, theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeRightText(&surface, ctx, 0, p.content_hash, theme.textOn(theme.PANEL, theme.MUTED));
+
+        var col: u16 = 2;
+        col = w.drawFilledBadge(&surface, ctx, 1, col, p.kind, theme.CANVAS, theme.GOLD);
+        col +|= 1;
+        _ = w.drawFilledBadge(&surface, ctx, 1, col, p.bundle_names, theme.CANVAS, theme.CYAN);
+
+        // Row 2: override / proposal status
+        var status_col: u16 = 2;
+        status_col = w.drawFilledBadge(&surface, ctx, 2, status_col, "LOCAL", theme.CANVAS, theme.WARN);
+        status_col +|= 1;
+        _ = w.drawFilledBadge(&surface, ctx, 2, status_col, "NO PROPOSAL", theme.TEXT_SOFT, theme.PANEL_ALT);
+
+        const metrics = try std.fmt.allocPrint(ctx.arena, "refer {s}   constraints {d}   bundles {d}", .{ p.refer_count, p.constraint_count, p.bundle_count });
+        w.writeText(&surface, ctx, 2, 3, metrics, theme.boldOn(theme.PANEL, theme.TEXT));
+        return surface;
+    }
+
+    fn drawDetailMain(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        w.fillSurface(&surface, theme.PANEL);
+
+        // Inner tab strip
+        var col: u16 = 0;
+        for (detail_tabs) |tab| {
+            col = w.drawInnerTabBadge(&surface, ctx, 0, col, tab.label(), tab == self.detail_tab);
+            col +|= 1;
+        }
+
+        const inner_h = ctx.max.height.? -| 2;
+        const inner_w = ctx.max.width.?;
+
+        switch (self.detail_tab) {
+            .overview => {
+                const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
+                const overview = try std.fmt.allocPrint(ctx.arena,
+                    \\Canonical Name
+                    \\{s}
+                    \\
+                    \\Kind
+                    \\{s}
+                    \\
+                    \\Bundles
+                    \\{s}
+                    \\
+                    \\Content Hash
+                    \\{s}
+                    \\
+                    \\Updated
+                    \\{s}
+                    \\
+                    \\Trend (last 7d)
+                    \\{s}
+                    \\
+                    \\Local Override
+                    \\Detected in ws: payments-api. Press p to propose.
+                , .{ p.canonical_name, p.kind, p.bundle_names, p.content_hash, p.updated, spark });
+
+                const text_widget: vxfw.Text = .{
+                    .text = overview,
+                    .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
+                    .width_basis = .parent,
+                };
+                const child_ctx = ctx.withConstraints(
+                    .{ .width = inner_w, .height = inner_h },
+                    .{ .width = inner_w, .height = inner_h },
+                );
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                children[0] = .{ .origin = .{ .row = 2, .col = 1 }, .surface = try text_widget.widget().draw(child_ctx) };
+                surface.children = children;
+            },
+            .content => {
+                self.syncContentWidget();
+                const child_ctx = ctx.withConstraints(
+                    .{ .width = inner_w, .height = inner_h },
+                    .{ .width = inner_w, .height = inner_h },
+                );
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+                children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = try self.content_scroll_bars.widget().draw(child_ctx) };
+                surface.children = children;
+            },
+            .history => {
+                self.syncHistoryWidgets();
+                const list_w: u16 = if (inner_w > 76) 34 else inner_w / 2;
+                const detail_w = inner_w - list_w - 1;
+
+                const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = inner_h }, .{ .width = list_w, .height = inner_h });
+                const det_ctx = ctx.withConstraints(.{ .width = detail_w, .height = inner_h }, .{ .width = detail_w, .height = inner_h });
+
+                self.history_scroll_bars.scroll_view.draw_cursor = false;
+                defer self.history_scroll_bars.scroll_view.draw_cursor = true;
+
+                var list_surface = try self.history_scroll_bars.widget().draw(list_ctx);
+                // No Panel border here, so cursor overlay targets row directly
+                const sv = &self.history_scroll_bars.scroll_view;
+                if (sv.cursor >= sv.scroll.top) {
+                    const vis_row = sv.cursor - sv.scroll.top;
+                    const crow: i17 = @intCast(vis_row);
+                    if (crow < list_surface.size.height) {
+                        const cbuf = try ctx.arena.alloc(vaxis.Cell, 1);
+                        cbuf[0] = .{
+                            .char = .{ .grapheme = "▌", .width = 1 },
+                            .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                        };
+                        const csurface: vxfw.Surface = .{
+                            .size = .{ .width = 1, .height = 1 },
+                            .widget = list_surface.widget,
+                            .buffer = cbuf,
+                            .children = &.{},
+                        };
+                        const old = list_surface.children;
+                        const new = try ctx.arena.alloc(vxfw.SubSurface, old.len + 1);
+                        @memcpy(new[0..old.len], old);
+                        new[old.len] = .{
+                            .origin = .{ .col = 0, .row = crow },
+                            .surface = csurface,
+                            .z_index = 1,
+                        };
+                        list_surface.children = new;
+                    }
+                }
+
+                const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+                children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = list_surface };
+                children[1] = .{ .origin = .{ .row = 2, .col = list_w + 1 }, .surface = try self.drawHistoryDetail(det_ctx) };
+                surface.children = children;
+            },
+        }
+
+        // Wrap in panel
+        const sw = try ctx.arena.create(w.SurfaceWidget);
+        sw.* = .{ .surface = surface, .widget_ref = self.widget() };
+        const panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Prompt Detail",
+            .subtitle = p.canonical_name,
+            .background = theme.PANEL,
+            .border_color = theme.BORDER,
+            .child = sw.widget(),
+            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
+        };
+        return panel.draw(ctx);
+    }
+
+    fn drawDetailSidebar(self: *Dashboard, ctx: vxfw.DrawContext, p: *const data.PromptEntry) std.mem.Allocator.Error!vxfw.Surface {
+        const spark = try w.sparkline(ctx.arena, p.trend[0..8]);
+        const sidebar = try std.fmt.allocPrint(ctx.arena,
+            \\Refer Count
+            \\{s}
+            \\
+            \\Constraints
+            \\{d}
+            \\
+            \\Trend
+            \\{s}
+            \\
+            \\Workspaces
+            \\API pending
+            \\
+            \\Actions
+            \\p  propose from local override
+            \\Enter  open diff from history
+            \\Esc  back to {s}
+        , .{ p.refer_count, p.constraint_count, spark, self.detail_origin.label() });
+
+        const text_widget: vxfw.Text = .{
+            .text = sidebar,
+            .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT),
+            .width_basis = .parent,
+        };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Usage Summary",
+            .subtitle = "API pending",
+            .background = theme.PANEL_ALT,
+            .border_color = theme.BORDER,
+            .child = wrapper.widget(),
+            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
+        };
+        return panel.draw(ctx);
+    }
+
+    fn drawHistoryDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const idx = @min(@as(usize, @intCast(self.history_scroll_bars.scroll_view.cursor)), data.HISTORY.len - 1);
+        const h = &data.HISTORY[idx];
+        const detail = try std.fmt.allocPrint(ctx.arena,
+            \\Date
+            \\{s}
+            \\
+            \\Hash
+            \\{s}
+            \\
+            \\Label
+            \\{s}
+            \\
+            \\Next
+            \\Enter opens a diff overlay vs current (Phase 2).
+        , .{ h.date, h.hash, h.label });
+
+        const text_widget: vxfw.Text = .{
+            .text = detail,
+            .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
+            .width_basis = .parent,
+        };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Version Detail",
+            .subtitle = if (idx == 0) "current" else "history",
+            .background = theme.PANEL,
+            .border_color = theme.BORDER,
+            .child = wrapper.widget(),
+            .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 },
+        };
+        return panel.draw(ctx);
+    }
+
+    // Proposal Review: queue + diff + sidebar (three-column)
+    fn drawProposalReview(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        self.syncReviewWidgets();
+        const proposal = &data.PROPOSALS[self.selectedProposalIdx()];
+        self.syncDiffWidgets(proposal);
+
+        const queue_w: u16 = if (size.width > 112) 28 else 24;
+        const side_w: u16 = if (size.width > 112) 28 else 24;
+        const diff_w: u16 = size.width - queue_w - side_w - 2;
+
+        const q_ctx = ctx.withConstraints(.{ .width = queue_w, .height = size.height }, .{ .width = queue_w, .height = size.height });
+        const d_ctx = ctx.withConstraints(.{ .width = diff_w, .height = size.height }, .{ .width = diff_w, .height = size.height });
+        const s_ctx = ctx.withConstraints(.{ .width = side_w, .height = size.height }, .{ .width = side_w, .height = size.height });
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawReviewQueue(q_ctx) };
+        children[1] = .{ .origin = .{ .row = 0, .col = queue_w + 1 }, .surface = try self.drawReviewDiff(d_ctx, proposal) };
+        children[2] = .{ .origin = .{ .row = 0, .col = queue_w + diff_w + 2 }, .surface = try self.drawReviewSidebar(s_ctx, proposal) };
+        root.children = children;
+        return root;
+    }
+
+    fn drawReviewQueue(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        self.review_scroll_bars.scroll_view.draw_cursor = false;
+        defer self.review_scroll_bars.scroll_view.draw_cursor = true;
+
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Proposal Queue", .subtitle = "status: open", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.review_scroll_bars.widget() };
+        var surface = try panel.draw(ctx);
+        return w.applyCursorOverlay(ctx, &surface, &self.review_scroll_bars.scroll_view);
+    }
+
+    fn drawReviewDiff(self: *Dashboard, ctx: vxfw.DrawContext, proposal: *const data.ProposalEntry) std.mem.Allocator.Error!vxfw.Surface {
+        const panel: w.Panel = .{ .owner = self.widget(), .title = proposal.prompt_name, .subtitle = proposal.id, .background = theme.PANEL, .border_color = theme.BORDER, .child = self.review_diff_scroll_bars.widget() };
+        return panel.draw(ctx);
+    }
+
+    fn drawReviewSidebar(self: *Dashboard, ctx: vxfw.DrawContext, proposal: *const data.ProposalEntry) std.mem.Allocator.Error!vxfw.Surface {
+        const sidebar = try std.fmt.allocPrint(ctx.arena,
+            \\Status
+            \\{s}
+            \\
+            \\Author
+            \\{s}
+            \\
+            \\Created
+            \\{s}
+            \\
+            \\Base Hash
+            \\{s}
+            \\
+            \\Trace Summary
+            \\refer {d}   sessions {d}
+            \\
+            \\Actions
+            \\a  accept (maintainer only)
+            \\x  reject (maintainer only)
+            \\c  comment (Phase 2)
+        , .{ proposal.status, proposal.author, proposal.created, proposal.base_hash, proposal.trace_refers, proposal.trace_sessions });
+
+        const text_widget: vxfw.Text = .{ .text = sidebar, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Review Lens", .subtitle = proposal.author, .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    // Workspace Status: list + detail (two-column)
+    fn drawWorkspaceStatus(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        self.syncWorkspaceWidgets();
+        const ws_idx = @min(@as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor)), data.WORKSPACES.len - 1);
+        const ws = &data.WORKSPACES[ws_idx];
+
+        // Summary bar (2 rows)
+        const summary_h: u16 = 3;
+        var summary = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = summary_h });
+        w.fillSurface(&summary, theme.PANEL);
+        w.drawBorder(&summary, theme.BORDER, theme.PANEL);
+        w.writeText(&summary, ctx, 2, 0, "Workspace Status", theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeRightText(&summary, ctx, 0, ws.name, theme.textOn(theme.PANEL, theme.MUTED));
+        const summary_text = try std.fmt.allocPrint(ctx.arena, " paths: {d}   prompts: {d}   context: {d}   overrides: {d}   rev: {d}/{d}   state: {s}", .{ ws.paths, ws.prompts, ws.contexts, ws.overrides, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws) });
+        w.writeText(&summary, ctx, 1, 1, summary_text, theme.textOn(theme.PANEL, theme.TEXT_SOFT));
+
+        // Inner tab strip + content area
+        const body_h = size.height - summary_h;
+        const body_ctx = ctx.withConstraints(.{ .width = size.width, .height = body_h }, .{ .width = size.width, .height = body_h });
+        const body_surface = try self.drawWsBody(body_ctx, ws);
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = summary };
+        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = body_surface };
+        root.children = children;
+        return root;
+    }
+
+    fn drawWsBody(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.CANVAS);
+
+        // Inner tabs
+        var tab_col: u16 = 1;
+        for (ws_tabs) |tab| {
+            tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, tab.label(), tab == self.ws_tab);
+            tab_col +|= 1;
+        }
+
+        const content_h = size.height -| 2;
+        const left_w: u16 = if (size.width > 100) size.width -| 36 else size.width;
+        const right_w: u16 = if (size.width > 100) 35 else 0;
+
+        const left_ctx = ctx.withConstraints(.{ .width = left_w, .height = content_h }, .{ .width = left_w, .height = content_h });
+        const right_ctx = ctx.withConstraints(.{ .width = right_w, .height = content_h }, .{ .width = right_w, .height = content_h });
+
+        const tab_content = switch (self.ws_tab) {
+            .prompts => try self.drawWsPrompts(left_ctx),
+            .context => try self.drawWsContext(left_ctx),
+            .overrides => try self.drawWsOverrides(left_ctx),
+        };
+
+        if (right_w > 0) {
+            const detail = try self.drawWsDetail(right_ctx, ws);
+            const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+            children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = tab_content };
+            children[1] = .{ .origin = .{ .row = 2, .col = left_w + 1 }, .surface = detail };
+            surface.children = children;
+        } else {
+            const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+            children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = tab_content };
+            surface.children = children;
+        }
+        return surface;
+    }
+
+    fn drawWsPrompts(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.appendSlice(ctx.arena, " NAME                KIND  OVR  STATE\n");
+        for (data.WS_PROMPTS) |p| {
+            const ovr: []const u8 = if (p.has_override) "yes" else " no";
+            const line = try std.fmt.allocPrint(ctx.arena, " {s:<18}  {s:<4}  {s}  {s}\n", .{ p.name, p.kind, ovr, p.state });
+            try buf.appendSlice(ctx.arena, line);
+        }
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Prompts", .subtitle = "a add  x remove", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawWsContext(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.appendSlice(ctx.arena, " PATH                      SIZE  STATE\n");
+        for (data.WS_CONTEXT) |f| {
+            const line = try std.fmt.allocPrint(ctx.arena, " {s:<24}  {s:<4}  {s}\n", .{ f.path, f.size, f.state });
+            try buf.appendSlice(ctx.arena, line);
+        }
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Context Files", .subtitle = "read-only", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawWsOverrides(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var buf: std.ArrayList(u8) = .empty;
+        try buf.appendSlice(ctx.arena, " PROMPT              BASE  CUR   STATUS\n");
+        for (data.WS_OVERRIDES) |o| {
+            const line = try std.fmt.allocPrint(ctx.arena, " {s:<18}  {s:<4}  {s:<4}  {s}\n", .{ o.prompt_name, o.base_hash, o.current_hash, o.status });
+            try buf.appendSlice(ctx.arena, line);
+        }
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Overrides", .subtitle = "conflict detection", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+        const detail = try std.fmt.allocPrint(ctx.arena,
+            \\Workspace
+            \\{s}
+            \\
+            \\Rev (local / remote)
+            \\{d} / {d}
+            \\
+            \\Sync State
+            \\{s}
+            \\
+            \\Bound Paths
+            \\{d}
+            \\
+            \\Actions
+            \\r  sync
+            \\a  add prompt (Phase 2)
+            \\x  remove prompt (Phase 2)
+        , .{ ws.name, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws), ws.paths });
+
+        const text_widget: vxfw.Text = .{ .text = detail, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = ws.name, .subtitle = data.syncStateLabel(ws), .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    // Compliance: workspace-first refer coverage analysis
+    fn drawCompliance(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&root, theme.CANVAS);
+
+        self.syncComplianceWidgets();
+
+        // Org summary bar (3 rows)
+        const summary_h: u16 = 3;
+        var summary = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = summary_h });
+        w.fillSurface(&summary, theme.PANEL);
+        w.drawBorder(&summary, theme.BORDER, theme.PANEL);
+        const title = try std.fmt.allocPrint(ctx.arena, "Compliance \xe2\x94\x80 org: acme \xe2\x94\x80 period: {s}", .{self.compliance_period.label()});
+        w.writeText(&summary, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeRightText(&summary, ctx, 0, "t cycle period", theme.textOn(theme.PANEL, theme.MUTED));
+
+        // Compute org totals from mock data
+        var total_refer: u32 = 0;
+        for (data.COMPLIANCE_WS) |cw| {
+            var val: u32 = 0;
+            for (cw.refer_count) |c| {
+                if (c >= '0' and c <= '9') {
+                    val = val * 10 + (c - '0');
+                }
+            }
+            total_refer += val;
+        }
+        const org_spark = try w.sparkline(ctx.arena, &data.COMPLIANCE_WS[0].trend);
+        const org_line = try std.fmt.allocPrint(ctx.arena, " workspaces {d}   prompts {d}   total refer ~{d}   org trend {s}", .{ data.COMPLIANCE_WS.len, data.PROMPTS.len, total_refer, org_spark });
+        w.writeText(&summary, ctx, 1, 1, org_line, theme.textOn(theme.PANEL, theme.TEXT_SOFT));
+
+        // Two-column: workspace rank (left) + selected detail (right)
+        const body_h = size.height - summary_h;
+        const left_w: u16 = if (size.width > 108) 44 else 36;
+        const right_w: u16 = size.width - left_w - 1;
+
+        const l_ctx = ctx.withConstraints(.{ .width = left_w, .height = body_h }, .{ .width = left_w, .height = body_h });
+        const r_ctx = ctx.withConstraints(.{ .width = right_w, .height = body_h }, .{ .width = right_w, .height = body_h });
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = summary };
+        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = try self.drawComplianceList(l_ctx) };
+        children[2] = .{ .origin = .{ .row = summary_h, .col = left_w + 1 }, .surface = try self.drawComplianceDetail(r_ctx) };
+        root.children = children;
+        return root;
+    }
+
+    fn drawComplianceList(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        self.compliance_scroll_bars.scroll_view.draw_cursor = false;
+        defer self.compliance_scroll_bars.scroll_view.draw_cursor = true;
+
+        const panel: w.Panel = .{ .owner = self.widget(), .title = "Workspace Coverage", .subtitle = "j/k select", .background = theme.PANEL, .border_color = theme.BORDER, .child = self.compliance_scroll_bars.widget() };
+        var surface = try panel.draw(ctx);
+        return w.applyCursorOverlay(ctx, &surface, &self.compliance_scroll_bars.scroll_view);
+    }
+
+    fn drawComplianceDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const cidx = @min(@as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor)), data.COMPLIANCE_WS.len - 1);
+        const cw = &data.COMPLIANCE_WS[cidx];
+        const spark = try w.sparkline(ctx.arena, cw.trend[0..8]);
+
+        var buf: std.ArrayList(u8) = .empty;
+        // Selected workspace detail
+        try buf.appendSlice(ctx.arena, try std.fmt.allocPrint(ctx.arena, "Workspace\n{s}\n\nCoverage\n{d}%\n\nRefer Count\n{s}\n\nTrend\n{s}\n\n", .{ cw.name, cw.coverage, cw.refer_count, spark }));
+
+        // Hotspots section
+        try buf.appendSlice(ctx.arena, "Prompt Hotspots\n");
+        for (data.HOTSPOTS) |h| {
+            try buf.appendSlice(ctx.arena, try std.fmt.allocPrint(ctx.arena, " {s:<24} {s}\n", .{ h.name, h.refer_count }));
+        }
+        try buf.appendSlice(ctx.arena, "\nMember Grouping\nAPI pending (s1-4 expansion needed)");
+
+        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
+        const wrapper = try ctx.arena.create(w.WidgetBox);
+        wrapper.* = .{ .widget_ref = text_widget.widget() };
+        const panel: w.Panel = .{ .owner = self.widget(), .title = cw.name, .subtitle = try std.fmt.allocPrint(ctx.arena, "coverage {d}%", .{cw.coverage}), .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
+        return panel.draw(ctx);
+    }
+
+    fn drawHelpOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        // Semi-transparent overlay: paint dimmed background
+        w.fillSurface(&surface, theme.CANVAS);
+
+        const box_w: u16 = 52;
+        const box_h: u16 = 19;
+        const start_col = (size.width -| box_w) / 2;
+        const start_row = (size.height -| box_h) / 2;
+
+        // Draw box background
+        var row: u16 = 0;
+        while (row < box_h) : (row += 1) {
+            var col: u16 = 0;
+            while (col < box_w) : (col += 1) {
+                surface.writeCell(start_col + col, start_row + row, .{
+                    .char = .{ .grapheme = " ", .width = 1 },
+                    .style = .{ .fg = theme.TEXT, .bg = theme.PANEL_ALT },
+                });
+            }
+        }
+
+        // Border
+        const s = vaxis.Style{ .fg = theme.ACCENT, .bg = theme.PANEL_ALT };
+        surface.writeCell(start_col, start_row, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = s });
+        surface.writeCell(start_col + box_w - 1, start_row, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = s });
+        surface.writeCell(start_col, start_row + box_h - 1, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = s });
+        surface.writeCell(start_col + box_w - 1, start_row + box_h - 1, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = s });
+        var c: u16 = 1;
+        while (c < box_w - 1) : (c += 1) {
+            surface.writeCell(start_col + c, start_row, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+            surface.writeCell(start_col + c, start_row + box_h - 1, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+        }
+        var r: u16 = 1;
+        while (r < box_h - 1) : (r += 1) {
+            surface.writeCell(start_col, start_row + r, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+            surface.writeCell(start_col + box_w - 1, start_row + r, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+        }
+
+        // Title
+        w.writeText(&surface, ctx, start_col + 2, start_row, " Keyboard Reference ", theme.boldOn(theme.PANEL_ALT, theme.ACCENT));
+
+        const lines = [_][]const u8{
+            "1-4            Switch top-level module",
+            "j / \xe2\x86\x93           Move down / next row",
+            "k / \xe2\x86\x91           Move up / previous row",
+            "h / \xe2\x86\x90           Previous tab / region",
+            "l / \xe2\x86\x92           Next tab / region",
+            "Enter          Open selected / confirm",
+            "Esc            Back / close overlay",
+            "g              Jump to first row",
+            "G              Jump to last row",
+            "a              Accept proposal (maintainer)",
+            "x              Reject proposal (maintainer)",
+            "r              Refresh / sync",
+            "w              Workspace switcher (future)",
+            "p              Propose from override",
+            "?              Toggle this help",
+            "q / Ctrl+C     Quit",
+        };
+        for (lines, 0..) |line, i| {
+            w.writeText(&surface, ctx, start_col + 2, @intCast(start_row + 2 + i), line, theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT));
+        }
+
+        return surface;
+    }
+
+    fn drawTooSmall(self: *Dashboard, ctx: vxfw.DrawContext, size: vxfw.Size) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        w.fillSurface(&surface, theme.CANVAS);
+        w.paintBand(&surface, 0, theme.ACCENT, theme.CANVAS);
+        w.writeText(&surface, ctx, 1, 0, "clumsies / prompt dashboard", .{ .fg = theme.CANVAS, .bg = theme.ACCENT, .bold = true });
+        w.writeText(&surface, ctx, 2, 2, "Terminal too small. Need at least 96x24.", theme.boldOn(theme.CANVAS, theme.TEXT));
+        w.writeText(&surface, ctx, 2, 4, "Resize the terminal, or press q / Ctrl-C to exit.", theme.textOn(theme.CANVAS, theme.TEXT_SOFT));
+        return surface;
+    }
+
+    // Library rows: name (flex=1) | kind (auto) | refer (auto, right) | age (auto, right)
+    fn syncLibraryWidgets(self: *Dashboard) void {
+        self.library_scroll_bars.scroll_view.cursor = @intCast(self.selected_prompt);
+        for (data.PROMPTS, 0..) |p, idx| {
+            const sel = idx == self.selected_prompt;
+            self.library_cols[idx] = .{
+                .{ .text = p.canonical_name, .flex = 1 },
+                .{ .text = p.kind, .flex = 0 },
+                .{ .text = p.refer_count, .flex = 0, .alignment = .right },
+                .{ .text = p.age, .flex = 0, .alignment = .right },
+            };
+            self.library_rows[idx] = .{
+                .columns = &self.library_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 2,
+            };
+            self.library_widgets[idx] = self.library_rows[idx].widget();
+        }
+        self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..] };
+        self.library_scroll_bars.estimated_content_height = data.PROMPTS.len;
+    }
+
+    fn syncContentWidget(self: *Dashboard) void {
+        self.content_text = .{
+            .text = data.SAMPLE_CONTENT,
+            .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT),
+        };
+        self.content_widget[0] = self.content_text.widget();
+        self.content_scroll_bars.scroll_view.children = .{ .slice = self.content_widget[0..1] };
+        self.content_scroll_bars.estimated_content_height = @intCast(@max(w.countLines(data.SAMPLE_CONTENT), 24));
+    }
+
+    fn syncHistoryWidgets(self: *Dashboard) void {
+        for (data.HISTORY, 0..) |h, idx| {
+            const sel = idx == @as(usize, @intCast(self.history_scroll_bars.scroll_view.cursor));
+            self.history_cols[idx] = .{
+                .{ .text = h.date, .flex = 0 },
+                .{ .text = h.hash, .flex = 0 },
+                .{ .text = h.label, .flex = 1 },
+            };
+            self.history_rows[idx] = .{
+                .columns = &self.history_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 2,
+            };
+            self.history_widgets[idx] = self.history_rows[idx].widget();
+        }
+        self.history_scroll_bars.scroll_view.children = .{ .slice = self.history_widgets[0..data.HISTORY.len] };
+        self.history_scroll_bars.estimated_content_height = data.HISTORY.len;
+    }
+
+    // Inner width budget: panel=24min → border=2 → inner=22.
+    // Row format: 1 + 9 id + 1 + 6 status + 1 = 18 fixed + truncated name. Fits.
+    fn syncReviewWidgets(self: *Dashboard) void {
+        self.review_scroll_bars.scroll_view.cursor = @min(self.review_scroll_bars.scroll_view.cursor, data.PROPOSALS.len - 1);
+        const sel_idx = self.selectedProposalIdx();
+        for (data.PROPOSALS, 0..) |p, idx| {
+            const sel = idx == sel_idx;
+            self.review_cols[idx] = .{
+                .{ .text = p.id, .flex = 0 },
+                .{ .text = p.status, .flex = 1 },
+            };
+            self.review_rows[idx] = .{
+                .columns = &self.review_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 2,
+            };
+            self.review_widgets[idx] = self.review_rows[idx].widget();
+        }
+        self.review_scroll_bars.scroll_view.children = .{ .slice = self.review_widgets[0..] };
+        self.review_scroll_bars.estimated_content_height = data.PROPOSALS.len;
+    }
+
+    fn syncDiffWidgets(self: *Dashboard, proposal: *const data.ProposalEntry) void {
+        self.review_diff_count = @min(proposal.diff.len, self.review_diff_widgets.len);
+        for (0..self.review_diff_count) |idx| {
+            const line = proposal.diff[idx];
+            self.review_diff_rows[idx] = .{
+                .text = line,
+                .style = theme.textOn(diffBg(line), diffFg(line)),
+                .softwrap = false,
+            };
+            self.review_diff_widgets[idx] = self.review_diff_rows[idx].widget();
+        }
+        self.review_diff_scroll_bars.scroll_view.children = .{ .slice = self.review_diff_widgets[0..self.review_diff_count] };
+        self.review_diff_scroll_bars.estimated_content_height = @intCast(self.review_diff_count);
+    }
+
+    fn syncWorkspaceWidgets(self: *Dashboard) void {
+        self.workspace_scroll_bars.scroll_view.cursor = @min(self.workspace_scroll_bars.scroll_view.cursor, data.WORKSPACES.len - 1);
+        const ws_sel = @as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor));
+        for (data.WORKSPACES, 0..) |ws, idx| {
+            const sel = idx == ws_sel;
+            const sync_label = data.syncStateLabel(&ws);
+            self.workspace_cols[idx] = .{
+                .{ .text = ws.name, .flex = 1 },
+                .{ .text = sync_label, .flex = 0 },
+                .{ .text = std.fmt.bufPrint(&workspace_buf[idx], "{d}p {d}o", .{ ws.prompts, ws.overrides }) catch "?", .flex = 0, .alignment = .right },
+            };
+            self.workspace_rows[idx] = .{
+                .columns = &self.workspace_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 1,
+            };
+            self.workspace_widgets[idx] = self.workspace_rows[idx].widget();
+        }
+        self.workspace_scroll_bars.scroll_view.children = .{ .slice = self.workspace_widgets[0..] };
+        self.workspace_scroll_bars.estimated_content_height = data.WORKSPACES.len;
+    }
+
+    // Inner width budget: panel=36min → border=2 → inner=34.
+    // Row format: 1 + 16 name + 1 + 3 pct + 1 + % + 2 + 4 count = ~29. Fits.
+    fn syncComplianceWidgets(self: *Dashboard) void {
+        self.compliance_scroll_bars.scroll_view.cursor = @min(self.compliance_scroll_bars.scroll_view.cursor, data.COMPLIANCE_WS.len - 1);
+        const sel_idx = @as(usize, @intCast(self.compliance_scroll_bars.scroll_view.cursor));
+        for (data.COMPLIANCE_WS, 0..) |cw, idx| {
+            const sel = idx == sel_idx;
+            self.compliance_cols[idx] = .{
+                .{ .text = cw.name, .flex = 1 },
+                .{ .text = std.fmt.bufPrint(&compliance_buf[idx], "{d}%", .{cw.coverage}) catch "?", .flex = 0, .alignment = .right },
+                .{ .text = cw.refer_count, .flex = 0, .alignment = .right },
+            };
+            self.compliance_rows[idx] = .{
+                .columns = &self.compliance_cols[idx],
+                .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
+                .gap = 2,
+            };
+            self.compliance_widgets[idx] = self.compliance_rows[idx].widget();
+        }
+        self.compliance_scroll_bars.scroll_view.children = .{ .slice = self.compliance_widgets[0..] };
+        self.compliance_scroll_bars.estimated_content_height = data.COMPLIANCE_WS.len;
+    }
+
+    fn selectedProposalIdx(self: *const Dashboard) usize {
+        return @min(@as(usize, @intCast(self.review_scroll_bars.scroll_view.cursor)), data.PROPOSALS.len - 1);
+    }
+
+    fn contextHint(self: *const Dashboard) []const u8 {
+        if (self.show_help) return "Keyboard reference overlay.";
+        if (self.show_detail) return switch (self.detail_tab) {
+            .overview => "Prompt metadata, usage summary, and override status.",
+            .content => "Full prompt body. j/k to scroll.",
+            .history => "Revision list left, version detail right.",
+        };
+        return switch (self.selected_module) {
+            .library => "Bundle facet, prompt list, and passive preview.",
+            .proposals => "Proposal queue left, diff center, review lens right.",
+            .workspace => "Workspace list and sync status detail.",
+            .compliance => "Refer coverage analysis (Phase 3, API pending).",
+        };
+    }
+
+    fn selectTab(self: *Dashboard, ctx: *vxfw.EventContext, tab: TopModule) void {
+        self.show_detail = false;
+        self.selected_module = tab;
+        self.status_line = tab.label();
+        ctx.consumeAndRedraw();
+    }
+
+    fn openDetail(self: *Dashboard, ctx: *vxfw.EventContext, prompt_idx: usize, origin: TopModule, initial_tab: DetailTab) void {
+        self.selected_prompt = @min(prompt_idx, data.PROMPTS.len - 1);
+        self.library_scroll_bars.scroll_view.cursor = @intCast(self.selected_prompt);
+        self.history_scroll_bars.scroll_view.cursor = 0;
+        self.detail_origin = origin;
+        self.detail_tab = initial_tab;
+        self.show_detail = true;
+        self.status_line = "Prompt detail opened.";
+        ctx.consumeAndRedraw();
+    }
+
+    fn shiftDetailTab(self: *Dashboard, delta: i8) void {
+        const current: i8 = @intCast(@intFromEnum(self.detail_tab));
+        const count: i8 = @intCast(detail_tabs.len);
+        const next = @mod(current + delta + count, count);
+        self.detail_tab = @enumFromInt(@as(u8, @intCast(next)));
+    }
+
+    fn shiftWsTab(self: *Dashboard, delta: i8) void {
+        const current: i8 = @intCast(@intFromEnum(self.ws_tab));
+        const count: i8 = @intCast(ws_tabs.len);
+        const next = @mod(current + delta + count, count);
+        self.ws_tab = @enumFromInt(@as(u8, @intCast(next)));
+    }
+};
+
+// Static row buffers to avoid per-frame allocation
+// Small buffers for inline-formatted column values (counts, percentages)
+var workspace_buf: [data.WORKSPACES.len][32]u8 = undefined;
+var compliance_buf: [data.COMPLIANCE_WS.len][16]u8 = undefined;
+
+fn diffFg(line: []const u8) vaxis.Color {
+    if (std.mem.startsWith(u8, line, "+")) return theme.OK;
+    if (std.mem.startsWith(u8, line, "-")) return theme.DANGER;
+    if (std.mem.startsWith(u8, line, "@@")) return theme.GOLD;
+    return theme.TEXT_SOFT;
+}
+
+fn diffBg(line: []const u8) vaxis.Color {
+    if (std.mem.startsWith(u8, line, "+")) return theme.rgb(0x1d2617);
+    if (std.mem.startsWith(u8, line, "-")) return theme.rgb(0x2a1b18);
+    if (std.mem.startsWith(u8, line, "@@")) return theme.PANEL_ALT;
+    return theme.PANEL;
+}

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -537,7 +537,7 @@ pub const Dashboard = struct {
                                 const all_p = self.getPrompts();
                                 const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
                                 if (all_p.len > 0) {
-                                    const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+                                    const prs_for = self.getPrsForPrompt(all_p[si].path);
                                     const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
                                     if (prs_for.len > 0) api.fetchPrDetailAsync(self.api_state, prs_for[pri].id);
                                 }
@@ -1244,7 +1244,7 @@ pub const Dashboard = struct {
         if (self.detail_tab == .pull_requests) {
             w.writeRightText(&surface, ctx, 0, "f filter", theme.textOn(theme.PANEL, theme.MUTED));
         } else {
-            w.writeRightText(&surface, ctx, 0, p.canonical_name, theme.textOn(theme.PANEL, theme.MUTED));
+            w.writeRightText(&surface, ctx, 0, p.path, theme.textOn(theme.PANEL, theme.MUTED));
         }
 
         const inner_h = ctx.max.height.? -| 2;
@@ -1275,7 +1275,7 @@ pub const Dashboard = struct {
                 surface.children = children;
             },
             .pull_requests => {
-                const prs = self.getPrsForPrompt(p.canonical_name);
+                const prs = self.getPrsForPrompt(p.path);
                 if (prs.len == 0) {
                     w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
                 } else if (self.show_pr_diff) {
@@ -1395,7 +1395,7 @@ pub const Dashboard = struct {
                 surface.children = children;
             },
             .pull_requests => {
-                const prs = self.getPrsForPrompt(p.canonical_name);
+                const prs = self.getPrsForPrompt(p.path);
                 if (prs.len == 0) {
                     w.writeText(&surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
                 } else if (self.show_pr_diff) {
@@ -1461,7 +1461,7 @@ pub const Dashboard = struct {
         w.fillSurface(&surface, theme.PANEL);
         const border_color = if (self.detail_focus_content) theme.ACCENT else theme.BORDER;
         w.drawBorder(&surface, border_color, theme.PANEL);
-        w.writeText(&surface, ctx, 2, 0, p.canonical_name, theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeText(&surface, ctx, 2, 0, p.path, theme.boldOn(theme.PANEL, theme.TEXT));
 
         self.syncContentWidget();
         const inner_w = ctx.max.width.? -| 4;
@@ -1614,12 +1614,12 @@ pub const Dashboard = struct {
                 var kv_row: u16 = 2;
                 var last_prefix: []const u8 = "";
                 if (live_ws) |ws_d| {
-                    // Live: cross-ref prompt_id with library for canonical_name
+                    // Cross-ref content_hash with library to get display path
                     const lib_prompts = self.getPrompts();
                     for (ws_d.ws_prompts, 0..) |wp, i| {
                         if (kv_row >= inner_h + 2) break;
                         const name = for (lib_prompts) |lp| {
-                            if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.canonical_name;
+                            if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
                         } else wp.prompt_id;
                         const prefix = data.pathPrefix(name);
                         if (!std.mem.eql(u8, prefix, last_prefix)) {
@@ -2357,14 +2357,14 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    fn getPrsForPrompt(self: *Dashboard, canonical_name: []const u8) []const data.PullRequestEntry {
+    fn getPrsForPrompt(self: *Dashboard, prompt_path: []const u8) []const data.PullRequestEntry {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         const live_prs = self.api_state.prompt_prs;
         const lib = self.api_state.prompts;
         if (live_prs) |prs| {
             const alloc = self.api_state.arena.allocator();
-            return api.toPrEntries(alloc, prs, canonical_name, lib, self.api_state);
+            return api.toPrEntries(alloc, prs, prompt_path, lib, self.api_state);
         }
         return &.{};
     }
@@ -2383,7 +2383,7 @@ pub const Dashboard = struct {
         const all_p = self.getPrompts();
         const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
         if (all_p.len == 0) return;
-        const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+        const prs_for = self.getPrsForPrompt(all_p[si].path);
         const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
         if (prs_for.len == 0) return;
 
@@ -2408,7 +2408,7 @@ pub const Dashboard = struct {
         const all_p = self.getPrompts();
         const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
         if (all_p.len == 0) return;
-        const prs_for = self.getPrsForPrompt(all_p[si].canonical_name);
+        const prs_for = self.getPrsForPrompt(all_p[si].path);
         const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
         if (prs_for.len == 0) return;
         const pr_id = prs_for[pri].id;
@@ -2654,7 +2654,7 @@ pub const Dashboard = struct {
         const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
         const title = if (all_prompts.len > 0) blk: {
             const p = &all_prompts[sel_idx];
-            const prs = self.getPrsForPrompt(p.canonical_name);
+            const prs = self.getPrsForPrompt(p.path);
             break :blk if (prs.len > 0 and self.selected_pr_idx < prs.len)
                 try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
             else
@@ -2718,8 +2718,8 @@ pub const Dashboard = struct {
                 if (std.mem.indexOf(u8, p.bundle_names, fname) == null) continue;
             }
 
-            const prefix = data.pathPrefix(p.canonical_name);
-            const name = data.promptName(p.canonical_name);
+            const prefix = data.pathPrefix(p.path);
+            const name = data.promptName(p.path);
 
             if (!std.mem.eql(u8, prefix, last_prefix)) {
                 if (row_idx < MAX_LIBRARY_ROWS) {
@@ -2793,7 +2793,7 @@ pub const Dashboard = struct {
         // Trigger fetch for the selected prompt content
         const prompts = self.getPrompts();
         if (self.selected_prompt < prompts.len) {
-            api.fetchPromptContentAsync(self.api_state, prompts[self.selected_prompt].canonical_name);
+            api.fetchPromptContentAsync(self.api_state, prompts[self.selected_prompt].path);
         }
     }
 
@@ -2807,7 +2807,7 @@ pub const Dashboard = struct {
         }
         const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
         const p = &all_prompts[sel_idx];
-        const prs = self.getPrsForPrompt(p.canonical_name);
+        const prs = self.getPrsForPrompt(p.path);
         var row_idx: usize = 0;
         for (prs, 0..) |pr, pi| {
             if (row_idx + 1 >= self.pr_widgets.len) break;
@@ -2862,7 +2862,7 @@ pub const Dashboard = struct {
         }
         const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
         const p = &all_prompts[sel_idx];
-        const prs = self.getPrsForPrompt(p.canonical_name);
+        const prs = self.getPrsForPrompt(p.path);
         if (prs.len == 0) {
             self.pr_diff_count = 0;
             return;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -373,7 +373,7 @@ pub const Dashboard = struct {
                             return;
                         }
                         const max_items: usize = switch (self.settings_tab) {
-                            .account => data.CURRENT_USER.workspaces.len,
+                            .account => self.accountWorkspaceCount(),
                             .organization => self.orgMemberCount(),
                             .token => data.ALL_SCOPES.len,
                         };
@@ -397,7 +397,9 @@ pub const Dashboard = struct {
                                 return;
                             }
                             if (key.matches(vaxis.Key.enter, .{})) {
-                                const sel = @min(self.settings_content_sel, data.CURRENT_USER.workspaces.len - 1);
+                                const ws_count = self.accountWorkspaceCount();
+                                if (ws_count == 0) return;
+                                const sel = @min(self.settings_content_sel, ws_count - 1);
                                 self.ws_sel = sel;
                                 self.show_settings = false;
                                 self.settings_focus = .sidebar;
@@ -585,7 +587,7 @@ pub const Dashboard = struct {
                                 self.api_state.mutex.lock();
                                 defer self.api_state.mutex.unlock();
                                 if (self.api_state.bundles) |lb| break :blk lb.len;
-                                break :blk data.BUNDLES.len;
+                                break :blk 0;
                             };
                             self.library_bundle_filter = (self.library_bundle_filter + 1) % (bundle_count + 1);
                             self.library_scroll_bars.scroll_view.cursor = 0;
@@ -737,7 +739,7 @@ pub const Dashboard = struct {
                         }
                         switch (self.ws_focus) {
                             .bar => {
-                                const ws_count = data.WORKSPACES.len;
+                                const ws_count = self.wsCount();
                                 const cols = self.ws_grid_cols;
                                 if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
                                     if (self.ws_sel + 1 < ws_count) {
@@ -797,8 +799,8 @@ pub const Dashboard = struct {
                                 }
                                 if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
                                     const max_items: usize = switch (self.ws_tab) {
-                                        .context => data.WS_CONTEXT.len,
-                                        .prompts => data.WS_PROMPTS.len,
+                                        .context => self.wsContextCount(),
+                                        .prompts => self.wsPromptsCount(),
                                     };
                                     if (self.ws_list_sel + 1 < max_items) {
                                         self.ws_list_sel += 1;
@@ -846,7 +848,7 @@ pub const Dashboard = struct {
                         }
                     },
                     .insights => {
-                        const ins = &data.INSIGHTS;
+                        const ins_counts = self.getInsightsCounts();
                         if (key.matches('t', .{})) {
                             self.insights_period = self.insights_period.next();
                             self.status_line = switch (self.insights_period) {
@@ -869,12 +871,12 @@ pub const Dashboard = struct {
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
                             switch (self.insights_focus) {
                                 .prompts => {
-                                    if (self.insights_prompt_cursor < ins.prompts.len - 1)
+                                    if (ins_counts.prompt_count > 0 and self.insights_prompt_cursor < ins_counts.prompt_count - 1)
                                         self.insights_prompt_cursor += 1;
                                     ctx.consumeAndRedraw();
                                 },
                                 .team => {
-                                    if (self.insights_member_cursor < ins.members.len - 1)
+                                    if (ins_counts.member_count > 0 and self.insights_member_cursor < ins_counts.member_count - 1)
                                         self.insights_member_cursor += 1;
                                     ctx.consumeAndRedraw();
                                 },
@@ -1029,7 +1031,7 @@ pub const Dashboard = struct {
             defer self.api_state.mutex.unlock();
             if (self.api_state.current_user) |u|
                 break :blk .{ .username = u.username, .role = u.role };
-            break :blk .{ .username = data.CURRENT_USER.username, .role = data.CURRENT_USER.role };
+            break :blk .{ .username = "\xe2\x80\x94", .role = "\xe2\x80\x94" };
         };
         const header_left = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} ({s})", .{ "acme", header_info.username, header_info.role });
         w.writeText(&surface, ctx, 1, 0, header_left, .{
@@ -1143,16 +1145,13 @@ pub const Dashboard = struct {
             const hint: []const u8 = if (self.ws_focus == .content)
                 (if (self.ws_show_diff) "d content" else "d diff")
             else if (self.ws_focus == .bar) blk: {
-                const ws_idx = @min(self.ws_sel, data.WORKSPACES.len - 1);
-                const wsi = &data.WORKSPACES[ws_idx];
+                const wss = self.getWorkspaces();
+                if (wss.len == 0) break :blk "No workspaces";
+                const ws_idx = @min(self.ws_sel, wss.len - 1);
+                const wsi = &wss[ws_idx];
                 break :blk if (wsi.local_rev != wsi.remote_rev) "New version available, press r to sync" else "Up to date";
             } else blk: {
-                const ws_sel = self.ws_list_sel;
-                const is_modified = switch (self.ws_tab) {
-                    .context => ws_sel < data.WS_CONTEXT.len and data.WS_CONTEXT[ws_sel].modified,
-                    .prompts => ws_sel < data.WS_PROMPTS.len and data.WS_PROMPTS[ws_sel].has_override,
-                };
-                break :blk if (is_modified) "New version available, press r to sync" else "Up to date";
+                break :blk "Up to date";
             };
             w.writeRightText(&surface, ctx, 0, hint, theme.fg(theme.TEXT_SOFT));
         }
@@ -1171,24 +1170,19 @@ pub const Dashboard = struct {
 
         const list_w: u16 = size.width / 3;
         const detail_w: u16 = size.width - list_w - 1;
-        const prompts: []const data.PromptEntry = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            if (self.api_state.prompts) |lp| {
-                const alloc = self.api_state.arena.allocator();
-                break :blk api.toPromptEntries(alloc, lp);
-            }
-            break :blk &data.PROMPTS;
-        };
+        const prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-        const p = if (prompts.len > 0) &prompts[sel_idx] else &data.PROMPTS[0];
 
         const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
         const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawPromptTable(list_ctx) };
-        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawLibraryDetail(detail_ctx, p) };
+        if (prompts.len > 0) {
+            children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawLibraryDetail(detail_ctx, &prompts[sel_idx]) };
+        } else {
+            children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawEmptyDetail(detail_ctx) };
+        }
         root.children = children;
         return root;
     }
@@ -1206,7 +1200,7 @@ pub const Dashboard = struct {
                 const a = self.api_state.arena.allocator();
                 break :blk api.toBundleEntries(a, lb);
             }
-            break :blk &data.BUNDLES;
+            break :blk &.{};
         };
         const bundle_label: []const u8 = if (self.library_bundle_filter == 0)
             "All"
@@ -1218,7 +1212,7 @@ pub const Dashboard = struct {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
             if (self.api_state.prompts) |p| break :blk p.len;
-            break :blk data.PROMPTS.len;
+            break :blk 0;
         };
         const subtitle = try std.fmt.allocPrint(ctx.arena, "{d} prompts  bundle: {s}  / search  b filter", .{ prompt_count, bundle_label });
         const list_border = if (!self.detail_focus_content) theme.ACCENT else theme.BORDER;
@@ -1334,10 +1328,15 @@ pub const Dashboard = struct {
         const size = ctx.max.size();
         const prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-        const p = if (prompts.len > 0) &prompts[sel_idx] else &data.PROMPTS[0];
 
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
+
+        if (prompts.len == 0) {
+            w.writeText(&root, ctx, 2, 1, "No prompts loaded.", theme.fg(theme.MUTED));
+            return root;
+        }
+        const p = &prompts[sel_idx];
 
         const info_w: u16 = size.width / 3;
         const content_w: u16 = size.width - info_w - 1;
@@ -1484,8 +1483,8 @@ pub const Dashboard = struct {
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.PANEL);
 
-        const ws_idx = @min(self.ws_sel, data.WORKSPACES.len - 1);
-        const ws = &data.WORKSPACES[ws_idx];
+        const wss = self.getWorkspaces();
+        const ws_count_raw = wss.len;
 
         // Top: workspace bar with grid layout (each card = 2 rows: name + status)
         // Fixed height: border(1) + 2 content rows per grid row + border(1)
@@ -1493,7 +1492,7 @@ pub const Dashboard = struct {
         const cols: u16 = if (inner_w >= 120) 4 else if (inner_w >= 80) 3 else 2;
         self.ws_grid_cols = cols;
         const card_w: u16 = inner_w / cols;
-        const ws_count: u16 = @intCast(data.WORKSPACES.len);
+        const ws_count: u16 = @intCast(if (ws_count_raw > 0) ws_count_raw else 1);
         const grid_rows: u16 = (ws_count + cols - 1) / cols;
         const bar_h: u16 = 1 + grid_rows + 1; // border + rows + border
 
@@ -1503,7 +1502,12 @@ pub const Dashboard = struct {
         w.drawBorder(&bar, bar_border, theme.PANEL);
         w.writeText(&bar, ctx, 2, 0, "Workspaces", theme.boldOn(theme.PANEL, theme.TEXT));
 
-        for (data.WORKSPACES, 0..) |wsi, i| {
+        if (wss.len == 0) {
+            w.writeText(&bar, ctx, 2, 1, "No workspaces loaded.", theme.fg(theme.MUTED));
+        }
+
+        const ws_idx = if (wss.len > 0) @min(self.ws_sel, wss.len - 1) else 0;
+        for (wss, 0..) |wsi, i| {
             const is_sel = i == ws_idx;
             const grid_col: u16 = @intCast(i % cols);
             const grid_row: u16 = @intCast(i / cols);
@@ -1545,7 +1549,8 @@ pub const Dashboard = struct {
         const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = body_h }, .{ .width = detail_w, .height = body_h });
 
         const list_surface = try self.drawWsList(list_ctx);
-        const detail_surface = try self.drawWsDetail(detail_ctx, ws);
+        const ws_ptr: ?*const data.WorkspaceEntry = if (wss.len > 0) &wss[ws_idx] else null;
+        const detail_surface = try self.drawWsDetail(detail_ctx, ws_ptr);
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = bar };
@@ -1602,31 +1607,7 @@ pub const Dashboard = struct {
                         kv_row += 1;
                     }
                 } else {
-                    for (data.WS_CONTEXT, 0..) |f, i| {
-                        if (kv_row >= inner_h + 2) break;
-                        const prefix = data.pathPrefix(f.path);
-                        if (!std.mem.eql(u8, prefix, last_prefix)) {
-                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
-                            kv_row += 1;
-                            last_prefix = prefix;
-                            if (kv_row >= inner_h + 2) break;
-                        }
-                        const sel = i == self.ws_list_sel;
-                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                        if (sel) {
-                            surface.writeCell(1, kv_row, .{
-                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                            });
-                        }
-                        const fname = data.promptName(f.path);
-                        w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
-                        if (f.modified) {
-                            const nw: u16 = @intCast(ctx.stringWidth(fname));
-                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                        }
-                        kv_row += 1;
-                    }
+                    w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
                 }
             },
             .prompts => {
@@ -1659,31 +1640,7 @@ pub const Dashboard = struct {
                         kv_row += 1;
                     }
                 } else {
-                    for (data.WS_PROMPTS, 0..) |p, i| {
-                        if (kv_row >= inner_h + 2) break;
-                        const prefix = data.pathPrefix(p.name);
-                        if (!std.mem.eql(u8, prefix, last_prefix)) {
-                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
-                            kv_row += 1;
-                            last_prefix = prefix;
-                            if (kv_row >= inner_h + 2) break;
-                        }
-                        const sel = i == self.ws_list_sel;
-                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                        if (sel) {
-                            surface.writeCell(1, kv_row, .{
-                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                            });
-                        }
-                        const fname = data.promptName(p.name);
-                        w.writeText(&surface, ctx, 2, kv_row, fname, name_style);
-                        if (p.has_override) {
-                            const nw: u16 = @intCast(ctx.stringWidth(fname));
-                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                        }
-                        kv_row += 1;
-                    }
+                    w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
                 }
             },
         }
@@ -1691,37 +1648,37 @@ pub const Dashboard = struct {
     }
 
     // Workspace content pane: shows selected item's content
-    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: ?*const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
         _ = ws;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         const content_border = if (self.ws_focus == .content) theme.ACCENT else theme.BORDER;
         w.fillSurface(&surface, theme.PANEL);
         w.drawBorder(&surface, content_border, theme.PANEL);
 
+        // Check for live workspace detail data
+        self.api_state.mutex.lock();
+        const live_ws = self.api_state.ws_detail;
+        self.api_state.mutex.unlock();
+
+        if (live_ws == null) {
+            w.writeText(&surface, ctx, 2, 0, "Content", theme.boldOn(theme.PANEL, theme.TEXT));
+            w.writeText(&surface, ctx, 2, 2, "No workspace data loaded.", theme.fg(theme.MUTED));
+            return surface;
+        }
+        const ws_d = live_ws.?;
         const sel = self.ws_list_sel;
 
         // Title: selected item name
         const title: []const u8 = switch (self.ws_tab) {
-            .context => if (sel < data.WS_CONTEXT.len) data.WS_CONTEXT[sel].path else "no files",
-            .prompts => if (sel < data.WS_PROMPTS.len) data.WS_PROMPTS[sel].name else "no prompts",
+            .context => if (sel < ws_d.context_files.len) ws_d.context_files[sel].path else "no files",
+            .prompts => if (sel < ws_d.ws_prompts.len) ws_d.ws_prompts[sel].prompt_id else "no prompts",
         };
-        // Title with diff marker (context branch or prompt local edit)
-        const has_diff = switch (self.ws_tab) {
-            .context => sel < data.WS_CONTEXT.len and data.WS_CONTEXT[sel].modified,
-            .prompts => sel < data.WS_PROMPTS.len and data.WS_PROMPTS[sel].has_override,
-        };
+        // Title with diff marker
+        const has_diff: bool = false; // Live data does not yet track diff state
         w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(theme.PANEL, if (has_diff) theme.WARN else theme.TEXT));
-        {
-            var marker_col: u16 = 2 + @as(u16, @intCast(ctx.stringWidth(title)));
-            if (has_diff) {
-                marker_col += 1;
-                w.writeText(&surface, ctx, marker_col, 0, "*", theme.boldOn(theme.PANEL, theme.WARN));
-                marker_col += 1;
-            }
-            if (self.ws_show_diff) {
-                marker_col += 1;
-                w.writeText(&surface, ctx, marker_col, 0, "diff", theme.boldOn(theme.PANEL, theme.ACCENT));
-            }
+        if (self.ws_show_diff) {
+            const tw: u16 = @intCast(ctx.stringWidth(title));
+            w.writeText(&surface, ctx, 2 + tw + 2, 0, "diff", theme.boldOn(theme.PANEL, theme.ACCENT));
         }
 
         var kv_row: u16 = 2;
@@ -1729,77 +1686,37 @@ pub const Dashboard = struct {
 
         switch (self.ws_tab) {
             .context => {
-                if (sel < data.WS_CONTEXT.len) {
-                    const f = &data.WS_CONTEXT[sel];
+                if (sel < ws_d.context_files.len) {
+                    const f = &ws_d.context_files[sel];
                     if (self.ws_show_diff) {
-                        if (f.branch_diff.len > 0) {
-                            // Show branch diff (GitHub-style colored lines)
-                            for (f.branch_diff) |line| {
-                                if (kv_row >= max_row) break;
-                                const line_color = if (std.mem.startsWith(u8, line, "+"))
-                                    theme.OK
-                                else if (std.mem.startsWith(u8, line, "-"))
-                                    theme.DANGER
-                                else
-                                    theme.TEXT_SOFT;
-                                const line_bg = if (std.mem.startsWith(u8, line, "+"))
-                                    theme.rgb(0x1d2617)
-                                else if (std.mem.startsWith(u8, line, "-"))
-                                    theme.rgb(0x2a1b18)
-                                else
-                                    theme.PANEL;
-                                w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
-                                kv_row += 1;
-                            }
-                        } else {
-                            w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
-                        }
+                        w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
                     } else {
-                        // Show file content
-                        var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
-                        while (line_iter.next()) |line| {
-                            if (kv_row >= max_row) break;
-                            w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
-                            kv_row += 1;
+                        w.writeText(&surface, ctx, 2, kv_row, f.path, theme.fg(theme.TEXT_SOFT));
+                        kv_row += 1;
+                        if (kv_row < max_row) {
+                            const size_label = try std.fmt.allocPrint(ctx.arena, "hash: {s}", .{f.hash});
+                            w.writeText(&surface, ctx, 2, kv_row, size_label, theme.fg(theme.MUTED));
                         }
                     }
+                } else {
+                    w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
                 }
             },
             .prompts => {
-                if (sel < data.WS_PROMPTS.len) {
-                    const p = &data.WS_PROMPTS[sel];
+                if (sel < ws_d.ws_prompts.len) {
+                    const p = &ws_d.ws_prompts[sel];
                     if (self.ws_show_diff) {
-                        if (p.override_diff.len > 0) {
-                            // Show diff (GitHub-style colored lines)
-                            for (p.override_diff) |line| {
-                                if (kv_row >= max_row) break;
-                                const line_color = if (std.mem.startsWith(u8, line, "+"))
-                                    theme.OK
-                                else if (std.mem.startsWith(u8, line, "-"))
-                                    theme.DANGER
-                                else
-                                    theme.TEXT_SOFT;
-                                const line_bg = if (std.mem.startsWith(u8, line, "+"))
-                                    theme.rgb(0x1d2617)
-                                else if (std.mem.startsWith(u8, line, "-"))
-                                    theme.rgb(0x2a1b18)
-                                else
-                                    theme.PANEL;
-                                w.writeText(&surface, ctx, 2, kv_row, line, .{ .fg = line_color, .bg = line_bg });
-                                kv_row += 1;
-                            }
-                        } else {
-                            w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
-                        }
+                        w.writeText(&surface, ctx, 2, kv_row, "No diff available", theme.fg(theme.MUTED));
                     } else {
-                        // Show prompt body
-                        var line_iter = std.mem.splitScalar(u8, data.SAMPLE_CONTENT, '\n');
-                        while (line_iter.next()) |line| {
-                            if (kv_row >= max_row) break;
-                            w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
-                            kv_row += 1;
+                        w.writeText(&surface, ctx, 2, kv_row, p.prompt_id, theme.fg(theme.TEXT_SOFT));
+                        kv_row += 1;
+                        if (kv_row < max_row) {
+                            const hash_label = try std.fmt.allocPrint(ctx.arena, "hash: {s}", .{p.content_hash});
+                            w.writeText(&surface, ctx, 2, kv_row, hash_label, theme.fg(theme.MUTED));
                         }
                     }
+                } else {
+                    w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
                 }
             },
         }
@@ -1812,14 +1729,28 @@ pub const Dashboard = struct {
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&root, theme.CANVAS);
 
-        // Use live stats for chart header if available, mock for everything else
+        // Use live stats if available, otherwise zero-initialized defaults
         var live_insights: ?data.InsightsData = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
             if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models);
             break :blk null;
         };
-        const ins: *const data.InsightsData = if (live_insights) |*li| li else &data.INSIGHTS;
+        var empty_insights: data.InsightsData = .{
+            .constraint_count = 0,
+            .active_constraint_count = 0,
+            .idle_constraint_count = 0,
+            .signal_ratio = 0,
+            .refers_per_hour = 0,
+            .today_delta_pct = 0,
+            .last_event_minutes_ago = 0,
+            .refer_trend = .{0} ** 30,
+            .prompts = &.{},
+            .members = &.{},
+            .models = &.{},
+            .alerts = &.{},
+        };
+        const ins: *const data.InsightsData = if (live_insights) |*li| li else &empty_insights;
 
         // Layout: chart(top, full width) + prompts|team (bottom, side by side)
         const chart_h: u16 = if (size.height > 40) 10 else 8;
@@ -2175,9 +2106,16 @@ pub const Dashboard = struct {
             defer self.api_state.mutex.unlock();
             if (self.api_state.current_user) |u|
                 break :blk .{ .user_id = u.user_id, .username = u.username, .role = u.role, .workspaces = &.{} };
-            break :blk .{ .user_id = data.CURRENT_USER.user_id, .username = data.CURRENT_USER.username, .role = data.CURRENT_USER.role, .workspaces = data.CURRENT_USER.workspaces };
+            break :blk .{ .user_id = "\xe2\x80\x94", .username = "\xe2\x80\x94", .role = "\xe2\x80\x94", .workspaces = &.{} };
         };
-        const cfg = data.CLIENT_CONFIG;
+        const cfg: data.ClientConfig = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            const url = if (self.api_state.hub_url) |u| u else "\xe2\x80\x94";
+            if (self.api_state.current_user) |_|
+                break :blk .{ .server_url = url, .sync_strategy = "session", .token_status = "active", .token_expires = "\xe2\x80\x94" };
+            break :blk .{ .server_url = url, .sync_strategy = "\xe2\x80\x94", .token_status = "\xe2\x80\x94", .token_expires = "\xe2\x80\x94" };
+        };
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
         w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
@@ -2289,11 +2227,8 @@ pub const Dashboard = struct {
             for (dir.members) |m| {
                 try member_views.append(ctx.arena, .{ .username = m.username, .role = m.role, .joined = m.joined_at });
             }
-        } else {
-            for (data.MEMBERS) |m| {
-                try member_views.append(ctx.arena, .{ .username = m.username, .role = m.role, .joined = m.joined });
-            }
         }
+        // No fallback: empty list when not connected
 
         var maintainer_count: u16 = 0;
         for (member_views.items) |m| {
@@ -2337,7 +2272,7 @@ pub const Dashboard = struct {
             if (self.api_state.current_user) |u| break :blk u.scopes;
             break :blk null;
         };
-        const t = data.CURRENT_TOKEN;
+        const t: data.TokenInfo = .{ .scopes = &.{}, .expires = "\xe2\x80\x94" };
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
         w.drawBorder(&surface, if (focused) theme.ACCENT else theme.BORDER, theme.PANEL);
@@ -2410,7 +2345,7 @@ pub const Dashboard = struct {
             const alloc = self.api_state.arena.allocator();
             return api.toPrEntries(alloc, prs, canonical_name, lib, self.api_state);
         }
-        return data.prsForPrompt(canonical_name);
+        return &.{};
     }
 
     fn getPrompts(self: *Dashboard) []const data.PromptEntry {
@@ -2420,7 +2355,7 @@ pub const Dashboard = struct {
             const alloc = self.api_state.arena.allocator();
             return api.toPromptEntries(alloc, lp);
         }
-        return &data.PROMPTS;
+        return &.{};
     }
 
     fn submitComment(self: *Dashboard) void {
@@ -2478,7 +2413,84 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         if (self.api_state.directory) |dir| return dir.members.len;
-        return data.MEMBERS.len;
+        return 0;
+    }
+
+    fn accountWorkspaceCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.current_user) |u| return u.workspaces.len;
+        return 0;
+    }
+
+    fn wsCount(self: *Dashboard) usize {
+        return self.getWorkspaces().len;
+    }
+
+    fn getWorkspaces(self: *Dashboard) []const data.WorkspaceEntry {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.current_user) |u| {
+            const alloc = self.api_state.arena.allocator();
+            var list: std.ArrayList(data.WorkspaceEntry) = .empty;
+            for (u.workspaces) |ws| {
+                const al: data.AccessLevel = if (std.mem.eql(u8, ws.role, "admin")) .admin else .member;
+                list.append(alloc, .{
+                    .name = ws.name,
+                    .prompts = 0,
+                    .contexts = 0,
+                    .overrides = 0,
+                    .local_rev = 0,
+                    .remote_rev = 0,
+                    .paths = 0,
+                    .open_prs = 0,
+                    .last_sync = "\xe2\x80\x94",
+                    .access_level = al,
+                }) catch continue;
+            }
+            return list.toOwnedSlice(alloc) catch &.{};
+        }
+        return &.{};
+    }
+
+    fn wsContextCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.ws_detail) |ws_d| return ws_d.context_files.len;
+        return 0;
+    }
+
+    fn wsPromptsCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.ws_detail) |ws_d| return ws_d.ws_prompts.len;
+        return 0;
+    }
+
+    const InsightsCounts = struct { prompt_count: usize, member_count: usize };
+
+    fn getInsightsCounts(self: *Dashboard) InsightsCounts {
+        // Returns counts of prompts and members for bounds checking in event handler.
+        // Uses live org_stats prompt/member counts if available, else 0.
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.org_stats) |stats| {
+            return .{
+                .prompt_count = stats.prompts.len,
+                .member_count = if (self.api_state.ws_stats_members) |m| m.len else 0,
+            };
+        }
+        return .{ .prompt_count = 0, .member_count = 0 };
+    }
+
+    fn drawEmptyDetail(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
+        const border_color = if (self.detail_focus_content) theme.ACCENT else theme.BORDER;
+        w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, border_color, theme.PANEL);
+        w.writeText(&surface, ctx, 2, 0, "Detail", theme.boldOn(theme.PANEL, theme.TEXT));
+        w.writeText(&surface, ctx, 2, 2, "No prompts loaded.", theme.fg(theme.MUTED));
+        return surface;
     }
 
     fn shiftSettingsTab(self: *Dashboard, delta: i8) void {
@@ -2619,12 +2631,14 @@ pub const Dashboard = struct {
         // Title: show reply context or "New Comment"
         const all_prompts = self.getPrompts();
         const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
-        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
-        const prs = self.getPrsForPrompt(p.canonical_name);
-        const title = if (prs.len > 0 and self.selected_pr_idx < prs.len)
-            try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
-        else
-            " New Comment ";
+        const title = if (all_prompts.len > 0) blk: {
+            const p = &all_prompts[sel_idx];
+            const prs = self.getPrsForPrompt(p.canonical_name);
+            break :blk if (prs.len > 0 and self.selected_pr_idx < prs.len)
+                try std.fmt.allocPrint(ctx.arena, " Comment on {s} ", .{prs[self.selected_pr_idx].id})
+            else
+                @as([]const u8, " New Comment ");
+        } else @as([]const u8, " New Comment ");
         w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(bg, theme.ACCENT));
 
         // Input text with cursor
@@ -2655,16 +2669,8 @@ pub const Dashboard = struct {
     // library_prompt_indices maps each row index to the PROMPTS array index
     // (null for group header rows, so cursor can skip them).
     fn syncLibraryWidgets(self: *Dashboard) void {
-        // Use live prompts if available, else mock
-        const prompts: []const data.PromptEntry = blk: {
-            self.api_state.mutex.lock();
-            defer self.api_state.mutex.unlock();
-            if (self.api_state.prompts) |lp| {
-                const alloc = self.api_state.arena.allocator();
-                break :blk api.toPromptEntries(alloc, lp);
-            }
-            break :blk &data.PROMPTS;
-        };
+        // Use live prompts if available, else empty
+        const prompts = self.getPrompts();
 
         const bundles: []const data.BundleEntry = blk: {
             self.api_state.mutex.lock();
@@ -2673,7 +2679,7 @@ pub const Dashboard = struct {
                 const alloc = self.api_state.arena.allocator();
                 break :blk api.toBundleEntries(alloc, lb);
             }
-            break :blk &data.BUNDLES;
+            break :blk &.{};
         };
 
         const filter_name: ?[]const u8 = if (self.library_bundle_filter == 0)
@@ -2748,12 +2754,12 @@ pub const Dashboard = struct {
     }
 
     fn syncContentWidget(self: *Dashboard) void {
-        // Use live prompt content if available, else mock
+        // Use live prompt content if available, else empty
         const content: []const u8 = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
             if (self.api_state.prompt_content) |c| break :blk c;
-            break :blk data.SAMPLE_CONTENT;
+            break :blk "";
         };
         self.content_text = .{
             .text = content,
@@ -2772,8 +2778,14 @@ pub const Dashboard = struct {
 
     fn syncPrWidgets(self: *Dashboard) void {
         const all_prompts = self.getPrompts();
-        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
-        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
+        if (all_prompts.len == 0) {
+            self.pr_row_count = 0;
+            self.pr_scroll_bars.scroll_view.children = .{ .slice = self.pr_widgets[0..0] };
+            self.pr_scroll_bars.estimated_content_height = 0;
+            return;
+        }
+        const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
+        const p = &all_prompts[sel_idx];
         const prs = self.getPrsForPrompt(p.canonical_name);
         var row_idx: usize = 0;
         for (prs, 0..) |pr, pi| {
@@ -2823,8 +2835,12 @@ pub const Dashboard = struct {
 
     fn syncPrDiffAndComments(self: *Dashboard, allocator: std.mem.Allocator) void {
         const all_prompts = self.getPrompts();
-        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
-        const p = if (all_prompts.len > 0) &all_prompts[sel_idx] else &data.PROMPTS[0];
+        if (all_prompts.len == 0) {
+            self.pr_diff_count = 0;
+            return;
+        }
+        const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
+        const p = &all_prompts[sel_idx];
         const prs = self.getPrsForPrompt(p.canonical_name);
         if (prs.len == 0) {
             self.pr_diff_count = 0;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -5,6 +5,7 @@ const theme = @import("theme.zig");
 const w = @import("widgets.zig");
 const data = @import("mock_data.zig");
 const api = @import("api.zig");
+const tree = @import("tree.zig");
 const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 
@@ -143,15 +144,20 @@ pub const Dashboard = struct {
     settings_content_sel: usize = 0, // cursor within content (members/teams/workspaces list)
     status_line: []const u8 = "Ready.",
 
-    // Library: grouped display with bundle filter
+    // Library: tree-structured display with bundle filter
     library_bundle_filter: usize = 0,
     library_scroll_bars: vxfw.ScrollBars,
     library_row_count: usize = 0,
     library_prompt_indices: [MAX_LIBRARY_ROWS]?usize = .{null} ** MAX_LIBRARY_ROWS,
+    library_row_dir_path: [MAX_LIBRARY_ROWS]?[]const u8 = .{null} ** MAX_LIBRARY_ROWS,
+    library_row_depth: [MAX_LIBRARY_ROWS]u8 = .{0} ** MAX_LIBRARY_ROWS,
     library_widgets: [MAX_LIBRARY_ROWS]vxfw.Widget = undefined,
     library_text_rows: [MAX_LIBRARY_ROWS]vxfw.Text = undefined,
     library_table_rows: [MAX_LIBRARY_ROWS]TableRow = undefined,
     library_table_cols: [MAX_LIBRARY_ROWS][2]Column = undefined,
+    library_row_text_bufs: [MAX_LIBRARY_ROWS][96]u8 = undefined,
+    library_expanded: std.StringHashMapUnmanaged(void) = .empty,
+    library_tree_initialized: bool = false,
 
     content_scroll_bars: vxfw.ScrollBars,
     content_widget: [1]vxfw.Widget = undefined,
@@ -600,11 +606,62 @@ pub const Dashboard = struct {
                             ctx.consumeAndRedraw();
                             return;
                         }
-                        // Enter from list: focus detail pane
+                        // Enter from list: toggle directory expansion, or focus detail for leaves.
                         if (!self.detail_focus_content and key.matches(vaxis.Key.enter, .{})) {
+                            self.syncLibraryWidgets();
+                            const pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+                            if (pos < self.library_row_count) {
+                                if (self.library_row_dir_path[pos]) |dir| {
+                                    self.toggleLibraryDir(dir);
+                                    ctx.consumeAndRedraw();
+                                    return;
+                                }
+                            }
                             self.detail_focus_content = true;
                             ctx.consumeAndRedraw();
                             return;
+                        }
+                        // List pane: l/right expands the dir under cursor.
+                        if (!self.detail_focus_content and (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{}))) {
+                            self.syncLibraryWidgets();
+                            const pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+                            if (pos < self.library_row_count) {
+                                if (self.library_row_dir_path[pos]) |dir| {
+                                    const alloc = self.api_state.arena.allocator();
+                                    if (!self.library_expanded.contains(dir)) {
+                                        _ = self.library_expanded.put(alloc, dir, {}) catch {};
+                                        ctx.consumeAndRedraw();
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        // List pane: h/left collapses current dir, or jumps to parent.
+                        if (!self.detail_focus_content and (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{}))) {
+                            self.syncLibraryWidgets();
+                            const pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
+                            if (pos < self.library_row_count) {
+                                if (self.library_row_dir_path[pos]) |dir| {
+                                    if (self.library_expanded.contains(dir)) {
+                                        _ = self.library_expanded.remove(dir);
+                                        ctx.consumeAndRedraw();
+                                        return;
+                                    }
+                                }
+                                // Jump to parent: scan upward for a row at a shallower depth.
+                                const cur_depth = self.library_row_depth[pos];
+                                if (cur_depth > 0 and pos > 0) {
+                                    var p: usize = pos;
+                                    while (p > 0) {
+                                        p -= 1;
+                                        if (self.library_row_depth[p] < cur_depth) {
+                                            self.library_scroll_bars.scroll_view.cursor = @intCast(p);
+                                            ctx.consumeAndRedraw();
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
                         }
                         if (self.detail_focus_content) {
                             // Detail pane has focus
@@ -696,25 +753,16 @@ pub const Dashboard = struct {
                             }
                             return;
                         }
-                        // List pane: j/k moves through prompts, skipping group headers.
-                        const prev = self.library_scroll_bars.scroll_view.cursor;
+                        // List pane: j/k moves through rows. Cursor can land on
+                        // dir nodes (which allows Enter to toggle them) as well
+                        // as leaf prompts.
                         try self.library_scroll_bars.scroll_view.handleEvent(ctx, event);
                         if (self.library_row_count == 0) return;
 
                         var pos = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
                         if (pos >= self.library_row_count) pos = self.library_row_count - 1;
+                        self.library_scroll_bars.scroll_view.cursor = @intCast(pos);
 
-                        // If landed on a group header, skip one row in direction of movement
-                        if (self.library_prompt_indices[pos] == null and self.library_scroll_bars.scroll_view.cursor != prev) {
-                            const moving_down = self.library_scroll_bars.scroll_view.cursor > prev;
-                            if (moving_down and pos + 1 < self.library_row_count) {
-                                pos += 1;
-                            } else if (!moving_down and pos > 0) {
-                                pos -= 1;
-                            }
-                            self.library_scroll_bars.scroll_view.cursor = @intCast(pos);
-                            ctx.consumeAndRedraw();
-                        }
                         if (self.library_prompt_indices[pos]) |pi| {
                             if (self.selected_prompt != pi) {
                                 self.selected_prompt = pi;
@@ -1584,27 +1632,55 @@ pub const Dashboard = struct {
         switch (self.ws_tab) {
             .context => {
                 var kv_row: u16 = 2;
-                var last_prefix: []const u8 = "";
                 if (live_ws) |ws_d| {
-                    for (ws_d.context_files, 0..) |f, i| {
-                        if (kv_row >= inner_h + 2) break;
-                        const prefix = data.pathPrefix(f.path);
-                        if (!std.mem.eql(u8, prefix, last_prefix)) {
-                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                    if (ws_d.context_files.len == 0) {
+                        w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
+                    } else {
+                        const MAX_ROWS = 128;
+                        var paths_buf: [MAX_ROWS][]const u8 = undefined;
+                        var orig_idx: [MAX_ROWS]usize = undefined;
+                        const n = @min(ws_d.context_files.len, MAX_ROWS);
+                        for (0..n) |i| {
+                            paths_buf[i] = ws_d.context_files[i].path;
+                            orig_idx[i] = i;
+                        }
+                        const SortCtx = struct {
+                            paths: [*]const []const u8,
+                            fn lt(cx: @This(), a: usize, b: usize) bool {
+                                return std.mem.lessThan(u8, cx.paths[a], cx.paths[b]);
+                            }
+                        };
+                        std.mem.sort(usize, orig_idx[0..n], SortCtx{ .paths = &paths_buf }, SortCtx.lt);
+                        var sorted_paths: [MAX_ROWS][]const u8 = undefined;
+                        for (0..n) |i| sorted_paths[i] = paths_buf[orig_idx[i]];
+
+                        var rows_buf: [MAX_ROWS]tree.Row = undefined;
+                        const row_count = tree.flatten(sorted_paths[0..n], null, &rows_buf);
+
+                        var text_buf: [96]u8 = undefined;
+                        var r: usize = 0;
+                        while (r < row_count and kv_row < inner_h + 2) : (r += 1) {
+                            const tr = rows_buf[r];
+                            var len = tree.renderPrefix(&text_buf, tr.depth, tr.is_last, null);
+                            len = tree.appendText(&text_buf, len, tr.label);
+                            if (tr.kind == .dir and len < text_buf.len) {
+                                text_buf[len] = '/';
+                                len += 1;
+                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], theme.boldOn(theme.PANEL, theme.ACCENT));
+                            } else {
+                                const file_i = orig_idx[tr.leaf_idx];
+                                const sel = file_i == self.ws_list_sel;
+                                if (sel) {
+                                    surface.writeCell(1, kv_row, .{
+                                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                                    });
+                                }
+                                const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], name_style);
+                            }
                             kv_row += 1;
-                            last_prefix = prefix;
-                            if (kv_row >= inner_h + 2) break;
                         }
-                        const sel = i == self.ws_list_sel;
-                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                        if (sel) {
-                            surface.writeCell(1, kv_row, .{
-                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                            });
-                        }
-                        w.writeText(&surface, ctx, 2, kv_row, data.promptName(f.path), name_style);
-                        kv_row += 1;
                     }
                 } else {
                     w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
@@ -1612,36 +1688,64 @@ pub const Dashboard = struct {
             },
             .prompts => {
                 var kv_row: u16 = 2;
-                var last_prefix: []const u8 = "";
                 if (live_ws) |ws_d| {
-                    const lib_prompts = self.getPrompts();
-                    for (ws_d.ws_prompts, 0..) |wp, i| {
-                        if (kv_row >= inner_h + 2) break;
-                        const name = for (lib_prompts) |lp| {
-                            if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
-                        } else wp.prompt_id;
-                        const prefix = data.pathPrefix(name);
-                        if (!std.mem.eql(u8, prefix, last_prefix)) {
-                            w.writeText(&surface, ctx, 2, kv_row, prefix, theme.boldOn(theme.PANEL, theme.ACCENT));
+                    if (ws_d.ws_prompts.len == 0) {
+                        w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
+                    } else {
+                        const MAX_ROWS = 128;
+                        const lib_prompts = self.getPrompts();
+                        var paths_buf: [MAX_ROWS][]const u8 = undefined;
+                        var orig_idx: [MAX_ROWS]usize = undefined;
+                        const n = @min(ws_d.ws_prompts.len, MAX_ROWS);
+                        for (0..n) |i| {
+                            const wp = ws_d.ws_prompts[i];
+                            paths_buf[i] = for (lib_prompts) |lp| {
+                                if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
+                            } else wp.prompt_id;
+                            orig_idx[i] = i;
+                        }
+                        const SortCtx = struct {
+                            paths: [*]const []const u8,
+                            fn lt(cx: @This(), a: usize, b: usize) bool {
+                                return std.mem.lessThan(u8, cx.paths[a], cx.paths[b]);
+                            }
+                        };
+                        std.mem.sort(usize, orig_idx[0..n], SortCtx{ .paths = &paths_buf }, SortCtx.lt);
+                        var sorted_paths: [MAX_ROWS][]const u8 = undefined;
+                        for (0..n) |i| sorted_paths[i] = paths_buf[orig_idx[i]];
+
+                        var rows_buf: [MAX_ROWS]tree.Row = undefined;
+                        const row_count = tree.flatten(sorted_paths[0..n], null, &rows_buf);
+
+                        var text_buf: [96]u8 = undefined;
+                        var r: usize = 0;
+                        while (r < row_count and kv_row < inner_h + 2) : (r += 1) {
+                            const tr = rows_buf[r];
+                            var len = tree.renderPrefix(&text_buf, tr.depth, tr.is_last, null);
+                            len = tree.appendText(&text_buf, len, tr.label);
+                            if (tr.kind == .dir and len < text_buf.len) {
+                                text_buf[len] = '/';
+                                len += 1;
+                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], theme.boldOn(theme.PANEL, theme.ACCENT));
+                            } else {
+                                const wp_i = orig_idx[tr.leaf_idx];
+                                const sel = wp_i == self.ws_list_sel;
+                                if (sel) {
+                                    surface.writeCell(1, kv_row, .{
+                                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                                    });
+                                }
+                                const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                                w.writeText(&surface, ctx, 2, kv_row, text_buf[0..len], name_style);
+                                // Draft marker: the full prompt path lives in sorted_paths[r]; hasDraftFor matches on path.
+                                if (self.hasDraftFor(sorted_paths[tr.leaf_idx])) {
+                                    const nw: u16 = @intCast(ctx.stringWidth(text_buf[0..len]));
+                                    w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
+                                }
+                            }
                             kv_row += 1;
-                            last_prefix = prefix;
-                            if (kv_row >= inner_h + 2) break;
                         }
-                        const sel = i == self.ws_list_sel;
-                        const name_style = if (sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-                        if (sel) {
-                            surface.writeCell(1, kv_row, .{
-                                .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                                .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                            });
-                        }
-                        const display_name = data.promptName(name);
-                        w.writeText(&surface, ctx, 2, kv_row, display_name, name_style);
-                        if (self.hasDraftFor(name)) {
-                            const nw: u16 = @intCast(ctx.stringWidth(display_name));
-                            w.writeText(&surface, ctx, 2 + nw + 1, kv_row, "*", theme.fg(theme.WARN));
-                        }
-                        kv_row += 1;
                     }
                 } else {
                     w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
@@ -2069,7 +2173,6 @@ pub const Dashboard = struct {
 
         return s;
     }
-
 
     // Settings: vertical sidebar + content pane (web-style layout)
     fn drawSettings(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -2717,12 +2820,11 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    // Library: grouped by path prefix with optional bundle filter.
-    // Builds a mixed list of group headers (Text) and prompt rows (TableRow).
-    // library_prompt_indices maps each row index to the PROMPTS array index
-    // (null for group header rows, so cursor can skip them).
+    // Library: directory tree flattened by current expansion state.
+    // Each row is either a directory node (library_row_dir_path[r] != null)
+    // or a leaf prompt (library_prompt_indices[r] != null). Cursor can land
+    // on either; Enter toggles dir expansion or focuses detail for leaves.
     fn syncLibraryWidgets(self: *Dashboard) void {
-        // Use live prompts if available, else empty
         const prompts = self.getPrompts();
 
         const bundles: []const data.BundleEntry = blk: {
@@ -2742,32 +2844,85 @@ pub const Dashboard = struct {
         else
             null;
 
-        var row_idx: usize = 0;
-        var last_prefix: []const u8 = "";
+        // Default-expand every depth-0 prefix the first time we see prompts.
+        if (!self.library_tree_initialized and prompts.len > 0) {
+            const alloc = self.api_state.arena.allocator();
+            for (prompts) |p| {
+                if (std.mem.indexOfScalar(u8, p.path, '/')) |i| {
+                    const top = p.path[0 .. i + 1];
+                    if (!self.library_expanded.contains(top)) {
+                        _ = self.library_expanded.put(alloc, top, {}) catch {};
+                    }
+                }
+            }
+            self.library_tree_initialized = true;
+        }
 
+        // Filter prompts by bundle, collect paths into a parallel array
+        // plus an index map back to the original prompts slice.
+        var filtered_paths: [MAX_LIBRARY_ROWS][]const u8 = undefined;
+        var filtered_orig: [MAX_LIBRARY_ROWS]usize = undefined;
+        var filtered_len: usize = 0;
         for (prompts, 0..) |p, pidx| {
             if (filter_name) |fname| {
                 if (std.mem.indexOf(u8, p.bundle_names, fname) == null) continue;
             }
+            if (filtered_len >= MAX_LIBRARY_ROWS) break;
+            filtered_paths[filtered_len] = p.path;
+            filtered_orig[filtered_len] = pidx;
+            filtered_len += 1;
+        }
 
-            const prefix = data.pathPrefix(p.path);
-            const name = data.promptName(p.path);
+        // Sort filtered paths lexicographically so siblings are adjacent;
+        // keep the index map in sync via a paired sort.
+        var sort_idx: [MAX_LIBRARY_ROWS]usize = undefined;
+        for (0..filtered_len) |si| sort_idx[si] = si;
+        const SortCtx = struct {
+            paths: [*]const []const u8,
+            fn lt(ctx: @This(), a: usize, b: usize) bool {
+                return std.mem.lessThan(u8, ctx.paths[a], ctx.paths[b]);
+            }
+        };
+        std.mem.sort(usize, sort_idx[0..filtered_len], SortCtx{ .paths = &filtered_paths }, SortCtx.lt);
 
-            if (!std.mem.eql(u8, prefix, last_prefix)) {
-                if (row_idx < MAX_LIBRARY_ROWS) {
-                    self.library_text_rows[row_idx] = .{
-                        .text = prefixWithPad(prefix),
-                        .style = theme.boldOn(theme.PANEL, theme.ACCENT),
-                    };
-                    self.library_widgets[row_idx] = self.library_text_rows[row_idx].widget();
-                    self.library_prompt_indices[row_idx] = null;
-                    row_idx += 1;
-                }
-                last_prefix = prefix;
+        var sorted_paths: [MAX_LIBRARY_ROWS][]const u8 = undefined;
+        var sorted_orig: [MAX_LIBRARY_ROWS]usize = undefined;
+        for (0..filtered_len) |si| {
+            sorted_paths[si] = filtered_paths[sort_idx[si]];
+            sorted_orig[si] = filtered_orig[sort_idx[si]];
+        }
+
+        var rows_buf: [MAX_LIBRARY_ROWS]tree.Row = undefined;
+        const row_count = tree.flatten(sorted_paths[0..filtered_len], &self.library_expanded, &rows_buf);
+
+        var i: usize = 0;
+        while (i < row_count) : (i += 1) {
+            const tr = rows_buf[i];
+            const buf = &self.library_row_text_bufs[i];
+            self.library_row_depth[i] = tr.depth;
+
+            const chevron: ?tree.Chevron = if (tr.kind == .dir)
+                (if (self.library_expanded.contains(tr.dir_prefix)) .expanded else .collapsed)
+            else
+                null;
+            var len = tree.renderPrefix(buf, tr.depth, tr.is_last, chevron);
+            len = tree.appendText(buf, len, tr.label);
+            if (tr.kind == .dir and len < buf.len) {
+                buf[len] = '/';
+                len += 1;
             }
 
-            if (row_idx < MAX_LIBRARY_ROWS) {
-                const sel = pidx == self.selected_prompt;
+            if (tr.kind == .dir) {
+                self.library_text_rows[i] = .{
+                    .text = buf[0..len],
+                    .style = theme.boldOn(theme.PANEL, theme.ACCENT),
+                };
+                self.library_widgets[i] = self.library_text_rows[i].widget();
+                self.library_prompt_indices[i] = null;
+                self.library_row_dir_path[i] = tr.dir_prefix;
+            } else {
+                const orig_pidx = sorted_orig[tr.leaf_idx];
+                const p = prompts[orig_pidx];
                 const pr_label: []const u8 = switch (p.open_pr_count) {
                     0 => "",
                     1 => "\xe2\x80\xa21",
@@ -2775,35 +2930,48 @@ pub const Dashboard = struct {
                     3 => "\xe2\x80\xa23",
                     else => "\xe2\x80\xa2+",
                 };
-                self.library_table_cols[row_idx] = .{
-                    .{ .text = name, .flex = 1 },
+                const sel = orig_pidx == self.selected_prompt;
+                self.library_table_cols[i] = .{
+                    .{ .text = buf[0..len], .flex = 1 },
                     .{ .text = pr_label, .flex = 0, .min_width = 2, .alignment = .right },
                 };
-                self.library_table_rows[row_idx] = .{
-                    .columns = &self.library_table_cols[row_idx],
+                self.library_table_rows[i] = .{
+                    .columns = &self.library_table_cols[i],
                     .style = theme.textOn(theme.PANEL, if (sel) theme.TEXT else theme.TEXT_SOFT),
                     .gap = 2,
                 };
-                self.library_widgets[row_idx] = self.library_table_rows[row_idx].widget();
-                self.library_prompt_indices[row_idx] = pidx;
-                row_idx += 1;
+                self.library_widgets[i] = self.library_table_rows[i].widget();
+                self.library_prompt_indices[i] = orig_pidx;
+                self.library_row_dir_path[i] = null;
             }
         }
+        // Clear trailing entries so stale dir/leaf markers don't linger.
+        var c: usize = row_count;
+        while (c < MAX_LIBRARY_ROWS) : (c += 1) {
+            self.library_prompt_indices[c] = null;
+            self.library_row_dir_path[c] = null;
+        }
 
-        self.library_row_count = row_idx;
-        self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..row_idx] };
-        self.library_scroll_bars.estimated_content_height = @intCast(row_idx);
+        self.library_row_count = row_count;
+        self.library_scroll_bars.scroll_view.children = .{ .slice = self.library_widgets[0..row_count] };
+        self.library_scroll_bars.estimated_content_height = @intCast(row_count);
 
         var cur = @as(usize, @intCast(self.library_scroll_bars.scroll_view.cursor));
-        while (cur < row_idx and self.library_prompt_indices[cur] == null) {
-            cur += 1;
-        }
+        if (cur >= row_count) cur = if (row_count > 0) row_count - 1 else 0;
         self.library_scroll_bars.scroll_view.cursor = @intCast(cur);
-        if (cur < row_idx) {
+        if (cur < row_count) {
             if (self.library_prompt_indices[cur]) |pi| {
                 self.selected_prompt = pi;
             }
         }
+    }
+
+    fn toggleLibraryDir(self: *Dashboard, prefix: []const u8) void {
+        const alloc = self.api_state.arena.allocator();
+        if (self.library_expanded.fetchRemove(prefix)) |_| {
+            return;
+        }
+        _ = self.library_expanded.put(alloc, prefix, {}) catch {};
     }
 
     fn syncContentWidget(self: *Dashboard) void {
@@ -3023,21 +3191,3 @@ pub const Dashboard = struct {
         self.ws_tab = @enumFromInt(@as(u8, @intCast(next)));
     }
 };
-
-// Static row buffers to avoid per-frame allocation
-// Small buffers for inline-formatted column values (counts, percentages)
-fn prefixWithPad(prefix: []const u8) []const u8 {
-    // Map known path prefixes to static padded strings
-    const map = std.StaticStringMap([]const u8).initComptime(.{
-        .{ "arch", " arch" },
-        .{ "cmd", " cmd" },
-        .{ "coding", " coding" },
-        .{ "style", " style" },
-        .{ "wf", " wf" },
-        .{ "zig", " zig" },
-    });
-    return map.get(prefix) orelse prefix;
-}
-
-// workspace_buf removed: workspace uses manual grid rendering
-

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -8,20 +8,20 @@ const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 
 const WsTab = enum(u8) {
-    prompts,
     context,
+    prompts,
     overrides,
 
     fn label(self: WsTab) []const u8 {
         return switch (self) {
-            .prompts => "Prompts",
             .context => "Context",
+            .prompts => "Prompts",
             .overrides => "Overrides",
         };
     }
 };
 
-const ws_tabs = [_]WsTab{ .prompts, .context, .overrides };
+const ws_tabs = [_]WsTab{ .context, .prompts, .overrides };
 
 const Period = enum(u8) {
     daily,
@@ -72,15 +72,15 @@ const ConfirmAction = enum {
 
 const TopModule = enum(u8) {
     library,
-    proposals,
     workspace,
+    proposals,
     insights,
 
     fn label(self: TopModule) []const u8 {
         return switch (self) {
             .library => "Library",
-            .proposals => "Proposals",
             .workspace => "Workspace",
+            .proposals => "Proposals",
             .insights => "Insights",
         };
     }
@@ -100,7 +100,7 @@ const DetailTab = enum(u8) {
     }
 };
 
-const top_tabs = [_]TopModule{ .library, .proposals, .workspace, .insights };
+const top_tabs = [_]TopModule{ .library, .workspace, .proposals, .insights };
 
 // 12 prompts + up to 12 group headers = 24 max rows
 const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
@@ -157,7 +157,7 @@ pub const Dashboard = struct {
     review_diff_count: usize = 0,
 
     // Workspace Status
-    ws_tab: WsTab = .prompts,
+    ws_tab: WsTab = .context,
     workspace_scroll_bars: vxfw.ScrollBars,
     workspace_widgets: [data.WORKSPACES.len]vxfw.Widget = undefined,
     workspace_rows: [data.WORKSPACES.len]TableRow = undefined,
@@ -376,8 +376,8 @@ pub const Dashboard = struct {
 
                 // Top-level tab switching
                 if (key.matches('1', .{})) return self.selectTab(ctx, .library);
-                if (key.matches('2', .{})) return self.selectTab(ctx, .proposals);
-                if (key.matches('3', .{})) return self.selectTab(ctx, .workspace);
+                if (key.matches('2', .{})) return self.selectTab(ctx, .workspace);
+                if (key.matches('3', .{})) return self.selectTab(ctx, .proposals);
                 if (key.matches('4', .{})) return self.selectTab(ctx, .insights);
 
                 // Module-specific input
@@ -954,6 +954,7 @@ pub const Dashboard = struct {
     }
 
     // Workspace Status: list + detail (two-column)
+    // Workspace: master-detail. Left = workspace list, right = detail with inner tabs.
     fn drawWorkspaceStatus(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
@@ -963,135 +964,106 @@ pub const Dashboard = struct {
         const ws_idx = @min(@as(usize, @intCast(self.workspace_scroll_bars.scroll_view.cursor)), data.WORKSPACES.len - 1);
         const ws = &data.WORKSPACES[ws_idx];
 
-        // Summary bar (2 rows)
-        const summary_h: u16 = 3;
-        var summary = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = summary_h });
-        w.fillSurface(&summary, theme.PANEL);
-        w.drawBorder(&summary, theme.BORDER, theme.PANEL);
-        w.writeText(&summary, ctx, 2, 0, "Workspace Status", theme.boldOn(theme.PANEL, theme.TEXT));
-        w.writeRightText(&summary, ctx, 0, ws.name, theme.textOn(theme.PANEL, theme.MUTED));
-        const summary_text = try std.fmt.allocPrint(ctx.arena, " paths: {d}   prompts: {d}   context: {d}   overrides: {d}   rev: {d}/{d}   state: {s}", .{ ws.paths, ws.prompts, ws.contexts, ws.overrides, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws) });
-        w.writeText(&summary, ctx, 1, 1, summary_text, theme.textOn(theme.PANEL, theme.TEXT_SOFT));
+        const list_w: u16 = size.width / 3;
+        const detail_w: u16 = size.width - list_w - 1;
 
-        // Inner tab strip + content area
-        const body_h = size.height - summary_h;
-        const body_ctx = ctx.withConstraints(.{ .width = size.width, .height = body_h }, .{ .width = size.width, .height = body_h });
-        const body_surface = try self.drawWsBody(body_ctx, ws);
+        const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
+        const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
+
+        // Workspace list panel
+        self.workspace_scroll_bars.scroll_view.draw_cursor = false;
+        defer self.workspace_scroll_bars.scroll_view.draw_cursor = true;
+        const list_panel: w.Panel = .{
+            .owner = self.widget(),
+            .title = "Workspaces",
+            .subtitle = "r sync",
+            .background = theme.PANEL,
+            .border_color = theme.BORDER,
+            .child = self.workspace_scroll_bars.widget(),
+        };
+        var list_surface = try list_panel.draw(list_ctx);
+        list_surface = try w.applyCursorOverlay(list_ctx, &list_surface, &self.workspace_scroll_bars.scroll_view);
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = summary };
-        children[1] = .{ .origin = .{ .row = summary_h, .col = 0 }, .surface = body_surface };
+        children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = list_surface };
+        children[1] = .{ .origin = .{ .row = 0, .col = list_w + 1 }, .surface = try self.drawWsDetail(detail_ctx, ws) };
         root.children = children;
         return root;
     }
 
-    fn drawWsBody(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
-        const size = ctx.max.size();
-        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+    // Workspace right pane: summary KV + inner tabs (Prompts/Context/Overrides)
+    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
         w.fillSurface(&surface, theme.PANEL);
+        w.drawBorder(&surface, theme.BORDER, theme.PANEL);
 
-        // Inner tabs
-        var tab_col: u16 = 1;
+        // Row 0: inner tabs + workspace name
+        var tab_col: u16 = 2;
         for (ws_tabs) |tab| {
             tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, tab.label(), tab == self.ws_tab);
             tab_col +|= 1;
         }
+        w.writeRightText(&surface, ctx, 0, ws.name, theme.textOn(theme.PANEL, theme.MUTED));
 
-        const content_h = size.height -| 2;
-        const left_w: u16 = if (size.width > 100) size.width -| 36 else size.width;
-        const right_w: u16 = if (size.width > 100) 35 else 0;
+        // Row 1: summary stats
+        const summary = try std.fmt.allocPrint(ctx.arena, " {d}p {d}c {d}o  rev {d}/{d}  {s}", .{ ws.prompts, ws.contexts, ws.overrides, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws) });
+        w.writeText(&surface, ctx, 2, 1, summary, theme.fg(theme.TEXT_SOFT));
 
-        const left_ctx = ctx.withConstraints(.{ .width = left_w, .height = content_h }, .{ .width = left_w, .height = content_h });
-        const right_ctx = ctx.withConstraints(.{ .width = right_w, .height = content_h }, .{ .width = right_w, .height = content_h });
+        const inner_h = ctx.max.height.? -| 3;
+        const inner_w = ctx.max.width.? -| 4;
 
-        const tab_content = switch (self.ws_tab) {
-            .prompts => try self.drawWsPrompts(left_ctx),
-            .context => try self.drawWsContext(left_ctx),
-            .overrides => try self.drawWsOverrides(left_ctx),
-        };
-
-        if (right_w > 0) {
-            const detail = try self.drawWsDetail(right_ctx, ws);
-            const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-            children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = tab_content };
-            children[1] = .{ .origin = .{ .row = 2, .col = left_w + 1 }, .surface = detail };
-            surface.children = children;
-        } else {
-            const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-            children[0] = .{ .origin = .{ .row = 2, .col = 0 }, .surface = tab_content };
-            surface.children = children;
+        switch (self.ws_tab) {
+            .context => {
+                // Main branch files
+                var kv_row: u16 = 3;
+                kv_row = w.writeSectionHeader(&surface, ctx, 2, kv_row, try std.fmt.allocPrint(ctx.arena, "main ({d} files)", .{ws.contexts}));
+                for (data.WS_CONTEXT) |f| {
+                    kv_row = w.writeKv(&surface, ctx, 2, kv_row, f.path, f.state, 26);
+                    if (kv_row >= inner_h + 2) break;
+                }
+                // Member branches
+                kv_row += 1;
+                kv_row = w.writeSectionHeader(&surface, ctx, 2, kv_row, "Branches");
+                for (data.CONTEXT_BRANCHES) |br| {
+                    if (std.mem.eql(u8, br.name, "main")) continue;
+                    const br_info = try std.fmt.allocPrint(ctx.arena, "{d} ahead  {d} behind", .{ br.ahead, br.behind });
+                    kv_row = w.writeKv(&surface, ctx, 2, kv_row, br.name, br_info, 10);
+                    if (kv_row >= inner_h + 2) break;
+                }
+                // Open PRs
+                kv_row += 1;
+                const pr_text = try std.fmt.allocPrint(ctx.arena, "{d} open", .{ws.open_prs});
+                kv_row = w.writeKv(&surface, ctx, 2, kv_row, "Context PRs", pr_text, 12);
+                for (data.CONTEXT_PRS) |pr| {
+                    if (!std.mem.eql(u8, pr.status, "open")) continue;
+                    const pr_line = try std.fmt.allocPrint(ctx.arena, "{s}: {s}", .{ pr.author, pr.description });
+                    w.writeText(&surface, ctx, 4, kv_row, pr_line, theme.fg(theme.TEXT_SOFT));
+                    kv_row += 1;
+                    if (kv_row >= inner_h + 2) break;
+                }
+            },
+            .prompts => {
+                var kv_row: u16 = 3;
+                for (data.WS_PROMPTS) |p| {
+                    const ovr: []const u8 = if (p.has_override) "yes" else " no";
+                    const line = try std.fmt.allocPrint(ctx.arena, " {s:<18} {s:<4} {s} {s}", .{ p.name, p.kind, ovr, p.state });
+                    w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
+                    kv_row += 1;
+                    if (kv_row >= inner_h + 3) break;
+                }
+            },
+            .overrides => {
+                var kv_row: u16 = 3;
+                for (data.WS_OVERRIDES) |o| {
+                    const line = try std.fmt.allocPrint(ctx.arena, " {s:<18} {s:<4} {s:<4} {s}", .{ o.prompt_name, o.base_hash, o.current_hash, o.status });
+                    w.writeText(&surface, ctx, 2, kv_row, line, theme.fg(theme.TEXT_SOFT));
+                    kv_row += 1;
+                    if (kv_row >= inner_h + 3) break;
+                }
+            },
         }
+        _ = inner_w;
         return surface;
-    }
-
-    fn drawWsPrompts(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        var buf: std.ArrayList(u8) = .empty;
-        try buf.appendSlice(ctx.arena, " NAME                KIND  OVR  STATE\n");
-        for (data.WS_PROMPTS) |p| {
-            const ovr: []const u8 = if (p.has_override) "yes" else " no";
-            const line = try std.fmt.allocPrint(ctx.arena, " {s:<18}  {s:<4}  {s}  {s}\n", .{ p.name, p.kind, ovr, p.state });
-            try buf.appendSlice(ctx.arena, line);
-        }
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Prompts", .subtitle = "a add  x remove", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
-        return panel.draw(ctx);
-    }
-
-    fn drawWsContext(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        var buf: std.ArrayList(u8) = .empty;
-        try buf.appendSlice(ctx.arena, " PATH                      SIZE  STATE\n");
-        for (data.WS_CONTEXT) |f| {
-            const line = try std.fmt.allocPrint(ctx.arena, " {s:<24}  {s:<4}  {s}\n", .{ f.path, f.size, f.state });
-            try buf.appendSlice(ctx.arena, line);
-        }
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Context Files", .subtitle = "read-only", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
-        return panel.draw(ctx);
-    }
-
-    fn drawWsOverrides(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        var buf: std.ArrayList(u8) = .empty;
-        try buf.appendSlice(ctx.arena, " PROMPT              BASE  CUR   STATUS\n");
-        for (data.WS_OVERRIDES) |o| {
-            const line = try std.fmt.allocPrint(ctx.arena, " {s:<18}  {s:<4}  {s:<4}  {s}\n", .{ o.prompt_name, o.base_hash, o.current_hash, o.status });
-            try buf.appendSlice(ctx.arena, line);
-        }
-        const text_widget: vxfw.Text = .{ .text = try ctx.arena.dupe(u8, buf.items), .style = theme.textOn(theme.PANEL, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = "Overrides", .subtitle = "conflict detection", .background = theme.PANEL, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 0, .right = 0, .top = 0, .bottom = 0 } };
-        return panel.draw(ctx);
-    }
-
-    fn drawWsDetail(self: *Dashboard, ctx: vxfw.DrawContext, ws: *const data.WorkspaceEntry) std.mem.Allocator.Error!vxfw.Surface {
-        const detail = try std.fmt.allocPrint(ctx.arena,
-            \\Workspace
-            \\{s}
-            \\
-            \\Rev (local / remote)
-            \\{d} / {d}
-            \\
-            \\Sync State
-            \\{s}
-            \\
-            \\Bound Paths
-            \\{d}
-            \\
-            \\Actions
-            \\r  sync
-            \\a  add prompt (Phase 2)
-            \\x  remove prompt (Phase 2)
-        , .{ ws.name, ws.local_rev, ws.remote_rev, data.syncStateLabel(ws), ws.paths });
-
-        const text_widget: vxfw.Text = .{ .text = detail, .style = theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT), .width_basis = .parent };
-        const wrapper = try ctx.arena.create(w.WidgetBox);
-        wrapper.* = .{ .widget_ref = text_widget.widget() };
-        const panel: w.Panel = .{ .owner = self.widget(), .title = ws.name, .subtitle = data.syncStateLabel(ws), .background = theme.PANEL_ALT, .border_color = theme.BORDER, .child = wrapper.widget(), .padding = .{ .left = 1, .right = 1, .top = 1, .bottom = 1 } };
-        return panel.draw(ctx);
     }
 
     // Insights: workspace-first refer coverage analysis
@@ -1621,10 +1593,14 @@ pub const Dashboard = struct {
         for (data.WORKSPACES, 0..) |ws, idx| {
             const sel = idx == ws_sel;
             const sync_label = data.syncStateLabel(&ws);
+            const counts = if (ws.open_prs > 0)
+                std.fmt.bufPrint(&workspace_buf[idx], "{d}pr {d}c {d}p", .{ ws.open_prs, ws.contexts, ws.prompts }) catch "?"
+            else
+                std.fmt.bufPrint(&workspace_buf[idx], "{d}c {d}p", .{ ws.contexts, ws.prompts }) catch "?";
             self.workspace_cols[idx] = .{
                 .{ .text = ws.name, .flex = 1 },
                 .{ .text = sync_label, .flex = 0 },
-                .{ .text = std.fmt.bufPrint(&workspace_buf[idx], "{d}p {d}o", .{ ws.prompts, ws.overrides }) catch "?", .flex = 0, .alignment = .right },
+                .{ .text = counts, .flex = 0, .alignment = .right },
             };
             self.workspace_rows[idx] = .{
                 .columns = &self.workspace_cols[idx],

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -2405,7 +2405,7 @@ pub const Dashboard = struct {
             const is_last = i + 1 == sessions_slice.len;
             const connector = if (is_last) "\xe2\x94\x94" else "\xe2\x94\x9c";
             w.writeText(&surface, ctx, 6, row, connector, theme.fg(theme.BORDER));
-            const line = try std.fmt.allocPrint(ctx.arena, "{s}  {s}  pid {d}  {s}", .{ sess.ws_id, sess.session_id, sess.pid, sess.age });
+            const line = try std.fmt.allocPrint(ctx.arena, "{s}  {s}  {s}", .{ sess.ws_id, sess.session_id, sess.age });
             w.writeText(&surface, ctx, 8, row, line, theme.fg(theme.TEXT_SOFT));
             row += 1;
         }
@@ -2666,7 +2666,6 @@ pub const Dashboard = struct {
             list.append(arena, .{
                 .ws_id = sess.ws_id,
                 .session_id = sess.session_id,
-                .pid = sess.pid,
                 .age = age,
             }) catch continue;
         }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -1792,7 +1792,7 @@ pub const Dashboard = struct {
         var live_insights: ?data.InsightsData = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
-            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts);
+            if (self.api_state.org_stats) |stats| break :blk api.insightsFromStats(ctx.arena, stats, self.api_state.prompts, self.api_state.ws_stats_members, self.api_state.ws_stats_models);
             break :blk null;
         };
         const ins: *const data.InsightsData = if (live_insights) |*li| li else &data.INSIGHTS;

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -4,6 +4,7 @@ const vxfw = vaxis.vxfw;
 const theme = @import("theme.zig");
 const w = @import("widgets.zig");
 const data = @import("mock_data.zig");
+const api = @import("api.zig");
 const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 
@@ -124,6 +125,7 @@ const MAX_LIBRARY_ROWS = data.PROMPTS.len + 12;
 const detail_tabs = [_]DetailTab{ .content, .pull_requests };
 
 pub const Dashboard = struct {
+    api_state: *api.ApiState,
     selected_module: TopModule = .insights,
     selected_prompt: usize = 0,
     show_help: bool = false,
@@ -194,13 +196,13 @@ pub const Dashboard = struct {
     insights_show_member_detail: bool = false,
     chart_offset: u16 = 0,
 
-    pub fn init() Dashboard {
+    pub fn init(api_state: *api.ApiState) Dashboard {
         return .{
+            .api_state = api_state,
             .library_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .content_scroll_bars = w.initPlainScrollBars(theme.PANEL, 3),
             .pr_scroll_bars = w.initCursorScrollBars(theme.PANEL),
             .pr_diff_scroll_bars = w.initPlainScrollBars(theme.PANEL, 2),
-            // workspace uses manual grid, no ScrollBars
         };
     }
 
@@ -356,7 +358,13 @@ pub const Dashboard = struct {
                         }
                         const max_items: usize = switch (self.settings_tab) {
                             .account => data.CURRENT_USER.workspaces.len,
-                            .organization => data.MEMBERS.len + data.TEAMS.len,
+                            .organization => blk: {
+                                self.api_state.mutex.lock();
+                                defer self.api_state.mutex.unlock();
+                                if (self.api_state.directory) |dir|
+                                    break :blk dir.members.len + dir.teams.len;
+                                break :blk data.MEMBERS.len + data.TEAMS.len;
+                            },
                             .token => data.ALL_SCOPES.len,
                         };
                         if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
@@ -398,7 +406,13 @@ pub const Dashboard = struct {
                             }
                         }
                         if (self.settings_tab == .organization) {
-                            const on_member = self.settings_content_sel < data.MEMBERS.len;
+                            const member_count = blk: {
+                                self.api_state.mutex.lock();
+                                defer self.api_state.mutex.unlock();
+                                if (self.api_state.directory) |dir| break :blk dir.members.len;
+                                break :blk data.MEMBERS.len;
+                            };
+                            const on_member = self.settings_content_sel < member_count;
                             if (on_member) {
                                 if (key.matches('r', .{})) {
                                     self.status_line = "Role change (not yet implemented)";
@@ -406,8 +420,7 @@ pub const Dashboard = struct {
                                     return;
                                 }
                                 if (key.matches('x', .{})) {
-                                    const sel = @min(self.settings_content_sel, data.MEMBERS.len - 1);
-                                    self.confirm_message = data.MEMBERS[sel].username;
+                                    self.confirm_message = "selected member";
                                     self.confirm_action = .remove_member;
                                     self.show_confirm = true;
                                     ctx.consumeAndRedraw();
@@ -435,9 +448,7 @@ pub const Dashboard = struct {
                                     return;
                                 }
                                 if (key.matches('x', .{})) {
-                                    const team_idx = self.settings_content_sel - data.MEMBERS.len;
-                                    const team_sel = @min(team_idx, data.TEAMS.len - 1);
-                                    self.confirm_message = data.TEAMS[team_sel].name;
+                                    self.confirm_message = "selected team";
                                     self.confirm_action = .delete_bundle;
                                     self.show_confirm = true;
                                     ctx.consumeAndRedraw();
@@ -1010,18 +1021,30 @@ pub const Dashboard = struct {
 
         // Row 0: Accent band with org/user context
         w.paintBand(&surface, 0, theme.ACCENT, theme.PANEL);
-        const user = data.CURRENT_USER;
-        const header_left = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} ({s})", .{ "acme", user.username, user.role });
+        const HeaderInfo = struct { username: []const u8, role: []const u8 };
+        const header_info: HeaderInfo = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.current_user) |u|
+                break :blk .{ .username = u.username, .role = u.role };
+            break :blk .{ .username = data.CURRENT_USER.username, .role = data.CURRENT_USER.role };
+        };
+        const header_left = try std.fmt.allocPrint(ctx.arena, "{s} \xe2\x94\x80 {s} ({s})", .{ "acme", header_info.username, header_info.role });
         w.writeText(&surface, ctx, 1, 0, header_left, .{
             .fg = theme.PANEL,
             .bg = theme.ACCENT,
             .bold = true,
         });
-        const minutes = data.INSIGHTS.last_event_minutes_ago;
-        const sync_label = if (minutes == 0)
-            "\xe2\x9c\x93 Synced"
-        else
-            try std.fmt.allocPrint(ctx.arena, "\xe2\x9c\x93 Synced {d}m ago", .{minutes});
+        const sync_label: []const u8 = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            break :blk switch (self.api_state.status) {
+                .connected => "\xe2\x9c\x93 Synced",
+                .connecting => "\xe2\x86\xbb Connecting...",
+                .disconnected => "Not connected",
+                .error_auth, .error_network => "\xe2\x9c\x97 Connection failed",
+            };
+        };
         w.writeRightText(&surface, ctx, 0, sync_label, .{
             .fg = theme.PANEL,
             .bg = theme.ACCENT,
@@ -1062,7 +1085,7 @@ pub const Dashboard = struct {
             "j/k section  Enter open  Tab focus  Esc close"
         else if (self.show_settings and self.settings_tab == .account)
             "j/k move  c change password  Enter go to workspace  x sign out  Esc back"
-        else if (self.show_settings and self.settings_tab == .organization and self.settings_content_sel < data.MEMBERS.len)
+        else if (self.show_settings and self.settings_tab == .organization and self.settings_content_sel < self.orgMemberCount())
             "j/k move  a invite  r role  x remove  Esc back"
         else if (self.show_settings and self.settings_tab == .organization)
             "j/k move  a create  = add member  - remove member  x delete  Esc back"
@@ -2054,7 +2077,14 @@ pub const Dashboard = struct {
     fn drawSettingsAccount(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         const focused = self.settings_focus == .content;
-        const user = data.CURRENT_USER;
+        const UserView = struct { user_id: []const u8, username: []const u8, role: []const u8, workspaces: []const data.WsAccess };
+        const user: UserView = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.current_user) |u|
+                break :blk .{ .user_id = u.user_id, .username = u.username, .role = u.role, .workspaces = &.{} };
+            break :blk .{ .user_id = data.CURRENT_USER.user_id, .username = data.CURRENT_USER.username, .role = data.CURRENT_USER.role, .workspaces = data.CURRENT_USER.workspaces };
+        };
         const cfg = data.CLIENT_CONFIG;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
@@ -2157,65 +2187,149 @@ pub const Dashboard = struct {
         var row: u16 = 2;
         const sel = self.settings_content_sel;
 
-        // Members section
-        var maintainer_count: u16 = 0;
-        for (data.MEMBERS) |m| {
-            if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
-        }
-        const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ data.MEMBERS.len, maintainer_count, data.MEMBERS.len - maintainer_count });
-        row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
+        // Check for live directory data
+        self.api_state.mutex.lock();
+        const live_dir = self.api_state.directory;
+        self.api_state.mutex.unlock();
 
-        w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
-        w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
-        w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
-        w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
-        row += 1;
-
-        for (data.MEMBERS, 0..) |m, i| {
-            const is_sel = i == sel and focused;
-            if (is_sel) {
-                surface.writeCell(1, row, .{
-                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                });
+        if (live_dir) |dir| {
+            // Live data path
+            var maintainer_count: u16 = 0;
+            for (dir.members) |m| {
+                if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
             }
-            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-            w.writeText(&surface, ctx, 4, row, m.username, name_style);
-            const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
-            w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
-            w.writeText(&surface, ctx, 30, row, m.teams, theme.fg(theme.TEXT_SOFT));
-            w.writeText(&surface, ctx, 52, row, m.joined, theme.fg(theme.MUTED));
+            const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ dir.members.len, maintainer_count, dir.members.len - maintainer_count });
+            row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
+
+            w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
             row += 1;
-            if (row >= size.height -| 10) break;
-        }
-        row += 1;
 
-        // Teams section
-        const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{data.TEAMS.len});
-        row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
-
-        w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
-        w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
-        row += 1;
-
-        for (data.TEAMS, 0..) |team, i| {
-            const team_idx = data.MEMBERS.len + i;
-            const is_sel = team_idx == sel and focused;
-            if (is_sel) {
-                surface.writeCell(1, row, .{
-                    .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-                    .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-                });
+            for (dir.members, 0..) |m, i| {
+                const is_sel = i == sel and focused;
+                if (is_sel) {
+                    surface.writeCell(1, row, .{
+                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                    });
+                }
+                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, 4, row, m.username, name_style);
+                const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
+                w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
+                // Resolve team_ids to team names
+                var teams_buf: std.ArrayList(u8) = .empty;
+                for (m.team_ids, 0..) |tid, ti| {
+                    for (dir.teams) |t| {
+                        if (std.mem.eql(u8, t.team_id, tid)) {
+                            try teams_buf.appendSlice(ctx.arena, t.name);
+                            break;
+                        }
+                    }
+                    if (ti + 1 < m.team_ids.len) try teams_buf.appendSlice(ctx.arena, ", ");
+                }
+                w.writeText(&surface, ctx, 30, row, try ctx.arena.dupe(u8, teams_buf.items), theme.fg(theme.TEXT_SOFT));
+                w.writeText(&surface, ctx, 52, row, m.joined_at, theme.fg(theme.MUTED));
+                row += 1;
+                if (row >= size.height -| 10) break;
             }
-            const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
-            w.writeText(&surface, ctx, 4, row, team.name, name_style);
-            var names_buf: std.ArrayList(u8) = .empty;
-            for (team.member_usernames, 0..) |username, mi| {
-                try names_buf.appendSlice(ctx.arena, username);
-                if (mi + 1 < team.member_usernames.len) try names_buf.appendSlice(ctx.arena, ", ");
-            }
-            w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
             row += 1;
+
+            // Teams section
+            const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{dir.teams.len});
+            row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
+
+            w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
+            row += 1;
+
+            for (dir.teams, 0..) |team, i| {
+                const team_idx = dir.members.len + i;
+                const is_sel = team_idx == sel and focused;
+                if (is_sel) {
+                    surface.writeCell(1, row, .{
+                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                    });
+                }
+                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, 4, row, team.name, name_style);
+                // Resolve member_ids to usernames
+                var names_buf: std.ArrayList(u8) = .empty;
+                for (team.member_ids, 0..) |mid, mi| {
+                    for (dir.members) |m| {
+                        if (std.mem.eql(u8, m.user_id, mid)) {
+                            try names_buf.appendSlice(ctx.arena, m.username);
+                            break;
+                        }
+                    }
+                    if (mi + 1 < team.member_ids.len) try names_buf.appendSlice(ctx.arena, ", ");
+                }
+                w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
+                row += 1;
+            }
+        } else {
+            // Fallback to mock data
+            var maintainer_count: u16 = 0;
+            for (data.MEMBERS) |m| {
+                if (std.mem.eql(u8, m.role, "maintainer")) maintainer_count += 1;
+            }
+            const members_title = try std.fmt.allocPrint(ctx.arena, "Members ({d}  {d} maintainer, {d} member)", .{ data.MEMBERS.len, maintainer_count, data.MEMBERS.len - maintainer_count });
+            row = w.writeSectionHeader(&surface, ctx, 2, row, members_title);
+
+            w.writeText(&surface, ctx, 4, row, "USERNAME", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 18, row, "ROLE", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 30, row, "TEAMS", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 52, row, "JOINED", theme.fg(theme.MUTED));
+            row += 1;
+
+            for (data.MEMBERS, 0..) |m, i| {
+                const is_sel = i == sel and focused;
+                if (is_sel) {
+                    surface.writeCell(1, row, .{
+                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                    });
+                }
+                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, 4, row, m.username, name_style);
+                const role_color = if (std.mem.eql(u8, m.role, "maintainer")) theme.ACCENT else theme.TEXT_SOFT;
+                w.writeText(&surface, ctx, 18, row, m.role, theme.fg(role_color));
+                w.writeText(&surface, ctx, 30, row, m.teams, theme.fg(theme.TEXT_SOFT));
+                w.writeText(&surface, ctx, 52, row, m.joined, theme.fg(theme.MUTED));
+                row += 1;
+                if (row >= size.height -| 10) break;
+            }
+            row += 1;
+
+            const teams_title = try std.fmt.allocPrint(ctx.arena, "Teams ({d})", .{data.TEAMS.len});
+            row = w.writeSectionHeader(&surface, ctx, 2, row, teams_title);
+
+            w.writeText(&surface, ctx, 4, row, "NAME", theme.fg(theme.MUTED));
+            w.writeText(&surface, ctx, 18, row, "MEMBERS", theme.fg(theme.MUTED));
+            row += 1;
+
+            for (data.TEAMS, 0..) |team, i| {
+                const team_idx = data.MEMBERS.len + i;
+                const is_sel = team_idx == sel and focused;
+                if (is_sel) {
+                    surface.writeCell(1, row, .{
+                        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+                        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+                    });
+                }
+                const name_style = if (is_sel) theme.boldOn(theme.PANEL, theme.TEXT) else theme.fg(theme.TEXT_SOFT);
+                w.writeText(&surface, ctx, 4, row, team.name, name_style);
+                var names_buf: std.ArrayList(u8) = .empty;
+                for (team.member_usernames, 0..) |username, mi| {
+                    try names_buf.appendSlice(ctx.arena, username);
+                    if (mi + 1 < team.member_usernames.len) try names_buf.appendSlice(ctx.arena, ", ");
+                }
+                w.writeText(&surface, ctx, 18, row, try ctx.arena.dupe(u8, names_buf.items), theme.fg(theme.MUTED));
+                row += 1;
+            }
         }
         row += 1;
 
@@ -2225,6 +2339,13 @@ pub const Dashboard = struct {
     fn drawSettingsToken(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const size = ctx.max.size();
         const focused = self.settings_focus == .content;
+        // Use live scopes (comma-separated string from /api/auth/me) or mock
+        const live_scopes: ?[]const u8 = blk: {
+            self.api_state.mutex.lock();
+            defer self.api_state.mutex.unlock();
+            if (self.api_state.current_user) |u| break :blk u.scopes;
+            break :blk null;
+        };
         const t = data.CURRENT_TOKEN;
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
         w.fillSurface(&surface, theme.PANEL);
@@ -2235,10 +2356,14 @@ pub const Dashboard = struct {
         // Token info
         var active_count: u16 = 0;
         for (data.ALL_SCOPES) |scope_def| {
-            for (t.scopes) |active| {
-                if (std.mem.eql(u8, scope_def.name, active)) {
-                    active_count += 1;
-                    break;
+            if (live_scopes) |scopes_csv| {
+                if (std.mem.indexOf(u8, scopes_csv, scope_def.name) != null) active_count += 1;
+            } else {
+                for (t.scopes) |active| {
+                    if (std.mem.eql(u8, scope_def.name, active)) {
+                        active_count += 1;
+                        break;
+                    }
                 }
             }
         }
@@ -2260,13 +2385,14 @@ pub const Dashboard = struct {
                 });
             }
             // Check if this scope is active
-            var is_active = false;
-            for (t.scopes) |active| {
-                if (std.mem.eql(u8, scope_def.name, active)) {
-                    is_active = true;
-                    break;
+            const is_active = if (live_scopes) |scopes_csv|
+                std.mem.indexOf(u8, scopes_csv, scope_def.name) != null
+            else blk: {
+                for (t.scopes) |active| {
+                    if (std.mem.eql(u8, scope_def.name, active)) break :blk true;
                 }
-            }
+                break :blk false;
+            };
             const check = if (is_active) "\xe2\x9c\x93" else "\xe2\x94\x80";
             const check_color = if (is_active) theme.OK else theme.MUTED;
             w.writeText(&surface, ctx, 4, row, check, theme.fg(check_color));
@@ -2282,6 +2408,13 @@ pub const Dashboard = struct {
             w.writeText(&surface, ctx, 2, row, "Effective permissions = min(org role, token scopes)", theme.fg(theme.MUTED));
         }
         return surface;
+    }
+
+    fn orgMemberCount(self: *Dashboard) usize {
+        self.api_state.mutex.lock();
+        defer self.api_state.mutex.unlock();
+        if (self.api_state.directory) |dir| return dir.members.len;
+        return data.MEMBERS.len;
     }
 
     fn shiftSettingsTab(self: *Dashboard, delta: i8) void {

--- a/src/tui/auth.zig
+++ b/src/tui/auth.zig
@@ -1,0 +1,163 @@
+const std = @import("std");
+const build_options = @import("build_options");
+const enable_keychain = build_options.enable_keychain;
+
+pub const AuthInfo = struct {
+    hub_url: []const u8,
+    username: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+
+    pub fn deinit(self: AuthInfo, allocator: std.mem.Allocator) void {
+        allocator.free(self.hub_url);
+        allocator.free(self.username);
+        allocator.free(self.access_token);
+        allocator.free(self.refresh_token);
+    }
+};
+
+const SERVICE_NAME = "clumsies";
+const ACCOUNT_NAME = "hub-auth";
+
+pub fn getBasePath(allocator: std.mem.Allocator) ![]const u8 {
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch
+        std.process.getEnvVarOwned(allocator, "USERPROFILE") catch
+        return error.HomeNotSet;
+    defer allocator.free(home);
+    return std.fs.path.join(allocator, &.{ home, ".clumsies" });
+}
+
+pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []const u8, access_token: []const u8, refresh_token: []const u8) !void {
+    const payload = AuthJson{
+        .hub_url = hub_url,
+        .username = username,
+        .access_token = access_token,
+        .refresh_token = refresh_token,
+    };
+    const json = std.json.Stringify.valueAlloc(allocator, payload, .{}) catch return error.SerializationFailed;
+    defer allocator.free(json);
+
+    if (comptime enable_keychain) {
+        try keychainStore(json);
+    } else {
+        try fileFallbackStore(allocator, json);
+    }
+}
+
+pub fn loadAuth(allocator: std.mem.Allocator) !AuthInfo {
+    const json = if (comptime enable_keychain)
+        keychainLookup(allocator) catch return error.NotAuthenticated
+    else
+        fileFallbackLoad(allocator) catch return error.NotAuthenticated;
+    defer allocator.free(json);
+
+    const parsed = std.json.parseFromSlice(AuthJson, allocator, json, .{ .allocate = .alloc_always }) catch return error.NotAuthenticated;
+    defer parsed.deinit();
+
+    return .{
+        .hub_url = try allocator.dupe(u8, parsed.value.hub_url),
+        .username = try allocator.dupe(u8, parsed.value.username),
+        .access_token = try allocator.dupe(u8, parsed.value.access_token),
+        .refresh_token = try allocator.dupe(u8, parsed.value.refresh_token),
+    };
+}
+
+const AuthJson = struct {
+    hub_url: []const u8,
+    username: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+};
+
+// macOS Keychain via Security framework
+const c = if (enable_keychain) @cImport({
+    @cInclude("Security/Security.h");
+    @cInclude("CoreFoundation/CoreFoundation.h");
+}) else struct {};
+
+fn cfString(s: []const u8) ?*anyopaque {
+    if (comptime !enable_keychain) return null;
+    return @ptrCast(@constCast(c.CFStringCreateWithBytes(null, s.ptr, @intCast(s.len), c.kCFStringEncodingUTF8, 0)));
+}
+
+fn keychainStore(data: []const u8) !void {
+    const cf_service = cfString(SERVICE_NAME) orelse return error.KeychainError;
+    defer c.CFRelease(cf_service);
+    const cf_account = cfString(ACCOUNT_NAME) orelse return error.KeychainError;
+    defer c.CFRelease(cf_account);
+    const cf_data: c.CFDataRef = c.CFDataCreate(null, data.ptr, @intCast(data.len)) orelse return error.KeychainError;
+    defer c.CFRelease(cf_data);
+
+    // Delete existing
+    var del_keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount };
+    var del_vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account };
+    const del_dict = c.CFDictionaryCreate(null, @ptrCast(&del_keys), @ptrCast(&del_vals), del_keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks);
+    if (del_dict) |d| {
+        _ = c.SecItemDelete(d);
+        c.CFRelease(d);
+    }
+
+    // Add new
+    var add_keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount, c.kSecValueData };
+    var add_vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account, @ptrCast(@constCast(cf_data)) };
+    const add_dict = c.CFDictionaryCreate(null, @ptrCast(&add_keys), @ptrCast(&add_vals), add_keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks) orelse return error.KeychainError;
+    defer c.CFRelease(add_dict);
+
+    const status = c.SecItemAdd(add_dict, null);
+    if (status != c.errSecSuccess) return error.KeychainError;
+}
+
+fn keychainLookup(allocator: std.mem.Allocator) ![]const u8 {
+    const cf_service = cfString(SERVICE_NAME) orelse return error.KeychainError;
+    defer c.CFRelease(cf_service);
+    const cf_account = cfString(ACCOUNT_NAME) orelse return error.KeychainError;
+    defer c.CFRelease(cf_account);
+
+    var keys = [_]?*const anyopaque{ c.kSecClass, c.kSecAttrService, c.kSecAttrAccount, c.kSecReturnData, c.kSecMatchLimit };
+    var vals = [_]?*const anyopaque{ c.kSecClassGenericPassword, cf_service, cf_account, c.kCFBooleanTrue, c.kSecMatchLimitOne };
+    const dict = c.CFDictionaryCreate(null, @ptrCast(&keys), @ptrCast(&vals), keys.len, &c.kCFTypeDictionaryKeyCallBacks, &c.kCFTypeDictionaryValueCallBacks) orelse return error.KeychainError;
+    defer c.CFRelease(dict);
+
+    var result: c.CFTypeRef = null;
+    const status = c.SecItemCopyMatching(dict, &result);
+    if (status != c.errSecSuccess) return error.NotAuthenticated;
+
+    const cf_data: c.CFDataRef = @ptrCast(result.?);
+    defer c.CFRelease(result.?);
+
+    const len: usize = @intCast(c.CFDataGetLength(cf_data));
+    const ptr = c.CFDataGetBytePtr(cf_data);
+    return try allocator.dupe(u8, ptr[0..len]);
+}
+
+// File fallback for non-macOS (Linux CI etc)
+fn fileFallbackStore(allocator: std.mem.Allocator, data: []const u8) !void {
+    const base = try getBasePath(allocator);
+    defer allocator.free(base);
+    const path = try std.fs.path.join(allocator, &.{ base, "auth.json" });
+    defer allocator.free(path);
+    std.fs.makeDirAbsolute(base) catch |err| {
+        if (err != error.PathAlreadyExists) return err;
+    };
+    const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    _ = try file.write(data);
+}
+
+fn fileFallbackLoad(allocator: std.mem.Allocator) ![]const u8 {
+    const base = try getBasePath(allocator);
+    defer allocator.free(base);
+    const path = try std.fs.path.join(allocator, &.{ base, "auth.json" });
+    defer allocator.free(path);
+    const file = std.fs.openFileAbsolute(path, .{}) catch return error.NotAuthenticated;
+    defer file.close();
+    var buf: [64 * 1024]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = file.read(buf[total..]) catch return error.NotAuthenticated;
+        if (n == 0) break;
+        total += n;
+    }
+    if (total == 0) return error.NotAuthenticated;
+    return try allocator.dupe(u8, buf[0..total]);
+}

--- a/src/tui/auth.zig
+++ b/src/tui/auth.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const build_options = @import("build_options");
 const enable_keychain = build_options.enable_keychain;
+const log = std.log.scoped(.auth);
 
 pub const AuthInfo = struct {
     hub_url: []const u8,
@@ -38,7 +39,10 @@ pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []c
     defer allocator.free(json);
 
     if (comptime enable_keychain) {
-        try keychainStore(json);
+        keychainStore(json) catch |err| {
+            log.warn("keychain store failed ({s}); falling back to auth.json", .{@errorName(err)});
+            try fileFallbackStore(allocator, json);
+        };
     } else {
         try fileFallbackStore(allocator, json);
     }
@@ -46,7 +50,12 @@ pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []c
 
 pub fn loadAuth(allocator: std.mem.Allocator) !AuthInfo {
     const json = if (comptime enable_keychain)
-        keychainLookup(allocator) catch return error.NotAuthenticated
+        keychainLookup(allocator) catch |err| blk: {
+            if (err != error.NotAuthenticated) {
+                log.warn("keychain lookup failed ({s}); trying auth.json", .{@errorName(err)});
+            }
+            break :blk fileFallbackLoad(allocator) catch return error.NotAuthenticated;
+        }
     else
         fileFallbackLoad(allocator) catch return error.NotAuthenticated;
     defer allocator.free(json);

--- a/src/tui/auth.zig
+++ b/src/tui/auth.zig
@@ -150,7 +150,7 @@ fn fileFallbackStore(allocator: std.mem.Allocator, data: []const u8) !void {
     };
     const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
     defer file.close();
-    _ = try file.write(data);
+    try file.writeAll(data);
 }
 
 fn fileFallbackLoad(allocator: std.mem.Allocator) ![]const u8 {

--- a/src/tui/auth.zig
+++ b/src/tui/auth.zig
@@ -150,7 +150,10 @@ fn fileFallbackStore(allocator: std.mem.Allocator, data: []const u8) !void {
     };
     const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
     defer file.close();
-    try file.writeAll(data);
+    var file_buffer: [4096]u8 = undefined;
+    var file_writer = std.fs.File.Writer.init(file, &file_buffer);
+    defer file_writer.interface.flush() catch {};
+    try file_writer.interface.writeAll(data);
 }
 
 fn fileFallbackLoad(allocator: std.mem.Allocator) ![]const u8 {

--- a/src/tui/drafts_reader.zig
+++ b/src/tui/drafts_reader.zig
@@ -1,0 +1,75 @@
+// Read local drafts/_index.json files across all workspaces.
+const std = @import("std");
+
+pub const DraftEntry = struct {
+    category: []const u8,
+    prompt_id: ?[]const u8 = null,
+    current_path: ?[]const u8 = null,
+    draft_path: []const u8,
+    operation: []const u8,
+    status: []const u8,
+};
+
+pub fn readAllDrafts(allocator: std.mem.Allocator) ?[]const DraftEntry {
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    const ws_root = std.fs.path.join(allocator, &.{ home, ".clumsies", "workspaces" }) catch return null;
+    defer allocator.free(ws_root);
+
+    var dir = std.fs.openDirAbsolute(ws_root, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var all: std.ArrayList(DraftEntry) = .empty;
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const index_path = std.fs.path.join(allocator, &.{ ws_root, entry.name, "drafts", "_index.json" }) catch continue;
+        defer allocator.free(index_path);
+        readIndexFile(allocator, index_path, &all);
+    }
+
+    if (all.items.len == 0) return null;
+    return all.items;
+}
+
+fn readIndexFile(allocator: std.mem.Allocator, path: []const u8, out: *std.ArrayList(DraftEntry)) void {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return;
+    defer file.close();
+
+    var buf: [64 * 1024]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = file.read(buf[total..]) catch return;
+        if (n == 0) break;
+        total += n;
+    }
+    if (total == 0) return;
+
+    const Json = struct {
+        version: u32 = 1,
+        drafts: []const struct {
+            category: []const u8 = "",
+            prompt_id: ?[]const u8 = null,
+            current_path: ?[]const u8 = null,
+            draft_path: []const u8 = "",
+            operation: []const u8 = "",
+            status: []const u8 = "",
+        } = &.{},
+    };
+    const parsed = std.json.parseFromSlice(Json, allocator, buf[0..total], .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return;
+    defer parsed.deinit();
+
+    for (parsed.value.drafts) |d| {
+        out.append(allocator, .{
+            .category = allocator.dupe(u8, d.category) catch continue,
+            .prompt_id = if (d.prompt_id) |pid| (allocator.dupe(u8, pid) catch continue) else null,
+            .current_path = if (d.current_path) |cp| (allocator.dupe(u8, cp) catch continue) else null,
+            .draft_path = allocator.dupe(u8, d.draft_path) catch continue,
+            .operation = allocator.dupe(u8, d.operation) catch continue,
+            .status = allocator.dupe(u8, d.status) catch continue,
+        }) catch continue;
+    }
+}

--- a/src/tui/drafts_reader.zig
+++ b/src/tui/drafts_reader.zig
@@ -10,8 +10,13 @@ pub const DraftEntry = struct {
     status: []const u8,
 };
 
+fn getHomeDirOwned(allocator: std.mem.Allocator) ?[]u8 {
+    return std.process.getEnvVarOwned(allocator, "HOME") catch
+        std.process.getEnvVarOwned(allocator, "USERPROFILE") catch null;
+}
+
 pub fn readAllDrafts(allocator: std.mem.Allocator) ?[]const DraftEntry {
-    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    const home = getHomeDirOwned(allocator) orelse return null;
     defer allocator.free(home);
     const ws_root = std.fs.path.join(allocator, &.{ home, ".clumsies", "workspaces" }) catch return null;
     defer allocator.free(ws_root);

--- a/src/tui/hub_client.zig
+++ b/src/tui/hub_client.zig
@@ -1,0 +1,80 @@
+const std = @import("std");
+const http = std.http;
+
+pub const Response = struct {
+    status: http.Status,
+    body: []const u8,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: Response) void {
+        self.allocator.free(self.body);
+    }
+};
+
+pub const HubClient = struct {
+    allocator: std.mem.Allocator,
+    hub_url: []const u8,
+    access_token: ?[]const u8,
+
+    pub fn init(allocator: std.mem.Allocator, hub_url: []const u8, access_token: ?[]const u8) HubClient {
+        return .{
+            .allocator = allocator,
+            .hub_url = hub_url,
+            .access_token = access_token,
+        };
+    }
+
+    pub fn get(self: *HubClient, path: []const u8) !Response {
+        return self.doFetch(.GET, path, null);
+    }
+
+    pub fn post(self: *HubClient, path: []const u8, body: []const u8) !Response {
+        return self.doFetch(.POST, path, body);
+    }
+
+    pub fn put(self: *HubClient, path: []const u8, body: []const u8) !Response {
+        return self.doFetch(.PUT, path, body);
+    }
+
+    fn doFetch(self: *HubClient, method: http.Method, path: []const u8, payload: ?[]const u8) !Response {
+        var client: http.Client = .{ .allocator = self.allocator };
+        defer client.deinit();
+
+        const url = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.hub_url, path });
+        defer self.allocator.free(url);
+
+        var extra_headers: [2]http.Header = undefined;
+        var header_count: usize = 0;
+
+        extra_headers[header_count] = .{ .name = "content-type", .value = "application/json" };
+        header_count += 1;
+
+        var auth_value: ?[]const u8 = null;
+        if (self.access_token) |token| {
+            auth_value = try std.fmt.allocPrint(self.allocator, "Bearer {s}", .{token});
+            extra_headers[header_count] = .{ .name = "authorization", .value = auth_value.? };
+            header_count += 1;
+        }
+        defer if (auth_value) |v| self.allocator.free(v);
+
+        // Create an Io.Writer backed by an ArrayList for capturing response body
+        var response_writer = std.Io.Writer.Allocating.init(self.allocator);
+        errdefer response_writer.deinit();
+
+        const result = try client.fetch(.{
+            .location = .{ .url = url },
+            .method = method,
+            .payload = payload,
+            .extra_headers = extra_headers[0..header_count],
+            .response_writer = &response_writer.writer,
+        });
+
+        const body = try response_writer.toOwnedSlice();
+
+        return .{
+            .status = result.status,
+            .body = body,
+            .allocator = self.allocator,
+        };
+    }
+};

--- a/src/tui/hub_client.zig
+++ b/src/tui/hub_client.zig
@@ -36,6 +36,14 @@ pub const HubClient = struct {
         return self.doFetch(.PUT, path, body);
     }
 
+    pub fn delete(self: *HubClient, path: []const u8) !Response {
+        return self.doFetch(.DELETE, path, null);
+    }
+
+    pub fn patch(self: *HubClient, path: []const u8, body: []const u8) !Response {
+        return self.doFetch(.PATCH, path, body);
+    }
+
     fn doFetch(self: *HubClient, method: http.Method, path: []const u8, payload: ?[]const u8) !Response {
         var client: http.Client = .{ .allocator = self.allocator };
         defer client.deinit();

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const Dashboard = @import("app.zig").Dashboard;
+
+pub fn main() !void {
+    var da: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = da.deinit();
+    const allocator = da.allocator();
+
+    var app = try vxfw.App.init(allocator);
+    defer app.deinit();
+
+    var dashboard = Dashboard.init();
+    try app.run(dashboard.widget(), .{});
+}

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 const Dashboard = @import("app.zig").Dashboard;
@@ -31,8 +32,9 @@ pub fn main() !void {
     var app = try vxfw.App.init(allocator);
     defer app.deinit();
 
-    const stdout = std.posix.STDOUT_FILENO;
-    _ = std.posix.write(stdout, "\x1b]2;clumsies hub\x07") catch {};
+    if (builtin.os.tag != .windows) {
+        std.fs.File.stdout().writeAll("\x1b]2;clumsies hub\x07") catch {};
+    }
 
     var dashboard = Dashboard.init(&api_state);
     try app.run(dashboard.widget(), .{});

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -40,5 +40,6 @@ pub fn main() !void {
     }
 
     var dashboard = Dashboard.init(&api_state);
+    defer dashboard.deinit();
     try app.run(dashboard.widget(), .{});
 }

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -11,6 +11,10 @@ pub fn main() !void {
     var app = try vxfw.App.init(allocator);
     defer app.deinit();
 
+    // Set terminal title (OSC 2)
+    const stdout = std.posix.STDOUT_FILENO;
+    _ = std.posix.write(stdout, "\x1b]2;clumsies hub\x07") catch {};
+
     var dashboard = Dashboard.init();
     try app.run(dashboard.widget(), .{});
 }

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -33,7 +33,10 @@ pub fn main() !void {
     defer app.deinit();
 
     if (builtin.os.tag != .windows) {
-        std.fs.File.stdout().writeAll("\x1b]2;clumsies hub\x07") catch {};
+        var title_buffer: [64]u8 = undefined;
+        var title_writer = std.fs.File.Writer.init(std.fs.File.stdout(), &title_buffer);
+        defer title_writer.interface.flush() catch {};
+        title_writer.interface.writeAll("\x1b]2;clumsies hub\x07") catch {};
     }
 
     var dashboard = Dashboard.init(&api_state);

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -2,19 +2,31 @@ const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 const Dashboard = @import("app.zig").Dashboard;
+const auth_mod = @import("auth.zig");
+const api = @import("api.zig");
 
 pub fn main() !void {
     var da: std.heap.DebugAllocator(.{}) = .init;
     defer _ = da.deinit();
     const allocator = da.allocator();
 
+    var api_state = api.ApiState.init(allocator);
+    defer api_state.deinit();
+
+    var fetch_thread: ?std.Thread = null;
+    if (auth_mod.loadAuth(allocator)) |auth_info| {
+        defer auth_info.deinit(allocator);
+        fetch_thread = api.startFetch(&api_state, auth_info.hub_url, auth_info.access_token) catch null;
+    } else |_| {}
+
     var app = try vxfw.App.init(allocator);
     defer app.deinit();
 
-    // Set terminal title (OSC 2)
     const stdout = std.posix.STDOUT_FILENO;
     _ = std.posix.write(stdout, "\x1b]2;clumsies hub\x07") catch {};
 
-    var dashboard = Dashboard.init();
+    var dashboard = Dashboard.init(&api_state);
     try app.run(dashboard.widget(), .{});
+
+    if (fetch_thread) |t| t.join();
 }

--- a/src/tui/main.zig
+++ b/src/tui/main.zig
@@ -5,15 +5,24 @@ const Dashboard = @import("app.zig").Dashboard;
 const auth_mod = @import("auth.zig");
 const api = @import("api.zig");
 
+fn recoverPanic(msg: []const u8, ra: ?usize) noreturn {
+    vaxis.recover();
+    std.debug.defaultPanic(msg, ra);
+}
+
+pub const panic = std.debug.FullPanic(recoverPanic);
+
 pub fn main() !void {
     var da: std.heap.DebugAllocator(.{}) = .init;
     defer _ = da.deinit();
     const allocator = da.allocator();
 
     var api_state = api.ApiState.init(allocator);
+    api_state.bindAllocator();
     defer api_state.deinit();
 
     var fetch_thread: ?std.Thread = null;
+    defer if (fetch_thread) |t| t.join();
     if (auth_mod.loadAuth(allocator)) |auth_info| {
         defer auth_info.deinit(allocator);
         fetch_thread = api.startFetch(&api_state, auth_info.hub_url, auth_info.access_token) catch null;
@@ -27,6 +36,4 @@ pub fn main() !void {
 
     var dashboard = Dashboard.init(&api_state);
     try app.run(dashboard.widget(), .{});
-
-    if (fetch_thread) |t| t.join();
 }

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -358,10 +358,18 @@ pub const MEMBERS = [_]MemberEntry{
     .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18", .teams = "platform, ops" },
 };
 
-// Mirrors GET /api/auth/me response
+// Mirrors GET /api/auth/me + config.toml workspace bindings
 pub const WsAccess = struct {
     name: []const u8,
     level: AccessLevel,
+    paths: []const []const u8,
+};
+
+pub const ClientConfig = struct {
+    server_url: []const u8,
+    sync_strategy: []const u8,
+    token_status: []const u8,
+    token_expires: []const u8,
 };
 
 pub const CurrentUser = struct {
@@ -401,15 +409,31 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "proposal:merge", .description = "Accept/reject proposals" },
 };
 
+const payments_paths = [_][]const u8{ "~/work/payments", "~/work/payments-v2" };
+const merchant_paths = [_][]const u8{ "~/work/merchant", "~/projects/merchant-staging" };
+const infra_paths = [_][]const u8{"~/work/infra-tools"};
+const bot_paths = [_][]const u8{"~/work/release-bot"};
+const docs_paths = [_][]const u8{"~/work/docs-site"};
+const mobile_paths = [_][]const u8{ "~/work/mobile", "~/projects/mobile-beta" };
+const pipeline_paths = [_][]const u8{"~/work/data-pipeline"};
+const empty_paths = [_][]const u8{};
+
 const my_workspaces = [_]WsAccess{
-    .{ .name = "payments-api", .level = .admin },
-    .{ .name = "merchant-portal", .level = .write },
-    .{ .name = "infra-tools", .level = .read },
-    .{ .name = "release-bot", .level = .write },
-    .{ .name = "docs-site", .level = .read },
-    .{ .name = "mobile-app", .level = .admin },
-    .{ .name = "data-pipeline", .level = .write },
-    .{ .name = "admin-dashboard", .level = .admin },
+    .{ .name = "payments-api", .level = .admin, .paths = &payments_paths },
+    .{ .name = "merchant-portal", .level = .write, .paths = &merchant_paths },
+    .{ .name = "infra-tools", .level = .read, .paths = &infra_paths },
+    .{ .name = "release-bot", .level = .write, .paths = &bot_paths },
+    .{ .name = "docs-site", .level = .read, .paths = &docs_paths },
+    .{ .name = "mobile-app", .level = .admin, .paths = &mobile_paths },
+    .{ .name = "data-pipeline", .level = .write, .paths = &pipeline_paths },
+    .{ .name = "admin-dashboard", .level = .admin, .paths = &empty_paths },
+};
+
+pub const CLIENT_CONFIG = ClientConfig{
+    .server_url = "https://hub.acme.io",
+    .sync_strategy = "session",
+    .token_status = "active",
+    .token_expires = "2026-04-07T12:00:00Z",
 };
 
 pub const CURRENT_USER = CurrentUser{

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -1,4 +1,4 @@
-// Mock data matching the real clumsies data model (spec s1-0 through s2-3).
+// Mock data for the TUI dashboard, matching the Hub Server data model.
 // No invented fields: only what the Hub Server API actually provides.
 
 pub const PromptEntry = struct {
@@ -38,6 +38,20 @@ pub const ProposalEntry = struct {
     trace_sessions: u8,
 };
 
+pub const AccessLevel = enum {
+    read,
+    write,
+    admin,
+
+    pub fn badge(self: AccessLevel) []const u8 {
+        return switch (self) {
+            .read => "r",
+            .write => "w",
+            .admin => "a",
+        };
+    }
+};
+
 pub const WorkspaceEntry = struct {
     name: []const u8,
     prompts: u8,
@@ -48,6 +62,7 @@ pub const WorkspaceEntry = struct {
     paths: u8,
     open_prs: u8,
     last_sync: []const u8,
+    access_level: AccessLevel,
 };
 
 pub const BUNDLES = [_]BundleEntry{
@@ -121,14 +136,14 @@ pub const PROPOSALS = [_]ProposalEntry{
 };
 
 pub const WORKSPACES = [_]WorkspaceEntry{
-    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2, .last_sync = "1h ago" },
-    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago" },
-    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago" },
-    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago" },
-    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago" },
-    .{ .name = "mobile-app", .prompts = 12, .contexts = 7, .overrides = 2, .local_rev = 28, .remote_rev = 30, .paths = 2, .open_prs = 1, .last_sync = "30 min ago" },
-    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago" },
-    .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago" },
+    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2, .last_sync = "1h ago", .access_level = .admin },
+    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago", .access_level = .write },
+    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago", .access_level = .read },
+    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago", .access_level = .write },
+    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago", .access_level = .read },
+    .{ .name = "mobile-app", .prompts = 12, .contexts = 7, .overrides = 2, .local_rev = 28, .remote_rev = 30, .paths = 2, .open_prs = 1, .last_sync = "30 min ago", .access_level = .admin },
+    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago", .access_level = .write },
+    .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago", .access_level = .admin },
 };
 
 pub const ContextBranch = struct {
@@ -333,22 +348,120 @@ pub const MemberEntry = struct {
     username: []const u8,
     role: []const u8,
     joined: []const u8,
+    teams: []const u8, // comma-separated team names
 };
 
 pub const MEMBERS = [_]MemberEntry{
-    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15" },
-    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20" },
-    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05" },
-    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18" },
+    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15", .teams = "platform, ops" },
+    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20", .teams = "platform, frontend" },
+    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05", .teams = "frontend" },
+    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18", .teams = "platform, ops" },
+};
+
+// Mirrors GET /api/auth/me response
+pub const WsAccess = struct {
+    name: []const u8,
+    level: AccessLevel,
+};
+
+pub const CurrentUser = struct {
+    user_id: []const u8,
+    username: []const u8,
+    role: []const u8,
+    scopes: []const []const u8,
+    workspaces: []const WsAccess,
+};
+
+const my_scopes = [_][]const u8{
+    "library:read",
+    "workspace:read",
+    "workspace:write",
+    "trace:write",
+    "stats:read",
+    "proposal:read",
+    "proposal:write",
+    "members:read",
+};
+
+// Token scope definitions for the Hub Server permission model
+pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
+    .{ .name = "library:read", .description = "Read prompts and bundles" },
+    .{ .name = "library:write", .description = "Create proposals" },
+    .{ .name = "bundle:write", .description = "Bundle CRUD" },
+    .{ .name = "workspace:read", .description = "Read workspace manifest/files" },
+    .{ .name = "workspace:write", .description = "Write context, create overrides" },
+    .{ .name = "trace:write", .description = "Upload trace events" },
+    .{ .name = "stats:read", .description = "Read statistics" },
+    .{ .name = "members:read", .description = "List org/workspace members" },
+    .{ .name = "members:write", .description = "Manage org/workspace members" },
+    .{ .name = "team:read", .description = "List teams and members" },
+    .{ .name = "team:write", .description = "Manage teams" },
+    .{ .name = "proposal:read", .description = "Read proposals and comments" },
+    .{ .name = "proposal:write", .description = "Create/comment on proposals" },
+    .{ .name = "proposal:merge", .description = "Accept/reject proposals" },
+};
+
+const my_workspaces = [_]WsAccess{
+    .{ .name = "payments-api", .level = .admin },
+    .{ .name = "merchant-portal", .level = .write },
+    .{ .name = "infra-tools", .level = .read },
+    .{ .name = "release-bot", .level = .write },
+    .{ .name = "docs-site", .level = .read },
+    .{ .name = "mobile-app", .level = .admin },
+    .{ .name = "data-pipeline", .level = .write },
+    .{ .name = "admin-dashboard", .level = .admin },
+};
+
+pub const CURRENT_USER = CurrentUser{
+    .user_id = "usr-0001",
+    .username = "alice",
+    .role = "maintainer",
+    .scopes = &my_scopes,
+    .workspaces = &my_workspaces,
 };
 
 pub const TokenInfo = struct {
-    scope: []const u8,
+    scopes: []const []const u8,
     expires: []const u8,
 };
 
+pub const TeamEntry = struct {
+    name: []const u8,
+    member_usernames: []const []const u8,
+};
+
+const platform_members = [_][]const u8{ "alice", "bob", "dave" };
+const frontend_members = [_][]const u8{ "bob", "carol" };
+const ops_members = [_][]const u8{ "alice", "dave" };
+
+pub const TEAMS = [_]TeamEntry{
+    .{ .name = "platform", .member_usernames = &platform_members },
+    .{ .name = "frontend", .member_usernames = &frontend_members },
+    .{ .name = "ops", .member_usernames = &ops_members },
+};
+
+pub const WsTeamAccess = struct {
+    team_name: []const u8,
+    level: AccessLevel,
+};
+
+pub const WsUserAccess = struct {
+    username: []const u8,
+    level: AccessLevel,
+};
+
+// Access rules for the "selected" workspace (payments-api)
+pub const WS_TEAM_ACCESS = [_]WsTeamAccess{
+    .{ .team_name = "platform", .level = .admin },
+    .{ .team_name = "frontend", .level = .write },
+};
+
+pub const WS_USER_ACCESS = [_]WsUserAccess{
+    .{ .username = "carol", .level = .read },
+};
+
 pub const CURRENT_TOKEN = TokenInfo{
-    .scope = "library:read workspace:read trace:write stats:read proposal:read proposal:write",
+    .scopes = &my_scopes,
     .expires = "2026-04-07T12:00:00Z",
 };
 

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -10,6 +10,7 @@ pub const PromptEntry = struct {
     bundle_names: []const u8,
     updated: []const u8,
     age: []const u8,
+    summary: []const u8,
     trend: [8]u8,
     content_hash: []const u8,
 };
@@ -58,18 +59,18 @@ pub const BUNDLES = [_]BundleEntry{
 
 // Sorted by path prefix for grouped display in Library
 pub const PROMPTS = [_]PromptEntry{
-    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
-    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7" },
-    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
-    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1" },
-    .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
-    .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
-    .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
-    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
-    .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
-    .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
-    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
-    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
+    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .summary = "Conventions for writing architecture decision records", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
+    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7" },
+    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
+    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1" },
+    .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .summary = "Breaking changes happen freely, no compatibility layers", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
+    .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .summary = "Comments must be final-form text, no thinking process", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
+    .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .summary = "UI/UX design method with pressure-testing and smoke checks", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
+    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .summary = "Pre-release verification steps for branch and CI", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
+    .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .summary = "Generate .gitignore based on project type and toolchain", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
+    .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .summary = "Create pull request with summary and test plan", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
+    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .summary = "Zig naming conventions, error handling, and memory management", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
+    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .summary = "Zig 0.15 removed and renamed APIs with replacements", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
 };
 
 pub fn pathPrefix(canonical_name: []const u8) []const u8 {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -14,6 +14,9 @@ pub const PromptEntry = struct {
     trend: [8]u8,
     content_hash: []const u8,
     open_pr_count: u8 = 0,
+    workspace_count: u8 = 0,
+    workspace_names: []const u8 = "",
+    revision: u16 = 1,
 };
 
 pub const BundleEntry = struct {
@@ -87,9 +90,9 @@ pub const BUNDLES = [_]BundleEntry{
 // Sorted by path prefix for grouped display in Library
 pub const PROMPTS = [_]PromptEntry{
     .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .summary = "Conventions for writing architecture decision records", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
-    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7", .open_pr_count = 1 },
-    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4", .open_pr_count = 1 },
-    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1", .open_pr_count = 1 },
+    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7", .open_pr_count = 1, .workspace_count = 8, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools \xc2\xb7 release-bot \xc2\xb7 docs-site \xc2\xb7 mobile-app \xc2\xb7 data-pipeline \xc2\xb7 admin-dashboard", .revision = 15 },
+    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4", .open_pr_count = 1, .workspace_count = 6, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools \xc2\xb7 release-bot \xc2\xb7 docs-site \xc2\xb7 mobile-app", .revision = 42 },
+    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1", .open_pr_count = 1, .workspace_count = 3, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools", .revision = 18 },
     .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .summary = "Breaking changes happen freely, no compatibility layers", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
     .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .summary = "Comments must be final-form text, no thinking process", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
     .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .summary = "UI/UX design method with pressure-testing and smoke checks", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
@@ -432,14 +435,14 @@ const zig_diff = [_][]const u8{
 const empty_diff = [_][]const u8{};
 
 pub const WS_PROMPTS = [_]WsPromptEntry{
-    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale", .override_diff = &style_diff },
     .{ .name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .has_override = false, .hash = "e4f5", .state = "fresh", .override_diff = &empty_diff },
     .{ .name = "coding/API_REVIEW", .kind = "rule", .has_override = true, .hash = "bcdd", .state = "local", .override_diff = &api_diff },
-    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh", .override_diff = &empty_diff },
     .{ .name = "coding/CODE_COMMENTS", .kind = "rule", .has_override = false, .hash = "u0v1", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale", .override_diff = &style_diff },
+    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh", .override_diff = &empty_diff },
     .{ .name = "zig/DEPRECATED_API", .kind = "rule", .has_override = true, .hash = "c8d9", .state = "stale", .override_diff = &zig_diff },
+    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh", .override_diff = &empty_diff },
 };
 
 pub const WS_CONTEXT = [_]ContextFile{

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -31,6 +31,13 @@ pub const CommentEntry = struct {
     created: []const u8,
 };
 
+pub const ActiveSessionView = struct {
+    ws_id: []const u8,
+    session_id: []const u8,
+    pid: i64,
+    age: []const u8,
+};
+
 pub const PullRequestEntry = struct {
     id: []const u8,
     prompt_name: []const u8,

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -195,6 +195,30 @@ pub const SAMPLE_CONTENT =
     \\8. No magic numbers; define named constants.
 ;
 
+pub const MemberEntry = struct {
+    user_id: []const u8,
+    username: []const u8,
+    role: []const u8,
+    joined: []const u8,
+};
+
+pub const MEMBERS = [_]MemberEntry{
+    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15" },
+    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20" },
+    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05" },
+    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18" },
+};
+
+pub const TokenInfo = struct {
+    scope: []const u8,
+    expires: []const u8,
+};
+
+pub const CURRENT_TOKEN = TokenInfo{
+    .scope = "library:read workspace:read trace:write stats:read proposal:read proposal:write",
+    .expires = "2026-04-07T12:00:00Z",
+};
+
 pub fn syncStateLabel(ws: *const WorkspaceEntry) []const u8 {
     if (ws.local_rev == ws.remote_rev) return "synced";
     return "out-of-sync";

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -1,0 +1,209 @@
+// Mock data matching the real clumsies data model (spec s1-0 through s2-3).
+// No invented fields: only what the Hub Server API actually provides.
+
+pub const PromptEntry = struct {
+    canonical_name: []const u8,
+    kind: []const u8,
+    refer_count: []const u8,
+    constraint_count: u8,
+    bundle_count: u8,
+    bundle_names: []const u8,
+    updated: []const u8,
+    age: []const u8,
+    trend: [8]u8,
+    content_hash: []const u8,
+};
+
+pub const BundleEntry = struct {
+    name: []const u8,
+    count: u16,
+};
+
+pub const HistoryEntry = struct {
+    date: []const u8,
+    hash: []const u8,
+    label: []const u8,
+};
+
+pub const ProposalEntry = struct {
+    id: []const u8,
+    prompt_name: []const u8,
+    status: []const u8,
+    author: []const u8,
+    created: []const u8,
+    base_hash: []const u8,
+    diff: []const []const u8,
+    trace_refers: u16,
+    trace_sessions: u8,
+};
+
+pub const WorkspaceEntry = struct {
+    name: []const u8,
+    prompts: u8,
+    contexts: u8,
+    overrides: u8,
+    local_rev: u16,
+    remote_rev: u16,
+    paths: u8,
+};
+
+pub const BUNDLES = [_]BundleEntry{
+    .{ .name = "All", .count = 47 },
+    .{ .name = "frontend", .count = 12 },
+    .{ .name = "backend", .count = 9 },
+    .{ .name = "release", .count = 5 },
+    .{ .name = "default", .count = 21 },
+    .{ .name = "ops", .count = 4 },
+};
+
+pub const PROMPTS = [_]PromptEntry{
+    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
+    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7" },
+    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1" },
+    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
+    .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
+    .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
+    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
+    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
+    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
+    .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
+    .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
+    .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
+};
+
+pub const HISTORY = [_]HistoryEntry{
+    .{ .date = "2026-04-04", .hash = "sha256:a1b2c3d4", .label = "current" },
+    .{ .date = "2026-03-28", .hash = "sha256:x9y8z7w6", .label = "prop-0042" },
+    .{ .date = "2026-03-10", .hash = "sha256:l3m4n5o6", .label = "prop-0038" },
+    .{ .date = "2026-02-14", .hash = "sha256:q1r2s3t4", .label = "seed" },
+};
+
+pub const PROPOSALS = [_]ProposalEntry{
+    .{ .id = "prop-0051", .prompt_name = "coding/STYLE", .status = "open", .author = "alice", .created = "2026-04-05 10:00", .base_hash = "sha256:a1b2c3d4", .diff = &.{
+        "@@ -1,3 +1,5 @@",
+        " # STYLE",
+        "-1. Prefer short names.",
+        "+1. Prefer explicit names over abbreviations.",
+        "+2. Group imports by scope.",
+        " 3. Sort file sections in dependency order.",
+    }, .trace_refers = 42, .trace_sessions = 12 },
+    .{ .id = "prop-0050", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "open", .author = "bob", .created = "2026-04-05 09:12", .base_hash = "sha256:e4f5g6h7", .diff = &.{
+        "@@ -1,2 +1,3 @@",
+        " # GEN_COMMIT_MSG",
+        "+Use conventional commit prefixes.",
+        " Keep message under 72 chars.",
+    }, .trace_refers = 18, .trace_sessions = 5 },
+    .{ .id = "prop-0049", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "accepted", .author = "carol", .created = "2026-04-04 16:30", .base_hash = "sha256:m2n3o4p5", .diff = &.{
+        "@@ -4,1 +4,2 @@",
+        " 4. Tag release branch.",
+        "+5. Verify CI green before merge.",
+    }, .trace_refers = 31, .trace_sessions = 8 },
+};
+
+pub const WORKSPACES = [_]WorkspaceEntry{
+    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2 },
+    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1 },
+    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1 },
+    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1 },
+};
+
+pub const OverrideEntry = struct {
+    prompt_name: []const u8,
+    base_hash: []const u8,
+    current_hash: []const u8,
+    status: []const u8,
+};
+
+pub const ContextFile = struct {
+    path: []const u8,
+    size: []const u8,
+    hash: []const u8,
+    state: []const u8,
+};
+
+pub const WsPromptEntry = struct {
+    name: []const u8,
+    kind: []const u8,
+    has_override: bool,
+    hash: []const u8,
+    state: []const u8,
+};
+
+pub const ComplianceWs = struct {
+    name: []const u8,
+    coverage: u8,
+    refer_count: []const u8,
+    trend: [8]u8,
+};
+
+pub const HotspotEntry = struct {
+    name: []const u8,
+    refer_count: []const u8,
+    prompt_idx: usize,
+};
+
+pub const WS_PROMPTS = [_]WsPromptEntry{
+    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale" },
+    .{ .name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .has_override = false, .hash = "e4f5", .state = "fresh" },
+    .{ .name = "coding/API_REVIEW", .kind = "rule", .has_override = true, .hash = "bcdd", .state = "local" },
+    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh" },
+    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh" },
+    .{ .name = "coding/CODE_COMMENTS", .kind = "rule", .has_override = false, .hash = "u0v1", .state = "fresh" },
+    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh" },
+    .{ .name = "zig/DEPRECATED_API", .kind = "rule", .has_override = true, .hash = "c8d9", .state = "stale" },
+};
+
+pub const WS_CONTEXT = [_]ContextFile{
+    .{ .path = "spec/API_DESIGN.md", .size = "2.0k", .hash = "x1y2", .state = "fresh" },
+    .{ .path = "research/competitor.md", .size = "1.0k", .hash = "m7n8", .state = "fresh" },
+    .{ .path = "journal/05_AUDIT.md", .size = "3.2k", .hash = "p9q0", .state = "local" },
+    .{ .path = "thesis/T0-observability.md", .size = "4.1k", .hash = "r3s4", .state = "fresh" },
+};
+
+pub const WS_OVERRIDES = [_]OverrideEntry{
+    .{ .prompt_name = "coding/STYLE", .base_hash = "a1b2", .current_hash = "c3d4", .status = "conflict" },
+    .{ .prompt_name = "coding/API_REVIEW", .base_hash = "f1e2", .current_hash = "f1e2", .status = "clean" },
+    .{ .prompt_name = "zig/DEPRECATED_API", .base_hash = "c8d9", .current_hash = "c8d9", .status = "clean" },
+};
+
+pub const COMPLIANCE_WS = [_]ComplianceWs{
+    .{ .name = "payments-api", .coverage = 82, .refer_count = "4.2k", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 } },
+    .{ .name = "merchant-portal", .coverage = 76, .refer_count = "3.1k", .trend = .{ 1, 2, 3, 4, 5, 5, 4, 3 } },
+    .{ .name = "infra-tools", .coverage = 74, .refer_count = "2.8k", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 } },
+    .{ .name = "release-bot", .coverage = 63, .refer_count = "1.1k", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 } },
+    .{ .name = "docs-site", .coverage = 61, .refer_count = "0.9k", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 } },
+};
+
+pub const HOTSPOTS = [_]HotspotEntry{
+    .{ .name = "coding/STYLE", .refer_count = "3210", .prompt_idx = 0 },
+    .{ .name = "coding/API_REVIEW", .refer_count = "990", .prompt_idx = 2 },
+    .{ .name = "wf/RELEASE_CHECKLIST", .refer_count = "611", .prompt_idx = 3 },
+    .{ .name = "coding/CODE_COMMENTS", .refer_count = "488", .prompt_idx = 5 },
+    .{ .name = "zig/ZIG_STYLE", .refer_count = "412", .prompt_idx = 6 },
+};
+
+pub const SAMPLE_CONTENT =
+    \\# STYLE
+    \\
+    \\1. Prefer explicit names over abbreviations.
+    \\2. Keep imports grouped by standard / third-party / local.
+    \\3. Sort file sections in dependency order.
+    \\4. One blank line between top-level declarations.
+    \\5. Constants at the top of the scope, mutable state below.
+    \\6. Error handling uses try; avoid manual catch unless re-wrapping.
+    \\7. Public API documented with doc comments.
+    \\8. No magic numbers; define named constants.
+;
+
+pub fn syncStateLabel(ws: *const WorkspaceEntry) []const u8 {
+    if (ws.local_rev == ws.remote_rev) return "synced";
+    return "out-of-sync";
+}
+
+pub fn syncStateColor(ws: *const WorkspaceEntry) @import("theme.zig").Color {
+    const t = @import("theme.zig");
+    if (ws.local_rev == ws.remote_rev) return t.OK;
+    return t.WARN;
+}
+
+const Color = @import("vaxis").Color;

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -56,20 +56,37 @@ pub const BUNDLES = [_]BundleEntry{
     .{ .name = "ops", .count = 4 },
 };
 
+// Sorted by path prefix for grouped display in Library
 pub const PROMPTS = [_]PromptEntry{
-    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
+    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
     .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7" },
+    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
     .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1" },
-    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
     .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
     .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
-    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
-    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
-    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
     .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
+    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
     .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
     .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
+    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
+    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
 };
+
+pub fn pathPrefix(canonical_name: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
+        return canonical_name[0..idx];
+    }
+    return canonical_name;
+}
+
+pub fn promptName(canonical_name: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
+        return canonical_name[idx + 1 ..];
+    }
+    return canonical_name;
+}
+
+const std = @import("std");
 
 pub const HISTORY = [_]HistoryEntry{
     .{ .date = "2026-04-04", .hash = "sha256:a1b2c3d4", .label = "current" },

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -34,7 +34,6 @@ pub const CommentEntry = struct {
 pub const ActiveSessionView = struct {
     ws_id: []const u8,
     session_id: []const u8,
-    pid: i64,
     age: []const u8,
 };
 

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -100,6 +100,7 @@ pub const InsightsPrompt = struct {
     idle_constraint_count: u8,
     signal_ratio: u8,
     refer_count: u32,
+    workspace_count: u8,
     rate_per_day: u16,
     delta_pct: i8,
     last_referred_days_ago: ?u16,

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -2,7 +2,7 @@
 const std = @import("std");
 
 pub const PromptEntry = struct {
-    canonical_name: []const u8,
+    path: []const u8,
     kind: []const u8,
     refer_count: []const u8,
     constraint_count: u8,
@@ -214,18 +214,40 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
 };
 
 // Helper functions
-pub fn pathPrefix(canonical_name: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
-        return canonical_name[0..idx];
+// Returns the group segment after the kind prefix.
+// e.g. "rule/coding/STYLE.md" -> "coding"
+pub fn pathPrefix(path: []const u8) []const u8 {
+    var p = path;
+    if (std.mem.indexOfScalar(u8, p, '/')) |first_slash| {
+        p = p[first_slash + 1 ..];
     }
-    return canonical_name;
+    if (std.mem.indexOfScalar(u8, p, '/')) |idx| {
+        return p[0..idx];
+    }
+    return p;
 }
 
-pub fn promptName(canonical_name: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
-        return canonical_name[idx + 1 ..];
+// Returns the last segment without .md extension.
+// e.g. "rule/coding/STYLE.md" -> "STYLE"
+pub fn promptName(path: []const u8) []const u8 {
+    const last_slash = std.mem.lastIndexOfScalar(u8, path, '/') orelse return stripMd(path);
+    return stripMd(path[last_slash + 1 ..]);
+}
+
+fn stripMd(name: []const u8) []const u8 {
+    if (std.mem.endsWith(u8, name, ".md")) return name[0 .. name.len - 3];
+    return name;
+}
+
+// Derives kind short label from path prefix.
+// e.g. "rule/..." -> "rule", "workflow/..." -> "wf"
+pub fn kindFromPath(path: []const u8) []const u8 {
+    if (std.mem.indexOfScalar(u8, path, '/')) |idx| {
+        const category = path[0..idx];
+        if (std.mem.eql(u8, category, "rule")) return "rule";
+        if (std.mem.eql(u8, category, "workflow")) return "wf";
     }
-    return canonical_name;
+    return "";
 }
 
 pub fn syncStateLabel(ws: *const WorkspaceEntry) []const u8 {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -43,6 +43,11 @@ pub const PullRequestEntry = struct {
     comments: []const CommentEntry = &.{},
     trace_refers: u16,
     trace_sessions: u8,
+    operation_count: u16 = 0,
+    op_type: []const u8 = "",
+    op_current_path: []const u8 = "",
+    op_new_path: []const u8 = "",
+    op_index: u16 = 0,
 };
 
 pub const AccessLevel = enum {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -24,11 +24,6 @@ pub const BundleEntry = struct {
     count: u16,
 };
 
-pub const HistoryEntry = struct {
-    date: []const u8,
-    hash: []const u8,
-    label: []const u8,
-};
 
 pub const CommentEntry = struct {
     id: []const u8,
@@ -138,13 +133,6 @@ pub fn prsForPrompt(canonical_name: []const u8) []const PullRequestEntry {
 
 const std = @import("std");
 
-pub const HISTORY = [_]HistoryEntry{
-    .{ .date = "2026-04-04", .hash = "sha256:a1b2c3d4", .label = "current" },
-    .{ .date = "2026-03-28", .hash = "sha256:x9y8z7w6", .label = "pr-0042" },
-    .{ .date = "2026-03-10", .hash = "sha256:l3m4n5o6", .label = "pr-0038" },
-    .{ .date = "2026-02-14", .hash = "sha256:q1r2s3t4", .label = "seed" },
-};
-
 pub const PULL_REQUESTS = [_]PullRequestEntry{
     // coding/STYLE: 3 PRs (open, rejected, accepted)
     .{ .id = "pr-0051", .prompt_name = "coding/STYLE", .status = "open", .author = "alice", .created = "2026-04-05 10:00", .description = "Prefer explicit names over abbreviations, add import grouping rule", .base_hash = "sha256:a1b2c3d4", .diff = &.{
@@ -242,39 +230,6 @@ pub const WORKSPACES = [_]WorkspaceEntry{
     .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago", .access_level = .admin },
 };
 
-pub const ContextBranch = struct {
-    name: []const u8,
-    file_count: u8,
-    ahead: u8,
-    behind: u8,
-};
-
-pub const ContextPR = struct {
-    id: []const u8,
-    author: []const u8,
-    status: []const u8,
-    description: []const u8,
-    files_changed: u8,
-};
-
-pub const CONTEXT_BRANCHES = [_]ContextBranch{
-    .{ .name = "main", .file_count = 9, .ahead = 0, .behind = 0 },
-    .{ .name = "alice", .file_count = 3, .ahead = 3, .behind = 0 },
-    .{ .name = "bob", .file_count = 1, .ahead = 1, .behind = 1 },
-    .{ .name = "carol", .file_count = 2, .ahead = 2, .behind = 0 },
-};
-
-pub const CONTEXT_PRS = [_]ContextPR{
-    .{ .id = "cpr-001", .author = "alice", .status = "open", .description = "Add API design spec for payments module", .files_changed = 2 },
-    .{ .id = "cpr-002", .author = "carol", .status = "open", .description = "Add observability research notes", .files_changed = 1 },
-};
-
-pub const OverrideEntry = struct {
-    prompt_name: []const u8,
-    base_hash: []const u8,
-    current_hash: []const u8,
-    status: []const u8,
-};
 
 pub const ContextFile = struct {
     path: []const u8,
@@ -452,11 +407,6 @@ pub const WS_CONTEXT = [_]ContextFile{
     .{ .path = "thesis/T0-observability.md", .size = "4.1k", .hash = "r3s4", .state = "fresh", .modified = false, .branch_diff = &ctx_empty_diff },
 };
 
-pub const WS_OVERRIDES = [_]OverrideEntry{
-    .{ .prompt_name = "coding/STYLE", .base_hash = "a1b2", .current_hash = "c3d4", .status = "conflict" },
-    .{ .prompt_name = "coding/API_REVIEW", .base_hash = "f1e2", .current_hash = "f1e2", .status = "clean" },
-    .{ .prompt_name = "zig/DEPRECATED_API", .base_hash = "c8d9", .current_hash = "c8d9", .status = "clean" },
-};
 
 const style_constraints = [_]ConstraintStat{
     .{ .id = "c-1", .label = "naming conventions", .refer_count = 1280, .idle_days = null },
@@ -710,25 +660,6 @@ pub const TEAMS = [_]TeamEntry{
     .{ .name = "ops", .member_usernames = &ops_members },
 };
 
-pub const WsTeamAccess = struct {
-    team_name: []const u8,
-    level: AccessLevel,
-};
-
-pub const WsUserAccess = struct {
-    username: []const u8,
-    level: AccessLevel,
-};
-
-// Access rules for the "selected" workspace (payments-api)
-pub const WS_TEAM_ACCESS = [_]WsTeamAccess{
-    .{ .team_name = "platform", .level = .admin },
-    .{ .team_name = "frontend", .level = .write },
-};
-
-pub const WS_USER_ACCESS = [_]WsUserAccess{
-    .{ .username = "carol", .level = .read },
-};
 
 pub const CURRENT_TOKEN = TokenInfo{
     .scopes = &my_scopes,

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -156,6 +156,12 @@ pub const InsightsData = struct {
     members: []const InsightsMember = &.{},
     models: []const InsightsModel = &.{},
     alerts: []const InsightsAlert = &.{},
+    inputs: []const InputItem = &.{},
+};
+
+pub const InputItem = struct {
+    timestamp: i64,
+    content: []const u8,
 };
 
 pub const ContextFile = struct {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -47,14 +47,12 @@ pub const PullRequestEntry = struct {
 };
 
 pub const AccessLevel = enum {
-    read,
-    write,
+    member,
     admin,
 
     pub fn badge(self: AccessLevel) []const u8 {
         return switch (self) {
-            .read => "r",
-            .write => "w",
+            .member => "m",
             .admin => "a",
         };
     }
@@ -221,12 +219,12 @@ pub const PULL_REQUESTS = [_]PullRequestEntry{
 
 pub const WORKSPACES = [_]WorkspaceEntry{
     .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2, .last_sync = "1h ago", .access_level = .admin },
-    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago", .access_level = .write },
-    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago", .access_level = .read },
-    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago", .access_level = .write },
-    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago", .access_level = .read },
+    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago", .access_level = .member },
+    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago", .access_level = .member },
+    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago", .access_level = .member },
+    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago", .access_level = .member },
     .{ .name = "mobile-app", .prompts = 12, .contexts = 7, .overrides = 2, .local_rev = 28, .remote_rev = 30, .paths = 2, .open_prs = 1, .last_sync = "30 min ago", .access_level = .admin },
-    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago", .access_level = .write },
+    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago", .access_level = .member },
     .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago", .access_level = .admin },
 };
 
@@ -544,20 +542,19 @@ pub const MemberEntry = struct {
     username: []const u8,
     role: []const u8,
     joined: []const u8,
-    teams: []const u8, // comma-separated team names
 };
 
 pub const MEMBERS = [_]MemberEntry{
-    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15", .teams = "platform, ops" },
-    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20", .teams = "platform, frontend" },
-    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05", .teams = "frontend" },
-    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18", .teams = "platform, ops" },
+    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15" },
+    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20" },
+    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05" },
+    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18" },
 };
 
 // Mirrors GET /api/auth/me + config.toml workspace bindings
 pub const WsAccess = struct {
     name: []const u8,
-    level: AccessLevel,
+    role: AccessLevel,
     paths: []const []const u8,
 };
 
@@ -598,8 +595,6 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "stats:read", .description = "Read statistics" },
     .{ .name = "members:read", .description = "List org/workspace members" },
     .{ .name = "members:write", .description = "Manage org/workspace members" },
-    .{ .name = "team:read", .description = "List teams and members" },
-    .{ .name = "team:write", .description = "Manage teams" },
     .{ .name = "pr:read", .description = "Read pull requests and comments" },
     .{ .name = "pr:write", .description = "Create/comment on pull requests" },
     .{ .name = "pr:merge", .description = "Accept/reject pull requests" },
@@ -615,14 +610,14 @@ const pipeline_paths = [_][]const u8{"~/work/data-pipeline"};
 const empty_paths = [_][]const u8{};
 
 const my_workspaces = [_]WsAccess{
-    .{ .name = "payments-api", .level = .admin, .paths = &payments_paths },
-    .{ .name = "merchant-portal", .level = .write, .paths = &merchant_paths },
-    .{ .name = "infra-tools", .level = .read, .paths = &infra_paths },
-    .{ .name = "release-bot", .level = .write, .paths = &bot_paths },
-    .{ .name = "docs-site", .level = .read, .paths = &docs_paths },
-    .{ .name = "mobile-app", .level = .admin, .paths = &mobile_paths },
-    .{ .name = "data-pipeline", .level = .write, .paths = &pipeline_paths },
-    .{ .name = "admin-dashboard", .level = .admin, .paths = &empty_paths },
+    .{ .name = "payments-api", .role = .admin, .paths = &payments_paths },
+    .{ .name = "merchant-portal", .role = .member, .paths = &merchant_paths },
+    .{ .name = "infra-tools", .role = .member, .paths = &infra_paths },
+    .{ .name = "release-bot", .role = .member, .paths = &bot_paths },
+    .{ .name = "docs-site", .role = .member, .paths = &docs_paths },
+    .{ .name = "mobile-app", .role = .admin, .paths = &mobile_paths },
+    .{ .name = "data-pipeline", .role = .member, .paths = &pipeline_paths },
+    .{ .name = "admin-dashboard", .role = .admin, .paths = &empty_paths },
 };
 
 pub const CLIENT_CONFIG = ClientConfig{
@@ -643,21 +638,6 @@ pub const CURRENT_USER = CurrentUser{
 pub const TokenInfo = struct {
     scopes: []const []const u8,
     expires: []const u8,
-};
-
-pub const TeamEntry = struct {
-    name: []const u8,
-    member_usernames: []const []const u8,
-};
-
-const platform_members = [_][]const u8{ "alice", "bob", "dave" };
-const frontend_members = [_][]const u8{ "bob", "carol" };
-const ops_members = [_][]const u8{ "alice", "dave" };
-
-pub const TEAMS = [_]TeamEntry{
-    .{ .name = "platform", .member_usernames = &platform_members },
-    .{ .name = "frontend", .member_usernames = &frontend_members },
-    .{ .name = "ops", .member_usernames = &ops_members },
 };
 
 

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -13,6 +13,7 @@ pub const PromptEntry = struct {
     summary: []const u8,
     trend: [8]u8,
     content_hash: []const u8,
+    open_pr_count: u8 = 0,
 };
 
 pub const BundleEntry = struct {
@@ -26,14 +27,23 @@ pub const HistoryEntry = struct {
     label: []const u8,
 };
 
-pub const ProposalEntry = struct {
+pub const CommentEntry = struct {
+    id: []const u8,
+    author: []const u8,
+    body: []const u8,
+    created: []const u8,
+};
+
+pub const PullRequestEntry = struct {
     id: []const u8,
     prompt_name: []const u8,
     status: []const u8,
     author: []const u8,
     created: []const u8,
+    description: []const u8,
     base_hash: []const u8,
     diff: []const []const u8,
+    comments: []const CommentEntry = &.{},
     trace_refers: u16,
     trace_sessions: u8,
 };
@@ -77,16 +87,16 @@ pub const BUNDLES = [_]BundleEntry{
 // Sorted by path prefix for grouped display in Library
 pub const PROMPTS = [_]PromptEntry{
     .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .summary = "Conventions for writing architecture decision records", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
-    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7" },
-    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4" },
-    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1" },
+    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7", .open_pr_count = 1 },
+    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4", .open_pr_count = 1 },
+    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1", .open_pr_count = 1 },
     .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .summary = "Breaking changes happen freely, no compatibility layers", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
     .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .summary = "Comments must be final-form text, no thinking process", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
     .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .summary = "UI/UX design method with pressure-testing and smoke checks", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
-    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .summary = "Pre-release verification steps for branch and CI", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5" },
+    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .summary = "Pre-release verification steps for branch and CI", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5", .open_pr_count = 1 },
     .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .summary = "Generate .gitignore based on project type and toolchain", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
     .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .summary = "Create pull request with summary and test plan", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
-    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .summary = "Zig naming conventions, error handling, and memory management", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7" },
+    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .summary = "Zig naming conventions, error handling, and memory management", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7", .open_pr_count = 1 },
     .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .summary = "Zig 0.15 removed and renamed APIs with replacements", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
 };
 
@@ -104,35 +114,118 @@ pub fn promptName(canonical_name: []const u8) []const u8 {
     return canonical_name;
 }
 
+pub fn prsForPrompt(canonical_name: []const u8) []const PullRequestEntry {
+    // Return a slice of PULL_REQUESTS matching the given prompt name.
+    // Since mock data is static and small, we scan the full array each time.
+    var start: usize = 0;
+    var end: usize = 0;
+    var found_start = false;
+    for (PULL_REQUESTS, 0..) |pr, i| {
+        if (std.mem.eql(u8, pr.prompt_name, canonical_name)) {
+            if (!found_start) {
+                start = i;
+                found_start = true;
+            }
+            end = i + 1;
+        }
+    }
+    if (!found_start) return &.{};
+    return PULL_REQUESTS[start..end];
+}
+
 const std = @import("std");
 
 pub const HISTORY = [_]HistoryEntry{
     .{ .date = "2026-04-04", .hash = "sha256:a1b2c3d4", .label = "current" },
-    .{ .date = "2026-03-28", .hash = "sha256:x9y8z7w6", .label = "prop-0042" },
-    .{ .date = "2026-03-10", .hash = "sha256:l3m4n5o6", .label = "prop-0038" },
+    .{ .date = "2026-03-28", .hash = "sha256:x9y8z7w6", .label = "pr-0042" },
+    .{ .date = "2026-03-10", .hash = "sha256:l3m4n5o6", .label = "pr-0038" },
     .{ .date = "2026-02-14", .hash = "sha256:q1r2s3t4", .label = "seed" },
 };
 
-pub const PROPOSALS = [_]ProposalEntry{
-    .{ .id = "prop-0051", .prompt_name = "coding/STYLE", .status = "open", .author = "alice", .created = "2026-04-05 10:00", .base_hash = "sha256:a1b2c3d4", .diff = &.{
+pub const PULL_REQUESTS = [_]PullRequestEntry{
+    // coding/STYLE: 3 PRs (open, rejected, accepted)
+    .{ .id = "pr-0051", .prompt_name = "coding/STYLE", .status = "open", .author = "alice", .created = "2026-04-05 10:00", .description = "Prefer explicit names over abbreviations, add import grouping rule", .base_hash = "sha256:a1b2c3d4", .diff = &.{
         "@@ -1,3 +1,5 @@",
         " # STYLE",
         "-1. Prefer short names.",
         "+1. Prefer explicit names over abbreviations.",
         "+2. Group imports by scope.",
         " 3. Sort file sections in dependency order.",
+    }, .comments = &.{
+        .{ .id = "cmt-0012", .author = "bob", .body = "Naming convention looks good, but consider keeping short names for loop variables.", .created = "2026-04-05 11:30" },
+        .{ .id = "cmt-0013", .author = "carol", .body = "Agreed with the import grouping rule. Should we also sort by scope?", .created = "2026-04-05 14:00" },
+        .{ .id = "cmt-0014", .author = "alice", .body = "Good point Bob. I'll add a note about loop variable exemptions.", .created = "2026-04-05 15:20" },
     }, .trace_refers = 42, .trace_sessions = 12 },
-    .{ .id = "prop-0050", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "open", .author = "bob", .created = "2026-04-05 09:12", .base_hash = "sha256:e4f5g6h7", .diff = &.{
+    .{ .id = "pr-0048", .prompt_name = "coding/STYLE", .status = "rejected", .author = "dave", .created = "2026-04-03 14:00", .description = "Remove all formatting rules and rely on zig fmt only", .base_hash = "sha256:a1b2c3d4", .diff = &.{
+        "@@ -1,5 +1,2 @@",
+        " # STYLE",
+        "-1. Prefer short names.",
+        "-2. Sort file sections in dependency order.",
+        "-3. Keep line length under 120.",
+        "+1. Use zig fmt for all formatting.",
+    }, .comments = &.{
+        .{ .id = "cmt-0010", .author = "carol", .body = "zig fmt doesn't cover naming conventions. We still need manual rules for those.", .created = "2026-04-03 15:00" },
+        .{ .id = "cmt-0011", .author = "bob", .body = "Agreed, rejecting. Formatting is only part of style.", .created = "2026-04-03 16:30" },
+    }, .trace_refers = 42, .trace_sessions = 12 },
+    .{ .id = "pr-0045", .prompt_name = "coding/STYLE", .status = "accepted", .author = "bob", .created = "2026-03-28 09:00", .description = "Add line length constraint and section ordering rule", .base_hash = "sha256:x9y8z7w6", .diff = &.{
+        "@@ -2,1 +2,3 @@",
+        " 1. Prefer short names.",
+        "+2. Sort file sections in dependency order.",
+        "+3. Keep line length under 120.",
+    }, .trace_refers = 38, .trace_sessions = 10 },
+    // cmd/GEN_COMMIT_MSG: 2 PRs (open, accepted)
+    .{ .id = "pr-0050", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "open", .author = "bob", .created = "2026-04-05 09:12", .description = "Use conventional commit prefixes for consistency", .base_hash = "sha256:e4f5g6h7", .diff = &.{
         "@@ -1,2 +1,3 @@",
         " # GEN_COMMIT_MSG",
         "+Use conventional commit prefixes.",
         " Keep message under 72 chars.",
+    }, .comments = &.{
+        .{ .id = "cmt-0015", .author = "alice", .body = "Which prefixes? feat/fix/chore? Please list them explicitly.", .created = "2026-04-05 10:30" },
     }, .trace_refers = 18, .trace_sessions = 5 },
-    .{ .id = "prop-0049", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "accepted", .author = "carol", .created = "2026-04-04 16:30", .base_hash = "sha256:m2n3o4p5", .diff = &.{
+    .{ .id = "pr-0044", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "accepted", .author = "carol", .created = "2026-03-25 11:00", .description = "Enforce 72-char subject line limit", .base_hash = "sha256:e4f5g6h7", .diff = &.{
+        "@@ -1,1 +1,2 @@",
+        " # GEN_COMMIT_MSG",
+        "+Keep message under 72 chars.",
+    }, .trace_refers = 15, .trace_sessions = 4 },
+    // wf/RELEASE_CHECKLIST: 2 PRs (open, accepted)
+    .{ .id = "pr-0052", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "open", .author = "dave", .created = "2026-04-06 08:30", .description = "Add rollback procedure and hotfix branch policy", .base_hash = "sha256:m2n3o4p5", .diff = &.{
+        "@@ -5,0 +5,3 @@",
+        " 5. Verify CI green before merge.",
+        "+6. Prepare rollback plan for critical paths.",
+        "+7. Hotfix branches must be named hotfix/<issue-id>.",
+        "+8. Post-release smoke test within 30 minutes.",
+    }, .comments = &.{
+        .{ .id = "cmt-0016", .author = "alice", .body = "30 minutes seems tight for large deployments. Can we make it configurable?", .created = "2026-04-06 09:00" },
+        .{ .id = "cmt-0017", .author = "dave", .body = "Fair point. Changed to 'within the agreed SLA window'.", .created = "2026-04-06 09:45" },
+    }, .trace_refers = 31, .trace_sessions = 8 },
+    .{ .id = "pr-0049", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "accepted", .author = "carol", .created = "2026-04-04 16:30", .description = "Add CI green verification step before merge", .base_hash = "sha256:m2n3o4p5", .diff = &.{
         "@@ -4,1 +4,2 @@",
         " 4. Tag release branch.",
         "+5. Verify CI green before merge.",
     }, .trace_refers = 31, .trace_sessions = 8 },
+    // coding/API_REVIEW: 1 PR (open)
+    .{ .id = "pr-0053", .prompt_name = "coding/API_REVIEW", .status = "open", .author = "carol", .created = "2026-04-06 11:00", .description = "Add rate limiting and pagination requirements to API review checklist", .base_hash = "sha256:i8j9k0l1", .diff = &.{
+        "@@ -10,0 +10,4 @@",
+        " 10. Validate error response schema.",
+        "+11. All list endpoints must support cursor-based pagination.",
+        "+12. Rate limiting headers (X-RateLimit-*) required on all public endpoints.",
+        "+13. Batch endpoints must document max items per request.",
+        "+14. Breaking changes require deprecation notice in previous release.",
+    }, .comments = &.{
+        .{ .id = "cmt-0018", .author = "bob", .body = "Should we also require idempotency keys for POST endpoints?", .created = "2026-04-06 12:00" },
+        .{ .id = "cmt-0019", .author = "carol", .body = "Good idea, adding that as item 15.", .created = "2026-04-06 12:30" },
+        .{ .id = "cmt-0020", .author = "alice", .body = "The deprecation notice rule should reference our versioning policy doc.", .created = "2026-04-06 14:00" },
+    }, .trace_refers = 55, .trace_sessions = 9 },
+    // zig/ZIG_STYLE: 1 PR (open)
+    .{ .id = "pr-0054", .prompt_name = "zig/ZIG_STYLE", .status = "open", .author = "alice", .created = "2026-04-07 09:00", .description = "Clarify comptime function naming and add allocator passing conventions", .base_hash = "sha256:y4z5a6b7", .diff = &.{
+        "@@ -5,2 +5,5 @@",
+        " - Comptime functions that return types use PascalCase",
+        "+- Functions accepting allocator must take it as first parameter",
+        "+- Prefer arena allocator for request-scoped work",
+        "+- Use errdefer to free on error paths, not manual cleanup",
+        " ",
+        " ## Formatting",
+    }, .trace_refers = 28, .trace_sessions = 7 },
 };
 
 pub const WORKSPACES = [_]WorkspaceEntry{
@@ -536,27 +629,27 @@ const my_scopes = [_][]const u8{
     "workspace:write",
     "trace:write",
     "stats:read",
-    "proposal:read",
-    "proposal:write",
+    "pr:read",
+    "pr:write",
     "members:read",
 };
 
 // Token scope definitions for the Hub Server permission model
 pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "library:read", .description = "Read prompts and bundles" },
-    .{ .name = "library:write", .description = "Create proposals" },
+    .{ .name = "library:write", .description = "Create pull requests" },
     .{ .name = "bundle:write", .description = "Bundle CRUD" },
     .{ .name = "workspace:read", .description = "Read workspace manifest/files" },
-    .{ .name = "workspace:write", .description = "Write context, create overrides" },
+    .{ .name = "workspace:write", .description = "Write context, create local edits" },
     .{ .name = "trace:write", .description = "Upload trace events" },
     .{ .name = "stats:read", .description = "Read statistics" },
     .{ .name = "members:read", .description = "List org/workspace members" },
     .{ .name = "members:write", .description = "Manage org/workspace members" },
     .{ .name = "team:read", .description = "List teams and members" },
     .{ .name = "team:write", .description = "Manage teams" },
-    .{ .name = "proposal:read", .description = "Read proposals and comments" },
-    .{ .name = "proposal:write", .description = "Create/comment on proposals" },
-    .{ .name = "proposal:merge", .description = "Accept/reject proposals" },
+    .{ .name = "pr:read", .description = "Read pull requests and comments" },
+    .{ .name = "pr:write", .description = "Create/comment on pull requests" },
+    .{ .name = "pr:merge", .description = "Accept/reject pull requests" },
 };
 
 const payments_paths = [_][]const u8{ "~/work/payments", "~/work/payments-v2" };

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -129,7 +129,7 @@ pub const WsPromptEntry = struct {
     state: []const u8,
 };
 
-pub const ComplianceWs = struct {
+pub const InsightsWs = struct {
     name: []const u8,
     coverage: u8,
     refer_count: []const u8,
@@ -166,7 +166,7 @@ pub const WS_OVERRIDES = [_]OverrideEntry{
     .{ .prompt_name = "zig/DEPRECATED_API", .base_hash = "c8d9", .current_hash = "c8d9", .status = "clean" },
 };
 
-pub const COMPLIANCE_WS = [_]ComplianceWs{
+pub const INSIGHTS_WS = [_]InsightsWs{
     .{ .name = "payments-api", .coverage = 82, .refer_count = "4.2k", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 } },
     .{ .name = "merchant-portal", .coverage = 76, .refer_count = "3.1k", .trend = .{ 1, 2, 3, 4, 5, 5, 4, 3 } },
     .{ .name = "infra-tools", .coverage = 74, .refer_count = "2.8k", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 } },

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -46,6 +46,7 @@ pub const WorkspaceEntry = struct {
     local_rev: u16,
     remote_rev: u16,
     paths: u8,
+    open_prs: u8,
 };
 
 pub const BUNDLES = [_]BundleEntry{
@@ -119,10 +120,37 @@ pub const PROPOSALS = [_]ProposalEntry{
 };
 
 pub const WORKSPACES = [_]WorkspaceEntry{
-    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2 },
-    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1 },
-    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1 },
-    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1 },
+    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2 },
+    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0 },
+    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1 },
+    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0 },
+};
+
+pub const ContextBranch = struct {
+    name: []const u8,
+    file_count: u8,
+    ahead: u8,
+    behind: u8,
+};
+
+pub const ContextPR = struct {
+    id: []const u8,
+    author: []const u8,
+    status: []const u8,
+    description: []const u8,
+    files_changed: u8,
+};
+
+pub const CONTEXT_BRANCHES = [_]ContextBranch{
+    .{ .name = "main", .file_count = 9, .ahead = 0, .behind = 0 },
+    .{ .name = "alice", .file_count = 3, .ahead = 3, .behind = 0 },
+    .{ .name = "bob", .file_count = 1, .ahead = 1, .behind = 1 },
+    .{ .name = "carol", .file_count = 2, .ahead = 2, .behind = 0 },
+};
+
+pub const CONTEXT_PRS = [_]ContextPR{
+    .{ .id = "cpr-001", .author = "alice", .status = "open", .description = "Add API design spec for payments module", .files_changed = 2 },
+    .{ .id = "cpr-002", .author = "carol", .status = "open", .description = "Add observability research notes", .files_changed = 1 },
 };
 
 pub const OverrideEntry = struct {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -47,6 +47,7 @@ pub const WorkspaceEntry = struct {
     remote_rev: u16,
     paths: u8,
     open_prs: u8,
+    last_sync: []const u8,
 };
 
 pub const BUNDLES = [_]BundleEntry{
@@ -120,10 +121,14 @@ pub const PROPOSALS = [_]ProposalEntry{
 };
 
 pub const WORKSPACES = [_]WorkspaceEntry{
-    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2 },
-    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0 },
-    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1 },
-    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0 },
+    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2, .last_sync = "1h ago" },
+    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago" },
+    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago" },
+    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago" },
+    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago" },
+    .{ .name = "mobile-app", .prompts = 12, .contexts = 7, .overrides = 2, .local_rev = 28, .remote_rev = 30, .paths = 2, .open_prs = 1, .last_sync = "30 min ago" },
+    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago" },
+    .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago" },
 };
 
 pub const ContextBranch = struct {
@@ -165,6 +170,8 @@ pub const ContextFile = struct {
     size: []const u8,
     hash: []const u8,
     state: []const u8,
+    modified: bool, // true = your branch differs from main
+    branch_diff: []const []const u8, // your branch diff vs main
 };
 
 pub const WsPromptEntry = struct {
@@ -173,6 +180,7 @@ pub const WsPromptEntry = struct {
     has_override: bool,
     hash: []const u8,
     state: []const u8,
+    override_diff: []const []const u8,
 };
 
 pub const InsightsWs = struct {
@@ -188,22 +196,78 @@ pub const HotspotEntry = struct {
     prompt_idx: usize,
 };
 
+// Context branch diffs (member branch vs main)
+const ctx_api_diff = [_][]const u8{
+    "  # API Design Spec",
+    "  ",
+    "  ## Authentication",
+    "- All endpoints require Bearer token.",
+    "+ All endpoints require Bearer token or API key.",
+    "+ API keys are scoped per-workspace.",
+    "  ",
+    "  ## Rate Limiting",
+    "  Default: 100 req/min per token.",
+    "+ Added: burst allowance of 20 req/s for batch ops.",
+    "  ",
+    "  ## Error Format",
+    "  All errors return JSON with `code` and `message`.",
+    "+ Added: `request_id` field for tracing.",
+    "+ Added: `retry_after` header on 429 responses.",
+};
+const ctx_audit_diff = [_][]const u8{
+    "  # Audit Journal 05",
+    "  ",
+    "- ## Findings: 3 issues identified",
+    "+ ## Findings: 5 issues identified",
+    "  ",
+    "  1. Token rotation not enforced",
+    "  2. Stale sessions not cleaned up",
+    "  3. Missing rate limit on /sync endpoint",
+    "+ 4. Webhook secrets stored in plaintext",
+    "+ 5. No audit log for permission changes",
+    "  ",
+    "  ## Recommendations",
+    "- Schedule fix for Q2.",
+    "+ Schedule fix for Q2. Items 4-5 are P0.",
+};
+const ctx_empty_diff = [_][]const u8{};
+
+const style_diff = [_][]const u8{
+    "  # STYLE",
+    "- 1. Prefer short names.",
+    "+ 1. Prefer explicit names over abbreviations.",
+    "+ 2. Group imports by scope.",
+    "  3. Sort file sections in dependency order.",
+};
+const api_diff = [_][]const u8{
+    "  # API_REVIEW",
+    "+ Added: validate response schemas against OpenAPI spec.",
+    "  Check error codes match documentation.",
+};
+const zig_diff = [_][]const u8{
+    "  # DEPRECATED_API",
+    "- std.heap.GeneralPurposeAllocator",
+    "+ std.heap.DebugAllocator",
+    "  Target version: 0.15.1",
+};
+const empty_diff = [_][]const u8{};
+
 pub const WS_PROMPTS = [_]WsPromptEntry{
-    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale" },
-    .{ .name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .has_override = false, .hash = "e4f5", .state = "fresh" },
-    .{ .name = "coding/API_REVIEW", .kind = "rule", .has_override = true, .hash = "bcdd", .state = "local" },
-    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh" },
-    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh" },
-    .{ .name = "coding/CODE_COMMENTS", .kind = "rule", .has_override = false, .hash = "u0v1", .state = "fresh" },
-    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh" },
-    .{ .name = "zig/DEPRECATED_API", .kind = "rule", .has_override = true, .hash = "c8d9", .state = "stale" },
+    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale", .override_diff = &style_diff },
+    .{ .name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .has_override = false, .hash = "e4f5", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "coding/API_REVIEW", .kind = "rule", .has_override = true, .hash = "bcdd", .state = "local", .override_diff = &api_diff },
+    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "coding/CODE_COMMENTS", .kind = "rule", .has_override = false, .hash = "u0v1", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh", .override_diff = &empty_diff },
+    .{ .name = "zig/DEPRECATED_API", .kind = "rule", .has_override = true, .hash = "c8d9", .state = "stale", .override_diff = &zig_diff },
 };
 
 pub const WS_CONTEXT = [_]ContextFile{
-    .{ .path = "spec/API_DESIGN.md", .size = "2.0k", .hash = "x1y2", .state = "fresh" },
-    .{ .path = "research/competitor.md", .size = "1.0k", .hash = "m7n8", .state = "fresh" },
-    .{ .path = "journal/05_AUDIT.md", .size = "3.2k", .hash = "p9q0", .state = "local" },
-    .{ .path = "thesis/T0-observability.md", .size = "4.1k", .hash = "r3s4", .state = "fresh" },
+    .{ .path = "spec/API_DESIGN.md", .size = "2.0k", .hash = "x1y2", .state = "fresh", .modified = true, .branch_diff = &ctx_api_diff },
+    .{ .path = "research/competitor.md", .size = "1.0k", .hash = "m7n8", .state = "fresh", .modified = false, .branch_diff = &ctx_empty_diff },
+    .{ .path = "journal/05_AUDIT.md", .size = "3.2k", .hash = "p9q0", .state = "local", .modified = true, .branch_diff = &ctx_audit_diff },
+    .{ .path = "thesis/T0-observability.md", .size = "4.1k", .hash = "r3s4", .state = "fresh", .modified = false, .branch_diff = &ctx_empty_diff },
 };
 
 pub const WS_OVERRIDES = [_]OverrideEntry{
@@ -289,8 +353,8 @@ pub const CURRENT_TOKEN = TokenInfo{
 };
 
 pub fn syncStateLabel(ws: *const WorkspaceEntry) []const u8 {
-    if (ws.local_rev == ws.remote_rev) return "synced";
-    return "out-of-sync";
+    if (ws.local_rev == ws.remote_rev) return "up to date";
+    return "behind";
 }
 
 pub fn syncStateColor(ws: *const WorkspaceEntry) @import("theme.zig").Color {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -1,5 +1,5 @@
-// Mock data for the TUI dashboard, matching the Hub Server data model.
-// No invented fields: only what the Hub Server API actually provides.
+// Data types for TUI display, matching the Hub Server API model.
+const std = @import("std");
 
 pub const PromptEntry = struct {
     canonical_name: []const u8,
@@ -23,7 +23,6 @@ pub const BundleEntry = struct {
     name: []const u8,
     count: u16,
 };
-
 
 pub const CommentEntry = struct {
     id: []const u8,
@@ -71,189 +70,11 @@ pub const WorkspaceEntry = struct {
     access_level: AccessLevel,
 };
 
-pub const BUNDLES = [_]BundleEntry{
-    .{ .name = "All", .count = 47 },
-    .{ .name = "frontend", .count = 12 },
-    .{ .name = "backend", .count = 9 },
-    .{ .name = "release", .count = 5 },
-    .{ .name = "default", .count = 21 },
-    .{ .name = "ops", .count = 4 },
-};
-
-// Sorted by path prefix for grouped display in Library
-pub const PROMPTS = [_]PromptEntry{
-    .{ .canonical_name = "arch/ADR_DOCUMENT", .kind = "rule", .refer_count = "291", .constraint_count = 6, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-25", .age = "12d", .summary = "Conventions for writing architecture decision records", .trend = .{ 1, 1, 1, 2, 2, 2, 1, 1 }, .content_hash = "sha256:g2h3i4j5" },
-    .{ .canonical_name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .refer_count = "1.1k", .constraint_count = 5, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-31", .age = "5d", .summary = "Review git changes and suggest a commit message", .trend = .{ 2, 3, 4, 4, 5, 5, 4, 3 }, .content_hash = "sha256:e4f5g6h7", .open_pr_count = 1, .workspace_count = 8, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools \xc2\xb7 release-bot \xc2\xb7 docs-site \xc2\xb7 mobile-app \xc2\xb7 data-pipeline \xc2\xb7 admin-dashboard", .revision = 15 },
-    .{ .canonical_name = "coding/STYLE", .kind = "rule", .refer_count = "3.2k", .constraint_count = 8, .bundle_count = 2, .bundle_names = "frontend, default", .updated = "2026-04-04", .age = "2d", .summary = "Naming, imports, formatting, and code organization rules", .trend = .{ 1, 2, 3, 5, 6, 8, 6, 5 }, .content_hash = "sha256:a1b2c3d4", .open_pr_count = 1, .workspace_count = 6, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools \xc2\xb7 release-bot \xc2\xb7 docs-site \xc2\xb7 mobile-app", .revision = 42 },
-    .{ .canonical_name = "coding/API_REVIEW", .kind = "rule", .refer_count = "842", .constraint_count = 12, .bundle_count = 1, .bundle_names = "backend", .updated = "2026-04-05", .age = "1d", .summary = "API design review checklist for consistency and safety", .trend = .{ 3, 4, 5, 6, 7, 8, 7, 6 }, .content_hash = "sha256:i8j9k0l1", .open_pr_count = 1, .workspace_count = 3, .workspace_names = "payments-api \xc2\xb7 merchant-portal \xc2\xb7 infra-tools", .revision = 18 },
-    .{ .canonical_name = "coding/COMPATIBILITY", .kind = "rule", .refer_count = "520", .constraint_count = 8, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-03", .age = "3d", .summary = "Breaking changes happen freely, no compatibility layers", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 }, .content_hash = "sha256:q6r7s8t9" },
-    .{ .canonical_name = "coding/CODE_COMMENTS", .kind = "rule", .refer_count = "488", .constraint_count = 9, .bundle_count = 2, .bundle_names = "frontend, backend", .updated = "2026-04-02", .age = "4d", .summary = "Comments must be final-form text, no thinking process", .trend = .{ 1, 2, 2, 3, 3, 4, 3, 3 }, .content_hash = "sha256:u0v1w2x3" },
-    .{ .canonical_name = "style/UIUX_DESIGN", .kind = "rule", .refer_count = "178", .constraint_count = 7, .bundle_count = 1, .bundle_names = "frontend", .updated = "2026-03-31", .age = "5d", .summary = "UI/UX design method with pressure-testing and smoke checks", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 }, .content_hash = "sha256:k6l7m8n9" },
-    .{ .canonical_name = "wf/RELEASE_CHECKLIST", .kind = "wf", .refer_count = "611", .constraint_count = 4, .bundle_count = 2, .bundle_names = "release, ops", .updated = "2026-03-28", .age = "8d", .summary = "Pre-release verification steps for branch and CI", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 }, .content_hash = "sha256:m2n3o4p5", .open_pr_count = 1 },
-    .{ .canonical_name = "wf/GEN_GITIGNORE", .kind = "wf", .refer_count = "145", .constraint_count = 3, .bundle_count = 1, .bundle_names = "ops", .updated = "2026-03-23", .age = "14d", .summary = "Generate .gitignore based on project type and toolchain", .trend = .{ 1, 1, 1, 1, 2, 1, 1, 1 }, .content_hash = "sha256:o0p1q2r3" },
-    .{ .canonical_name = "wf/GEN_PR", .kind = "wf", .refer_count = "102", .constraint_count = 4, .bundle_count = 1, .bundle_names = "default", .updated = "2026-03-28", .age = "8d", .summary = "Create pull request with summary and test plan", .trend = .{ 0, 1, 1, 1, 2, 2, 1, 1 }, .content_hash = "sha256:s4t5u6v7" },
-    .{ .canonical_name = "zig/ZIG_STYLE", .kind = "rule", .refer_count = "412", .constraint_count = 11, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-04", .age = "2d", .summary = "Zig naming conventions, error handling, and memory management", .trend = .{ 3, 3, 4, 5, 5, 6, 5, 4 }, .content_hash = "sha256:y4z5a6b7", .open_pr_count = 1 },
-    .{ .canonical_name = "zig/DEPRECATED_API", .kind = "rule", .refer_count = "387", .constraint_count = 59, .bundle_count = 1, .bundle_names = "default", .updated = "2026-04-05", .age = "1d", .summary = "Zig 0.15 removed and renamed APIs with replacements", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 }, .content_hash = "sha256:c8d9e0f1" },
-};
-
-pub fn pathPrefix(canonical_name: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
-        return canonical_name[0..idx];
-    }
-    return canonical_name;
-}
-
-pub fn promptName(canonical_name: []const u8) []const u8 {
-    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
-        return canonical_name[idx + 1 ..];
-    }
-    return canonical_name;
-}
-
-pub fn prsForPrompt(canonical_name: []const u8) []const PullRequestEntry {
-    // Return a slice of PULL_REQUESTS matching the given prompt name.
-    // Since mock data is static and small, we scan the full array each time.
-    var start: usize = 0;
-    var end: usize = 0;
-    var found_start = false;
-    for (PULL_REQUESTS, 0..) |pr, i| {
-        if (std.mem.eql(u8, pr.prompt_name, canonical_name)) {
-            if (!found_start) {
-                start = i;
-                found_start = true;
-            }
-            end = i + 1;
-        }
-    }
-    if (!found_start) return &.{};
-    return PULL_REQUESTS[start..end];
-}
-
-const std = @import("std");
-
-pub const PULL_REQUESTS = [_]PullRequestEntry{
-    // coding/STYLE: 3 PRs (open, rejected, accepted)
-    .{ .id = "pr-0051", .prompt_name = "coding/STYLE", .status = "open", .author = "alice", .created = "2026-04-05 10:00", .description = "Prefer explicit names over abbreviations, add import grouping rule", .base_hash = "sha256:a1b2c3d4", .diff = &.{
-        "@@ -1,3 +1,5 @@",
-        " # STYLE",
-        "-1. Prefer short names.",
-        "+1. Prefer explicit names over abbreviations.",
-        "+2. Group imports by scope.",
-        " 3. Sort file sections in dependency order.",
-    }, .comments = &.{
-        .{ .id = "cmt-0012", .author = "bob", .body = "Naming convention looks good, but consider keeping short names for loop variables.", .created = "2026-04-05 11:30" },
-        .{ .id = "cmt-0013", .author = "carol", .body = "Agreed with the import grouping rule. Should we also sort by scope?", .created = "2026-04-05 14:00" },
-        .{ .id = "cmt-0014", .author = "alice", .body = "Good point Bob. I'll add a note about loop variable exemptions.", .created = "2026-04-05 15:20" },
-    }, .trace_refers = 42, .trace_sessions = 12 },
-    .{ .id = "pr-0048", .prompt_name = "coding/STYLE", .status = "rejected", .author = "dave", .created = "2026-04-03 14:00", .description = "Remove all formatting rules and rely on zig fmt only", .base_hash = "sha256:a1b2c3d4", .diff = &.{
-        "@@ -1,5 +1,2 @@",
-        " # STYLE",
-        "-1. Prefer short names.",
-        "-2. Sort file sections in dependency order.",
-        "-3. Keep line length under 120.",
-        "+1. Use zig fmt for all formatting.",
-    }, .comments = &.{
-        .{ .id = "cmt-0010", .author = "carol", .body = "zig fmt doesn't cover naming conventions. We still need manual rules for those.", .created = "2026-04-03 15:00" },
-        .{ .id = "cmt-0011", .author = "bob", .body = "Agreed, rejecting. Formatting is only part of style.", .created = "2026-04-03 16:30" },
-    }, .trace_refers = 42, .trace_sessions = 12 },
-    .{ .id = "pr-0045", .prompt_name = "coding/STYLE", .status = "accepted", .author = "bob", .created = "2026-03-28 09:00", .description = "Add line length constraint and section ordering rule", .base_hash = "sha256:x9y8z7w6", .diff = &.{
-        "@@ -2,1 +2,3 @@",
-        " 1. Prefer short names.",
-        "+2. Sort file sections in dependency order.",
-        "+3. Keep line length under 120.",
-    }, .trace_refers = 38, .trace_sessions = 10 },
-    // cmd/GEN_COMMIT_MSG: 2 PRs (open, accepted)
-    .{ .id = "pr-0050", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "open", .author = "bob", .created = "2026-04-05 09:12", .description = "Use conventional commit prefixes for consistency", .base_hash = "sha256:e4f5g6h7", .diff = &.{
-        "@@ -1,2 +1,3 @@",
-        " # GEN_COMMIT_MSG",
-        "+Use conventional commit prefixes.",
-        " Keep message under 72 chars.",
-    }, .comments = &.{
-        .{ .id = "cmt-0015", .author = "alice", .body = "Which prefixes? feat/fix/chore? Please list them explicitly.", .created = "2026-04-05 10:30" },
-    }, .trace_refers = 18, .trace_sessions = 5 },
-    .{ .id = "pr-0044", .prompt_name = "cmd/GEN_COMMIT_MSG", .status = "accepted", .author = "carol", .created = "2026-03-25 11:00", .description = "Enforce 72-char subject line limit", .base_hash = "sha256:e4f5g6h7", .diff = &.{
-        "@@ -1,1 +1,2 @@",
-        " # GEN_COMMIT_MSG",
-        "+Keep message under 72 chars.",
-    }, .trace_refers = 15, .trace_sessions = 4 },
-    // wf/RELEASE_CHECKLIST: 2 PRs (open, accepted)
-    .{ .id = "pr-0052", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "open", .author = "dave", .created = "2026-04-06 08:30", .description = "Add rollback procedure and hotfix branch policy", .base_hash = "sha256:m2n3o4p5", .diff = &.{
-        "@@ -5,0 +5,3 @@",
-        " 5. Verify CI green before merge.",
-        "+6. Prepare rollback plan for critical paths.",
-        "+7. Hotfix branches must be named hotfix/<issue-id>.",
-        "+8. Post-release smoke test within 30 minutes.",
-    }, .comments = &.{
-        .{ .id = "cmt-0016", .author = "alice", .body = "30 minutes seems tight for large deployments. Can we make it configurable?", .created = "2026-04-06 09:00" },
-        .{ .id = "cmt-0017", .author = "dave", .body = "Fair point. Changed to 'within the agreed SLA window'.", .created = "2026-04-06 09:45" },
-    }, .trace_refers = 31, .trace_sessions = 8 },
-    .{ .id = "pr-0049", .prompt_name = "wf/RELEASE_CHECKLIST", .status = "accepted", .author = "carol", .created = "2026-04-04 16:30", .description = "Add CI green verification step before merge", .base_hash = "sha256:m2n3o4p5", .diff = &.{
-        "@@ -4,1 +4,2 @@",
-        " 4. Tag release branch.",
-        "+5. Verify CI green before merge.",
-    }, .trace_refers = 31, .trace_sessions = 8 },
-    // coding/API_REVIEW: 1 PR (open)
-    .{ .id = "pr-0053", .prompt_name = "coding/API_REVIEW", .status = "open", .author = "carol", .created = "2026-04-06 11:00", .description = "Add rate limiting and pagination requirements to API review checklist", .base_hash = "sha256:i8j9k0l1", .diff = &.{
-        "@@ -10,0 +10,4 @@",
-        " 10. Validate error response schema.",
-        "+11. All list endpoints must support cursor-based pagination.",
-        "+12. Rate limiting headers (X-RateLimit-*) required on all public endpoints.",
-        "+13. Batch endpoints must document max items per request.",
-        "+14. Breaking changes require deprecation notice in previous release.",
-    }, .comments = &.{
-        .{ .id = "cmt-0018", .author = "bob", .body = "Should we also require idempotency keys for POST endpoints?", .created = "2026-04-06 12:00" },
-        .{ .id = "cmt-0019", .author = "carol", .body = "Good idea, adding that as item 15.", .created = "2026-04-06 12:30" },
-        .{ .id = "cmt-0020", .author = "alice", .body = "The deprecation notice rule should reference our versioning policy doc.", .created = "2026-04-06 14:00" },
-    }, .trace_refers = 55, .trace_sessions = 9 },
-    // zig/ZIG_STYLE: 1 PR (open)
-    .{ .id = "pr-0054", .prompt_name = "zig/ZIG_STYLE", .status = "open", .author = "alice", .created = "2026-04-07 09:00", .description = "Clarify comptime function naming and add allocator passing conventions", .base_hash = "sha256:y4z5a6b7", .diff = &.{
-        "@@ -5,2 +5,5 @@",
-        " - Comptime functions that return types use PascalCase",
-        "+- Functions accepting allocator must take it as first parameter",
-        "+- Prefer arena allocator for request-scoped work",
-        "+- Use errdefer to free on error paths, not manual cleanup",
-        " ",
-        " ## Formatting",
-    }, .trace_refers = 28, .trace_sessions = 7 },
-};
-
-pub const WORKSPACES = [_]WorkspaceEntry{
-    .{ .name = "payments-api", .prompts = 18, .contexts = 9, .overrides = 3, .local_rev = 41, .remote_rev = 43, .paths = 2, .open_prs = 2, .last_sync = "1h ago", .access_level = .admin },
-    .{ .name = "merchant-portal", .prompts = 14, .contexts = 5, .overrides = 1, .local_rev = 37, .remote_rev = 37, .paths = 1, .open_prs = 0, .last_sync = "2 min ago", .access_level = .member },
-    .{ .name = "infra-tools", .prompts = 8, .contexts = 3, .overrides = 0, .local_rev = 22, .remote_rev = 22, .paths = 1, .open_prs = 1, .last_sync = "5 min ago", .access_level = .member },
-    .{ .name = "release-bot", .prompts = 5, .contexts = 2, .overrides = 0, .local_rev = 15, .remote_rev = 15, .paths = 1, .open_prs = 0, .last_sync = "3 min ago", .access_level = .member },
-    .{ .name = "docs-site", .prompts = 6, .contexts = 4, .overrides = 0, .local_rev = 10, .remote_rev = 10, .paths = 1, .open_prs = 0, .last_sync = "10 min ago", .access_level = .member },
-    .{ .name = "mobile-app", .prompts = 12, .contexts = 7, .overrides = 2, .local_rev = 28, .remote_rev = 30, .paths = 2, .open_prs = 1, .last_sync = "30 min ago", .access_level = .admin },
-    .{ .name = "data-pipeline", .prompts = 9, .contexts = 6, .overrides = 0, .local_rev = 19, .remote_rev = 19, .paths = 1, .open_prs = 0, .last_sync = "8 min ago", .access_level = .member },
-    .{ .name = "admin-dashboard", .prompts = 11, .contexts = 4, .overrides = 1, .local_rev = 25, .remote_rev = 25, .paths = 1, .open_prs = 2, .last_sync = "15 min ago", .access_level = .admin },
-};
-
-
-pub const ContextFile = struct {
-    path: []const u8,
-    size: []const u8,
-    hash: []const u8,
-    state: []const u8,
-    modified: bool, // true = your branch differs from main
-    branch_diff: []const []const u8, // your branch diff vs main
-};
-
-pub const WsPromptEntry = struct {
-    name: []const u8,
-    kind: []const u8,
-    has_override: bool,
-    hash: []const u8,
-    state: []const u8,
-    override_diff: []const []const u8,
-};
-
-// ── Insights data model (aligned with s1-4 signal_ratio spec) ──
-
 pub const ConstraintStat = struct {
     id: []const u8,
     label: []const u8,
     refer_count: u32,
-    idle_days: ?u16, // null = active
+    idle_days: ?u16,
 };
 
 pub const MemberPromptStat = struct {
@@ -266,11 +87,11 @@ pub const InsightsPrompt = struct {
     constraint_count: u8,
     active_constraint_count: u8,
     idle_constraint_count: u8,
-    signal_ratio: u8, // 0-100, displayed as percentage
+    signal_ratio: u8,
     refer_count: u32,
     rate_per_day: u16,
     delta_pct: i8,
-    last_referred_days_ago: ?u16, // null = never referred
+    last_referred_days_ago: ?u16,
     trend: [30]u16,
     constraints: []const ConstraintStat,
 };
@@ -279,7 +100,7 @@ pub const InsightsMember = struct {
     username: []const u8,
     refer_count: u32,
     active_days: u8,
-    trend: [30]u16, // daily refer counts (30d), used for contribution heatmap
+    trend: [30]u16,
     top_prompts: []const MemberPromptStat,
     models: []const InsightsModel,
 };
@@ -287,19 +108,19 @@ pub const InsightsMember = struct {
 pub const InsightsModel = struct {
     model_id: []const u8,
     refer_count: u32,
-    pct: u8, // percentage of total
+    pct: u8,
 };
 
 pub const AlertLevel = enum {
-    prune, // idle constraints, needs pruning
-    declining, // refer rate dropping
-    healthy, // all good
+    prune,
+    declining,
+    healthy,
 
     pub fn icon(self: AlertLevel) []const u8 {
         return switch (self) {
-            .prune => "\xe2\x9a\xa0", // ⚠
-            .declining => "\xe2\x86\x93", // ↓
-            .healthy => "\xe2\x9c\x93", // ✓
+            .prune => "\xe2\x9a\xa0",
+            .declining => "\xe2\x86\x93",
+            .healthy => "\xe2\x9c\x93",
         };
     }
 };
@@ -311,231 +132,37 @@ pub const InsightsAlert = struct {
 };
 
 pub const InsightsData = struct {
-    // Header
-    constraint_count: u32,
-    active_constraint_count: u32,
-    idle_constraint_count: u32,
-    signal_ratio: u8, // 0-100
-    refers_per_hour: u16,
-    today_delta_pct: i8,
-    last_event_minutes_ago: u16,
-    // Chart
-    refer_trend: [30]u16, // daily refer counts (30d)
-    // Prompts
-    prompts: []const InsightsPrompt,
-    // Members
-    members: []const InsightsMember,
-    // Models
-    models: []const InsightsModel,
-    // Alerts
-    alerts: []const InsightsAlert,
+    constraint_count: u32 = 0,
+    active_constraint_count: u32 = 0,
+    idle_constraint_count: u32 = 0,
+    signal_ratio: u8 = 0,
+    refers_per_hour: u16 = 0,
+    today_delta_pct: i8 = 0,
+    last_event_minutes_ago: u16 = 0,
+    refer_trend: [30]u16 = .{0} ** 30,
+    prompts: []const InsightsPrompt = &.{},
+    members: []const InsightsMember = &.{},
+    models: []const InsightsModel = &.{},
+    alerts: []const InsightsAlert = &.{},
 };
 
-// Context branch diffs (member branch vs main)
-const ctx_api_diff = [_][]const u8{
-    "  # API Design Spec",
-    "  ",
-    "  ## Authentication",
-    "- All endpoints require Bearer token.",
-    "+ All endpoints require Bearer token or API key.",
-    "+ API keys are scoped per-workspace.",
-    "  ",
-    "  ## Rate Limiting",
-    "  Default: 100 req/min per token.",
-    "+ Added: burst allowance of 20 req/s for batch ops.",
-    "  ",
-    "  ## Error Format",
-    "  All errors return JSON with `code` and `message`.",
-    "+ Added: `request_id` field for tracing.",
-    "+ Added: `retry_after` header on 429 responses.",
-};
-const ctx_audit_diff = [_][]const u8{
-    "  # Audit Journal 05",
-    "  ",
-    "- ## Findings: 3 issues identified",
-    "+ ## Findings: 5 issues identified",
-    "  ",
-    "  1. Token rotation not enforced",
-    "  2. Stale sessions not cleaned up",
-    "  3. Missing rate limit on /sync endpoint",
-    "+ 4. Webhook secrets stored in plaintext",
-    "+ 5. No audit log for permission changes",
-    "  ",
-    "  ## Recommendations",
-    "- Schedule fix for Q2.",
-    "+ Schedule fix for Q2. Items 4-5 are P0.",
-};
-const ctx_empty_diff = [_][]const u8{};
-
-const style_diff = [_][]const u8{
-    "  # STYLE",
-    "- 1. Prefer short names.",
-    "+ 1. Prefer explicit names over abbreviations.",
-    "+ 2. Group imports by scope.",
-    "  3. Sort file sections in dependency order.",
-};
-const api_diff = [_][]const u8{
-    "  # API_REVIEW",
-    "+ Added: validate response schemas against OpenAPI spec.",
-    "  Check error codes match documentation.",
-};
-const zig_diff = [_][]const u8{
-    "  # DEPRECATED_API",
-    "- std.heap.GeneralPurposeAllocator",
-    "+ std.heap.DebugAllocator",
-    "  Target version: 0.15.1",
-};
-const empty_diff = [_][]const u8{};
-
-pub const WS_PROMPTS = [_]WsPromptEntry{
-    .{ .name = "cmd/GEN_COMMIT_MSG", .kind = "wf", .has_override = false, .hash = "e4f5", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "coding/API_REVIEW", .kind = "rule", .has_override = true, .hash = "bcdd", .state = "local", .override_diff = &api_diff },
-    .{ .name = "coding/CODE_COMMENTS", .kind = "rule", .has_override = false, .hash = "u0v1", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "coding/COMPATIBILITY", .kind = "rule", .has_override = false, .hash = "q6r7", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "coding/STYLE", .kind = "rule", .has_override = true, .hash = "a1b2", .state = "stale", .override_diff = &style_diff },
-    .{ .name = "wf/RELEASE_CHECKLIST", .kind = "wf", .has_override = false, .hash = "91ab", .state = "fresh", .override_diff = &empty_diff },
-    .{ .name = "zig/DEPRECATED_API", .kind = "rule", .has_override = true, .hash = "c8d9", .state = "stale", .override_diff = &zig_diff },
-    .{ .name = "zig/ZIG_STYLE", .kind = "rule", .has_override = false, .hash = "y4z5", .state = "fresh", .override_diff = &empty_diff },
+pub const ContextFile = struct {
+    path: []const u8,
+    size: []const u8,
+    hash: []const u8,
+    state: []const u8,
+    modified: bool,
+    branch_diff: []const []const u8,
 };
 
-pub const WS_CONTEXT = [_]ContextFile{
-    .{ .path = "spec/API_DESIGN.md", .size = "2.0k", .hash = "x1y2", .state = "fresh", .modified = true, .branch_diff = &ctx_api_diff },
-    .{ .path = "research/competitor.md", .size = "1.0k", .hash = "m7n8", .state = "fresh", .modified = false, .branch_diff = &ctx_empty_diff },
-    .{ .path = "journal/05_AUDIT.md", .size = "3.2k", .hash = "p9q0", .state = "local", .modified = true, .branch_diff = &ctx_audit_diff },
-    .{ .path = "thesis/T0-observability.md", .size = "4.1k", .hash = "r3s4", .state = "fresh", .modified = false, .branch_diff = &ctx_empty_diff },
+pub const WsPromptEntry = struct {
+    name: []const u8,
+    kind: []const u8,
+    has_override: bool,
+    hash: []const u8,
+    state: []const u8,
+    override_diff: []const []const u8,
 };
-
-
-const style_constraints = [_]ConstraintStat{
-    .{ .id = "c-1", .label = "naming conventions", .refer_count = 1280, .idle_days = null },
-    .{ .id = "c-2", .label = "import ordering", .refer_count = 890, .idle_days = null },
-    .{ .id = "c-3", .label = "formatting rules", .refer_count = 720, .idle_days = null },
-    .{ .id = "c-4", .label = "code organization", .refer_count = 180, .idle_days = null },
-    .{ .id = "c-5", .label = "file structure", .refer_count = 80, .idle_days = null },
-    .{ .id = "c-6", .label = "error handling", .refer_count = 40, .idle_days = null },
-    .{ .id = "c-7", .label = "test conventions", .refer_count = 20, .idle_days = null },
-    .{ .id = "c-8", .label = "unused rule", .refer_count = 0, .idle_days = 14 },
-};
-
-const empty_constraints = [_]ConstraintStat{};
-
-const alice_prompts = [_]MemberPromptStat{
-    .{ .name = "coding/STYLE", .refer_count = 68 },
-    .{ .name = "zig/ZIG_STYLE", .refer_count = 32 },
-    .{ .name = "coding/API_REVIEW", .refer_count = 24 },
-};
-const bob_prompts = [_]MemberPromptStat{
-    .{ .name = "coding/STYLE", .refer_count = 42 },
-    .{ .name = "zig/DEPRECATED", .refer_count = 28 },
-};
-const carol_prompts = [_]MemberPromptStat{
-    .{ .name = "coding/COMMENTS", .refer_count = 35 },
-    .{ .name = "coding/STYLE", .refer_count = 22 },
-};
-const dave_prompts = [_]MemberPromptStat{
-    .{ .name = "wf/RELEASE", .refer_count = 18 },
-};
-
-const alice_models = [_]InsightsModel{
-    .{ .model_id = "claude-opus", .refer_count = 138, .pct = 97 },
-    .{ .model_id = "gpt-4o", .refer_count = 4, .pct = 3 },
-};
-const bob_models = [_]InsightsModel{
-    .{ .model_id = "claude-opus", .refer_count = 95, .pct = 97 },
-    .{ .model_id = "gpt-4o", .refer_count = 3, .pct = 3 },
-};
-const single_model = [_]InsightsModel{
-    .{ .model_id = "claude-opus", .refer_count = 67, .pct = 100 },
-};
-
-// @zig-fmt: off
-const insights_prompts = [_]InsightsPrompt{
-    .{ .name = "coding/STYLE",      .constraint_count = 8,  .active_constraint_count = 7,  .idle_constraint_count = 1, .signal_ratio = 87,  .refer_count = 3210, .rate_per_day = 42, .delta_pct = 8,   .last_referred_days_ago = 0,  .trend = .{ 85, 90, 95, 88, 102, 108, 112, 98, 105, 115, 120, 110, 118, 125, 130, 122, 128, 135, 140, 132, 138, 142, 148, 140, 145, 150, 155, 148, 152, 158 }, .constraints = &style_constraints },
-    .{ .name = "coding/API_REVIEW", .constraint_count = 12, .active_constraint_count = 10, .idle_constraint_count = 2, .signal_ratio = 83,  .refer_count = 842,  .rate_per_day = 12, .delta_pct = 14,  .last_referred_days_ago = 0,  .trend = .{ 18, 20, 22, 25, 24, 28, 30, 26, 32, 35, 28, 30, 34, 38, 36, 40, 42, 38, 35, 40, 45, 42, 48, 44, 40, 46, 50, 48, 52, 55 }, .constraints = &empty_constraints },
-    .{ .name = "wf/RELEASE",        .constraint_count = 4,  .active_constraint_count = 4,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 611,  .rate_per_day = 8,  .delta_pct = -2,  .last_referred_days_ago = 1,  .trend = .{ 25, 28, 30, 32, 28, 26, 24, 22, 25, 28, 30, 26, 24, 22, 20, 22, 24, 26, 22, 20, 18, 20, 22, 24, 20, 18, 16, 18, 20, 18 }, .constraints = &empty_constraints },
-    .{ .name = "coding/COMMENTS",   .constraint_count = 9,  .active_constraint_count = 7,  .idle_constraint_count = 2, .signal_ratio = 77,  .refer_count = 488,  .rate_per_day = 6,  .delta_pct = 5,   .last_referred_days_ago = 0,  .trend = .{ 12, 14, 15, 16, 14, 18, 20, 16, 18, 20, 22, 18, 20, 22, 24, 20, 22, 24, 26, 22, 24, 26, 28, 24, 26, 28, 30, 26, 28, 30 }, .constraints = &empty_constraints },
-    .{ .name = "zig/ZIG_STYLE",     .constraint_count = 11, .active_constraint_count = 8,  .idle_constraint_count = 3, .signal_ratio = 72,  .refer_count = 412,  .rate_per_day = 5,  .delta_pct = 3,   .last_referred_days_ago = 0,  .trend = .{ 10, 12, 14, 12, 15, 16, 14, 18, 16, 14, 18, 20, 16, 18, 20, 22, 18, 16, 20, 22, 18, 20, 22, 24, 20, 18, 22, 24, 20, 22 }, .constraints = &empty_constraints },
-    .{ .name = "zig/DEPRECATED",    .constraint_count = 59, .active_constraint_count = 52, .idle_constraint_count = 7, .signal_ratio = 88,  .refer_count = 387,  .rate_per_day = 5,  .delta_pct = 11,  .last_referred_days_ago = 0,  .trend = .{ 5, 6, 8, 10, 8, 12, 14, 10, 12, 15, 18, 14, 16, 18, 20, 16, 18, 22, 24, 18, 20, 22, 25, 20, 22, 25, 28, 22, 25, 28 }, .constraints = &empty_constraints },
-    .{ .name = "coding/COMPAT",     .constraint_count = 8,  .active_constraint_count = 8,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 198,  .rate_per_day = 3,  .delta_pct = 1,   .last_referred_days_ago = 1,  .trend = .{ 5, 6, 6, 7, 6, 7, 8, 6, 7, 8, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7 }, .constraints = &empty_constraints },
-    .{ .name = "wf/GEN_PR",         .constraint_count = 4,  .active_constraint_count = 4,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 102,  .rate_per_day = 1,  .delta_pct = -5,  .last_referred_days_ago = 2,  .trend = .{ 6, 5, 5, 4, 5, 4, 4, 3, 4, 3, 4, 3, 3, 4, 3, 3, 2, 3, 3, 2, 3, 2, 2, 3, 2, 2, 1, 2, 2, 1 }, .constraints = &empty_constraints },
-    .{ .name = "arch/ADR_DOC",      .constraint_count = 6,  .active_constraint_count = 6,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 58,   .rate_per_day = 1,  .delta_pct = 0,   .last_referred_days_ago = 3,  .trend = .{ 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2 }, .constraints = &empty_constraints },
-    .{ .name = "style/UIUX",        .constraint_count = 7,  .active_constraint_count = 0,  .idle_constraint_count = 7, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = 14, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
-    .{ .name = "wf/GITIGNORE",      .constraint_count = 3,  .active_constraint_count = 0,  .idle_constraint_count = 3, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = null, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
-    .{ .name = "cmd/GEN_ISSUE",     .constraint_count = 4,  .active_constraint_count = 0,  .idle_constraint_count = 4, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = 21, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
-};
-
-const insights_members = [_]InsightsMember{
-    .{ .username = "alice", .refer_count = 142, .active_days = 22, .trend = .{ 4, 6, 5, 8, 7, 0, 0, 5, 7, 6, 9, 8, 1, 0, 6, 8, 7, 10, 9, 2, 0, 7, 9, 8, 11, 10, 3, 1, 8, 10 }, .top_prompts = &alice_prompts, .models = &alice_models },
-    .{ .username = "bob",   .refer_count = 98,  .active_days = 18, .trend = .{ 3, 4, 0, 5, 6, 0, 0, 4, 3, 0, 6, 7, 2, 0, 3, 5, 0, 7, 8, 0, 0, 4, 6, 0, 8, 7, 1, 0, 5, 7 }, .top_prompts = &bob_prompts, .models = &bob_models },
-    .{ .username = "carol", .refer_count = 67,  .active_days = 15, .trend = .{ 0, 3, 4, 2, 0, 0, 0, 0, 4, 5, 3, 0, 0, 0, 0, 5, 6, 4, 0, 0, 0, 0, 6, 5, 3, 0, 0, 0, 5, 4 }, .top_prompts = &carol_prompts, .models = &single_model },
-    .{ .username = "dave",  .refer_count = 31,  .active_days = 8,  .trend = .{ 2, 0, 0, 3, 2, 0, 0, 0, 0, 0, 4, 3, 0, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 4, 3, 0, 0, 0, 2 }, .top_prompts = &dave_prompts, .models = &single_model },
-};
-// @zig-fmt: on
-
-const insights_models = [_]InsightsModel{
-    .{ .model_id = "claude-opus", .refer_count = 3800, .pct = 90 },
-    .{ .model_id = "gpt-4o", .refer_count = 400, .pct = 10 },
-};
-
-const insights_alerts = [_]InsightsAlert{
-    .{ .prompt_name = "style/UIUX", .level = .prune, .message = "7 idle constraints \u{2014} consider pruning" },
-    .{ .prompt_name = "wf/GITIGNORE", .level = .prune, .message = "3 idle \u{2014} never referred" },
-    .{ .prompt_name = "cmd/GEN_ISSUE", .level = .prune, .message = "4 idle for 21d" },
-    .{ .prompt_name = "wf/GEN_PR", .level = .declining, .message = "refer rate -5% this week" },
-    .{ .prompt_name = "wf/RELEASE", .level = .declining, .message = "refer rate -2% this week" },
-    .{ .prompt_name = "coding/STYLE", .level = .healthy, .message = "signal 7/8, +8% this week" },
-};
-
-pub const INSIGHTS: InsightsData = .{
-    .constraint_count = 380,
-    .active_constraint_count = 312,
-    .idle_constraint_count = 68,
-    .signal_ratio = 82,
-    .refers_per_hour = 42,
-    .today_delta_pct = 12,
-    .last_event_minutes_ago = 2,
-    .refer_trend = .{ 145, 160, 155, 172, 168, 42, 28, 158, 175, 168, 192, 188, 48, 32, 172, 190, 182, 210, 205, 55, 35, 185, 205, 195, 225, 218, 62, 38, 198, 215 },
-    .prompts = &insights_prompts,
-    .members = &insights_members,
-    .models = &insights_models,
-    .alerts = &insights_alerts,
-};
-
-pub const SAMPLE_CONTENT =
-    \\# Code Comments
-    \\
-    \\Code comments must be final-form text. No thinking
-    \\process or intermediate reasoning.
-    \\
-    \\## Prohibited comment types
-    \\
-    \\- Thinking process: `// Wait, let me recalculate...`
-    \\- Personal dialogue: `// Actually...`
-    \\- Vague markers: `// TODO: Fix this later`
-    \\  (must state what specifically needs fixing)
-    \\
-    \\## Allowed comment types
-    \\
-    \\- Technical notes: explain complex logic, algorithms
-    \\- Functional markers: `// TODO: Implement signature
-    \\  verification for production`
-    \\- Security warnings: `// SECURITY: Must validate
-    \\  inputs before...`
-    \\
-    \\## No decorative separators
-    \\
-    \\Do not use repeated symbols to draw separators,
-    \\borders, or decorations in comments.
-    \\
-    \\## Language
-    \\
-    \\All code comments must be in English.
-    \\
-    \\## Audience
-    \\
-    \\All code comments must assume the reader is another
-    \\developer, not a personal memo.
-;
 
 pub const MemberEntry = struct {
     user_id: []const u8,
@@ -544,14 +171,6 @@ pub const MemberEntry = struct {
     joined: []const u8,
 };
 
-pub const MEMBERS = [_]MemberEntry{
-    .{ .user_id = "usr-001", .username = "alice", .role = "maintainer", .joined = "2026-01-15" },
-    .{ .user_id = "usr-002", .username = "bob", .role = "member", .joined = "2026-02-20" },
-    .{ .user_id = "usr-003", .username = "carol", .role = "member", .joined = "2026-03-05" },
-    .{ .user_id = "usr-004", .username = "dave", .role = "member", .joined = "2026-03-18" },
-};
-
-// Mirrors GET /api/auth/me + config.toml workspace bindings
 pub const WsAccess = struct {
     name: []const u8,
     role: AccessLevel,
@@ -573,18 +192,12 @@ pub const CurrentUser = struct {
     workspaces: []const WsAccess,
 };
 
-const my_scopes = [_][]const u8{
-    "library:read",
-    "workspace:read",
-    "workspace:write",
-    "trace:write",
-    "stats:read",
-    "pr:read",
-    "pr:write",
-    "members:read",
+pub const TokenInfo = struct {
+    scopes: []const []const u8,
+    expires: []const u8,
 };
 
-// Token scope definitions for the Hub Server permission model
+// Token scope definitions
 pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "library:read", .description = "Read prompts and bundles" },
     .{ .name = "library:write", .description = "Create pull requests" },
@@ -600,51 +213,20 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "pr:merge", .description = "Accept/reject pull requests" },
 };
 
-const payments_paths = [_][]const u8{ "~/work/payments", "~/work/payments-v2" };
-const merchant_paths = [_][]const u8{ "~/work/merchant", "~/projects/merchant-staging" };
-const infra_paths = [_][]const u8{"~/work/infra-tools"};
-const bot_paths = [_][]const u8{"~/work/release-bot"};
-const docs_paths = [_][]const u8{"~/work/docs-site"};
-const mobile_paths = [_][]const u8{ "~/work/mobile", "~/projects/mobile-beta" };
-const pipeline_paths = [_][]const u8{"~/work/data-pipeline"};
-const empty_paths = [_][]const u8{};
+// Helper functions
+pub fn pathPrefix(canonical_name: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
+        return canonical_name[0..idx];
+    }
+    return canonical_name;
+}
 
-const my_workspaces = [_]WsAccess{
-    .{ .name = "payments-api", .role = .admin, .paths = &payments_paths },
-    .{ .name = "merchant-portal", .role = .member, .paths = &merchant_paths },
-    .{ .name = "infra-tools", .role = .member, .paths = &infra_paths },
-    .{ .name = "release-bot", .role = .member, .paths = &bot_paths },
-    .{ .name = "docs-site", .role = .member, .paths = &docs_paths },
-    .{ .name = "mobile-app", .role = .admin, .paths = &mobile_paths },
-    .{ .name = "data-pipeline", .role = .member, .paths = &pipeline_paths },
-    .{ .name = "admin-dashboard", .role = .admin, .paths = &empty_paths },
-};
-
-pub const CLIENT_CONFIG = ClientConfig{
-    .server_url = "https://hub.acme.io",
-    .sync_strategy = "session",
-    .token_status = "active",
-    .token_expires = "2026-04-07T12:00:00Z",
-};
-
-pub const CURRENT_USER = CurrentUser{
-    .user_id = "usr-0001",
-    .username = "alice",
-    .role = "maintainer",
-    .scopes = &my_scopes,
-    .workspaces = &my_workspaces,
-};
-
-pub const TokenInfo = struct {
-    scopes: []const []const u8,
-    expires: []const u8,
-};
-
-
-pub const CURRENT_TOKEN = TokenInfo{
-    .scopes = &my_scopes,
-    .expires = "2026-04-07T12:00:00Z",
-};
+pub fn promptName(canonical_name: []const u8) []const u8 {
+    if (std.mem.indexOf(u8, canonical_name, "/")) |idx| {
+        return canonical_name[idx + 1 ..];
+    }
+    return canonical_name;
+}
 
 pub fn syncStateLabel(ws: *const WorkspaceEntry) []const u8 {
     if (ws.local_rev == ws.remote_rev) return "up to date";
@@ -656,5 +238,3 @@ pub fn syncStateColor(ws: *const WorkspaceEntry) @import("theme.zig").Color {
     if (ws.local_rev == ws.remote_rev) return t.OK;
     return t.WARN;
 }
-
-const Color = @import("vaxis").Color;

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -200,16 +200,39 @@ pub const HOTSPOTS = [_]HotspotEntry{
 };
 
 pub const SAMPLE_CONTENT =
-    \\# STYLE
+    \\# Code Comments
     \\
-    \\1. Prefer explicit names over abbreviations.
-    \\2. Keep imports grouped by standard / third-party / local.
-    \\3. Sort file sections in dependency order.
-    \\4. One blank line between top-level declarations.
-    \\5. Constants at the top of the scope, mutable state below.
-    \\6. Error handling uses try; avoid manual catch unless re-wrapping.
-    \\7. Public API documented with doc comments.
-    \\8. No magic numbers; define named constants.
+    \\Code comments must be final-form text. No thinking
+    \\process or intermediate reasoning.
+    \\
+    \\## Prohibited comment types
+    \\
+    \\- Thinking process: `// Wait, let me recalculate...`
+    \\- Personal dialogue: `// Actually...`
+    \\- Vague markers: `// TODO: Fix this later`
+    \\  (must state what specifically needs fixing)
+    \\
+    \\## Allowed comment types
+    \\
+    \\- Technical notes: explain complex logic, algorithms
+    \\- Functional markers: `// TODO: Implement signature
+    \\  verification for production`
+    \\- Security warnings: `// SECURITY: Must validate
+    \\  inputs before...`
+    \\
+    \\## No decorative separators
+    \\
+    \\Do not use repeated symbols to draw separators,
+    \\borders, or decorations in comments.
+    \\
+    \\## Language
+    \\
+    \\All code comments must be in English.
+    \\
+    \\## Audience
+    \\
+    \\All code comments must assume the reader is another
+    \\developer, not a personal memo.
 ;
 
 pub const MemberEntry = struct {

--- a/src/tui/mock_data.zig
+++ b/src/tui/mock_data.zig
@@ -198,17 +198,88 @@ pub const WsPromptEntry = struct {
     override_diff: []const []const u8,
 };
 
-pub const InsightsWs = struct {
-    name: []const u8,
-    coverage: u8,
-    refer_count: []const u8,
-    trend: [8]u8,
+// ── Insights data model (aligned with s1-4 signal_ratio spec) ──
+
+pub const ConstraintStat = struct {
+    id: []const u8,
+    label: []const u8,
+    refer_count: u32,
+    idle_days: ?u16, // null = active
 };
 
-pub const HotspotEntry = struct {
+pub const MemberPromptStat = struct {
     name: []const u8,
-    refer_count: []const u8,
-    prompt_idx: usize,
+    refer_count: u32,
+};
+
+pub const InsightsPrompt = struct {
+    name: []const u8,
+    constraint_count: u8,
+    active_constraint_count: u8,
+    idle_constraint_count: u8,
+    signal_ratio: u8, // 0-100, displayed as percentage
+    refer_count: u32,
+    rate_per_day: u16,
+    delta_pct: i8,
+    last_referred_days_ago: ?u16, // null = never referred
+    trend: [30]u16,
+    constraints: []const ConstraintStat,
+};
+
+pub const InsightsMember = struct {
+    username: []const u8,
+    refer_count: u32,
+    active_days: u8,
+    trend: [30]u16, // daily refer counts (30d), used for contribution heatmap
+    top_prompts: []const MemberPromptStat,
+    models: []const InsightsModel,
+};
+
+pub const InsightsModel = struct {
+    model_id: []const u8,
+    refer_count: u32,
+    pct: u8, // percentage of total
+};
+
+pub const AlertLevel = enum {
+    prune, // idle constraints, needs pruning
+    declining, // refer rate dropping
+    healthy, // all good
+
+    pub fn icon(self: AlertLevel) []const u8 {
+        return switch (self) {
+            .prune => "\xe2\x9a\xa0", // ⚠
+            .declining => "\xe2\x86\x93", // ↓
+            .healthy => "\xe2\x9c\x93", // ✓
+        };
+    }
+};
+
+pub const InsightsAlert = struct {
+    prompt_name: []const u8,
+    level: AlertLevel,
+    message: []const u8,
+};
+
+pub const InsightsData = struct {
+    // Header
+    constraint_count: u32,
+    active_constraint_count: u32,
+    idle_constraint_count: u32,
+    signal_ratio: u8, // 0-100
+    refers_per_hour: u16,
+    today_delta_pct: i8,
+    last_event_minutes_ago: u16,
+    // Chart
+    refer_trend: [30]u16, // daily refer counts (30d)
+    // Prompts
+    prompts: []const InsightsPrompt,
+    // Members
+    members: []const InsightsMember,
+    // Models
+    models: []const InsightsModel,
+    // Alerts
+    alerts: []const InsightsAlert,
 };
 
 // Context branch diffs (member branch vs main)
@@ -291,20 +362,99 @@ pub const WS_OVERRIDES = [_]OverrideEntry{
     .{ .prompt_name = "zig/DEPRECATED_API", .base_hash = "c8d9", .current_hash = "c8d9", .status = "clean" },
 };
 
-pub const INSIGHTS_WS = [_]InsightsWs{
-    .{ .name = "payments-api", .coverage = 82, .refer_count = "4.2k", .trend = .{ 2, 3, 4, 5, 6, 7, 6, 5 } },
-    .{ .name = "merchant-portal", .coverage = 76, .refer_count = "3.1k", .trend = .{ 1, 2, 3, 4, 5, 5, 4, 3 } },
-    .{ .name = "infra-tools", .coverage = 74, .refer_count = "2.8k", .trend = .{ 2, 2, 3, 3, 4, 4, 3, 3 } },
-    .{ .name = "release-bot", .coverage = 63, .refer_count = "1.1k", .trend = .{ 1, 1, 2, 2, 3, 3, 2, 2 } },
-    .{ .name = "docs-site", .coverage = 61, .refer_count = "0.9k", .trend = .{ 0, 1, 1, 2, 2, 3, 2, 2 } },
+const style_constraints = [_]ConstraintStat{
+    .{ .id = "c-1", .label = "naming conventions", .refer_count = 1280, .idle_days = null },
+    .{ .id = "c-2", .label = "import ordering", .refer_count = 890, .idle_days = null },
+    .{ .id = "c-3", .label = "formatting rules", .refer_count = 720, .idle_days = null },
+    .{ .id = "c-4", .label = "code organization", .refer_count = 180, .idle_days = null },
+    .{ .id = "c-5", .label = "file structure", .refer_count = 80, .idle_days = null },
+    .{ .id = "c-6", .label = "error handling", .refer_count = 40, .idle_days = null },
+    .{ .id = "c-7", .label = "test conventions", .refer_count = 20, .idle_days = null },
+    .{ .id = "c-8", .label = "unused rule", .refer_count = 0, .idle_days = 14 },
 };
 
-pub const HOTSPOTS = [_]HotspotEntry{
-    .{ .name = "coding/STYLE", .refer_count = "3210", .prompt_idx = 0 },
-    .{ .name = "coding/API_REVIEW", .refer_count = "990", .prompt_idx = 2 },
-    .{ .name = "wf/RELEASE_CHECKLIST", .refer_count = "611", .prompt_idx = 3 },
-    .{ .name = "coding/CODE_COMMENTS", .refer_count = "488", .prompt_idx = 5 },
-    .{ .name = "zig/ZIG_STYLE", .refer_count = "412", .prompt_idx = 6 },
+const empty_constraints = [_]ConstraintStat{};
+
+const alice_prompts = [_]MemberPromptStat{
+    .{ .name = "coding/STYLE", .refer_count = 68 },
+    .{ .name = "zig/ZIG_STYLE", .refer_count = 32 },
+    .{ .name = "coding/API_REVIEW", .refer_count = 24 },
+};
+const bob_prompts = [_]MemberPromptStat{
+    .{ .name = "coding/STYLE", .refer_count = 42 },
+    .{ .name = "zig/DEPRECATED", .refer_count = 28 },
+};
+const carol_prompts = [_]MemberPromptStat{
+    .{ .name = "coding/COMMENTS", .refer_count = 35 },
+    .{ .name = "coding/STYLE", .refer_count = 22 },
+};
+const dave_prompts = [_]MemberPromptStat{
+    .{ .name = "wf/RELEASE", .refer_count = 18 },
+};
+
+const alice_models = [_]InsightsModel{
+    .{ .model_id = "claude-opus", .refer_count = 138, .pct = 97 },
+    .{ .model_id = "gpt-4o", .refer_count = 4, .pct = 3 },
+};
+const bob_models = [_]InsightsModel{
+    .{ .model_id = "claude-opus", .refer_count = 95, .pct = 97 },
+    .{ .model_id = "gpt-4o", .refer_count = 3, .pct = 3 },
+};
+const single_model = [_]InsightsModel{
+    .{ .model_id = "claude-opus", .refer_count = 67, .pct = 100 },
+};
+
+// @zig-fmt: off
+const insights_prompts = [_]InsightsPrompt{
+    .{ .name = "coding/STYLE",      .constraint_count = 8,  .active_constraint_count = 7,  .idle_constraint_count = 1, .signal_ratio = 87,  .refer_count = 3210, .rate_per_day = 42, .delta_pct = 8,   .last_referred_days_ago = 0,  .trend = .{ 85, 90, 95, 88, 102, 108, 112, 98, 105, 115, 120, 110, 118, 125, 130, 122, 128, 135, 140, 132, 138, 142, 148, 140, 145, 150, 155, 148, 152, 158 }, .constraints = &style_constraints },
+    .{ .name = "coding/API_REVIEW", .constraint_count = 12, .active_constraint_count = 10, .idle_constraint_count = 2, .signal_ratio = 83,  .refer_count = 842,  .rate_per_day = 12, .delta_pct = 14,  .last_referred_days_ago = 0,  .trend = .{ 18, 20, 22, 25, 24, 28, 30, 26, 32, 35, 28, 30, 34, 38, 36, 40, 42, 38, 35, 40, 45, 42, 48, 44, 40, 46, 50, 48, 52, 55 }, .constraints = &empty_constraints },
+    .{ .name = "wf/RELEASE",        .constraint_count = 4,  .active_constraint_count = 4,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 611,  .rate_per_day = 8,  .delta_pct = -2,  .last_referred_days_ago = 1,  .trend = .{ 25, 28, 30, 32, 28, 26, 24, 22, 25, 28, 30, 26, 24, 22, 20, 22, 24, 26, 22, 20, 18, 20, 22, 24, 20, 18, 16, 18, 20, 18 }, .constraints = &empty_constraints },
+    .{ .name = "coding/COMMENTS",   .constraint_count = 9,  .active_constraint_count = 7,  .idle_constraint_count = 2, .signal_ratio = 77,  .refer_count = 488,  .rate_per_day = 6,  .delta_pct = 5,   .last_referred_days_ago = 0,  .trend = .{ 12, 14, 15, 16, 14, 18, 20, 16, 18, 20, 22, 18, 20, 22, 24, 20, 22, 24, 26, 22, 24, 26, 28, 24, 26, 28, 30, 26, 28, 30 }, .constraints = &empty_constraints },
+    .{ .name = "zig/ZIG_STYLE",     .constraint_count = 11, .active_constraint_count = 8,  .idle_constraint_count = 3, .signal_ratio = 72,  .refer_count = 412,  .rate_per_day = 5,  .delta_pct = 3,   .last_referred_days_ago = 0,  .trend = .{ 10, 12, 14, 12, 15, 16, 14, 18, 16, 14, 18, 20, 16, 18, 20, 22, 18, 16, 20, 22, 18, 20, 22, 24, 20, 18, 22, 24, 20, 22 }, .constraints = &empty_constraints },
+    .{ .name = "zig/DEPRECATED",    .constraint_count = 59, .active_constraint_count = 52, .idle_constraint_count = 7, .signal_ratio = 88,  .refer_count = 387,  .rate_per_day = 5,  .delta_pct = 11,  .last_referred_days_ago = 0,  .trend = .{ 5, 6, 8, 10, 8, 12, 14, 10, 12, 15, 18, 14, 16, 18, 20, 16, 18, 22, 24, 18, 20, 22, 25, 20, 22, 25, 28, 22, 25, 28 }, .constraints = &empty_constraints },
+    .{ .name = "coding/COMPAT",     .constraint_count = 8,  .active_constraint_count = 8,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 198,  .rate_per_day = 3,  .delta_pct = 1,   .last_referred_days_ago = 1,  .trend = .{ 5, 6, 6, 7, 6, 7, 8, 6, 7, 8, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7, 6, 7, 8, 7 }, .constraints = &empty_constraints },
+    .{ .name = "wf/GEN_PR",         .constraint_count = 4,  .active_constraint_count = 4,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 102,  .rate_per_day = 1,  .delta_pct = -5,  .last_referred_days_ago = 2,  .trend = .{ 6, 5, 5, 4, 5, 4, 4, 3, 4, 3, 4, 3, 3, 4, 3, 3, 2, 3, 3, 2, 3, 2, 2, 3, 2, 2, 1, 2, 2, 1 }, .constraints = &empty_constraints },
+    .{ .name = "arch/ADR_DOC",      .constraint_count = 6,  .active_constraint_count = 6,  .idle_constraint_count = 0, .signal_ratio = 100, .refer_count = 58,   .rate_per_day = 1,  .delta_pct = 0,   .last_referred_days_ago = 3,  .trend = .{ 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 1, 2, 2, 2 }, .constraints = &empty_constraints },
+    .{ .name = "style/UIUX",        .constraint_count = 7,  .active_constraint_count = 0,  .idle_constraint_count = 7, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = 14, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
+    .{ .name = "wf/GITIGNORE",      .constraint_count = 3,  .active_constraint_count = 0,  .idle_constraint_count = 3, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = null, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
+    .{ .name = "cmd/GEN_ISSUE",     .constraint_count = 4,  .active_constraint_count = 0,  .idle_constraint_count = 4, .signal_ratio = 0,   .refer_count = 0,    .rate_per_day = 0,  .delta_pct = 0,   .last_referred_days_ago = 21, .trend = .{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, .constraints = &empty_constraints },
+};
+
+const insights_members = [_]InsightsMember{
+    .{ .username = "alice", .refer_count = 142, .active_days = 22, .trend = .{ 4, 6, 5, 8, 7, 0, 0, 5, 7, 6, 9, 8, 1, 0, 6, 8, 7, 10, 9, 2, 0, 7, 9, 8, 11, 10, 3, 1, 8, 10 }, .top_prompts = &alice_prompts, .models = &alice_models },
+    .{ .username = "bob",   .refer_count = 98,  .active_days = 18, .trend = .{ 3, 4, 0, 5, 6, 0, 0, 4, 3, 0, 6, 7, 2, 0, 3, 5, 0, 7, 8, 0, 0, 4, 6, 0, 8, 7, 1, 0, 5, 7 }, .top_prompts = &bob_prompts, .models = &bob_models },
+    .{ .username = "carol", .refer_count = 67,  .active_days = 15, .trend = .{ 0, 3, 4, 2, 0, 0, 0, 0, 4, 5, 3, 0, 0, 0, 0, 5, 6, 4, 0, 0, 0, 0, 6, 5, 3, 0, 0, 0, 5, 4 }, .top_prompts = &carol_prompts, .models = &single_model },
+    .{ .username = "dave",  .refer_count = 31,  .active_days = 8,  .trend = .{ 2, 0, 0, 3, 2, 0, 0, 0, 0, 0, 4, 3, 0, 0, 0, 0, 0, 5, 2, 0, 0, 0, 0, 0, 4, 3, 0, 0, 0, 2 }, .top_prompts = &dave_prompts, .models = &single_model },
+};
+// @zig-fmt: on
+
+const insights_models = [_]InsightsModel{
+    .{ .model_id = "claude-opus", .refer_count = 3800, .pct = 90 },
+    .{ .model_id = "gpt-4o", .refer_count = 400, .pct = 10 },
+};
+
+const insights_alerts = [_]InsightsAlert{
+    .{ .prompt_name = "style/UIUX", .level = .prune, .message = "7 idle constraints \u{2014} consider pruning" },
+    .{ .prompt_name = "wf/GITIGNORE", .level = .prune, .message = "3 idle \u{2014} never referred" },
+    .{ .prompt_name = "cmd/GEN_ISSUE", .level = .prune, .message = "4 idle for 21d" },
+    .{ .prompt_name = "wf/GEN_PR", .level = .declining, .message = "refer rate -5% this week" },
+    .{ .prompt_name = "wf/RELEASE", .level = .declining, .message = "refer rate -2% this week" },
+    .{ .prompt_name = "coding/STYLE", .level = .healthy, .message = "signal 7/8, +8% this week" },
+};
+
+pub const INSIGHTS: InsightsData = .{
+    .constraint_count = 380,
+    .active_constraint_count = 312,
+    .idle_constraint_count = 68,
+    .signal_ratio = 82,
+    .refers_per_hour = 42,
+    .today_delta_pct = 12,
+    .last_event_minutes_ago = 2,
+    .refer_trend = .{ 145, 160, 155, 172, 168, 42, 28, 158, 175, 168, 192, 188, 48, 32, 172, 190, 182, 210, 205, 55, 35, 185, 205, 195, 225, 218, 62, 38, 198, 215 },
+    .prompts = &insights_prompts,
+    .members = &insights_members,
+    .models = &insights_models,
+    .alerts = &insights_alerts,
 };
 
 pub const SAMPLE_CONTENT =

--- a/src/tui/session_reader.zig
+++ b/src/tui/session_reader.zig
@@ -1,0 +1,81 @@
+// Read per-workspace current_session.json markers written by the MCP
+// serve process on startup. Each file advertises the session_id, pid
+// and start timestamp for an active MCP on that workspace; the file is
+// removed on graceful shutdown. The TUI uses this to show which
+// sessions are currently live.
+
+const std = @import("std");
+
+pub const ActiveSession = struct {
+    ws_id: []const u8,
+    session_id: []const u8,
+    pid: i64,
+    started_at: i64,
+};
+
+pub fn readAllSessions(allocator: std.mem.Allocator) ?[]const ActiveSession {
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    const ws_root = std.fs.path.join(allocator, &.{ home, ".clumsies", "workspaces" }) catch return null;
+    defer allocator.free(ws_root);
+
+    var dir = std.fs.openDirAbsolute(ws_root, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var list: std.ArrayList(ActiveSession) = .empty;
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (entry.kind != .directory) continue;
+        const marker = std.fs.path.join(allocator, &.{ ws_root, entry.name, "current_session.json" }) catch continue;
+        defer allocator.free(marker);
+        readMarker(allocator, entry.name, marker, &list);
+    }
+
+    if (list.items.len == 0) return null;
+    return list.items;
+}
+
+fn readMarker(allocator: std.mem.Allocator, ws_id: []const u8, path: []const u8, out: *std.ArrayList(ActiveSession)) void {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return;
+    defer file.close();
+
+    var buf: [2048]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = file.read(buf[total..]) catch return;
+        if (n == 0) break;
+        total += n;
+    }
+    if (total == 0) return;
+
+    const Json = struct {
+        session_id: []const u8 = "",
+        pid: i64 = 0,
+        started_at: i64 = 0,
+    };
+    const parsed = std.json.parseFromSlice(Json, allocator, buf[0..total], .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return;
+    defer parsed.deinit();
+
+    if (parsed.value.session_id.len == 0) return;
+
+    // A stale marker from a crashed MCP can linger on disk. Probe the
+    // pid with signal 0 (no-op) to verify the process is still alive;
+    // if the kill check fails we skip the entry rather than report a
+    // ghost session.
+    if (parsed.value.pid > 0 and !pidAlive(@intCast(parsed.value.pid))) return;
+
+    out.append(allocator, .{
+        .ws_id = allocator.dupe(u8, ws_id) catch return,
+        .session_id = allocator.dupe(u8, parsed.value.session_id) catch return,
+        .pid = parsed.value.pid,
+        .started_at = parsed.value.started_at,
+    }) catch return;
+}
+
+fn pidAlive(pid: std.c.pid_t) bool {
+    const rc = std.c.kill(pid, 0);
+    return rc == 0;
+}

--- a/src/tui/session_reader.zig
+++ b/src/tui/session_reader.zig
@@ -9,7 +9,6 @@ const std = @import("std");
 pub const ActiveSession = struct {
     ws_id: []const u8,
     session_id: []const u8,
-    pid: i64,
     started_at: i64,
 };
 
@@ -50,7 +49,6 @@ fn readMarker(allocator: std.mem.Allocator, ws_id: []const u8, path: []const u8,
 
     const Json = struct {
         session_id: []const u8 = "",
-        pid: i64 = 0,
         started_at: i64 = 0,
     };
     const parsed = std.json.parseFromSlice(Json, allocator, buf[0..total], .{
@@ -61,21 +59,9 @@ fn readMarker(allocator: std.mem.Allocator, ws_id: []const u8, path: []const u8,
 
     if (parsed.value.session_id.len == 0) return;
 
-    // A stale marker from a crashed MCP can linger on disk. Probe the
-    // pid with signal 0 (no-op) to verify the process is still alive;
-    // if the kill check fails we skip the entry rather than report a
-    // ghost session.
-    if (parsed.value.pid > 0 and !pidAlive(@intCast(parsed.value.pid))) return;
-
     out.append(allocator, .{
         .ws_id = allocator.dupe(u8, ws_id) catch return,
         .session_id = allocator.dupe(u8, parsed.value.session_id) catch return,
-        .pid = parsed.value.pid,
         .started_at = parsed.value.started_at,
     }) catch return;
-}
-
-fn pidAlive(pid: std.c.pid_t) bool {
-    const rc = std.c.kill(pid, 0);
-    return rc == 0;
 }

--- a/src/tui/session_reader.zig
+++ b/src/tui/session_reader.zig
@@ -12,8 +12,13 @@ pub const ActiveSession = struct {
     started_at: i64,
 };
 
+fn getHomeDirOwned(allocator: std.mem.Allocator) ?[]u8 {
+    return std.process.getEnvVarOwned(allocator, "HOME") catch
+        std.process.getEnvVarOwned(allocator, "USERPROFILE") catch null;
+}
+
 pub fn readAllSessions(allocator: std.mem.Allocator) ?[]const ActiveSession {
-    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    const home = getHomeDirOwned(allocator) orelse return null;
     defer allocator.free(home);
     const ws_root = std.fs.path.join(allocator, &.{ home, ".clumsies", "workspaces" }) catch return null;
     defer allocator.free(ws_root);

--- a/src/tui/table_row.zig
+++ b/src/tui/table_row.zig
@@ -17,6 +17,7 @@ const theme = @import("theme.zig");
 pub const Column = struct {
     text: []const u8,
     flex: u16 = 0,
+    min_width: u16 = 0,
     alignment: enum { left, right } = .left,
 };
 
@@ -24,6 +25,7 @@ pub const TableRow = struct {
     columns: []const Column,
     style: vaxis.Style = .{},
     gap: u16 = 1,
+    padding_left: u16 = 1,
 
     pub fn widget(self: *const TableRow) vxfw.Widget {
         return .{
@@ -48,13 +50,15 @@ pub const TableRow = struct {
         var total_flex: u16 = 0;
         for (self.columns, 0..) |col, i| {
             if (col.flex == 0) {
-                fixed_total += @intCast(@min(ctx.stringWidth(col.text), total_width));
+                const text_w: u16 = @intCast(@min(ctx.stringWidth(col.text), total_width));
+                fixed_total += @max(text_w, col.min_width);
             }
             total_flex += col.flex;
             if (i < self.columns.len - 1) fixed_total += self.gap;
         }
 
-        const remaining = total_width -| fixed_total;
+        const content_width = total_width -| self.padding_left;
+        const remaining = content_width -| fixed_total;
 
         // Second pass: render each column at its computed position
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{
@@ -67,11 +71,12 @@ pub const TableRow = struct {
         };
         @memset(surface.buffer, theme.blank(bg_color));
 
-        var col_x: u16 = 0;
+        var col_x: u16 = self.padding_left;
         for (self.columns, 0..) |col, i| {
-            const col_width: u16 = if (col.flex == 0)
-                @intCast(@min(ctx.stringWidth(col.text), total_width))
-            else if (i == self.columns.len - 1)
+            const col_width: u16 = if (col.flex == 0) blk: {
+                const text_w: u16 = @intCast(@min(ctx.stringWidth(col.text), total_width));
+                break :blk @max(text_w, col.min_width);
+            } else if (i == self.columns.len - 1)
                 total_width -| col_x
             else if (total_flex > 0) (remaining * col.flex) / total_flex else 0;
 

--- a/src/tui/table_row.zig
+++ b/src/tui/table_row.zig
@@ -1,0 +1,104 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("theme.zig");
+
+// A table row widget that distributes columns across the available width.
+// Uses ctx.min.width (set by ScrollView from the parent Panel's inner width)
+// as the total row width, solving the flex layout problem inside ScrollView
+// where ctx.max.width is null.
+//
+// Column model inspired by CSS grid-template-columns:
+//   flex = 0  -> column uses its content width (like `auto`)
+//   flex = N  -> column gets N shares of remaining space (like `Nfr`)
+//
+// Unlike vxfw.FlexRow, this widget reads min.width instead of max.width,
+// making it safe to use as a ScrollView child.
+pub const Column = struct {
+    text: []const u8,
+    flex: u16 = 0,
+    alignment: enum { left, right } = .left,
+};
+
+pub const TableRow = struct {
+    columns: []const Column,
+    style: vaxis.Style = .{},
+    gap: u16 = 1,
+
+    pub fn widget(self: *const TableRow) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const TableRow = @ptrCast(@alignCast(ptr));
+        return self.draw(ctx);
+    }
+
+    pub fn draw(self: *const TableRow, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        // Use min.width as the row width. ScrollView sets this to the
+        // Panel's inner width. If min.width is 0, fall back to a
+        // reasonable default.
+        const total_width: u16 = if (ctx.min.width > 0) ctx.min.width else if (ctx.max.width) |w| w else 80;
+
+        // First pass: measure fixed columns and count flex units
+        var fixed_total: u16 = 0;
+        var total_flex: u16 = 0;
+        for (self.columns, 0..) |col, i| {
+            if (col.flex == 0) {
+                fixed_total += @intCast(@min(ctx.stringWidth(col.text), total_width));
+            }
+            total_flex += col.flex;
+            if (i < self.columns.len - 1) fixed_total += self.gap;
+        }
+
+        const remaining = total_width -| fixed_total;
+
+        // Second pass: render each column at its computed position
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{
+            .width = total_width,
+            .height = 1,
+        });
+        const bg_color: vaxis.Color = switch (self.style.bg) {
+            .default => theme.PANEL,
+            else => self.style.bg,
+        };
+        @memset(surface.buffer, theme.blank(bg_color));
+
+        var col_x: u16 = 0;
+        for (self.columns, 0..) |col, i| {
+            const col_width: u16 = if (col.flex == 0)
+                @intCast(@min(ctx.stringWidth(col.text), total_width))
+            else if (i == self.columns.len - 1)
+                total_width -| col_x
+            else if (total_flex > 0) (remaining * col.flex) / total_flex else 0;
+
+            // Write text into this column region
+            const text_width: u16 = @intCast(@min(ctx.stringWidth(col.text), col_width));
+            const start_x: u16 = switch (col.alignment) {
+                .left => col_x,
+                .right => col_x + col_width -| text_width,
+            };
+
+            var cursor = start_x;
+            var iter = ctx.graphemeIterator(col.text);
+            while (iter.next()) |grapheme| {
+                if (cursor >= col_x + col_width) break;
+                const bytes = grapheme.bytes(col.text);
+                const gwidth: u16 = @intCast(ctx.stringWidth(bytes));
+                if (gwidth == 0 or cursor + gwidth > col_x + col_width) break;
+                surface.writeCell(cursor, 0, .{
+                    .char = .{ .grapheme = bytes, .width = @intCast(gwidth) },
+                    .style = self.style,
+                });
+                cursor += gwidth;
+            }
+
+            col_x += col_width + if (i < self.columns.len - 1) self.gap else 0;
+        }
+
+        return surface;
+    }
+};

--- a/src/tui/theme.zig
+++ b/src/tui/theme.zig
@@ -4,16 +4,26 @@ pub fn rgb(hex: u24) vaxis.Color {
     return vaxis.Color.rgbFromUint(hex);
 }
 
-pub fn style(fg: vaxis.Color, bg: vaxis.Color) vaxis.Style {
-    return .{ .fg = fg, .bg = bg };
+pub fn style(foreground: vaxis.Color, background: vaxis.Color) vaxis.Style {
+    return .{ .fg = foreground, .bg = background };
 }
 
-pub fn textOn(bg: vaxis.Color, fg: vaxis.Color) vaxis.Style {
-    return .{ .fg = fg, .bg = bg };
+pub fn textOn(background: vaxis.Color, foreground: vaxis.Color) vaxis.Style {
+    return .{ .fg = foreground, .bg = background };
 }
 
-pub fn boldOn(bg: vaxis.Color, fg: vaxis.Color) vaxis.Style {
-    return .{ .fg = fg, .bg = bg, .bold = true };
+pub fn boldOn(background: vaxis.Color, foreground: vaxis.Color) vaxis.Style {
+    return .{ .fg = foreground, .bg = background, .bold = true };
+}
+
+// Default styles: foreground color on PANEL background.
+// Use instead of raw .{ .fg = color } to prevent terminal black bg.
+pub fn fg(color: vaxis.Color) vaxis.Style {
+    return .{ .fg = color, .bg = PANEL };
+}
+
+pub fn fgBold(color: vaxis.Color) vaxis.Style {
+    return .{ .fg = color, .bg = PANEL, .bold = true };
 }
 
 // Zig-themed warm palette: amber primary on calm dark surfaces.

--- a/src/tui/theme.zig
+++ b/src/tui/theme.zig
@@ -1,0 +1,68 @@
+const vaxis = @import("vaxis");
+
+pub fn rgb(hex: u24) vaxis.Color {
+    return vaxis.Color.rgbFromUint(hex);
+}
+
+pub fn style(fg: vaxis.Color, bg: vaxis.Color) vaxis.Style {
+    return .{ .fg = fg, .bg = bg };
+}
+
+pub fn textOn(bg: vaxis.Color, fg: vaxis.Color) vaxis.Style {
+    return .{ .fg = fg, .bg = bg };
+}
+
+pub fn boldOn(bg: vaxis.Color, fg: vaxis.Color) vaxis.Style {
+    return .{ .fg = fg, .bg = bg, .bold = true };
+}
+
+// Zig-themed warm palette: amber primary on calm dark surfaces.
+// Surface hierarchy: CANVAS < HEADER < PANEL < PANEL_ALT < PANEL_SOFT
+pub const CANVAS = rgb(0x1a1816);
+pub const HEADER = rgb(0x1c1a18);
+pub const PANEL = rgb(0x1f1c19);
+pub const PANEL_ALT = rgb(0x24201d);
+pub const PANEL_SOFT = rgb(0x2c2722);
+pub const RAIL = rgb(0x1b1917);
+pub const BORDER = rgb(0x5e4b31);
+pub const BORDER_MUTED = rgb(0x463929);
+
+// Text tones
+pub const TEXT = rgb(0xe7ddd0);
+pub const TEXT_SOFT = rgb(0xcdbca8);
+pub const MUTED = rgb(0xa08f7b);
+pub const DIM = rgb(0x756755);
+
+// Accent colors (Zig amber family)
+pub const ACCENT = rgb(0xf7a41d);
+pub const ACCENT_SOFT = rgb(0xffcf78);
+pub const GOLD = rgb(0xd7a032);
+pub const MINT = rgb(0xe8b04a);
+pub const CYAN = rgb(0xd08a3c);
+
+// Module accents
+pub const ACCENT_LIBRARY = ACCENT;
+pub const ACCENT_PROPOSAL = GOLD;
+pub const ACCENT_WORKSPACE = rgb(0xb3ba73);
+pub const ACCENT_COMPLIANCE = rgb(0xe7b868);
+
+// Semantic status
+pub const OK = rgb(0xa9bf6f);
+pub const WARN = rgb(0xe0b14b);
+pub const DANGER = rgb(0xd3745a);
+pub const INFO = rgb(0xe7b868);
+
+// Sparkline block characters
+pub const SPARKLINE = [8][]const u8{ "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" };
+
+pub const CANVAS_CELL: vaxis.Cell = .{
+    .char = .{ .grapheme = " ", .width = 1 },
+    .style = style(TEXT, CANVAS),
+};
+
+pub fn blank(bg: vaxis.Color) vaxis.Cell {
+    return .{
+        .char = .{ .grapheme = " ", .width = 1 },
+        .style = .{ .fg = TEXT, .bg = bg },
+    };
+}

--- a/src/tui/theme.zig
+++ b/src/tui/theme.zig
@@ -52,7 +52,7 @@ pub const CYAN = rgb(0xd08a3c);
 
 // Module accents
 pub const ACCENT_LIBRARY = ACCENT;
-pub const ACCENT_PROPOSAL = GOLD;
+pub const ACCENT_PR = GOLD;
 pub const ACCENT_WORKSPACE = rgb(0xb3ba73);
 pub const ACCENT_INSIGHTS = rgb(0xe7b868);
 

--- a/src/tui/theme.zig
+++ b/src/tui/theme.zig
@@ -70,6 +70,25 @@ pub const CANVAS_CELL: vaxis.Cell = .{
     .style = style(TEXT, CANVAS),
 };
 
+pub fn lerpColor(a: vaxis.Color, b: vaxis.Color, t: f32) vaxis.Color {
+    const a_rgb = switch (a) {
+        .rgb => |v| v,
+        else => [3]u8{ 0, 0, 0 },
+    };
+    const b_rgb = switch (b) {
+        .rgb => |v| v,
+        else => [3]u8{ 0, 0, 0 },
+    };
+    const inv = 1.0 - t;
+    return .{
+        .rgb = .{
+            @intFromFloat(@as(f32, @floatFromInt(a_rgb[0])) * inv + @as(f32, @floatFromInt(b_rgb[0])) * t),
+            @intFromFloat(@as(f32, @floatFromInt(a_rgb[1])) * inv + @as(f32, @floatFromInt(b_rgb[1])) * t),
+            @intFromFloat(@as(f32, @floatFromInt(a_rgb[2])) * inv + @as(f32, @floatFromInt(b_rgb[2])) * t),
+        },
+    };
+}
+
 pub fn blank(bg: vaxis.Color) vaxis.Cell {
     return .{
         .char = .{ .grapheme = " ", .width = 1 },

--- a/src/tui/theme.zig
+++ b/src/tui/theme.zig
@@ -44,7 +44,7 @@ pub const CYAN = rgb(0xd08a3c);
 pub const ACCENT_LIBRARY = ACCENT;
 pub const ACCENT_PROPOSAL = GOLD;
 pub const ACCENT_WORKSPACE = rgb(0xb3ba73);
-pub const ACCENT_COMPLIANCE = rgb(0xe7b868);
+pub const ACCENT_INSIGHTS = rgb(0xe7b868);
 
 // Semantic status
 pub const OK = rgb(0xa9bf6f);
@@ -53,7 +53,7 @@ pub const DANGER = rgb(0xd3745a);
 pub const INFO = rgb(0xe7b868);
 
 // Sparkline block characters
-pub const SPARKLINE = [8][]const u8{ "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" };
+pub const SPARKLINE = [8][]const u8{ "\xe2\x96\x81", "\xe2\x96\x82", "\xe2\x96\x83", "\xe2\x96\x84", "\xe2\x96\x85", "\xe2\x96\x86", "\xe2\x96\x87", "\xe2\x96\x88" };
 
 pub const CANVAS_CELL: vaxis.Cell = .{
     .char = .{ .grapheme = " ", .width = 1 },

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -9,6 +9,12 @@ pub const LocalStats = struct {
     signal_ratio: u8 = 0,
     refer_trend: [30]u16 = .{0} ** 30,
     prompts: []const data.InsightsPrompt = &.{},
+    inputs: []const InputEvent = &.{},
+};
+
+pub const InputEvent = struct {
+    timestamp: i64,
+    content: []const u8,
 };
 
 const TraceEvent = struct {
@@ -18,6 +24,7 @@ const TraceEvent = struct {
     prompt_hash: ?[]const u8 = null,
     constraint_id: ?[]const u8 = null,
     reason: ?[]const u8 = null,
+    content: ?[]const u8 = null,
 };
 
 pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
@@ -81,10 +88,21 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
     };
     var prompt_map: std.StringHashMap(PromptAcc) = .init(allocator);
 
+    var inputs_list: std.ArrayList(InputEvent) = .empty;
+
     const now_ms: i64 = std.time.milliTimestamp();
     const day_ms: i64 = 86400 * 1000;
 
     for (events) |ev| {
+        if (std.mem.eql(u8, ev.type, "session_input")) {
+            if (ev.content) |c| {
+                inputs_list.append(allocator, .{
+                    .timestamp = ev.timestamp,
+                    .content = c,
+                }) catch {};
+            }
+            continue;
+        }
         if (!std.mem.eql(u8, ev.type, "refer")) continue;
         stats.total_refer_count += 1;
 
@@ -149,6 +167,13 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
     else
         0;
     stats.prompts = prompts_list.items;
+
+    std.mem.sort(InputEvent, inputs_list.items, {}, struct {
+        fn cmp(_: void, a: InputEvent, b: InputEvent) bool {
+            return a.timestamp > b.timestamp;
+        }
+    }.cmp);
+    stats.inputs = inputs_list.items;
 
     return stats;
 }

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -1,0 +1,159 @@
+// Read local trace.jsonl files and compute Insights stats.
+const std = @import("std");
+const data = @import("mock_data.zig");
+
+pub const LocalStats = struct {
+    total_refer_count: u32 = 0,
+    constraint_count: u32 = 0,
+    active_constraint_count: u32 = 0,
+    signal_ratio: u8 = 0,
+    refer_trend: [30]u16 = .{0} ** 30,
+    prompts: []const data.InsightsPrompt = &.{},
+};
+
+const TraceEvent = struct {
+    type: []const u8 = "",
+    ts: i64 = 0,
+    prompt_id: ?[]const u8 = null,
+    prompt_hash: ?[]const u8 = null,
+    constraint_id: ?[]const u8 = null,
+    reason: ?[]const u8 = null,
+};
+
+pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
+    const log_dir = getLogDir(allocator) orelse return null;
+    defer allocator.free(log_dir);
+
+    // Read all workspace trace files
+    var dir = std.fs.openDirAbsolute(log_dir, .{ .iterate = true }) catch return null;
+    defer dir.close();
+
+    var all_events: std.ArrayList(TraceEvent) = .empty;
+    var it = dir.iterate();
+    while (it.next() catch null) |entry| {
+        if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
+        const path = std.fs.path.join(allocator, &.{ log_dir, entry.name }) catch continue;
+        defer allocator.free(path);
+        readEventsFromFile(allocator, path, &all_events);
+    }
+
+    if (all_events.items.len == 0) return null;
+    return computeStats(allocator, all_events.items);
+}
+
+fn getLogDir(allocator: std.mem.Allocator) ?[]const u8 {
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    defer allocator.free(home);
+    return std.fs.path.join(allocator, &.{ home, ".clumsies", "log" }) catch null;
+}
+
+fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, events: *std.ArrayList(TraceEvent)) void {
+    const file = std.fs.openFileAbsolute(path, .{}) catch return;
+    defer file.close();
+
+    var buf: [64 * 1024]u8 = undefined;
+    var total: usize = 0;
+    while (total < buf.len) {
+        const n = file.read(buf[total..]) catch return;
+        if (n == 0) break;
+        total += n;
+    }
+    if (total == 0) return;
+
+    var line_it = std.mem.splitScalar(u8, buf[0..total], '\n');
+    while (line_it.next()) |line| {
+        if (line.len == 0) continue;
+        const parsed = std.json.parseFromSlice(TraceEvent, allocator, line, .{
+            .allocate = .alloc_always,
+            .ignore_unknown_fields = true,
+        }) catch continue;
+        events.append(allocator, parsed.value) catch continue;
+    }
+}
+
+fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalStats {
+    var stats: LocalStats = .{};
+
+    // Count refers per prompt, track unique constraints
+    const PromptAcc = struct {
+        refer_count: u32 = 0,
+        constraints: std.StringHashMap(u32),
+    };
+    var prompt_map: std.StringHashMap(PromptAcc) = .init(allocator);
+
+    // 30-day trend: bucket events by day
+    const now_ms: i64 = std.time.milliTimestamp();
+    const day_ms: i64 = 86400 * 1000;
+
+    for (events) |ev| {
+        if (!std.mem.eql(u8, ev.type, "refer")) continue;
+        stats.total_refer_count += 1;
+
+        // Trend: which day bucket (0 = 30 days ago, 29 = today)
+        const age_days = @divTrunc(now_ms - ev.ts, day_ms);
+        if (age_days >= 0 and age_days < 30) {
+            const bucket: usize = @intCast(29 - age_days);
+            stats.refer_trend[bucket] += 1;
+        }
+
+        // Per-prompt accumulation
+        const pid = ev.prompt_id orelse continue;
+        const entry = prompt_map.getOrPut(pid) catch continue;
+        if (!entry.found_existing) {
+            entry.value_ptr.* = .{ .refer_count = 0, .constraints = .init(allocator) };
+        }
+        entry.value_ptr.refer_count += 1;
+
+        if (ev.constraint_id) |cid| {
+            const c_entry = entry.value_ptr.constraints.getOrPut(cid) catch continue;
+            if (!c_entry.found_existing) c_entry.value_ptr.* = 0;
+            c_entry.value_ptr.* += 1;
+        }
+    }
+
+    // Build InsightsPrompt list
+    var prompts_list: std.ArrayList(data.InsightsPrompt) = .empty;
+    var total_constraints: u32 = 0;
+    var active_constraints: u32 = 0;
+
+    var map_it = prompt_map.iterator();
+    while (map_it.next()) |kv| {
+        const c_count: u8 = @intCast(@min(kv.value_ptr.constraints.count(), 255));
+        total_constraints += c_count;
+        active_constraints += c_count;
+
+        const rate: u16 = @intCast(@min(@divTrunc(kv.value_ptr.refer_count, 30), std.math.maxInt(u16)));
+        const sig: u8 = if (c_count > 0) 100 else 0;
+
+        prompts_list.append(allocator, .{
+            .name = kv.key_ptr.*,
+            .constraint_count = c_count,
+            .active_constraint_count = c_count,
+            .idle_constraint_count = 0,
+            .signal_ratio = sig,
+            .refer_count = kv.value_ptr.refer_count,
+            .rate_per_day = rate,
+            .delta_pct = 0,
+            .last_referred_days_ago = 0,
+            .trend = .{0} ** 30,
+            .constraints = &.{},
+        }) catch continue;
+    }
+
+    // Sort by refer_count descending
+    std.mem.sort(data.InsightsPrompt, prompts_list.items, {}, struct {
+        fn cmp(_: void, a: data.InsightsPrompt, b: data.InsightsPrompt) bool {
+            return a.refer_count > b.refer_count;
+        }
+    }.cmp);
+
+    stats.constraint_count = total_constraints;
+    stats.active_constraint_count = active_constraints;
+    stats.signal_ratio = if (total_constraints > 0)
+        @intCast(@min(@divTrunc(active_constraints * 100, total_constraints), 100))
+    else
+        0;
+    stats.prompts = prompts_list.items;
+
+    return stats;
+}

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -106,7 +106,8 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
 }
 
 fn getBaseDir(allocator: std.mem.Allocator) ?[]const u8 {
-    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch
+        std.process.getEnvVarOwned(allocator, "USERPROFILE") catch return null;
     defer allocator.free(home);
     return std.fs.path.join(allocator, &.{ home, ".clumsies" }) catch null;
 }

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -72,11 +72,14 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     while (it.next() catch null) |entry| {
         if (entry.kind != .directory) continue;
         const ws_id = allocator.dupe(u8, entry.name) catch continue;
+        var keep_ws_id = false;
+        defer if (!keep_ws_id) allocator.free(ws_id);
         const trace_path = std.fs.path.join(allocator, &.{ ws_root, entry.name, "trace.jsonl" }) catch continue;
         defer allocator.free(trace_path);
         var ws_events: std.ArrayList(TraceEvent) = .empty;
         readEventsFromFile(allocator, trace_path, ws_id, &ws_events);
         if (ws_events.items.len == 0) continue;
+        keep_ws_id = true;
 
         const ws_stats = computeStats(allocator, ws_events.items);
         workspace_stats.append(allocator, .{
@@ -142,10 +145,61 @@ fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, ws_id: []c
             .allocate = .alloc_always,
             .ignore_unknown_fields = true,
         }) catch continue;
-        var ev = parsed.value;
-        ev.ws_id = ws_id;
-        events.append(allocator, ev) catch continue;
+        defer parsed.deinit();
+
+        const ev = cloneTraceEvent(allocator, ws_id, parsed.value) catch continue;
+        events.append(allocator, ev) catch {
+            freeTraceEventOwned(allocator, ev);
+            continue;
+        };
     }
+}
+
+fn cloneTraceEvent(allocator: std.mem.Allocator, ws_id: []const u8, src: TraceEvent) !TraceEvent {
+    var out = TraceEvent{
+        .ws_id = ws_id,
+        .session_id = try allocator.dupe(u8, src.session_id),
+        .type = try allocator.dupe(u8, src.type),
+        .timestamp = src.timestamp,
+        .prompt_id = null,
+        .prompt_hash = null,
+        .constraint_id = null,
+        .reason = null,
+        .content = null,
+    };
+    errdefer allocator.free(out.session_id);
+    errdefer allocator.free(out.type);
+
+    out.prompt_id = try dupeOptional(allocator, src.prompt_id);
+    errdefer if (out.prompt_id) |s| allocator.free(s);
+
+    out.prompt_hash = try dupeOptional(allocator, src.prompt_hash);
+    errdefer if (out.prompt_hash) |s| allocator.free(s);
+
+    out.constraint_id = try dupeOptional(allocator, src.constraint_id);
+    errdefer if (out.constraint_id) |s| allocator.free(s);
+
+    out.reason = try dupeOptional(allocator, src.reason);
+    errdefer if (out.reason) |s| allocator.free(s);
+
+    out.content = try dupeOptional(allocator, src.content);
+    errdefer if (out.content) |s| allocator.free(s);
+
+    return out;
+}
+
+fn dupeOptional(allocator: std.mem.Allocator, maybe: ?[]const u8) !?[]const u8 {
+    return if (maybe) |value| try allocator.dupe(u8, value) else null;
+}
+
+fn freeTraceEventOwned(allocator: std.mem.Allocator, ev: TraceEvent) void {
+    allocator.free(ev.session_id);
+    allocator.free(ev.type);
+    if (ev.prompt_id) |s| allocator.free(s);
+    if (ev.prompt_hash) |s| allocator.free(s);
+    if (ev.constraint_id) |s| allocator.free(s);
+    if (ev.reason) |s| allocator.free(s);
+    if (ev.content) |s| allocator.free(s);
 }
 
 fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalStats {

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -13,7 +13,7 @@ pub const LocalStats = struct {
 
 const TraceEvent = struct {
     type: []const u8 = "",
-    ts: i64 = 0,
+    timestamp: i64 = 0,
     prompt_id: ?[]const u8 = null,
     prompt_hash: ?[]const u8 = null,
     constraint_id: ?[]const u8 = null,
@@ -21,37 +21,38 @@ const TraceEvent = struct {
 };
 
 pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
-    const log_dir = getLogDir(allocator) orelse return null;
-    defer allocator.free(log_dir);
+    const base = getBaseDir(allocator) orelse return null;
+    defer allocator.free(base);
+    const ws_root = std.fs.path.join(allocator, &.{ base, "workspaces" }) catch return null;
+    defer allocator.free(ws_root);
 
-    // Read all workspace trace files
-    var dir = std.fs.openDirAbsolute(log_dir, .{ .iterate = true }) catch return null;
+    var dir = std.fs.openDirAbsolute(ws_root, .{ .iterate = true }) catch return null;
     defer dir.close();
 
     var all_events: std.ArrayList(TraceEvent) = .empty;
     var it = dir.iterate();
     while (it.next() catch null) |entry| {
-        if (!std.mem.endsWith(u8, entry.name, ".jsonl")) continue;
-        const path = std.fs.path.join(allocator, &.{ log_dir, entry.name }) catch continue;
-        defer allocator.free(path);
-        readEventsFromFile(allocator, path, &all_events);
+        if (entry.kind != .directory) continue;
+        const trace_path = std.fs.path.join(allocator, &.{ ws_root, entry.name, "trace.jsonl" }) catch continue;
+        defer allocator.free(trace_path);
+        readEventsFromFile(allocator, trace_path, &all_events);
     }
 
     if (all_events.items.len == 0) return null;
     return computeStats(allocator, all_events.items);
 }
 
-fn getLogDir(allocator: std.mem.Allocator) ?[]const u8 {
+fn getBaseDir(allocator: std.mem.Allocator) ?[]const u8 {
     const home = std.process.getEnvVarOwned(allocator, "HOME") catch return null;
     defer allocator.free(home);
-    return std.fs.path.join(allocator, &.{ home, ".clumsies", "log" }) catch null;
+    return std.fs.path.join(allocator, &.{ home, ".clumsies" }) catch null;
 }
 
 fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, events: *std.ArrayList(TraceEvent)) void {
     const file = std.fs.openFileAbsolute(path, .{}) catch return;
     defer file.close();
 
-    var buf: [64 * 1024]u8 = undefined;
+    var buf: [256 * 1024]u8 = undefined;
     var total: usize = 0;
     while (total < buf.len) {
         const n = file.read(buf[total..]) catch return;
@@ -74,14 +75,12 @@ fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, events: *s
 fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalStats {
     var stats: LocalStats = .{};
 
-    // Count refers per prompt, track unique constraints
     const PromptAcc = struct {
         refer_count: u32 = 0,
         constraints: std.StringHashMap(u32),
     };
     var prompt_map: std.StringHashMap(PromptAcc) = .init(allocator);
 
-    // 30-day trend: bucket events by day
     const now_ms: i64 = std.time.milliTimestamp();
     const day_ms: i64 = 86400 * 1000;
 
@@ -89,14 +88,12 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         if (!std.mem.eql(u8, ev.type, "refer")) continue;
         stats.total_refer_count += 1;
 
-        // Trend: which day bucket (0 = 30 days ago, 29 = today)
-        const age_days = @divTrunc(now_ms - ev.ts, day_ms);
+        const age_days = @divTrunc(now_ms - ev.timestamp, day_ms);
         if (age_days >= 0 and age_days < 30) {
             const bucket: usize = @intCast(29 - age_days);
             stats.refer_trend[bucket] += 1;
         }
 
-        // Per-prompt accumulation
         const pid = ev.prompt_id orelse continue;
         const entry = prompt_map.getOrPut(pid) catch continue;
         if (!entry.found_existing) {
@@ -111,7 +108,6 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         }
     }
 
-    // Build InsightsPrompt list
     var prompts_list: std.ArrayList(data.InsightsPrompt) = .empty;
     var total_constraints: u32 = 0;
     var active_constraints: u32 = 0;
@@ -140,7 +136,6 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         }) catch continue;
     }
 
-    // Sort by refer_count descending
     std.mem.sort(data.InsightsPrompt, prompts_list.items, {}, struct {
         fn cmp(_: void, a: data.InsightsPrompt, b: data.InsightsPrompt) bool {
             return a.refer_count > b.refer_count;

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -8,16 +8,46 @@ pub const LocalStats = struct {
     active_constraint_count: u32 = 0,
     signal_ratio: u8 = 0,
     refer_trend: [30]u16 = .{0} ** 30,
+    refers: []const ReferEvent = &.{},
+    prompts: []const data.InsightsPrompt = &.{},
+    inputs: []const InputEvent = &.{},
+    workspaces: []const WorkspaceLocalStats = &.{},
+
+    pub fn workspace(self: *const LocalStats, ws_id: []const u8) ?*const WorkspaceLocalStats {
+        for (self.workspaces) |*ws| {
+            if (std.mem.eql(u8, ws.ws_id, ws_id)) return ws;
+        }
+        return null;
+    }
+};
+
+pub const WorkspaceLocalStats = struct {
+    ws_id: []const u8,
+    total_refer_count: u32 = 0,
+    constraint_count: u32 = 0,
+    active_constraint_count: u32 = 0,
+    signal_ratio: u8 = 0,
+    refer_trend: [30]u16 = .{0} ** 30,
+    refers: []const ReferEvent = &.{},
     prompts: []const data.InsightsPrompt = &.{},
     inputs: []const InputEvent = &.{},
 };
 
+pub const ReferEvent = struct {
+    ws_id: []const u8 = "",
+    timestamp: i64,
+};
+
 pub const InputEvent = struct {
+    ws_id: []const u8 = "",
+    session_id: []const u8 = "",
     timestamp: i64,
     content: []const u8,
 };
 
 const TraceEvent = struct {
+    ws_id: []const u8 = "",
+    session_id: []const u8 = "",
     type: []const u8 = "",
     timestamp: i64 = 0,
     prompt_id: ?[]const u8 = null,
@@ -37,16 +67,39 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     defer dir.close();
 
     var all_events: std.ArrayList(TraceEvent) = .empty;
+    var workspace_stats: std.ArrayList(WorkspaceLocalStats) = .empty;
     var it = dir.iterate();
     while (it.next() catch null) |entry| {
         if (entry.kind != .directory) continue;
+        const ws_id = allocator.dupe(u8, entry.name) catch continue;
         const trace_path = std.fs.path.join(allocator, &.{ ws_root, entry.name, "trace.jsonl" }) catch continue;
         defer allocator.free(trace_path);
-        readEventsFromFile(allocator, trace_path, &all_events);
+        var ws_events: std.ArrayList(TraceEvent) = .empty;
+        readEventsFromFile(allocator, trace_path, ws_id, &ws_events);
+        if (ws_events.items.len == 0) continue;
+
+        const ws_stats = computeStats(allocator, ws_events.items);
+        workspace_stats.append(allocator, .{
+            .ws_id = ws_id,
+            .total_refer_count = ws_stats.total_refer_count,
+            .constraint_count = ws_stats.constraint_count,
+            .active_constraint_count = ws_stats.active_constraint_count,
+            .signal_ratio = ws_stats.signal_ratio,
+            .refer_trend = ws_stats.refer_trend,
+            .refers = ws_stats.refers,
+            .prompts = ws_stats.prompts,
+            .inputs = ws_stats.inputs,
+        }) catch continue;
+
+        for (ws_events.items) |ev| {
+            all_events.append(allocator, ev) catch break;
+        }
     }
 
     if (all_events.items.len == 0) return null;
-    return computeStats(allocator, all_events.items);
+    var all_stats = computeStats(allocator, all_events.items);
+    all_stats.workspaces = workspace_stats.items;
+    return all_stats;
 }
 
 fn getBaseDir(allocator: std.mem.Allocator) ?[]const u8 {
@@ -55,27 +108,43 @@ fn getBaseDir(allocator: std.mem.Allocator) ?[]const u8 {
     return std.fs.path.join(allocator, &.{ home, ".clumsies" }) catch null;
 }
 
-fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, events: *std.ArrayList(TraceEvent)) void {
+fn readEventsFromFile(allocator: std.mem.Allocator, path: []const u8, ws_id: []const u8, events: *std.ArrayList(TraceEvent)) void {
     const file = std.fs.openFileAbsolute(path, .{}) catch return;
     defer file.close();
 
-    var buf: [256 * 1024]u8 = undefined;
-    var total: usize = 0;
-    while (total < buf.len) {
-        const n = file.read(buf[total..]) catch return;
-        if (n == 0) break;
-        total += n;
-    }
+    const max_trace_bytes: u64 = 8 * 1024 * 1024;
+    const end_pos = file.getEndPos() catch return;
+    if (end_pos == 0) return;
+
+    const read_from: u64 = if (end_pos > max_trace_bytes) end_pos - max_trace_bytes else 0;
+    file.seekTo(read_from) catch return;
+
+    const read_len: usize = @intCast(end_pos - read_from);
+    const buf = allocator.alloc(u8, read_len) catch return;
+    defer allocator.free(buf);
+
+    const total = file.readAll(buf) catch return;
     if (total == 0) return;
 
-    var line_it = std.mem.splitScalar(u8, buf[0..total], '\n');
+    var contents = buf[0..total];
+    if (read_from > 0) {
+        if (std.mem.indexOfScalar(u8, contents, '\n')) |newline| {
+            contents = contents[newline + 1 ..];
+        } else {
+            return;
+        }
+    }
+
+    var line_it = std.mem.splitScalar(u8, contents, '\n');
     while (line_it.next()) |line| {
         if (line.len == 0) continue;
         const parsed = std.json.parseFromSlice(TraceEvent, allocator, line, .{
             .allocate = .alloc_always,
             .ignore_unknown_fields = true,
         }) catch continue;
-        events.append(allocator, parsed.value) catch continue;
+        var ev = parsed.value;
+        ev.ws_id = ws_id;
+        events.append(allocator, ev) catch continue;
     }
 }
 
@@ -88,6 +157,7 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
     };
     var prompt_map: std.StringHashMap(PromptAcc) = .init(allocator);
 
+    var refers_list: std.ArrayList(ReferEvent) = .empty;
     var inputs_list: std.ArrayList(InputEvent) = .empty;
 
     const now_ms: i64 = std.time.milliTimestamp();
@@ -97,6 +167,8 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         if (std.mem.eql(u8, ev.type, "session_input")) {
             if (ev.content) |c| {
                 inputs_list.append(allocator, .{
+                    .ws_id = ev.ws_id,
+                    .session_id = ev.session_id,
                     .timestamp = ev.timestamp,
                     .content = c,
                 }) catch {};
@@ -105,6 +177,10 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         }
         if (!std.mem.eql(u8, ev.type, "refer")) continue;
         stats.total_refer_count += 1;
+        refers_list.append(allocator, .{
+            .ws_id = ev.ws_id,
+            .timestamp = ev.timestamp,
+        }) catch {};
 
         const age_days = @divTrunc(now_ms - ev.timestamp, day_ms);
         if (age_days >= 0 and age_days < 30) {
@@ -139,6 +215,25 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         const rate: u16 = @intCast(@min(@divTrunc(kv.value_ptr.refer_count, 30), std.math.maxInt(u16)));
         const sig: u8 = if (c_count > 0) 100 else 0;
 
+        var constraints_list: std.ArrayList(data.ConstraintStat) = .empty;
+        var c_it = kv.value_ptr.constraints.iterator();
+        while (c_it.next()) |cv| {
+            constraints_list.append(allocator, .{
+                .id = cv.key_ptr.*,
+                .label = cv.key_ptr.*,
+                .refer_count = cv.value_ptr.*,
+                .idle_days = null,
+            }) catch continue;
+        }
+        std.mem.sort(data.ConstraintStat, constraints_list.items, {}, struct {
+            fn cmp(_: void, a: data.ConstraintStat, b: data.ConstraintStat) bool {
+                if (a.refer_count == b.refer_count) {
+                    return std.mem.lessThan(u8, a.id, b.id);
+                }
+                return a.refer_count > b.refer_count;
+            }
+        }.cmp);
+
         prompts_list.append(allocator, .{
             .name = kv.key_ptr.*,
             .constraint_count = c_count,
@@ -146,11 +241,12 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
             .idle_constraint_count = 0,
             .signal_ratio = sig,
             .refer_count = kv.value_ptr.refer_count,
+            .workspace_count = 0,
             .rate_per_day = rate,
             .delta_pct = 0,
-            .last_referred_days_ago = 0,
+            .last_referred_days_ago = null,
             .trend = .{0} ** 30,
-            .constraints = &.{},
+            .constraints = constraints_list.items,
         }) catch continue;
     }
 
@@ -166,6 +262,7 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
         @intCast(@min(@divTrunc(active_constraints * 100, total_constraints), 100))
     else
         0;
+    stats.refers = refers_list.items;
     stats.prompts = prompts_list.items;
 
     std.mem.sort(InputEvent, inputs_list.items, {}, struct {

--- a/src/tui/tree.zig
+++ b/src/tui/tree.zig
@@ -1,0 +1,185 @@
+// Tree flattening for path-structured lists.
+//
+// Given a sorted list of slash-separated paths and a set of expanded
+// directory prefixes, produces a flat sequence of visible rows: directory
+// headers whose ancestors are all expanded, and leaves whose full ancestor
+// chain is expanded. Siblings are adjacent so tree connectors (├/└) can be
+// computed with a single forward sweep.
+//
+// Callers own the output buffer. Pass `expanded = null` to render the
+// whole tree as fully expanded (useful for non-interactive nested views).
+
+const std = @import("std");
+
+pub const MAX_DEPTH = 8;
+
+pub const RowKind = enum { dir, leaf };
+
+pub const Row = struct {
+    depth: u8,
+    is_last: bool,
+    kind: RowKind,
+    label: []const u8,
+    dir_prefix: []const u8,
+    leaf_idx: usize,
+};
+
+/// Flattens `paths` into `out`. Returns the number of rows written.
+/// `paths` must be sorted lexicographically so siblings are adjacent.
+pub fn flatten(
+    paths: []const []const u8,
+    expanded: ?*const std.StringHashMapUnmanaged(void),
+    out: []Row,
+) usize {
+    var row_count: usize = 0;
+    var stack: [MAX_DEPTH][]const u8 = undefined;
+    var stack_len: usize = 0;
+
+    for (paths, 0..) |path, idx| {
+        var parents: [MAX_DEPTH][]const u8 = undefined;
+        var parents_len: usize = 0;
+        {
+            var scan: usize = 0;
+            while (std.mem.indexOfScalarPos(u8, path, scan, '/')) |slash| {
+                if (parents_len >= MAX_DEPTH) break;
+                parents[parents_len] = path[0 .. slash + 1];
+                parents_len += 1;
+                scan = slash + 1;
+            }
+        }
+
+        var common: usize = 0;
+        while (common < stack_len and common < parents_len and std.mem.eql(u8, stack[common], parents[common])) : (common += 1) {}
+        stack_len = common;
+
+        while (stack_len < parents_len) {
+            const depth: usize = stack_len;
+            const this_prefix = parents[depth];
+            stack[stack_len] = this_prefix;
+            stack_len += 1;
+
+            var ancestors_open = true;
+            var j: usize = 0;
+            while (j < depth) : (j += 1) {
+                if (!isExpanded(expanded, stack[j])) {
+                    ancestors_open = false;
+                    break;
+                }
+            }
+            if (!ancestors_open) continue;
+            if (row_count >= out.len) break;
+
+            const without_slash = this_prefix[0 .. this_prefix.len - 1];
+            const label_start: usize = if (std.mem.lastIndexOfScalar(u8, without_slash, '/')) |s| s + 1 else 0;
+            out[row_count] = .{
+                .depth = @intCast(depth),
+                .is_last = false,
+                .kind = .dir,
+                .label = without_slash[label_start..],
+                .dir_prefix = this_prefix,
+                .leaf_idx = 0,
+            };
+            row_count += 1;
+        }
+
+        var leaf_visible = true;
+        var k: usize = 0;
+        while (k < parents_len) : (k += 1) {
+            if (!isExpanded(expanded, parents[k])) {
+                leaf_visible = false;
+                break;
+            }
+        }
+        if (!leaf_visible) continue;
+        if (row_count >= out.len) continue;
+
+        out[row_count] = .{
+            .depth = @intCast(parents_len),
+            .is_last = false,
+            .kind = .leaf,
+            .label = basename(path),
+            .dir_prefix = "",
+            .leaf_idx = idx,
+        };
+        row_count += 1;
+    }
+
+    var r: usize = 0;
+    while (r < row_count) : (r += 1) {
+        const d = out[r].depth;
+        var last = true;
+        var s: usize = r + 1;
+        while (s < row_count) : (s += 1) {
+            const d2 = out[s].depth;
+            if (d2 < d) break;
+            if (d2 == d) {
+                last = false;
+                break;
+            }
+        }
+        out[r].is_last = last;
+    }
+
+    return row_count;
+}
+
+fn isExpanded(set: ?*const std.StringHashMapUnmanaged(void), key: []const u8) bool {
+    const s = set orelse return true;
+    return s.contains(key);
+}
+
+fn basename(path: []const u8) []const u8 {
+    const last_slash = std.mem.lastIndexOfScalar(u8, path, '/') orelse return stripMd(path);
+    return stripMd(path[last_slash + 1 ..]);
+}
+
+fn stripMd(name: []const u8) []const u8 {
+    if (std.mem.endsWith(u8, name, ".md")) return name[0 .. name.len - 3];
+    return name;
+}
+
+/// Writes `depth`-level indent + tree connector + optional chevron into `buf`.
+/// Returns the number of bytes written. Safe against buffer overflow.
+pub fn renderPrefix(
+    buf: []u8,
+    depth: u8,
+    is_last: bool,
+    chevron: ?Chevron,
+) usize {
+    var len: usize = 0;
+    var pad: u8 = 0;
+    while (pad < depth) : (pad += 1) {
+        if (len + 2 > buf.len) return len;
+        buf[len] = ' ';
+        buf[len + 1] = ' ';
+        len += 2;
+    }
+    if (depth > 0) {
+        const connector: []const u8 = if (is_last)
+            "\xe2\x94\x94\xe2\x94\x80 " // "└─ "
+        else
+            "\xe2\x94\x9c\xe2\x94\x80 "; // "├─ "
+        if (len + connector.len > buf.len) return len;
+        @memcpy(buf[len .. len + connector.len], connector);
+        len += connector.len;
+    }
+    if (chevron) |ch| {
+        const g: []const u8 = switch (ch) {
+            .expanded => "\xe2\x96\xbc ", // "▼ "
+            .collapsed => "\xe2\x96\xb6 ", // "▶ "
+        };
+        if (len + g.len > buf.len) return len;
+        @memcpy(buf[len .. len + g.len], g);
+        len += g.len;
+    }
+    return len;
+}
+
+pub const Chevron = enum { collapsed, expanded };
+
+pub fn appendText(buf: []u8, start: usize, text: []const u8) usize {
+    const cap = buf.len -| start;
+    const take = @min(text.len, cap);
+    if (take > 0) @memcpy(buf[start .. start + take], text[0..take]);
+    return start + take;
+}

--- a/src/tui/tree.zig
+++ b/src/tui/tree.zig
@@ -216,3 +216,102 @@ pub fn appendText(buf: []u8, start: usize, text: []const u8) usize {
     if (take > 0) @memcpy(buf[start .. start + take], text[0..take]);
     return start + take;
 }
+
+test "flatten marks nested rows and last siblings correctly" {
+    const expectEqual = std.testing.expectEqual;
+    const expectEqualStrings = std.testing.expectEqualStrings;
+
+    const paths = [_][]const u8{
+        "rule/api/NAMING.md",
+        "rule/db/E2E.md",
+        "workflow/GEN_PR.md",
+    };
+    var rows: [16]Row = undefined;
+
+    const count = flatten(paths[0..], null, &rows);
+    try expectEqual(@as(usize, 7), count);
+
+    try expectEqual(RowKind.dir, rows[0].kind);
+    try expectEqual(@as(u8, 0), rows[0].depth);
+    try expectEqual(false, rows[0].is_last);
+    try expectEqualStrings("rule", rows[0].label);
+
+    try expectEqual(RowKind.dir, rows[1].kind);
+    try expectEqual(@as(u8, 1), rows[1].depth);
+    try expectEqual(false, rows[1].is_last);
+    try expectEqualStrings("api", rows[1].label);
+
+    try expectEqual(RowKind.leaf, rows[2].kind);
+    try expectEqual(@as(u8, 2), rows[2].depth);
+    try expectEqual(true, rows[2].is_last);
+    try expectEqualStrings("NAMING", rows[2].label);
+
+    try expectEqual(RowKind.dir, rows[3].kind);
+    try expectEqual(@as(u8, 1), rows[3].depth);
+    try expectEqual(true, rows[3].is_last);
+    try expectEqualStrings("db", rows[3].label);
+
+    try expectEqual(RowKind.leaf, rows[4].kind);
+    try expectEqual(@as(u8, 2), rows[4].depth);
+    try expectEqual(true, rows[4].is_last);
+    try expectEqualStrings("E2E", rows[4].label);
+
+    try expectEqual(RowKind.dir, rows[5].kind);
+    try expectEqual(@as(u8, 0), rows[5].depth);
+    try expectEqual(true, rows[5].is_last);
+    try expectEqualStrings("workflow", rows[5].label);
+
+    try expectEqual(RowKind.leaf, rows[6].kind);
+    try expectEqual(@as(u8, 1), rows[6].depth);
+    try expectEqual(true, rows[6].is_last);
+    try expectEqualStrings("GEN_PR", rows[6].label);
+}
+
+test "flatten respects expansion state and hides collapsed leaves" {
+    const expectEqual = std.testing.expectEqual;
+    const expectEqualStrings = std.testing.expectEqualStrings;
+
+    const paths = [_][]const u8{
+        "rule/api/NAMING.md",
+        "rule/db/E2E.md",
+        "workflow/GEN_PR.md",
+    };
+    var expanded: std.StringHashMapUnmanaged(void) = .empty;
+    defer expanded.deinit(std.testing.allocator);
+    try expanded.put(std.testing.allocator, "rule/", {});
+
+    var rows: [16]Row = undefined;
+    const count = flatten(paths[0..], &expanded, &rows);
+
+    try expectEqual(@as(usize, 4), count);
+    try expectEqualStrings("rule", rows[0].label);
+    try expectEqualStrings("api", rows[1].label);
+    try expectEqualStrings("db", rows[2].label);
+    try expectEqualStrings("workflow", rows[3].label);
+    try expectEqual(RowKind.dir, rows[1].kind);
+    try expectEqual(RowKind.dir, rows[2].kind);
+    try expectEqual(RowKind.dir, rows[3].kind);
+}
+
+test "flatten caps directory depth at MAX_DEPTH" {
+    const expectEqual = std.testing.expectEqual;
+    const expectEqualStrings = std.testing.expectEqualStrings;
+
+    const paths = [_][]const u8{"a/b/c/d/e/f/g/h/i/j.md"};
+    var rows: [16]Row = undefined;
+
+    const count = flatten(paths[0..], null, &rows);
+    try expectEqual(@as(usize, 9), count);
+    try expectEqual(RowKind.dir, rows[7].kind);
+    try expectEqual(@as(u8, 7), rows[7].depth);
+    try expectEqualStrings("h", rows[7].label);
+    try expectEqual(RowKind.leaf, rows[8].kind);
+    try expectEqual(@as(u8, MAX_DEPTH), rows[8].depth);
+    try expectEqualStrings("j", rows[8].label);
+}
+
+test "renderPrefix draws guides connectors and chevrons" {
+    var buf: [32]u8 = undefined;
+    const len = renderPrefix(&buf, 3, 0b0010, false, .collapsed);
+    try std.testing.expectEqualStrings("\xe2\x94\x82   \xe2\x94\x9c\xe2\x94\x80 \xe2\x96\xb6 ", buf[0..len]);
+}

--- a/src/tui/tree.zig
+++ b/src/tui/tree.zig
@@ -17,6 +17,7 @@ pub const RowKind = enum { dir, leaf };
 
 pub const Row = struct {
     depth: u8,
+    ancestor_mask: u16,
     is_last: bool,
     kind: RowKind,
     label: []const u8,
@@ -73,6 +74,7 @@ pub fn flatten(
             const label_start: usize = if (std.mem.lastIndexOfScalar(u8, without_slash, '/')) |s| s + 1 else 0;
             out[row_count] = .{
                 .depth = @intCast(depth),
+                .ancestor_mask = 0,
                 .is_last = false,
                 .kind = .dir,
                 .label = without_slash[label_start..],
@@ -95,6 +97,7 @@ pub fn flatten(
 
         out[row_count] = .{
             .depth = @intCast(parents_len),
+            .ancestor_mask = 0,
             .is_last = false,
             .kind = .leaf,
             .label = basename(path),
@@ -120,6 +123,30 @@ pub fn flatten(
         out[r].is_last = last;
     }
 
+    var ancestor_last: [MAX_DEPTH]bool = .{true} ** MAX_DEPTH;
+    var ancestor_len: usize = 0;
+    r = 0;
+    while (r < row_count) : (r += 1) {
+        const d = out[r].depth;
+        while (ancestor_len > d) {
+            ancestor_len -= 1;
+        }
+
+        var mask: u16 = 0;
+        var level: usize = 0;
+        while (level < d) : (level += 1) {
+            if (!ancestor_last[level]) {
+                mask |= @as(u16, 1) << @intCast(level);
+            }
+        }
+        out[r].ancestor_mask = mask;
+
+        if (d < MAX_DEPTH) {
+            ancestor_last[d] = out[r].is_last;
+            ancestor_len = d + 1;
+        }
+    }
+
     return row_count;
 }
 
@@ -138,21 +165,27 @@ fn stripMd(name: []const u8) []const u8 {
     return name;
 }
 
-/// Writes `depth`-level indent + tree connector + optional chevron into `buf`.
+/// Writes tree guides + connector + optional chevron into `buf`.
+/// Depth-1 rows start directly with the branch connector instead of an extra
+/// blank indent segment, which keeps the tree visually aligned with the root.
 /// Returns the number of bytes written. Safe against buffer overflow.
 pub fn renderPrefix(
     buf: []u8,
     depth: u8,
+    ancestor_mask: u16,
     is_last: bool,
     chevron: ?Chevron,
 ) usize {
     var len: usize = 0;
-    var pad: u8 = 0;
+    var pad: u8 = 1;
     while (pad < depth) : (pad += 1) {
-        if (len + 2 > buf.len) return len;
-        buf[len] = ' ';
-        buf[len + 1] = ' ';
-        len += 2;
+        const guide: []const u8 = if ((ancestor_mask & (@as(u16, 1) << @intCast(pad))) == 0)
+            "  "
+        else
+            "\xe2\x94\x82 "; // "│ "
+        if (len + guide.len > buf.len) return len;
+        @memcpy(buf[len .. len + guide.len], guide);
+        len += guide.len;
     }
     if (depth > 0) {
         const connector: []const u8 = if (is_last)

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -465,6 +465,7 @@ pub fn applyCursorOverlay(
     ctx: vxfw.DrawContext,
     surface: *vxfw.Surface,
     scroll_view: *const vxfw.ScrollView,
+    bg: vaxis.Color,
 ) std.mem.Allocator.Error!vxfw.Surface {
     const cursor_pos = scroll_view.cursor;
     const scroll_top = scroll_view.scroll.top;
@@ -478,7 +479,7 @@ pub fn applyCursorOverlay(
     const cursor_buf = try ctx.arena.alloc(vaxis.Cell, 1);
     cursor_buf[0] = .{
         .char = .{ .grapheme = "▌", .width = 1 },
-        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+        .style = .{ .fg = theme.ACCENT_SOFT, .bg = bg },
     };
     const cursor_surface: vxfw.Surface = .{
         .size = .{ .width = 1, .height = 1 },

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -122,21 +122,6 @@ pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16
     );
 }
 
-// Build a sparkline string from raw values (0-based, max determines scale).
-pub fn sparkline(allocator: std.mem.Allocator, values: []const u8) ![]const u8 {
-    var max: u8 = 1;
-    for (values) |v| {
-        if (v > max) max = v;
-    }
-    var list: std.ArrayList(u8) = .empty;
-    for (values, 0..) |v, idx| {
-        if (idx > 0) try list.append(allocator, ' ');
-        const normalized: usize = @min(@as(usize, v) * theme.SPARKLINE.len / (@as(usize, max) + 1), theme.SPARKLINE.len - 1);
-        try list.appendSlice(allocator, theme.SPARKLINE[normalized]);
-    }
-    return try list.toOwnedSlice(allocator);
-}
-
 // Draw a braille area chart with gradient coloring (btop-style).
 // Area is filled from the data line down to the bottom, creating
 // a solid "mountain" shape. Gradient: ACCENT_SOFT (bottom) → OK (top).

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -137,6 +137,158 @@ pub fn sparkline(allocator: std.mem.Allocator, values: []const u8) ![]const u8 {
     return try list.toOwnedSlice(allocator);
 }
 
+// Draw a braille area chart with gradient coloring (btop-style).
+// Area is filled from the data line down to the bottom, creating
+// a solid "mountain" shape. Gradient: ACCENT_SOFT (bottom) → OK (top).
+pub fn drawBrailleAreaChart(surface: *vxfw.Surface, allocator: std.mem.Allocator, trend: []const u16, x: u16, y: u16, width: u16, height: u16) void {
+    if (width == 0 or height == 0 or trend.len == 0) return;
+
+    var max_val: u16 = 1;
+    var min_val: u16 = std.math.maxInt(u16);
+    for (trend) |v| {
+        if (v > max_val) max_val = v;
+        if (v < min_val) min_val = v;
+    }
+    const padding: u16 = @max(max_val / 10, 1);
+    min_val = min_val -| padding;
+    max_val = max_val + padding;
+
+    const braille_h: u32 = @as(u32, height) * 4;
+    const cols: u32 = @min(@as(u32, width) * 2, 512);
+    const rows: u32 = @min(braille_h, 128);
+
+    var dots: [512][128]bool = undefined;
+    for (&dots) |*r| @memset(r, false);
+
+    // Plot data and fill area below each point
+    for (0..cols) |col_idx| {
+        const data_idx: usize = col_idx * (trend.len - 1) / @max(cols - 1, 1);
+        const val = trend[@min(data_idx, trend.len - 1)];
+        const clamped = @max(val, min_val) - min_val;
+        const normalized: u32 = @as(u32, clamped) * (rows - 1) / @as(u32, max_val - min_val);
+        const dot_y: u32 = rows - 1 - normalized;
+
+        // Fill from dot_y down to bottom (area fill)
+        var fill_y = dot_y;
+        while (fill_y < rows) : (fill_y += 1) {
+            dots[col_idx][fill_y] = true;
+        }
+    }
+
+    // Render braille characters with vertical gradient
+    const char_cols = (cols + 1) / 2;
+    const char_rows = (rows + 3) / 4;
+
+    for (0..char_rows) |cr| {
+        for (0..char_cols) |cc| {
+            var cp: u21 = 0x2800;
+            const dx = cc * 2;
+            const dy = cr * 4;
+
+            if (dx < cols) {
+                if (dy + 0 < rows and dots[dx][dy + 0]) cp |= 0x01;
+                if (dy + 1 < rows and dots[dx][dy + 1]) cp |= 0x02;
+                if (dy + 2 < rows and dots[dx][dy + 2]) cp |= 0x04;
+                if (dy + 3 < rows and dots[dx][dy + 3]) cp |= 0x40;
+            }
+            if (dx + 1 < cols) {
+                if (dy + 0 < rows and dots[dx + 1][dy + 0]) cp |= 0x08;
+                if (dy + 1 < rows and dots[dx + 1][dy + 1]) cp |= 0x10;
+                if (dy + 2 < rows and dots[dx + 1][dy + 2]) cp |= 0x20;
+                if (dy + 3 < rows and dots[dx + 1][dy + 3]) cp |= 0x80;
+            }
+
+            if (cp == 0x2800) continue;
+
+            // Vertical gradient: top rows = ACCENT (deep amber), bottom rows = ACCENT_SOFT (light amber)
+            const vert_t: f32 = if (char_rows > 1) 1.0 - @as(f32, @floatFromInt(cr)) / @as(f32, @floatFromInt(char_rows - 1)) else 0.5;
+            const color = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, vert_t);
+
+            var tmp: [4]u8 = undefined;
+            const len = std.unicode.utf8Encode(cp, &tmp) catch continue;
+            const grapheme = allocator.dupe(u8, tmp[0..len]) catch continue;
+
+            const col: u16 = x + @as(u16, @intCast(cc));
+            const row: u16 = y + @as(u16, @intCast(cr));
+            if (col < surface.size.width and row < surface.size.height) {
+                surface.writeCell(col, row, .{
+                    .char = .{ .grapheme = grapheme, .width = 1 },
+                    .style = .{ .fg = color, .bg = theme.PANEL },
+                });
+            }
+        }
+    }
+}
+
+// Draw a signal gauge: ███████░░ active/total
+pub fn drawSignalGauge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, active: u8, total: u8, max_width: u16) void {
+    if (total == 0) return;
+    const gauge_w: u16 = @min(@as(u16, total), max_width);
+    const active_w: u16 = @min(@as(u16, active) * gauge_w / @as(u16, total), gauge_w);
+
+    var c = col;
+    // Active part (bright)
+    for (0..active_w) |_| {
+        if (c >= surface.size.width) break;
+        surface.writeCell(c, row, .{
+            .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
+            .style = .{ .fg = theme.ACCENT, .bg = theme.PANEL },
+        });
+        c += 1;
+    }
+    // Idle part (dim)
+    for (0..gauge_w - active_w) |_| {
+        if (c >= surface.size.width) break;
+        surface.writeCell(c, row, .{
+            .char = .{ .grapheme = "\xe2\x96\x91", .width = 1 },
+            .style = .{ .fg = theme.DIM, .bg = theme.PANEL },
+        });
+        c += 1;
+    }
+    // Label
+    const label = std.fmt.allocPrint(ctx.arena, " {d}/{d}", .{ active, total }) catch return;
+    writeText(surface, ctx, c + 1, row, label, .{ .fg = theme.MUTED, .bg = theme.PANEL });
+}
+
+// Draw a GitHub contribution graph style heatmap row.
+// Uses ■ (U+25A0, centered square) — naturally small and centered in the cell.
+// 1-char gap between cells, 2-char gap between weeks.
+// Returns the column after the last cell (for positioning totals).
+pub fn drawHeatmapRow(surface: *vxfw.Surface, col: u16, row: u16, values: []const u16, team_max: u16) u16 {
+    const max_f: f32 = @floatFromInt(@max(team_max, 1));
+    var c: u16 = col;
+    for (values, 0..) |val, i| {
+        if (i > 0 and i % 7 == 0) c += 2 // week gap
+        else if (i > 0) c += 1; // cell gap
+        if (c >= surface.size.width -| 1) break;
+        const fg = if (val == 0)
+            theme.PANEL_ALT
+        else
+            theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, @as(f32, @floatFromInt(val)) / max_f);
+        surface.writeCell(c, row, .{
+            .char = .{ .grapheme = "\xe2\x96\xa0", .width = 1 }, // ■ centered square
+            .style = .{ .fg = fg, .bg = theme.PANEL },
+        });
+        c += 1;
+    }
+    return c;
+}
+
+// Write a delta percentage with directional arrow and color.
+pub fn writeDelta(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, delta_pct: i8) void {
+    if (delta_pct == 0) {
+        writeText(surface, ctx, col, row, " 0%", .{ .fg = theme.MUTED, .bg = theme.PANEL });
+        return;
+    }
+    const is_positive = delta_pct > 0;
+    const abs_val: u8 = if (is_positive) @intCast(delta_pct) else @intCast(-delta_pct);
+    const sign: []const u8 = if (is_positive) "+" else "-";
+    const arrow: []const u8 = if (is_positive) " \xe2\x86\x91" else " \xe2\x86\x93";
+    const color = if (is_positive) theme.OK else theme.DANGER;
+    const text = std.fmt.allocPrint(ctx.arena, "{s}{d}%{s}", .{ sign, abs_val, arrow }) catch return;
+    writeText(surface, ctx, col, row, text, .{ .fg = color, .bg = theme.PANEL });
+}
+
 // Initialize ScrollBars for selectable lists. draw_cursor is set to true
 // so that j/k keys trigger nextItem/prevItem (cursor movement) rather
 // than bare viewport scrolling. However, draw_cursor=true also activates

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -66,6 +66,22 @@ pub fn writeRightText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, t
     writeText(surface, ctx, surface.size.width - width - 1, row, text, s);
 }
 
+// Horizontal key-value pair: key in MUTED, value in TEXT.
+// key_width is the fixed column width for the key (left-aligned, padded).
+// Returns the next available row (row + 1).
+pub fn writeKv(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, key: []const u8, value: []const u8, key_width: u16) u16 {
+    writeText(surface, ctx, col, row, key, theme.fg(theme.MUTED));
+    writeText(surface, ctx, col + key_width + 1, row, value, theme.fg(theme.TEXT));
+    return row + 1;
+}
+
+// Section header: bold accent text, used before vertical KV groups.
+// Returns the next available row (row + 1).
+pub fn writeSectionHeader(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8) u16 {
+    writeText(surface, ctx, col, row, text, theme.fgBold(theme.ACCENT));
+    return row + 1;
+}
+
 // Draw a filled badge (pill) with background. Returns the column after the badge.
 pub fn drawFilledBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, fg: vaxis.Color, bg: vaxis.Color) u16 {
     const width = @as(u16, @intCast(ctx.stringWidth(text))) + 2;
@@ -88,7 +104,7 @@ pub fn drawTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col
         row,
         col,
         text,
-        if (selected) theme.CANVAS else theme.TEXT_SOFT,
+        if (selected) theme.PANEL else theme.TEXT_SOFT,
         if (selected) theme.MINT else theme.PANEL_ALT,
     );
 }
@@ -101,7 +117,7 @@ pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16
         row,
         col,
         text,
-        if (selected) theme.CANVAS else theme.TEXT_SOFT,
+        if (selected) theme.PANEL else theme.TEXT_SOFT,
         if (selected) theme.GOLD else theme.PANEL_ALT,
     );
 }

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -1,0 +1,353 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("theme.zig");
+
+// Fill entire surface buffer with a background color.
+pub fn fillSurface(surface: *vxfw.Surface, bg: vaxis.Color) void {
+    @memset(surface.buffer, theme.blank(bg));
+}
+
+// Paint a full-width band on a single row with a background color.
+pub fn paintBand(surface: *vxfw.Surface, row: u16, bg: vaxis.Color, fg: vaxis.Color) void {
+    for (0..surface.size.width) |col| {
+        surface.writeCell(@intCast(col), row, .{
+            .char = .{ .grapheme = " ", .width = 1 },
+            .style = .{ .fg = fg, .bg = bg },
+        });
+    }
+}
+
+// Draw a rounded border (╭╮╰╯─│) around the entire surface.
+pub fn drawBorder(surface: *vxfw.Surface, fg: vaxis.Color, bg: vaxis.Color) void {
+    const right = surface.size.width -| 1;
+    const bottom = surface.size.height -| 1;
+    const s = vaxis.Style{ .fg = fg, .bg = bg };
+
+    surface.writeCell(0, 0, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = s });
+    surface.writeCell(right, 0, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = s });
+    surface.writeCell(right, bottom, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = s });
+    surface.writeCell(0, bottom, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = s });
+
+    var col: u16 = 1;
+    while (col < right) : (col += 1) {
+        surface.writeCell(col, 0, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+        surface.writeCell(col, bottom, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+    }
+    var row: u16 = 1;
+    while (row < bottom) : (row += 1) {
+        surface.writeCell(0, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+        surface.writeCell(right, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+    }
+}
+
+// Write text at (col, row) using grapheme-aware width.
+pub fn writeText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8, s: vaxis.Style) void {
+    var cursor = col;
+    var iter = ctx.graphemeIterator(text);
+    while (iter.next()) |grapheme| {
+        if (cursor >= surface.size.width or row >= surface.size.height) break;
+        const bytes = grapheme.bytes(text);
+        if (std.mem.eql(u8, bytes, "\n")) break;
+        const width: u16 = @intCast(ctx.stringWidth(bytes));
+        if (width == 0 or cursor + width > surface.size.width) break;
+        surface.writeCell(cursor, row, .{
+            .char = .{ .grapheme = bytes, .width = @intCast(width) },
+            .style = s,
+        });
+        cursor += width;
+    }
+}
+
+// Write text right-aligned on a given row.
+pub fn writeRightText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, text: []const u8, s: vaxis.Style) void {
+    const width: u16 = @intCast(ctx.stringWidth(text));
+    if (width >= surface.size.width) return;
+    writeText(surface, ctx, surface.size.width - width - 1, row, text, s);
+}
+
+// Draw a filled badge (pill) with background. Returns the column after the badge.
+pub fn drawFilledBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, fg: vaxis.Color, bg: vaxis.Color) u16 {
+    const width = @as(u16, @intCast(ctx.stringWidth(text))) + 2;
+    for (0..width) |offset| {
+        if (col + offset >= surface.size.width) break;
+        surface.writeCell(@intCast(col + offset), row, .{
+            .char = .{ .grapheme = " ", .width = 1 },
+            .style = .{ .fg = fg, .bg = bg },
+        });
+    }
+    writeText(surface, ctx, col + 1, row, text, .{ .fg = fg, .bg = bg, .bold = true });
+    return col + width;
+}
+
+// Draw a tab-style badge: selected = gold bg, unselected = panel_alt bg.
+pub fn drawTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
+    return drawFilledBadge(
+        surface,
+        ctx,
+        row,
+        col,
+        text,
+        if (selected) theme.CANVAS else theme.TEXT_SOFT,
+        if (selected) theme.MINT else theme.PANEL_ALT,
+    );
+}
+
+// Draw an inner tab badge (smaller emphasis): selected = gold, unselected = panel_alt.
+pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
+    return drawFilledBadge(
+        surface,
+        ctx,
+        row,
+        col,
+        text,
+        if (selected) theme.CANVAS else theme.TEXT_SOFT,
+        if (selected) theme.GOLD else theme.PANEL_ALT,
+    );
+}
+
+// Build a sparkline string from raw values (0-based, max determines scale).
+pub fn sparkline(allocator: std.mem.Allocator, values: []const u8) ![]const u8 {
+    var max: u8 = 1;
+    for (values) |v| {
+        if (v > max) max = v;
+    }
+    var list: std.ArrayList(u8) = .empty;
+    for (values, 0..) |v, idx| {
+        if (idx > 0) try list.append(allocator, ' ');
+        const normalized: usize = @min(@as(usize, v) * theme.SPARKLINE.len / (@as(usize, max) + 1), theme.SPARKLINE.len - 1);
+        try list.appendSlice(allocator, theme.SPARKLINE[normalized]);
+    }
+    return try list.toOwnedSlice(allocator);
+}
+
+// Initialize ScrollBars for selectable lists. draw_cursor is set to true
+// so that j/k keys trigger nextItem/prevItem (cursor movement) rather
+// than bare viewport scrolling. However, draw_cursor=true also activates
+// a buggy rendering path in libvaxis 0.5.1 that clips the selected row
+// to zero width (see applyCursorOverlay for the full explanation).
+//
+// The rendering workaround: each draw*() call-site temporarily sets
+// draw_cursor=false via defer before Panel.draw(), then calls
+// applyCursorOverlay() to paint the ▌ indicator as a z_index=1 overlay.
+// This decouples event handling (needs draw_cursor=true) from rendering
+// (needs draw_cursor=false to avoid the bug).
+//
+// Upstream fix: https://github.com/rockorager/libvaxis/pull/256
+// See .prompts/context/issues/001_scrollview_cursor_clipping.md
+pub fn initCursorScrollBars(background: vaxis.Color) vxfw.ScrollBars {
+    return .{
+        .scroll_view = .{
+            .children = .{ .slice = &.{} },
+            .wheel_scroll = 1,
+            .draw_cursor = true,
+        },
+        .draw_horizontal_scrollbar = false,
+        .vertical_scrollbar_thumb = .{
+            .char = .{ .grapheme = "▐", .width = 1 },
+            .style = .{ .fg = theme.BORDER, .bg = background },
+        },
+        .vertical_scrollbar_hover_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.GOLD, .bg = background },
+        },
+        .vertical_scrollbar_drag_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.ACCENT, .bg = background },
+        },
+    };
+}
+
+// Initialize ScrollBars without cursor (for content scrolling).
+pub fn initPlainScrollBars(background: vaxis.Color, wheel_scroll: u8) vxfw.ScrollBars {
+    return .{
+        .scroll_view = .{
+            .children = .{ .slice = &.{} },
+            .wheel_scroll = wheel_scroll,
+        },
+        .draw_horizontal_scrollbar = false,
+        .vertical_scrollbar_thumb = .{
+            .char = .{ .grapheme = "▐", .width = 1 },
+            .style = .{ .fg = theme.BORDER, .bg = background },
+        },
+        .vertical_scrollbar_hover_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.GOLD, .bg = background },
+        },
+        .vertical_scrollbar_drag_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.ACCENT, .bg = background },
+        },
+    };
+}
+
+// Wraps an already-rendered Surface into a Widget for passing to containers.
+pub const SurfaceWidget = struct {
+    surface: vxfw.Surface,
+    widget_ref: vxfw.Widget,
+
+    pub fn widget(self: *const SurfaceWidget) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, _: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const SurfaceWidget = @ptrCast(@alignCast(ptr));
+        var surface = self.surface;
+        surface.widget = self.widget_ref;
+        return surface;
+    }
+};
+
+// Wraps a widget reference with stable identity for containers that need it.
+pub const WidgetBox = struct {
+    widget_ref: vxfw.Widget,
+
+    pub fn widget(self: *const WidgetBox) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const WidgetBox = @ptrCast(@alignCast(ptr));
+        var surface = try self.widget_ref.draw(ctx);
+        surface.widget = self.widget();
+        return surface;
+    }
+};
+
+// Reusable bordered panel with title, subtitle, padding, and child widget.
+pub const Panel = struct {
+    owner: vxfw.Widget,
+    title: []const u8,
+    subtitle: []const u8 = "",
+    background: vaxis.Color,
+    border_color: vaxis.Color,
+    child: vxfw.Widget,
+    padding: Padding = .{},
+
+    pub const Padding = struct {
+        left: u16 = 0,
+        right: u16 = 0,
+        top: u16 = 0,
+        bottom: u16 = 0,
+    };
+
+    pub fn draw(self: *const Panel, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.owner, size);
+        fillSurface(&surface, self.background);
+        drawBorder(&surface, self.border_color, self.background);
+
+        // Title takes priority. Subtitle only renders if enough space
+        // remains after title + 2 cell gap. Prevents overlap on narrow panels.
+        const title_w: u16 = @intCast(ctx.stringWidth(self.title));
+        writeText(&surface, ctx, 2, 0, self.title, theme.boldOn(self.background, theme.TEXT));
+        if (self.subtitle.len > 0) {
+            const sub_w: u16 = @intCast(ctx.stringWidth(self.subtitle));
+            const title_end = 2 + title_w + 2;
+            const sub_start = size.width -| sub_w -| 1;
+            if (sub_start > title_end) {
+                writeRightText(&surface, ctx, 0, self.subtitle, theme.textOn(self.background, theme.MUTED));
+            }
+        }
+
+        const inner_width = size.width -| 2 -| self.padding.left -| self.padding.right;
+        const inner_height = size.height -| 2 -| self.padding.top -| self.padding.bottom;
+        const child_ctx = ctx.withConstraints(
+            .{ .width = inner_width, .height = inner_height },
+            .{ .width = inner_width, .height = inner_height },
+        );
+        const child_surface = try self.child.draw(child_ctx);
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        children[0] = .{
+            .origin = .{
+                .row = 1 + self.padding.top,
+                .col = 1 + self.padding.left,
+            },
+            .surface = child_surface,
+        };
+        surface.children = children;
+        return surface;
+    }
+};
+
+// Render a ▌ cursor indicator on a Panel surface at the ScrollView's
+// selected row. This is our workaround for a libvaxis rendering bug.
+//
+// The problem: ScrollView.draw_cursor wraps the selected row in a
+// cursor_surf with width=2, then places the text child at col=2 inside
+// it. During compositing, Window.initChild clamps the text window to
+// max_width = parent_width(2) - x_off(2) = 0. The text is invisible.
+// Only the ▌ at col=0 of cursor_surf survives.
+//
+// The fix PR has been open since 2025-10-13 with no review:
+// https://github.com/rockorager/libvaxis/pull/256
+//
+// Our workaround: keep draw_cursor=false so ScrollView never creates
+// the buggy cursor_surf. Instead, after Panel.draw() produces the
+// final surface (with ScrollBars content as z_index=0 children), we
+// append a 1×1 ▌ surface at z_index=1. vxfw's Surface.render sorts
+// children by z_index before drawing, so our overlay paints on top of
+// the list content at the exact row of the selected item.
+//
+// This approach does not touch ScrollView internals. It reads two
+// public fields (scroll_view.cursor for the selected index and
+// scroll_view.scroll.top for the viewport offset) to compute the
+// visible row, then composites via the standard SubSurface z_index
+// mechanism.
+//
+// TODO: Remove this workaround when libvaxis merges PR #256 and we
+// update the dependency. Re-enable draw_cursor in initCursorScrollBars
+// and delete the applyCursorOverlay calls in app.zig.
+//
+// Constraints: Panel must have a 1-cell border (content starts at
+// col=1, row=1). Each ScrollView child must be exactly 1 row tall
+// (softwrap=false single-line Text).
+pub fn applyCursorOverlay(
+    ctx: vxfw.DrawContext,
+    surface: *vxfw.Surface,
+    scroll_view: *const vxfw.ScrollView,
+) std.mem.Allocator.Error!vxfw.Surface {
+    const cursor_pos = scroll_view.cursor;
+    const scroll_top = scroll_view.scroll.top;
+    if (cursor_pos < scroll_top) return surface.*;
+
+    const visible_row = cursor_pos - scroll_top;
+    const target_row: i17 = @intCast(1 + visible_row);
+
+    if (target_row >= surface.size.height -| 1) return surface.*;
+
+    const cursor_buf = try ctx.arena.alloc(vaxis.Cell, 1);
+    cursor_buf[0] = .{
+        .char = .{ .grapheme = "▌", .width = 1 },
+        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+    };
+    const cursor_surface: vxfw.Surface = .{
+        .size = .{ .width = 1, .height = 1 },
+        .widget = surface.widget,
+        .buffer = cursor_buf,
+        .children = &.{},
+    };
+
+    const old_children = surface.children;
+    const new_children = try ctx.arena.alloc(vxfw.SubSurface, old_children.len + 1);
+    @memcpy(new_children[0..old_children.len], old_children);
+    new_children[old_children.len] = .{
+        .origin = .{ .col = 1, .row = target_row },
+        .surface = cursor_surface,
+        .z_index = 1,
+    };
+    surface.children = new_children;
+
+    return surface.*;
+}
+
+pub fn countLines(text: []const u8) usize {
+    if (text.len == 0) return 0;
+    return 1 + std.mem.count(u8, text, "\n");
+}


### PR DESCRIPTION
## Summary

This PR lands the initial alpha TUI for Clumsies on top of
libvaxis/vxfw. It replaces the mock-only shell with authenticated,
Hub-backed views for the dashboard, library, workspace browser,
prompt detail, pull request review, and settings so the terminal
client can be used against a real organization instead of static
fixtures.

The UI is organized around master-detail navigation and live data
flows. Library and workspace prompts now render as navigable
directory trees, prompt detail can load content and linked pull
requests on demand, and review actions, comment submission, and
token revocation all go through the same Hub client layer. Local
trace, draft, and session readers feed the live dashboard while
aggregate analysis stays remote-first.

This also hardens the alpha experience by removing mock fallback as
the default disconnected state, fixing empty-state and tree
rendering bugs, falling back to auth.json when keychain access
fails, and recovering the terminal before rethrowing panics so
crashes do not leave the shell stuck in the alternate screen.

## Test plan

- [x] `zig build tui`
- [x] Start `clumsies-hub`, log in with `./zig-out/bin/clumsies-tui login`,
      then launch `./zig-out/bin/clumsies-tui` and verify Dashboard,
      Workspace, Library, Analysis, and Settings render against live data
- [x] In Library and Workspace, navigate with `j/k`, arrow keys, `Enter`,
      and `Tab`, then open prompt detail and PR views to confirm tree
      expansion, selection, and master-detail updates
