### PR TITLE
tui: fix local analysis signal and stabilize dev fixtures

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -91,6 +91,7 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{
             .{ .name = "build_options", .module = options.createModule() },
+            .{ .name = "clumsies_lib", .module = lib },
         },
     });
     tui_module.addImport("vaxis", vaxis_dep.module("vaxis"));

--- a/src/commands/init_cmd.zig
+++ b/src/commands/init_cmd.zig
@@ -77,7 +77,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
             return;
         }
 
-        const parsed = std.json.parseFromSlice(WorkspaceResponse, allocator, response.body, .{ .allocate = .alloc_always }) catch {
+        const parsed = parseWorkspaceResponse(allocator, response.body) catch {
             try stderr.print("{s}{s}{s}Error:{s} Failed to parse workspace response\n", .{ P, Color.bold, Color.red, Color.reset });
             return;
         };
@@ -85,7 +85,8 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
         ws_id_owned = try allocator.dupe(u8, parsed.value.ws_id);
         ws_id = ws_id_owned.?;
-        ws_name = name;
+        ws_name_owned = try allocator.dupe(u8, parsed.value.name);
+        ws_name = ws_name_owned.?;
     } else if (ws_id_flag) |id| {
         // GET /api/workspaces/{ws_id} to verify access
         const path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}", .{id});
@@ -98,7 +99,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
             return;
         }
 
-        const parsed = std.json.parseFromSlice(WorkspaceResponse, allocator, response.body, .{ .allocate = .alloc_always }) catch {
+        const parsed = parseWorkspaceResponse(allocator, response.body) catch {
             try stderr.print("{s}{s}{s}Error:{s} Failed to parse workspace response\n", .{ P, Color.bold, Color.red, Color.reset });
             return;
         };
@@ -144,7 +145,15 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 const WorkspaceResponse = struct {
     ws_id: []const u8,
     name: []const u8,
+    revision: ?i32 = null,
 };
+
+fn parseWorkspaceResponse(allocator: std.mem.Allocator, body: []const u8) !std.json.Parsed(WorkspaceResponse) {
+    return std.json.parseFromSlice(WorkspaceResponse, allocator, body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+}
 
 fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}Usage: {s}clumsies init [--create <name> | --ws-id <id>] [--bundle <bundle_id>]{s}\n", .{ P, Color.cyan, Color.reset });
@@ -153,4 +162,17 @@ fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}  {s}--create <name>{s}     Create a new workspace with this name\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}--ws-id <id>{s}        Bind to an existing workspace by ID\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}  {s}--bundle <bundle_id>{s} Associate a bundle (with --create)\n", .{ P, Color.cyan, Color.reset });
+}
+
+test "parseWorkspaceResponse ignores added fields from hub responses" {
+    const body =
+        \\{"ws_id":"ws-123","name":"clumsiesws","revision":4}
+    ;
+
+    const parsed = try parseWorkspaceResponse(std.testing.allocator, body);
+    defer parsed.deinit();
+
+    try std.testing.expectEqualStrings("ws-123", parsed.value.ws_id);
+    try std.testing.expectEqualStrings("clumsiesws", parsed.value.name);
+    try std.testing.expectEqual(@as(?i32, 4), parsed.value.revision);
 }

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -59,6 +59,11 @@ pub const PumpScenario = struct {
     refers: []const PumpRefer,
 };
 
+pub const PumpProfile = struct {
+    name: []const u8,
+    session_rates: []const u8,
+};
+
 pub const META_PROMPT_CONTENT =
     \\# clumsies Meta-Prompt File
     \\
@@ -304,6 +309,20 @@ const RESET_REFERS = [_]PumpRefer{
     .{ .prompt_id = "p-seed-trace", .constraint_id = "trace.keep-pump-structurally-pure", .reason = "pump stayed focused on activity data instead of schema churn" },
 };
 
+const PROFILE_RAMP_UP = [_]u8{ 1, 1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8 };
+const PROFILE_COOLDOWN = [_]u8{ 8, 7, 6, 5, 4, 3, 2, 2, 1, 1, 1, 0 };
+const PROFILE_WAVE = [_]u8{ 2, 3, 5, 6, 5, 3, 2, 3, 5, 6, 4, 2 };
+const PROFILE_SPIKE = [_]u8{ 0, 0, 1, 1, 2, 8, 10, 3, 1, 1, 0, 0 };
+const PROFILE_LOW_AMBIENT = [_]u8{ 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0 };
+
+pub const PUMP_PROFILES = [_]PumpProfile{
+    .{ .name = "ramp-up", .session_rates = &PROFILE_RAMP_UP },
+    .{ .name = "cooldown", .session_rates = &PROFILE_COOLDOWN },
+    .{ .name = "wave", .session_rates = &PROFILE_WAVE },
+    .{ .name = "spike", .session_rates = &PROFILE_SPIKE },
+    .{ .name = "low-ambient", .session_rates = &PROFILE_LOW_AMBIENT },
+};
+
 pub const PUMP_SCENARIOS = [_]PumpScenario{
     .{
         .user_id = "usr-seed-dylan",
@@ -344,6 +363,20 @@ pub fn promptById(prompt_id: []const u8) ?*const PromptFixture {
     return null;
 }
 
+pub fn userById(user_id: []const u8) ?*const UserFixture {
+    for (&USERS) |*user| {
+        if (std.mem.eql(u8, user.id, user_id)) return user;
+    }
+    return null;
+}
+
+pub fn workspaceById(ws_id: []const u8) ?*const WorkspaceFixture {
+    for (&WORKSPACES) |*workspace| {
+        if (std.mem.eql(u8, workspace.id, ws_id)) return workspace;
+    }
+    return null;
+}
+
 pub fn isSeedWorkspaceId(ws_id: []const u8) bool {
     return std.mem.startsWith(u8, ws_id, SEED_WORKSPACE_PREFIX);
 }
@@ -351,6 +384,13 @@ pub fn isSeedWorkspaceId(ws_id: []const u8) bool {
 test "promptById returns known prompt fixtures" {
     try std.testing.expect(promptById("p-seed-meta") != null);
     try std.testing.expect(promptById("missing") == null);
+}
+
+test "seed lookup helpers resolve user and workspace fixtures" {
+    try std.testing.expect(userById("usr-seed-admin") != null);
+    try std.testing.expect(userById("missing") == null);
+    try std.testing.expect(workspaceById("ws-seed-tui") != null);
+    try std.testing.expect(workspaceById("missing") == null);
 }
 
 test "isSeedWorkspaceId matches fixed seed prefix" {

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -8,11 +8,114 @@ const prompt_lib = clumsies_lib.prompt;
 
 const log = std.log.scoped(.pump);
 
+const PumpTick = struct {
+    emit_count: u16,
+    active_profile: data.PumpProfile,
+    profile_switched: bool,
+};
+
+const EmitBatch = struct {
+    emitted_count: u16 = 0,
+    last_scenario: ?*const data.PumpScenario = null,
+};
+
+const PumpPlanner = struct {
+    rng: std.Random.DefaultPrng,
+    current_profile_idx: usize = 0,
+    next_sweep_profile_idx: usize = if (data.PUMP_PROFILES.len > 1) 1 else 0,
+    sweep_complete: bool = data.PUMP_PROFILES.len <= 1,
+    profile_elapsed_ms: u64 = 0,
+    session_budget: f32 = 0,
+    scenario_cursor: usize = 0,
+    total_sessions: u64 = 0,
+
+    fn init() PumpPlanner {
+        var seed: u64 = 0;
+        std.crypto.random.bytes(std.mem.asBytes(&seed));
+        return initWithSeed(seed);
+    }
+
+    fn initWithSeed(seed: u64) PumpPlanner {
+        return .{
+            .rng = std.Random.DefaultPrng.init(seed),
+        };
+    }
+
+    fn currentProfile(self: *const PumpPlanner) data.PumpProfile {
+        return data.PUMP_PROFILES[self.current_profile_idx];
+    }
+
+    fn nextScenario(self: *PumpPlanner) *const data.PumpScenario {
+        const idx = self.scenario_cursor % data.PUMP_SCENARIOS.len;
+        self.scenario_cursor += 1;
+        return &data.PUMP_SCENARIOS[idx];
+    }
+
+    fn planTick(self: *PumpPlanner, interval_ms: u64) PumpTick {
+        var remaining_ms = interval_ms;
+        var profile_switched = false;
+
+        while (remaining_ms > 0) {
+            const profile = self.currentProfile();
+            const total_profile_ms = profileTotalMs(profile);
+            const second_idx = @min(
+                profile.session_rates.len - 1,
+                @as(usize, @intCast(self.profile_elapsed_ms / std.time.ms_per_s)),
+            );
+            const second_progress_ms = self.profile_elapsed_ms % std.time.ms_per_s;
+            const step_remaining_ms = std.time.ms_per_s - second_progress_ms;
+            const profile_remaining_ms = total_profile_ms - self.profile_elapsed_ms;
+            const slice_ms = @min(remaining_ms, @min(step_remaining_ms, profile_remaining_ms));
+            const rate = profile.session_rates[second_idx];
+
+            self.session_budget +=
+                @as(f32, @floatFromInt(rate)) *
+                @as(f32, @floatFromInt(slice_ms)) /
+                @as(f32, @floatFromInt(std.time.ms_per_s));
+
+            self.profile_elapsed_ms += slice_ms;
+            remaining_ms -= slice_ms;
+
+            if (self.profile_elapsed_ms == total_profile_ms) {
+                profile_switched = true;
+                self.advanceProfile();
+            }
+        }
+
+        const emit_count: u16 = @intFromFloat(@floor(self.session_budget));
+        self.session_budget -= @as(f32, @floatFromInt(emit_count));
+
+        return .{
+            .emit_count = emit_count,
+            .active_profile = self.currentProfile(),
+            .profile_switched = profile_switched,
+        };
+    }
+
+    fn advanceProfile(self: *PumpPlanner) void {
+        self.profile_elapsed_ms = 0;
+
+        if (!self.sweep_complete) {
+            self.current_profile_idx = self.next_sweep_profile_idx;
+            self.next_sweep_profile_idx += 1;
+            if (self.next_sweep_profile_idx >= data.PUMP_PROFILES.len) {
+                self.sweep_complete = true;
+            }
+            return;
+        }
+
+        self.current_profile_idx = pickRandomProfileIndex(self.rng.random(), self.current_profile_idx);
+    }
+};
+
 pub fn run(pool: *pg.Pool, interval_ms: u64) !void {
     log.info("pump started (interval: {d}ms, Ctrl-C to stop)", .{interval_ms});
 
     var tick: u64 = 0;
+    var planner = PumpPlanner.init();
     const sleep_ns = std.math.mul(u64, interval_ms, std.time.ns_per_ms) catch std.math.maxInt(u64);
+
+    logActiveProfile(planner.currentProfile());
 
     while (true) {
         const conn = pool.acquire() catch {
@@ -22,26 +125,53 @@ pub fn run(pool: *pg.Pool, interval_ms: u64) !void {
         };
         defer conn.release();
 
-        emitScenario(conn, tick);
+        const plan = planner.planTick(interval_ms);
+        const batch = emitBatch(conn, &planner, tick, plan.emit_count);
 
         tick += 1;
         if (tick % data.CLEANUP_INTERVAL == 0) {
             cleanupTrace(conn);
-            log.info("{d} sessions emitted (db cleanup done)", .{tick});
+            logBatchSummary(planner.total_sessions, plan.active_profile, batch, true);
+        } else if (plan.profile_switched) {
+            logActiveProfile(plan.active_profile);
+            logBatchSummary(planner.total_sessions, plan.active_profile, batch, false);
         } else if (tick % 10 == 0) {
-            log.info("{d} sessions emitted", .{tick});
+            logBatchSummary(planner.total_sessions, plan.active_profile, batch, false);
         }
 
         std.Thread.sleep(sleep_ns);
     }
 }
 
-fn emitScenario(conn: *pg.Conn, tick: u64) void {
-    const scenario = data.PUMP_SCENARIOS[tick % data.PUMP_SCENARIOS.len];
-    const timestamp_base = std.time.milliTimestamp();
+fn emitBatch(conn: *pg.Conn, planner: *PumpPlanner, tick: u64, emit_count: u16) EmitBatch {
+    var batch: EmitBatch = .{};
+
+    for (0..emit_count) |slot_idx| {
+        const scenario = planner.nextScenario();
+        emitScenario(conn, scenario, tick, planner.total_sessions, @intCast(slot_idx));
+        planner.total_sessions += 1;
+        batch.emitted_count += 1;
+        batch.last_scenario = scenario;
+    }
+
+    return batch;
+}
+
+fn emitScenario(
+    conn: *pg.Conn,
+    scenario: *const data.PumpScenario,
+    tick: u64,
+    session_serial: u64,
+    slot_idx: u16,
+) void {
+    const timestamp_base = std.time.milliTimestamp() + @as(i64, @intCast(slot_idx * 10));
 
     var session_buf: [64]u8 = undefined;
-    const session_id = std.fmt.bufPrint(&session_buf, "ses-seed-{d}-{d}", .{ timestamp_base, tick }) catch return;
+    const session_id = std.fmt.bufPrint(&session_buf, "ses-seed-{d}-{d}-{d}", .{
+        timestamp_base,
+        tick,
+        session_serial,
+    }) catch return;
 
     insertTraceEvent(conn, scenario.user_id, .{
         .ws_id = scenario.ws_id,
@@ -122,4 +252,122 @@ fn cleanupTrace(conn: *pg.Conn) void {
     , .{data.CAP_TRACE_EVENTS}) catch |err| {
         log.warn("trace cleanup failed: {}", .{err});
     };
+}
+
+fn logActiveProfile(profile: data.PumpProfile) void {
+    log.info("profile {s} active (~{d} session/s)", .{
+        profile.name,
+        averageSessionRate(profile),
+    });
+}
+
+fn logBatchSummary(total_sessions: u64, active_profile: data.PumpProfile, batch: EmitBatch, cleanup_done: bool) void {
+    var summary_buf: [160]u8 = undefined;
+    const summary = if (batch.last_scenario) |scenario|
+        formatScenarioSummary(&summary_buf, scenario)
+    else
+        "latest: idle window";
+
+    if (cleanup_done) {
+        log.info("{d} sessions emitted [{s}] {s} (db cleanup done)", .{
+            total_sessions,
+            active_profile.name,
+            summary,
+        });
+        return;
+    }
+
+    log.info("{d} sessions emitted [{s}] {s}", .{
+        total_sessions,
+        active_profile.name,
+        summary,
+    });
+}
+
+fn formatScenarioSummary(buf: *[160]u8, scenario: *const data.PumpScenario) []const u8 {
+    const workspace = if (data.workspaceById(scenario.ws_id)) |ws| ws.name else scenario.ws_id;
+    const user = if (data.userById(scenario.user_id)) |u| u.username else scenario.user_id;
+
+    var input_buf: [80]u8 = undefined;
+    const input = truncateForLog(&input_buf, scenario.input);
+
+    return std.fmt.bufPrint(buf, "latest: {s} / {s} / {s}", .{
+        workspace,
+        user,
+        input,
+    }) catch "latest: seed activity";
+}
+
+fn truncateForLog(buf: []u8, text: []const u8) []const u8 {
+    if (text.len <= buf.len) {
+        @memcpy(buf[0..text.len], text);
+        return buf[0..text.len];
+    }
+
+    if (buf.len <= 3) {
+        @memcpy(buf, text[0..buf.len]);
+        return buf;
+    }
+
+    const head_len = buf.len - 3;
+    @memcpy(buf[0..head_len], text[0..head_len]);
+    @memcpy(buf[head_len..], "...");
+    return buf;
+}
+
+fn averageSessionRate(profile: data.PumpProfile) u16 {
+    var total: u32 = 0;
+    for (profile.session_rates) |rate| total += rate;
+    const rounded = (total + profile.session_rates.len / 2) / profile.session_rates.len;
+    return @intCast(rounded);
+}
+
+fn profileTotalMs(profile: data.PumpProfile) u64 {
+    return @as(u64, @intCast(profile.session_rates.len)) * std.time.ms_per_s;
+}
+
+fn pickRandomProfileIndex(random: std.Random, current_idx: usize) usize {
+    if (data.PUMP_PROFILES.len <= 1) return current_idx;
+
+    var idx = current_idx;
+    while (idx == current_idx) {
+        idx = random.intRangeLessThan(usize, 0, data.PUMP_PROFILES.len);
+    }
+    return idx;
+}
+
+test "planner sweeps each profile before entering random rotation" {
+    var planner = PumpPlanner.initWithSeed(7);
+
+    try std.testing.expectEqual(@as(usize, 0), planner.current_profile_idx);
+    for (1..data.PUMP_PROFILES.len) |expected_idx| {
+        _ = planner.planTick(profileTotalMs(planner.currentProfile()));
+        try std.testing.expectEqual(expected_idx, planner.current_profile_idx);
+    }
+
+    const before_random = planner.current_profile_idx;
+    _ = planner.planTick(profileTotalMs(planner.currentProfile()));
+    if (data.PUMP_PROFILES.len > 1) {
+        try std.testing.expect(planner.current_profile_idx != before_random);
+    }
+}
+
+test "planner preserves total profile volume across subsecond ticks" {
+    var planner = PumpPlanner.initWithSeed(11);
+    const profile = planner.currentProfile();
+    const tick_ms: u64 = 250;
+    const tick_count = @divExact(profileTotalMs(profile), tick_ms);
+
+    var emitted: u32 = 0;
+    for (0..tick_count) |_| {
+        emitted += planner.planTick(tick_ms).emit_count;
+    }
+
+    var expected: u32 = 0;
+    for (profile.session_rates) |rate| expected += rate;
+
+    try std.testing.expectEqual(expected, emitted);
+    if (data.PUMP_PROFILES.len > 1) {
+        try std.testing.expectEqual(@as(usize, 1), planner.current_profile_idx);
+    }
 }

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -82,7 +82,12 @@ const PumpPlanner = struct {
             }
         }
 
-        const emit_count: u16 = @intFromFloat(@floor(self.session_budget));
+        const whole_budget = @floor(self.session_budget);
+        const max_emit_count = std.math.maxInt(u16);
+        const emit_count: u16 = if (whole_budget > @as(f32, @floatFromInt(max_emit_count)))
+            max_emit_count
+        else
+            @intFromFloat(whole_budget);
         self.session_budget -= @as(f32, @floatFromInt(emit_count));
 
         return .{
@@ -370,4 +375,14 @@ test "planner preserves total profile volume across subsecond ticks" {
     if (data.PUMP_PROFILES.len > 1) {
         try std.testing.expectEqual(@as(usize, 1), planner.current_profile_idx);
     }
+}
+
+test "planner clamps oversized emit batches to u16 max" {
+    var planner = PumpPlanner.initWithSeed(19);
+    planner.session_budget = @as(f32, @floatFromInt(std.math.maxInt(u16))) + 42.5;
+
+    const tick = planner.planTick(100);
+
+    try std.testing.expectEqual(std.math.maxInt(u16), tick.emit_count);
+    try std.testing.expectApproxEqAbs(@as(f32, 42.5), planner.session_budget, 0.001);
 }

--- a/src/tui/app.zig
+++ b/src/tui/app.zig
@@ -3400,10 +3400,54 @@ pub const Dashboard = struct {
     };
 
     const ChartSeries = struct {
-        values: []const u16,
+        values: []const f32,
         left_label: []const u8,
         right_label: []const u8,
     };
+
+    fn smoothLocalChartBuckets(arena: std.mem.Allocator, source: []const u16) []const f32 {
+        if (source.len == 0) return &.{};
+
+        const values = arena.alloc(f32, source.len) catch return &.{};
+        const kernel = [_]f32{ 1, 2, 3, 2, 1 };
+
+        // Smooth the second-level refer buckets just for display. This keeps
+        // the underlying counts exact while turning isolated spikes into a
+        // more legible local activity wave.
+        for (source, 0..) |_, center| {
+            var weighted_sum: f32 = 0;
+            var weight_total: f32 = 0;
+
+            for (kernel, 0..) |weight, kernel_idx| {
+                const offset: isize = @as(isize, @intCast(kernel_idx)) - 2;
+                const sample_idx_signed: isize = @as(isize, @intCast(center)) + offset;
+                if (sample_idx_signed < 0 or sample_idx_signed >= @as(isize, @intCast(source.len))) continue;
+
+                const sample_idx: usize = @intCast(sample_idx_signed);
+                weighted_sum += @as(f32, @floatFromInt(source[sample_idx])) * weight;
+                weight_total += weight;
+            }
+
+            values[center] = if (weight_total > 0)
+                weighted_sum / weight_total
+            else
+                @as(f32, @floatFromInt(source[center]));
+        }
+
+        return values;
+    }
+
+    test "smoothLocalChartBuckets softens an isolated spike" {
+        const source = [_]u16{ 0, 0, 0, 6, 0, 0, 0 };
+        const values = smoothLocalChartBuckets(std.testing.allocator, &source);
+        defer std.testing.allocator.free(values);
+
+        try std.testing.expectApproxEqAbs(@as(f32, 2.0 / 3.0), values[1], 0.001);
+        try std.testing.expectApproxEqAbs(@as(f32, 4.0 / 3.0), values[2], 0.001);
+        try std.testing.expectApproxEqAbs(@as(f32, 2.0), values[3], 0.001);
+        try std.testing.expectApproxEqAbs(@as(f32, 4.0 / 3.0), values[4], 0.001);
+        try std.testing.expectApproxEqAbs(@as(f32, 2.0 / 3.0), values[5], 0.001);
+    }
 
     fn currentInsightsScopeLocked(self: *const Dashboard) InsightsScopeInfo {
         const workspaces = if (self.api_state.current_user) |u| u.workspaces else &.{};
@@ -3477,10 +3521,7 @@ pub const Dashboard = struct {
         const bucket_count: usize = 60;
         const span_ms: i64 = bucket_ms * bucket_count;
 
-        const values = arena.alloc(u16, bucket_count) catch {
-            return .{ .values = &.{}, .left_label = "60s ago", .right_label = "now" };
-        };
-        @memset(values, 0);
+        var raw_values: [bucket_count]u16 = .{0} ** bucket_count;
 
         const now_ms = std.time.milliTimestamp();
         const current_bucket_start_ms = now_ms - @mod(now_ms, bucket_ms);
@@ -3490,11 +3531,11 @@ pub const Dashboard = struct {
             if (rv.timestamp < start_ms or rv.timestamp >= end_ms) continue;
             const idx: usize = @intCast(@divFloor(rv.timestamp - start_ms, bucket_ms));
             if (idx >= bucket_count) continue;
-            values[idx] +|= 1;
+            raw_values[idx] +|= 1;
         }
 
         return .{
-            .values = values,
+            .values = smoothLocalChartBuckets(arena, raw_values[0..]),
             .left_label = "60s ago",
             .right_label = "now",
         };

--- a/src/tui/trace_reader.zig
+++ b/src/tui/trace_reader.zig
@@ -1,6 +1,8 @@
 // Read local trace.jsonl files and compute Insights stats.
 const std = @import("std");
+const clumsies_lib = @import("clumsies_lib");
 const data = @import("mock_data.zig");
+const workspace_prompt = clumsies_lib.workspace_prompt;
 
 pub const LocalStats = struct {
     total_refer_count: u32 = 0,
@@ -57,6 +59,8 @@ const TraceEvent = struct {
     content: ?[]const u8 = null,
 };
 
+const PromptConstraintTotals = std.StringHashMap(u16);
+
 pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     const base = getBaseDir(allocator) orelse return null;
     defer allocator.free(base);
@@ -68,12 +72,16 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
 
     var all_events: std.ArrayList(TraceEvent) = .empty;
     var workspace_stats: std.ArrayList(WorkspaceLocalStats) = .empty;
+    var all_prompt_totals: PromptConstraintTotals = .init(allocator);
+    defer deinitPromptConstraintTotals(allocator, &all_prompt_totals);
     var it = dir.iterate();
     while (it.next() catch null) |entry| {
         if (entry.kind != .directory) continue;
         const ws_id = allocator.dupe(u8, entry.name) catch continue;
         var keep_ws_id = false;
         defer if (!keep_ws_id) allocator.free(ws_id);
+        const ws_dir = std.fs.path.join(allocator, &.{ ws_root, entry.name }) catch continue;
+        defer allocator.free(ws_dir);
         const trace_path = std.fs.path.join(allocator, &.{ ws_root, entry.name, "trace.jsonl" }) catch continue;
         defer allocator.free(trace_path);
         var ws_events: std.ArrayList(TraceEvent) = .empty;
@@ -81,7 +89,12 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
         if (ws_events.items.len == 0) continue;
         keep_ws_id = true;
 
-        const ws_stats = computeStats(allocator, ws_events.items);
+        var ws_prompt_totals = loadPromptConstraintTotals(allocator, ws_dir) catch PromptConstraintTotals.init(allocator);
+        defer deinitPromptConstraintTotals(allocator, &ws_prompt_totals);
+
+        mergePromptConstraintTotals(allocator, &all_prompt_totals, &ws_prompt_totals);
+
+        const ws_stats = computeStats(allocator, ws_events.items, &ws_prompt_totals);
         workspace_stats.append(allocator, .{
             .ws_id = ws_id,
             .total_refer_count = ws_stats.total_refer_count,
@@ -100,7 +113,7 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     }
 
     if (all_events.items.len == 0) return null;
-    var all_stats = computeStats(allocator, all_events.items);
+    var all_stats = computeStats(allocator, all_events.items, &all_prompt_totals);
     all_stats.workspaces = workspace_stats.items;
     return all_stats;
 }
@@ -203,7 +216,82 @@ fn freeTraceEventOwned(allocator: std.mem.Allocator, ev: TraceEvent) void {
     if (ev.content) |s| allocator.free(s);
 }
 
-fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalStats {
+fn loadPromptConstraintTotals(allocator: std.mem.Allocator, ws_dir: []const u8) !PromptConstraintTotals {
+    var totals: PromptConstraintTotals = .init(allocator);
+    errdefer deinitPromptConstraintTotals(allocator, &totals);
+
+    var manifest = workspace_prompt.loadManifest(allocator, ws_dir) catch |err| switch (err) {
+        error.InvalidManifest, error.FileNotFound => return totals,
+        else => return err,
+    };
+    defer manifest.deinit(allocator);
+
+    var ids: std.ArrayList([]const u8) = .empty;
+    defer ids.deinit(allocator);
+
+    var it = manifest.prompts.iterator();
+    while (it.next()) |entry| {
+        ids.append(allocator, entry.key_ptr.*) catch continue;
+    }
+
+    if (ids.items.len == 0) return totals;
+
+    var loaded = workspace_prompt.loadPrompts(allocator, ws_dir, ids.items, &.{}) catch |err| switch (err) {
+        error.UnknownPromptId, error.FileNotFound, error.UnsafeCachePath => return totals,
+        else => return err,
+    };
+    defer loaded.deinit(allocator);
+
+    for (loaded.items.items) |prompt_item| {
+        const content = prompt_item.content orelse continue;
+        var parsed = workspace_prompt.parseConstraints(allocator, content) catch continue;
+        defer parsed.deinit(allocator);
+
+        const constraint_total: u16 = @intCast(@min(parsed.constraints.items.len, std.math.maxInt(u16)));
+        putPromptConstraintTotal(allocator, &totals, prompt_item.id, constraint_total) catch continue;
+    }
+
+    return totals;
+}
+
+fn mergePromptConstraintTotals(
+    allocator: std.mem.Allocator,
+    target: *PromptConstraintTotals,
+    source: *const PromptConstraintTotals,
+) void {
+    var it = source.iterator();
+    while (it.next()) |entry| {
+        putPromptConstraintTotal(allocator, target, entry.key_ptr.*, entry.value_ptr.*) catch continue;
+    }
+}
+
+fn putPromptConstraintTotal(
+    allocator: std.mem.Allocator,
+    totals: *PromptConstraintTotals,
+    prompt_id: []const u8,
+    constraint_total: u16,
+) !void {
+    if (totals.getPtr(prompt_id)) |value_ptr| {
+        if (constraint_total > value_ptr.*) value_ptr.* = constraint_total;
+        return;
+    }
+
+    const key = try allocator.dupe(u8, prompt_id);
+    errdefer allocator.free(key);
+    try totals.put(key, constraint_total);
+}
+
+fn deinitPromptConstraintTotals(allocator: std.mem.Allocator, totals: *PromptConstraintTotals) void {
+    var key_it = totals.keyIterator();
+    while (key_it.next()) |key| allocator.free(key.*);
+    totals.deinit();
+}
+
+fn computeStats(
+    allocator: std.mem.Allocator,
+    events: []const TraceEvent,
+    prompt_totals: *const PromptConstraintTotals,
+) LocalStats {
     var stats: LocalStats = .{};
 
     const PromptAcc = struct {
@@ -263,12 +351,23 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
 
     var map_it = prompt_map.iterator();
     while (map_it.next()) |kv| {
-        const c_count: u8 = @intCast(@min(kv.value_ptr.constraints.count(), 255));
-        total_constraints += c_count;
-        active_constraints += c_count;
+        const active_count_u32: u32 = @intCast(kv.value_ptr.constraints.count());
+        const total_count_u32: u32 = if (prompt_totals.get(kv.key_ptr.*)) |count|
+            @max(@as(u32, count), active_count_u32)
+        else
+            active_count_u32;
+        const active_count: u8 = @intCast(@min(active_count_u32, 255));
+        const total_count: u8 = @intCast(@min(total_count_u32, 255));
+        const idle_count: u8 = total_count -| active_count;
+
+        total_constraints += total_count_u32;
+        active_constraints += @min(active_count_u32, total_count_u32);
 
         const rate: u16 = @intCast(@min(@divTrunc(kv.value_ptr.refer_count, 30), std.math.maxInt(u16)));
-        const sig: u8 = if (c_count > 0) 100 else 0;
+        const sig: u8 = if (total_count_u32 > 0)
+            @intCast(@min(@divTrunc(@min(active_count_u32, total_count_u32) * 100, total_count_u32), 100))
+        else
+            0;
 
         var constraints_list: std.ArrayList(data.ConstraintStat) = .empty;
         var c_it = kv.value_ptr.constraints.iterator();
@@ -291,9 +390,9 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
 
         prompts_list.append(allocator, .{
             .name = kv.key_ptr.*,
-            .constraint_count = c_count,
-            .active_constraint_count = c_count,
-            .idle_constraint_count = 0,
+            .constraint_count = total_count,
+            .active_constraint_count = active_count,
+            .idle_constraint_count = idle_count,
             .signal_ratio = sig,
             .refer_count = kv.value_ptr.refer_count,
             .workspace_count = 0,
@@ -328,4 +427,69 @@ fn computeStats(allocator: std.mem.Allocator, events: []const TraceEvent) LocalS
     stats.inputs = inputs_list.items;
 
     return stats;
+}
+
+test "computeStats uses prompt totals to derive non-100 signal ratios" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const events = [_]TraceEvent{
+        .{
+            .ws_id = "ws-1",
+            .session_id = "ses-1",
+            .type = "refer",
+            .timestamp = std.time.milliTimestamp(),
+            .prompt_id = "p-1",
+            .constraint_id = "c-1",
+        },
+        .{
+            .ws_id = "ws-1",
+            .session_id = "ses-1",
+            .type = "refer",
+            .timestamp = std.time.milliTimestamp(),
+            .prompt_id = "p-1",
+            .constraint_id = "c-2",
+        },
+    };
+
+    var totals: PromptConstraintTotals = .init(alloc);
+    defer deinitPromptConstraintTotals(alloc, &totals);
+    try putPromptConstraintTotal(alloc, &totals, "p-1", 4);
+
+    const stats = computeStats(alloc, &events, &totals);
+
+    try std.testing.expectEqual(@as(u32, 4), stats.constraint_count);
+    try std.testing.expectEqual(@as(u32, 2), stats.active_constraint_count);
+    try std.testing.expectEqual(@as(u8, 50), stats.signal_ratio);
+    try std.testing.expectEqual(@as(u8, 4), stats.prompts[0].constraint_count);
+    try std.testing.expectEqual(@as(u8, 2), stats.prompts[0].active_constraint_count);
+    try std.testing.expectEqual(@as(u8, 2), stats.prompts[0].idle_constraint_count);
+    try std.testing.expectEqual(@as(u8, 50), stats.prompts[0].signal_ratio);
+}
+
+test "computeStats falls back to active constraint counts when prompt totals are unavailable" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    const events = [_]TraceEvent{
+        .{
+            .ws_id = "ws-1",
+            .session_id = "ses-1",
+            .type = "refer",
+            .timestamp = std.time.milliTimestamp(),
+            .prompt_id = "p-1",
+            .constraint_id = "c-1",
+        },
+    };
+
+    var totals: PromptConstraintTotals = .init(alloc);
+    defer deinitPromptConstraintTotals(alloc, &totals);
+
+    const stats = computeStats(alloc, &events, &totals);
+
+    try std.testing.expectEqual(@as(u32, 1), stats.constraint_count);
+    try std.testing.expectEqual(@as(u32, 1), stats.active_constraint_count);
+    try std.testing.expectEqual(@as(u8, 100), stats.signal_ratio);
 }

--- a/src/tui/widgets.zig
+++ b/src/tui/widgets.zig
@@ -29,6 +29,99 @@ fn brailleGrapheme(cp: u21) []const u8 {
     return braille_utf8_table[idx][0..];
 }
 
+fn sampleInterpolatedValue(trend: []const f32, sample_x: f32) f32 {
+    if (trend.len == 0) return 0;
+    if (trend.len == 1) return trend[0];
+
+    const max_x = @as(f32, @floatFromInt(trend.len - 1));
+    const clamped_x = std.math.clamp(sample_x, 0.0, max_x);
+    const left_x = @floor(clamped_x);
+    const left_idx: usize = @intFromFloat(left_x);
+    const right_idx = @min(left_idx + 1, trend.len - 1);
+    const t = clamped_x - left_x;
+
+    return trend[left_idx] * (1.0 - t) + trend[right_idx] * t;
+}
+
+const ChartScale = struct {
+    min_val: f32,
+    max_val: f32,
+};
+
+fn transformChartValue(value: f32) f32 {
+    return @sqrt(@max(value, 0.0));
+}
+
+fn quantileSorted(values: []const f32, q: f32) f32 {
+    if (values.len == 0) return 0;
+    if (values.len == 1) return values[0];
+
+    const clamped_q = std.math.clamp(q, 0.0, 1.0);
+    const scaled_idx = clamped_q * @as(f32, @floatFromInt(values.len - 1));
+    const left_idx: usize = @intFromFloat(@floor(scaled_idx));
+    const right_idx = @min(left_idx + 1, values.len - 1);
+    const t = scaled_idx - @as(f32, @floatFromInt(left_idx));
+
+    return values[left_idx] * (1.0 - t) + values[right_idx] * t;
+}
+
+fn resolveChartScale(trend: []const f32) ChartScale {
+    if (trend.len == 0) return .{ .min_val = 0, .max_val = 1 };
+
+    var sorted_samples: [256]f32 = undefined;
+    const sample_count = @min(trend.len, sorted_samples.len);
+    if (sample_count == 0) return .{ .min_val = 0, .max_val = 1 };
+
+    for (0..sample_count) |i| {
+        const src_idx = if (sample_count == trend.len or sample_count == 1)
+            i
+        else
+            i * (trend.len - 1) / (sample_count - 1);
+        sorted_samples[i] = transformChartValue(trend[src_idx]);
+    }
+
+    std.mem.sort(f32, sorted_samples[0..sample_count], {}, struct {
+        fn lessThan(_: void, a: f32, b: f32) bool {
+            return a < b;
+        }
+    }.lessThan);
+
+    const min_sample = sorted_samples[0];
+    const max_sample = sorted_samples[sample_count - 1];
+    const lower_q = quantileSorted(sorted_samples[0..sample_count], 0.12);
+    const upper_q = quantileSorted(sorted_samples[0..sample_count], 0.88);
+    const center = (lower_q + upper_q) * 0.5;
+    const robust_span = @max(upper_q - lower_q, 0.35);
+
+    // Use a robust band instead of raw min/max so one burst does not flatten
+    // the rest of the minute, while still leaving some headroom for spikes.
+    const lower_pad = @max(robust_span * 0.35, (lower_q - min_sample) * 0.5, 0.12);
+    const upper_pad = @max(robust_span * 0.45, (max_sample - upper_q) * 0.4, 0.25);
+
+    var min_val = @max(lower_q - lower_pad, 0.0);
+    var max_val = upper_q + upper_pad;
+
+    const min_display_span = @max(robust_span * 1.4, 0.9);
+    if (max_val - min_val < min_display_span) {
+        const half_span = min_display_span * 0.5;
+        min_val = @max(center - half_span, 0.0);
+        max_val = center + half_span;
+    }
+
+    if (max_val - min_val < 0.1) {
+        max_val = min_val + 0.1;
+    }
+
+    return .{ .min_val = min_val, .max_val = max_val };
+}
+
+fn chartDotY(value: f32, min_val: f32, max_val: f32, rows: u32) u32 {
+    const span = @max(max_val - min_val, 0.001);
+    const ratio = std.math.clamp((value - min_val) / span, 0.0, 1.0);
+    const max_row = @as(f32, @floatFromInt(rows - 1));
+    return @intFromFloat(@round((1.0 - ratio) * max_row));
+}
+
 // Fill entire surface buffer with a background color.
 pub fn fillSurface(surface: *vxfw.Surface, bg: vaxis.Color) void {
     @memset(surface.buffer, theme.blank(bg));
@@ -151,18 +244,10 @@ pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16
 // Draw a braille area chart with gradient coloring (btop-style).
 // Area is filled from the data line down to the bottom, creating
 // a solid "mountain" shape. Gradient: ACCENT_SOFT (bottom) → OK (top).
-pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const u16, x: u16, y: u16, width: u16, height: u16) void {
+pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const f32, x: u16, y: u16, width: u16, height: u16) void {
     if (width == 0 or height == 0 or trend.len == 0) return;
 
-    var max_val: u16 = 1;
-    var min_val: u16 = std.math.maxInt(u16);
-    for (trend) |v| {
-        if (v > max_val) max_val = v;
-        if (v < min_val) min_val = v;
-    }
-    const padding: u16 = @max(max_val / 10, 1);
-    min_val = min_val -| padding;
-    max_val = max_val + padding;
+    const scale = resolveChartScale(trend);
 
     const braille_h: u32 = @as(u32, height) * 4;
     const cols: u32 = @min(@as(u32, width) * 2, 512);
@@ -171,13 +256,17 @@ pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const u16, x: u16, 
     var dots: [512][128]bool = undefined;
     for (&dots) |*r| @memset(r, false);
 
-    // Plot data and fill area below each point
+    // Sample a continuous curve across the discrete buckets so the chart
+    // reads as a local activity wave rather than a stack of isolated bars.
     for (0..cols) |col_idx| {
-        const data_idx: usize = col_idx * (trend.len - 1) / @max(cols - 1, 1);
-        const val = trend[@min(data_idx, trend.len - 1)];
-        const clamped = @max(val, min_val) - min_val;
-        const normalized: u32 = @as(u32, clamped) * (rows - 1) / @as(u32, max_val - min_val);
-        const dot_y: u32 = rows - 1 - normalized;
+        const sample_x = if (cols > 1)
+            @as(f32, @floatFromInt(col_idx)) *
+                @as(f32, @floatFromInt(trend.len - 1)) /
+                @as(f32, @floatFromInt(cols - 1))
+        else
+            0.0;
+        const val = sampleInterpolatedValue(trend, sample_x);
+        const dot_y = chartDotY(transformChartValue(val), scale.min_val, scale.max_val, rows);
 
         // Fill from dot_y down to bottom (area fill)
         var fill_y = dot_y;
@@ -230,6 +319,36 @@ pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const u16, x: u16, 
 test "brailleGrapheme uses stable utf8 lookups" {
     try std.testing.expectEqualStrings("\xe2\xa0\x81", brailleGrapheme(0x2801));
     try std.testing.expectEqualStrings("\xe2\xa3\xbf", brailleGrapheme(0x28ff));
+}
+
+test "sampleInterpolatedValue blends neighboring buckets" {
+    const trend = [_]f32{ 0, 10, 0 };
+    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 0.5), 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 1.5), 0.001);
+}
+
+test "resolveChartScale keeps steady low activity off the bottom edge" {
+    const trend = [_]f32{ 1, 1, 1, 1, 1 };
+    const scale = resolveChartScale(&trend);
+    const dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
+
+    try std.testing.expect(dot_y > 1);
+    try std.testing.expect(dot_y < 6);
+}
+
+test "resolveChartScale preserves low-band motion when a spike arrives" {
+    const trend = [_]f32{ 1, 1, 1, 1, 100 };
+    const scale = resolveChartScale(&trend);
+    const low_dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
+    const spike_dot_y = chartDotY(transformChartValue(100), scale.min_val, scale.max_val, 8);
+
+    try std.testing.expect(low_dot_y < 7);
+    try std.testing.expectEqual(@as(u32, 0), spike_dot_y);
+}
+
+test "chartDotY maps higher values toward the top" {
+    try std.testing.expectEqual(@as(u32, 7), chartDotY(0, 0, 10, 8));
+    try std.testing.expectEqual(@as(u32, 0), chartDotY(10, 0, 10, 8));
 }
 
 // Draw a signal gauge: ███████░░ active/total


### PR DESCRIPTION
## Summary
- vary the seed pump across fixed activity profiles before switching to random rotation, and add lightweight batch logs for local analysis testing
- make `clumsies init --create` accept workspace responses with added fields so successful creates still bind locally
- compute local Analysis signal from prompt constraint coverage and smooth the local trend chart with adaptive scaling

## Test plan
- [x] `zig build test`
- [x] `zig build`