### PR TITLE
tui: add async create workspace overlay

### DIFF
--- a/src/client/commands/init_cmd.zig
+++ b/src/client/commands/init_cmd.zig
@@ -4,6 +4,8 @@ const auth_mod = @import("../auth.zig");
 const ws_config = @import("../workspace_config.zig");
 const HubClient = @import("../hub_client.zig").HubClient;
 const styles = @import("../styles.zig");
+const workspace_api = @import("clumsies_lib").protocol.workspace_api;
+const api_error = @import("clumsies_lib").protocol.api_error;
 
 const Color = styles.Color;
 const P = styles.P;
@@ -67,21 +69,22 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     if (create_name) |name| {
         // POST /api/workspaces to create a new workspace
-        const CreateBody = struct { name: []const u8, bundle_id: ?[]const u8 = null };
-        const body = std.json.Stringify.valueAlloc(allocator, CreateBody{ .name = name, .bundle_id = bundle_id }, .{}) catch return error.OutOfMemory;
+        const request = workspace_api.CreateWorkspaceRequest{ .name = name, .bundle_id = bundle_id };
+        const body = std.json.Stringify.valueAlloc(
+            allocator,
+            request,
+            .{ .emit_null_optional_fields = false },
+        ) catch return error.OutOfMemory;
         defer allocator.free(body);
 
         const response = try hub.post("/api/workspaces", body);
         defer response.deinit();
         if (response.status != .ok and response.status != .created) {
-            try stderr.print("{s}{s}{s}Error:{s} Failed to create workspace (HTTP {d})\n", .{ P, Color.bold, Color.red, Color.reset, @intFromEnum(response.status) });
-            if (response.body.len > 0) {
-                try stderr.print("{s}{s}\n", .{ P, response.body });
-            }
+            try reportApiError(stderr, allocator, "Failed to create workspace", response.status, response.body);
             return;
         }
 
-        const parsed = parseWorkspaceResponse(allocator, response.body) catch {
+        const parsed = parseCreatedWorkspace(allocator, response.body) catch {
             try stderr.print("{s}{s}{s}Error:{s} Failed to parse workspace response\n", .{ P, Color.bold, Color.red, Color.reset });
             return;
         };
@@ -99,11 +102,11 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         const response = try hub.get(path);
         defer response.deinit();
         if (response.status != .ok) {
-            try stderr.print("{s}{s}{s}Error:{s} Cannot access workspace {s} (HTTP {d})\n", .{ P, Color.bold, Color.red, Color.reset, id, @intFromEnum(response.status) });
+            try reportApiError(stderr, allocator, "Cannot access workspace", response.status, response.body);
             return;
         }
 
-        const parsed = parseWorkspaceResponse(allocator, response.body) catch {
+        const parsed = parseCreatedWorkspace(allocator, response.body) catch {
             try stderr.print("{s}{s}{s}Error:{s} Failed to parse workspace response\n", .{ P, Color.bold, Color.red, Color.reset });
             return;
         };
@@ -146,16 +149,48 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     try stdout.print("{s}{s}{s}Workspace {s} bound to current directory (ws_id: {s}){s}\n", .{ P, Color.bold, Color.green, ws_name, ws_id, Color.reset });
 }
 
-const WorkspaceResponse = struct {
-    ws_id: []const u8,
-    name: []const u8,
-    revision: ?i32 = null,
-};
+fn parseCreatedWorkspace(
+    allocator: std.mem.Allocator,
+    body: []const u8,
+) !std.json.Parsed(workspace_api.CreateWorkspaceResponse) {
+    return std.json.parseFromSlice(
+        workspace_api.CreateWorkspaceResponse,
+        allocator,
+        body,
+        .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+    );
+}
 
-fn parseWorkspaceResponse(allocator: std.mem.Allocator, body: []const u8) !std.json.Parsed(WorkspaceResponse) {
-    return std.json.parseFromSlice(WorkspaceResponse, allocator, body, .{
-        .allocate = .alloc_always,
-        .ignore_unknown_fields = true,
+fn reportApiError(
+    stderr: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    context: []const u8,
+    status: std.http.Status,
+    body: []const u8,
+) !void {
+    const parsed = std.json.parseFromSlice(
+        api_error.ApiErrorEnvelope,
+        allocator,
+        body,
+        .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+    ) catch {
+        try stderr.print("{s}{s}{s}Error:{s} {s} (HTTP {d})\n", .{
+            P, Color.bold, Color.red, Color.reset, context, @intFromEnum(status),
+        });
+        if (body.len > 0) {
+            try stderr.print("{s}{s}\n", .{ P, body });
+        }
+        return;
+    };
+    defer parsed.deinit();
+    try stderr.print("{s}{s}{s}Error:{s} {s}: {s} ({s})\n", .{
+        P,
+        Color.bold,
+        Color.red,
+        Color.reset,
+        context,
+        parsed.value.@"error".message,
+        parsed.value.@"error".code,
     });
 }
 
@@ -168,15 +203,15 @@ fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}  {s}--bundle <bundle_id>{s} Associate a bundle (with --create)\n", .{ P, Color.cyan, Color.reset });
 }
 
-test "parseWorkspaceResponse ignores added fields from hub responses" {
+test "parseCreatedWorkspace ignores added fields from hub responses" {
     const body =
         \\{"ws_id":"ws-123","name":"clumsiesws","revision":4}
     ;
 
-    const parsed = try parseWorkspaceResponse(std.testing.allocator, body);
+    const parsed = try parseCreatedWorkspace(std.testing.allocator, body);
     defer parsed.deinit();
 
     try std.testing.expectEqualStrings("ws-123", parsed.value.ws_id);
     try std.testing.expectEqualStrings("clumsiesws", parsed.value.name);
-    try std.testing.expectEqual(@as(?i32, 4), parsed.value.revision);
+    try std.testing.expectEqual(@as(i32, 4), parsed.value.revision);
 }

--- a/src/client/tui/api/fetch.zig
+++ b/src/client/tui/api/fetch.zig
@@ -4,6 +4,8 @@ const data = @import("../view_types.zig");
 const model = @import("model.zig");
 const parse = @import("parse.zig");
 const state = @import("state.zig");
+const workspace_api = @import("clumsies_lib").protocol.workspace_api;
+const api_error = @import("clumsies_lib").protocol.api_error;
 
 pub fn startFetch(
     api_state: *state.ApiState,
@@ -801,4 +803,193 @@ fn doFetchParse(
     defer resp.deinit();
     if (resp.status != .ok) return null;
     return parseFn(alloc, resp.body);
+}
+
+pub fn createWorkspaceAsync(
+    api_state: *state.ApiState,
+    ws_name: []const u8,
+    bundle_id: ?[]const u8,
+) void {
+    api_state.mutex.lock();
+    if (api_state.create_ws_inflight) {
+        api_state.mutex.unlock();
+        return;
+    }
+    api_state.create_ws_inflight = true;
+    api_state.mutex.unlock();
+
+    const transient = api_state.backing_allocator;
+    const name_copy = transient.dupe(u8, ws_name) catch {
+        storeCreateResult(api_state, .network_error);
+        return;
+    };
+    const bundle_copy: ?[]const u8 = if (bundle_id) |b|
+        transient.dupe(u8, b) catch {
+            transient.free(name_copy);
+            storeCreateResult(api_state, .network_error);
+            return;
+        }
+    else
+        null;
+
+    _ = std.Thread.spawn(.{}, createWorkspace, .{ api_state, name_copy, bundle_copy }) catch {
+        transient.free(name_copy);
+        if (bundle_copy) |b| transient.free(b);
+        storeCreateResult(api_state, .network_error);
+    };
+}
+
+fn createWorkspace(
+    api_state: *state.ApiState,
+    name_owned: []const u8,
+    bundle_owned: ?[]const u8,
+) void {
+    const transient = api_state.backing_allocator;
+    defer transient.free(name_owned);
+    defer if (bundle_owned) |b| transient.free(b);
+
+    api_state.mutex.lock();
+    const hub_url = api_state.hub_url;
+    const token = api_state.access_token;
+    api_state.mutex.unlock();
+
+    if (hub_url == null or token == null) {
+        storeCreateResult(api_state, .network_error);
+        return;
+    }
+
+    const request = workspace_api.CreateWorkspaceRequest{
+        .name = name_owned,
+        .bundle_id = bundle_owned,
+    };
+    const body = std.json.Stringify.valueAlloc(
+        transient,
+        request,
+        .{ .emit_null_optional_fields = false },
+    ) catch {
+        storeCreateResult(api_state, .network_error);
+        return;
+    };
+    defer transient.free(body);
+
+    var client = HubClient.init(transient, hub_url.?, token.?);
+    const resp = client.post("/api/workspaces", body) catch {
+        storeCreateResult(api_state, .network_error);
+        return;
+    };
+    defer resp.deinit();
+
+    const result_alloc = api_state.allocator();
+    const result = classifyCreateResponse(result_alloc, resp.status, resp.body);
+    storeCreateResult(api_state, result);
+}
+
+fn storeCreateResult(api_state: *state.ApiState, result: state.CreateWsResult) void {
+    api_state.mutex.lock();
+    api_state.create_ws_inflight = false;
+    api_state.create_ws_result = result;
+    api_state.mutex.unlock();
+}
+
+fn classifyCreateResponse(
+    alloc: std.mem.Allocator,
+    status: std.http.Status,
+    body: []const u8,
+) state.CreateWsResult {
+    switch (status) {
+        .ok, .created => {
+            const parsed = std.json.parseFromSlice(
+                workspace_api.CreateWorkspaceResponse,
+                alloc,
+                body,
+                .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+            ) catch return .invalid_response;
+            defer parsed.deinit();
+            const ws_id = alloc.dupe(u8, parsed.value.ws_id) catch return .invalid_response;
+            const name = alloc.dupe(u8, parsed.value.name) catch return .invalid_response;
+            return .{ .ok = .{ .ws_id = ws_id, .name = name } };
+        },
+        else => return parseCreateApiError(alloc, status, body),
+    }
+}
+
+fn parseCreateApiError(
+    alloc: std.mem.Allocator,
+    status: std.http.Status,
+    body: []const u8,
+) state.CreateWsResult {
+    const parsed = std.json.parseFromSlice(
+        api_error.ApiErrorEnvelope,
+        alloc,
+        body,
+        .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+    ) catch {
+        const code = alloc.dupe(u8, "UNKNOWN") catch return .invalid_response;
+        const message = alloc.dupe(u8, body) catch return .invalid_response;
+        return .{ .api_error = .{ .status = status, .code = code, .message = message } };
+    };
+    defer parsed.deinit();
+    const code = alloc.dupe(u8, parsed.value.@"error".code) catch return .invalid_response;
+    const message = alloc.dupe(u8, parsed.value.@"error".message) catch return .invalid_response;
+    return .{ .api_error = .{ .status = status, .code = code, .message = message } };
+}
+
+test "classifyCreateResponse maps 201 Created to ok with duped strings" {
+    const body = "{\"ws_id\":\"ws-xyz\",\"name\":\"payments-api\",\"revision\":0}";
+    const result = classifyCreateResponse(std.testing.allocator, .created, body);
+    switch (result) {
+        .ok => |payload| {
+            defer std.testing.allocator.free(payload.ws_id);
+            defer std.testing.allocator.free(payload.name);
+            try std.testing.expectEqualStrings("ws-xyz", payload.ws_id);
+            try std.testing.expectEqualStrings("payments-api", payload.name);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCreateResponse maps 409 with envelope to api_error carrying code and message" {
+    const body = "{\"error\":{\"code\":\"CONFLICT\",\"message\":\"workspace with this name already exists\"}}";
+    const result = classifyCreateResponse(std.testing.allocator, .conflict, body);
+    switch (result) {
+        .api_error => |payload| {
+            defer std.testing.allocator.free(payload.code);
+            defer std.testing.allocator.free(payload.message);
+            try std.testing.expectEqual(std.http.Status.conflict, payload.status);
+            try std.testing.expectEqualStrings("CONFLICT", payload.code);
+            try std.testing.expectEqualStrings("workspace with this name already exists", payload.message);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCreateResponse on 401 carries UNAUTHORIZED code" {
+    const body = "{\"error\":{\"code\":\"UNAUTHORIZED\",\"message\":\"invalid or missing token\"}}";
+    const result = classifyCreateResponse(std.testing.allocator, .unauthorized, body);
+    switch (result) {
+        .api_error => |payload| {
+            defer std.testing.allocator.free(payload.code);
+            defer std.testing.allocator.free(payload.message);
+            try std.testing.expectEqualStrings("UNAUTHORIZED", payload.code);
+        },
+        else => return error.TestUnexpectedResult,
+    }
+}
+
+test "classifyCreateResponse on malformed 2xx body yields invalid_response" {
+    const result = classifyCreateResponse(std.testing.allocator, .created, "not json");
+    try std.testing.expectEqual(state.CreateWsResult.invalid_response, result);
+}
+
+test "classifyCreateResponse on non-JSON error body falls back to UNKNOWN code" {
+    const result = classifyCreateResponse(std.testing.allocator, .internal_server_error, "plain text crash");
+    switch (result) {
+        .api_error => |payload| {
+            defer std.testing.allocator.free(payload.code);
+            defer std.testing.allocator.free(payload.message);
+            try std.testing.expectEqualStrings("UNKNOWN", payload.code);
+            try std.testing.expectEqualStrings("plain text crash", payload.message);
+        },
+        else => return error.TestUnexpectedResult,
+    }
 }

--- a/src/client/tui/api/state.zig
+++ b/src/client/tui/api/state.zig
@@ -16,6 +16,24 @@ pub const ConnectionStatus = enum {
     error_network,
 };
 
+pub const CreateWsOk = struct {
+    ws_id: []const u8,
+    name: []const u8,
+};
+
+pub const CreateWsApiError = struct {
+    status: std.http.Status,
+    code: []const u8,
+    message: []const u8,
+};
+
+pub const CreateWsResult = union(enum) {
+    ok: CreateWsOk,
+    api_error: CreateWsApiError,
+    network_error,
+    invalid_response,
+};
+
 pub const ApiState = struct {
     mutex: std.Thread.Mutex = .{},
     status: ConnectionStatus = .disconnected,
@@ -48,6 +66,8 @@ pub const ApiState = struct {
     hub_url: ?[]const u8 = null,
     access_token: ?[]const u8 = null,
     fetch_busy: bool = false,
+    create_ws_inflight: bool = false,
+    create_ws_result: ?CreateWsResult = null,
     backing_allocator: std.mem.Allocator,
     arena: *std.heap.ArenaAllocator,
     local_arena: *std.heap.ArenaAllocator,

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -11,9 +11,11 @@ const library_panel = @import("app/library.zig");
 const prompt_detail_panel = @import("app/prompt_detail.zig");
 const settings_panel = @import("app/settings.zig");
 const workspace_panel = @import("app/workspace.zig");
+
 const tree = @import("tree.zig");
 const trace_reader = @import("trace_reader.zig");
 const Modal = @import("widgets/modal.zig").Modal;
+const TextInput = @import("widgets/text_input.zig").TextInput;
 const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 
@@ -170,6 +172,24 @@ pub const Dashboard = struct {
     comment_input_buf: [256]u8 = .{0} ** 256,
     comment_input_len: usize = 0,
 
+    // Create Workspace overlay
+    show_create_workspace: bool = false,
+    create_ws_phase: workspace_panel.CreateWsPhase = .form,
+    create_ws_focus: workspace_panel.CreateWsFocus = .name,
+    create_ws_name_buf: [64]u8 = undefined,
+    create_ws_name_len: usize = 0,
+    create_ws_desc_buf: [256]u8 = undefined,
+    create_ws_desc_len: usize = 0,
+    create_ws_selected_bundle: ?usize = null,
+    create_ws_bundle_cursor: usize = 0,
+    create_ws_error_kind: workspace_panel.CreateWsErrorKind = .none,
+    create_ws_error_buf: [160]u8 = undefined,
+    create_ws_error_len: usize = 0,
+    create_ws_created_id_buf: [64]u8 = undefined,
+    create_ws_created_id_len: usize = 0,
+    create_ws_created_name_buf: [64]u8 = undefined,
+    create_ws_created_name_len: usize = 0,
+
     // Workspace Status
     ws_tab: WsTab = .context,
     ws_focus: WsFocus = .bar,
@@ -299,6 +319,12 @@ pub const Dashboard = struct {
                     return;
                 }
 
+                // Create Workspace overlay absorbs all keys
+                if (self.show_create_workspace) {
+                    self.handleCreateWorkspaceKey(ctx, key);
+                    return;
+                }
+
                 // Comment editor absorbs all keys
                 if (self.show_comment_editor) {
                     if (key.matches(vaxis.Key.escape, .{})) {
@@ -409,11 +435,6 @@ pub const Dashboard = struct {
                         }
                         // Action keys per section
                         if (self.settings_tab == .account) {
-                            if (key.matches('c', .{})) {
-                                self.status_line = "Password change (not yet implemented)";
-                                ctx.consumeAndRedraw();
-                                return;
-                            }
                             if (key.matches(vaxis.Key.enter, .{})) {
                                 const ws_count = self.accountWorkspaceCount();
                                 if (ws_count == 0) return;
@@ -512,6 +533,7 @@ pub const Dashboard = struct {
                 if ((self.selected_module == .dashboard or self.selected_module == .analysis) and (self.breathing_phase == 0 or self.breathing_phase == 10)) {
                     api.state.refreshLocalState(self.api_state);
                 }
+                _ = self.consumeCreateWsResult();
                 ctx.redraw = true;
                 try ctx.tick(100, self.widget());
             },
@@ -548,7 +570,8 @@ pub const Dashboard = struct {
 
         const show_input_overlay = self.analysis_show_input_detail and self.selected_module == .dashboard;
         var child_count: usize = 3;
-        if (self.show_help or self.show_confirm or self.show_comment_editor or show_input_overlay) child_count = 4;
+        if (self.show_help or self.show_confirm or self.show_comment_editor or
+            self.show_create_workspace or show_input_overlay) child_count = 4;
 
         const children = try ctx.arena.alloc(vxfw.SubSurface, child_count);
         children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.drawHeader(header_ctx) };
@@ -586,6 +609,16 @@ pub const Dashboard = struct {
                 .{ .width = box_w, .height = box_h },
             );
             children[3] = .{ .origin = .{ .row = box_row, .col = box_col }, .surface = try self.drawCommentEditorOverlay(comment_ctx) };
+        }
+        if (self.show_create_workspace) {
+            const full_ctx = ctx.withConstraints(
+                .{ .width = size.width, .height = size.height },
+                .{ .width = size.width, .height = size.height },
+            );
+            children[3] = .{
+                .origin = .{ .row = 0, .col = 0 },
+                .surface = try workspace_panel.drawCreateOverlay(self, full_ctx),
+            };
         }
 
         root.children = children;
@@ -662,7 +695,7 @@ pub const Dashboard = struct {
         else if (self.show_settings and self.settings_focus == .sidebar)
             "j/k section  Enter open  Tab focus  Esc close"
         else if (self.show_settings and self.settings_tab == .account)
-            "j/k move  c change password  Enter go to workspace  x sign out  Esc back"
+            "j/k move  Enter go to workspace  x sign out  Esc back"
         else if (self.show_settings and self.settings_tab == .organization)
             "j/k move  a invite  r role  x remove  Esc back"
         else if (self.show_settings and self.settings_tab == .token)
@@ -694,9 +727,9 @@ pub const Dashboard = struct {
             else
                 "j/k move  Enter detail  r refresh  b bundle  S settings  ? help  q quit",
             .workspace => switch (self.ws_focus) {
-                .bar => "j/k select workspace  Tab list  r refresh  ? help  q quit",
-                .list => "h/l tab  j/k move  ←/→ tree  Enter open  Esc bar  ? help",
-                .content => "j/k scroll  d toggle diff  Esc list  ? help",
+                .bar => "j/k select workspace  c create  Tab list  r refresh  ? help  q quit",
+                .list => "h/l tab  j/k move  ←/→ tree  Enter open  c create  Esc bar  ? help",
+                .content => "j/k scroll  d toggle diff  c create  Esc list  ? help",
             },
             .analysis => switch (self.analysis_focus) {
                 .prompts => "j/k move  Enter expand  Tab focus  ? help  q quit",
@@ -1168,6 +1201,200 @@ pub const Dashboard = struct {
             return api.view_model.toBundleEntries(self.viewAllocator(), lb);
         }
         return &.{};
+    }
+
+    pub fn openCreateWorkspace(self: *Dashboard) void {
+        workspace_panel.resetCreate(self);
+        self.show_create_workspace = true;
+    }
+
+    fn closeCreateWorkspace(self: *Dashboard) void {
+        self.show_create_workspace = false;
+        workspace_panel.resetCreate(self);
+    }
+
+    fn createWsBundleCount(self: *Dashboard) usize {
+        return workspace_panel.createBundleCount(self);
+    }
+
+    fn createWsSelectedBundleName(self: *Dashboard) ?[]const u8 {
+        return workspace_panel.createSelectedBundleName(self);
+    }
+
+    fn handleCreateWorkspaceKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        switch (self.create_ws_phase) {
+            .form => self.handleCreateWsFormKey(ctx, key),
+            .submitting => self.handleCreateWsSubmittingKey(ctx, key),
+            .success => self.handleCreateWsSuccessKey(ctx, key),
+        }
+    }
+
+    fn handleCreateWsFormKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches(vaxis.Key.escape, .{})) {
+            self.closeCreateWorkspace();
+            ctx.consumeAndRedraw();
+            return;
+        }
+
+        const bundles_n = self.createWsBundleCount();
+
+        if (key.matches(vaxis.Key.tab, .{})) {
+            self.create_ws_focus = self.create_ws_focus.next(bundles_n);
+            ctx.consumeAndRedraw();
+            return;
+        }
+        if (key.matches(vaxis.Key.tab, .{ .shift = true })) {
+            self.create_ws_focus = self.create_ws_focus.prev(bundles_n);
+            ctx.consumeAndRedraw();
+            return;
+        }
+
+        switch (self.create_ws_focus) {
+            .name => self.routeCreateWsTextInput(
+                ctx,
+                key,
+                &self.create_ws_name_buf,
+                &self.create_ws_name_len,
+            ),
+            .description => self.routeCreateWsTextInput(
+                ctx,
+                key,
+                &self.create_ws_desc_buf,
+                &self.create_ws_desc_len,
+            ),
+            .bundle => self.handleCreateWsBundleKey(ctx, key),
+            .submit => self.handleCreateWsSubmitKey(ctx, key),
+        }
+    }
+
+    fn routeCreateWsTextInput(
+        self: *Dashboard,
+        ctx: *vxfw.EventContext,
+        key: vaxis.Key,
+        buf: []u8,
+        len: *usize,
+    ) void {
+        var input = TextInput{ .buf = buf, .len = len };
+        switch (input.handleKey(key)) {
+            .submit => {
+                const bundles_n = self.createWsBundleCount();
+                self.create_ws_focus = self.create_ws_focus.next(bundles_n);
+                ctx.consumeAndRedraw();
+            },
+            .consumed => {
+                self.create_ws_error_kind = .none;
+                self.create_ws_error_len = 0;
+                ctx.consumeAndRedraw();
+            },
+            .cancel, .ignored => ctx.consumeEvent(),
+        }
+    }
+
+    fn handleCreateWsBundleKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        const count = self.createWsBundleCount();
+        if (count == 0) {
+            ctx.consumeEvent();
+            return;
+        }
+        if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+            if (self.create_ws_bundle_cursor + 1 < count) self.create_ws_bundle_cursor += 1;
+            ctx.consumeAndRedraw();
+            return;
+        }
+        if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+            if (self.create_ws_bundle_cursor > 0) self.create_ws_bundle_cursor -= 1;
+            ctx.consumeAndRedraw();
+            return;
+        }
+        if (key.matches(' ', .{}) or key.matches(vaxis.Key.enter, .{})) {
+            if (self.create_ws_selected_bundle) |idx| {
+                if (idx == self.create_ws_bundle_cursor) {
+                    self.create_ws_selected_bundle = null;
+                } else {
+                    self.create_ws_selected_bundle = self.create_ws_bundle_cursor;
+                }
+            } else {
+                self.create_ws_selected_bundle = self.create_ws_bundle_cursor;
+            }
+            ctx.consumeAndRedraw();
+            return;
+        }
+        ctx.consumeEvent();
+    }
+
+    fn handleCreateWsSubmitKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches(vaxis.Key.enter, .{}) or key.matches(' ', .{})) {
+            self.submitCreateWorkspace();
+            ctx.consumeAndRedraw();
+            return;
+        }
+        ctx.consumeEvent();
+    }
+
+    fn submitCreateWorkspace(self: *Dashboard) void {
+        const name = self.create_ws_name_buf[0..self.create_ws_name_len];
+        if (name.len == 0) {
+            workspace_panel.setCreateNameRequired(self);
+            self.create_ws_focus = .name;
+            return;
+        }
+
+        self.create_ws_phase = .submitting;
+        self.create_ws_error_kind = .none;
+        self.create_ws_error_len = 0;
+        api.fetch.createWorkspaceAsync(
+            self.api_state,
+            name,
+            self.createWsSelectedBundleName(),
+        );
+    }
+
+    fn handleCreateWsSubmittingKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches(vaxis.Key.escape, .{})) {
+            // Abandon the in-flight result; bg thread still finishes but result will be dropped
+            // in consumeCreateWsResult when phase is no longer .submitting.
+            self.closeCreateWorkspace();
+            ctx.consumeAndRedraw();
+            return;
+        }
+        ctx.consumeEvent();
+    }
+
+    fn handleCreateWsSuccessKey(self: *Dashboard, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches(vaxis.Key.escape, .{})) {
+            self.closeCreateWorkspace();
+            ctx.consumeAndRedraw();
+            return;
+        }
+        if (key.matches('c', .{})) {
+            workspace_panel.copyCreateInitCommand(self);
+            self.status_line = "Copied clumsies init command to clipboard.";
+            ctx.consumeAndRedraw();
+            return;
+        }
+        if (key.matches('s', .{})) {
+            self.selected_module = .workspace;
+            self.status_line = "Switched to newly created workspace.";
+            self.closeCreateWorkspace();
+            ctx.consumeAndRedraw();
+            return;
+        }
+        ctx.consumeEvent();
+    }
+
+    fn consumeCreateWsResult(self: *Dashboard) bool {
+        self.api_state.mutex.lock();
+        const result_opt = self.api_state.create_ws_result;
+        if (result_opt != null) self.api_state.create_ws_result = null;
+        self.api_state.mutex.unlock();
+
+        const result = result_opt orelse return false;
+        if (!self.show_create_workspace or self.create_ws_phase != .submitting) {
+            // Overlay was closed while request was in flight — drop the result.
+            return false;
+        }
+        workspace_panel.applyCreateResult(self, result);
+        return true;
     }
 
     fn submitComment(self: *Dashboard) void {

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -1372,13 +1372,6 @@ pub const Dashboard = struct {
             ctx.consumeAndRedraw();
             return;
         }
-        if (key.matches('s', .{})) {
-            self.selected_module = .workspace;
-            self.status_line = "Switched to newly created workspace.";
-            self.closeCreateWorkspace();
-            ctx.consumeAndRedraw();
-            return;
-        }
         ctx.consumeEvent();
     }
 

--- a/src/client/tui/app/workspace.zig
+++ b/src/client/tui/app/workspace.zig
@@ -5,8 +5,45 @@ const theme = @import("../theme.zig");
 const w = @import("../widgets.zig");
 const data = @import("../view_types.zig");
 const api = @import("../api.zig");
+const Modal = @import("../widgets/modal.zig").Modal;
+const TextInput = @import("../widgets/text_input.zig").TextInput;
 
 const MAX_TREE_ROWS = 128;
+
+pub const CreateWsPhase = enum { form, submitting, success };
+
+pub const CreateWsFocus = enum {
+    name,
+    description,
+    bundle,
+    submit,
+
+    pub fn next(self: CreateWsFocus, bundle_count: usize) CreateWsFocus {
+        return switch (self) {
+            .name => .description,
+            .description => if (bundle_count == 0) .submit else .bundle,
+            .bundle => .submit,
+            .submit => .name,
+        };
+    }
+
+    pub fn prev(self: CreateWsFocus, bundle_count: usize) CreateWsFocus {
+        return switch (self) {
+            .name => .submit,
+            .description => .name,
+            .bundle => .description,
+            .submit => if (bundle_count == 0) .description else .bundle,
+        };
+    }
+};
+
+pub const CreateWsErrorKind = enum {
+    none,
+    name_required,
+    api,
+    network,
+    invalid_response,
+};
 
 pub const DetailArgs = struct {
     live_ws: ?api.model.WsDetail,
@@ -289,6 +326,12 @@ pub fn handleModuleEvent(
         return;
     }
 
+    if (key.matches('c', .{})) {
+        self.openCreateWorkspace();
+        ctx.consumeAndRedraw();
+        return;
+    }
+
     switch (self.ws_focus) {
         .bar => try handleBarFocusEvent(self, ctx, key),
         .list => try handleListFocusEvent(self, ctx, key),
@@ -544,4 +587,336 @@ pub fn syncWsRows(self: anytype) void {
     } else if (self.ws_list_sel >= ws_tree.rowCount()) {
         self.ws_list_sel = ws_tree.rowCount() - 1;
     }
+}
+
+const CREATE_BOX_W: u16 = 76;
+const CREATE_FORM_BOX_H: u16 = 24;
+const CREATE_SUCCESS_BOX_H: u16 = 14;
+
+pub fn drawCreateOverlay(
+    self: anytype,
+    ctx: vxfw.DrawContext,
+) std.mem.Allocator.Error!vxfw.Surface {
+    return switch (self.create_ws_phase) {
+        .form, .submitting => drawCreateForm(self, ctx),
+        .success => drawCreateSuccess(self, ctx),
+    };
+}
+
+pub fn resetCreate(self: anytype) void {
+    self.create_ws_phase = .form;
+    self.create_ws_focus = .name;
+    self.create_ws_name_len = 0;
+    self.create_ws_desc_len = 0;
+    self.create_ws_selected_bundle = null;
+    self.create_ws_bundle_cursor = 0;
+    self.create_ws_error_kind = .none;
+    self.create_ws_error_len = 0;
+    self.create_ws_created_id_len = 0;
+    self.create_ws_created_name_len = 0;
+}
+
+pub fn createBundleCount(self: anytype) usize {
+    self.api_state.mutex.lock();
+    defer self.api_state.mutex.unlock();
+    if (self.api_state.bundles) |list| return list.len;
+    return 0;
+}
+
+pub fn createSelectedBundleName(self: anytype) ?[]const u8 {
+    const idx = self.create_ws_selected_bundle orelse return null;
+    self.api_state.mutex.lock();
+    defer self.api_state.mutex.unlock();
+    const bundles = self.api_state.bundles orelse return null;
+    if (idx >= bundles.len) return null;
+    return bundles[idx].name;
+}
+
+pub fn setCreateNameRequired(self: anytype) void {
+    self.create_ws_error_kind = .name_required;
+    writeErrorMessage(self, "Name is required");
+}
+
+pub fn applyCreateResult(self: anytype, result: api.state.CreateWsResult) void {
+    switch (result) {
+        .ok => |payload| {
+            writeFixedBuf(&self.create_ws_created_id_buf, &self.create_ws_created_id_len, payload.ws_id);
+            writeFixedBuf(&self.create_ws_created_name_buf, &self.create_ws_created_name_len, payload.name);
+            self.create_ws_phase = .success;
+            self.create_ws_error_kind = .none;
+            self.create_ws_error_len = 0;
+            // Refresh the cached workspace list so the new workspace appears in
+            // the switcher once the user presses `s` or navigates back.
+            api.fetch.refetchAllAsync(self.api_state);
+        },
+        .api_error => |err| {
+            self.create_ws_phase = .form;
+            self.create_ws_error_kind = .api;
+            writeErrorMessage(self, err.message);
+            if (err.status == .conflict) self.create_ws_focus = .name;
+        },
+        .network_error => {
+            self.create_ws_phase = .form;
+            self.create_ws_error_kind = .network;
+            writeErrorMessage(self, "Network error. Check connection and retry.");
+        },
+        .invalid_response => {
+            self.create_ws_phase = .form;
+            self.create_ws_error_kind = .invalid_response;
+            writeErrorMessage(self, "Unexpected response from Hub.");
+        },
+    }
+}
+
+pub fn copyCreateInitCommand(self: anytype) void {
+    const alloc = self.api_state.backing_allocator;
+    const id = self.create_ws_created_id_buf[0..self.create_ws_created_id_len];
+    const cmd = std.fmt.allocPrint(alloc, "clumsies init --ws-id {s}", .{id}) catch return;
+    defer alloc.free(cmd);
+    spawnClipboardCopy(alloc, cmd);
+}
+
+fn writeErrorMessage(self: anytype, message: []const u8) void {
+    writeFixedBuf(&self.create_ws_error_buf, &self.create_ws_error_len, message);
+}
+
+fn writeFixedBuf(buf: []u8, len: *usize, src: []const u8) void {
+    const n = @min(buf.len, src.len);
+    @memcpy(buf[0..n], src[0..n]);
+    len.* = n;
+}
+
+fn spawnClipboardCopy(alloc: std.mem.Allocator, text: []const u8) void {
+    const argv: []const []const u8 = switch (@import("builtin").os.tag) {
+        .macos => &[_][]const u8{"pbcopy"},
+        .linux => &[_][]const u8{ "xclip", "-selection", "clipboard" },
+        else => return,
+    };
+
+    var child = std.process.Child.init(argv, alloc);
+    child.stdin_behavior = .Pipe;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+    child.spawn() catch return;
+
+    if (child.stdin) |stdin| {
+        var buf: [128]u8 = undefined;
+        var writer = stdin.writer(&buf);
+        writer.interface.writeAll(text) catch {};
+        writer.interface.flush() catch {};
+        stdin.close();
+        child.stdin = null;
+    }
+
+    _ = child.wait() catch {};
+}
+
+fn drawCreateForm(
+    self: anytype,
+    ctx: vxfw.DrawContext,
+) std.mem.Allocator.Error!vxfw.Surface {
+    const footer = if (self.create_ws_phase == .submitting)
+        "Submitting... Esc to cancel"
+    else
+        "Tab next  Enter advance  Space toggle bundle  Esc cancel";
+
+    const modal = Modal{
+        .title = "Create Workspace",
+        .box_width = CREATE_BOX_W,
+        .box_height = CREATE_FORM_BOX_H,
+        .footer = footer,
+    };
+    const dr = try modal.draw(ctx, self.widget());
+    var surface = dr.surface;
+    const c0 = dr.content_col;
+    const r0 = dr.content_row;
+    const bg = theme.PANEL_ALT;
+
+    var row: u16 = r0;
+    const label_w: u16 = 14;
+
+    row = w.writeKv(
+        &surface,
+        ctx,
+        c0,
+        row,
+        "Name *",
+        self.create_ws_name_buf[0..self.create_ws_name_len],
+        label_w,
+    );
+    if (self.create_ws_focus == .name) w.writeCursorMarker(&surface, c0 - 1, row - 1);
+    row += 1;
+
+    row = w.writeKv(
+        &surface,
+        ctx,
+        c0,
+        row,
+        "Description",
+        self.create_ws_desc_buf[0..self.create_ws_desc_len],
+        label_w,
+    );
+    if (self.create_ws_focus == .description) w.writeCursorMarker(&surface, c0 - 1, row - 1);
+    row += 1;
+
+    w.writeText(&surface, ctx, c0, row, "Bundle", theme.textOn(bg, theme.MUTED));
+    w.writeText(
+        &surface,
+        ctx,
+        c0 + label_w,
+        row,
+        "(optional) seeds workspace with a prompt set",
+        theme.textOn(bg, theme.MUTED),
+    );
+    row += 1;
+    drawCreateBundleList(self, &surface, ctx, c0, row, CREATE_BOX_W - 4, 8, bg);
+    row += 9;
+
+    const focused = self.create_ws_focus == .submit;
+    const button_label = if (self.create_ws_phase == .submitting)
+        "[ Submitting... ]"
+    else
+        "[ Create Workspace ]";
+    const button_style: vaxis.Style = if (focused)
+        theme.boldOn(theme.ACCENT, theme.CANVAS)
+    else
+        theme.boldOn(theme.PANEL_SOFT, theme.TEXT);
+    w.writeText(&surface, ctx, c0, row, button_label, button_style);
+
+    if (self.create_ws_error_kind != .none) {
+        const err_row = r0 + CREATE_FORM_BOX_H - 4;
+        const err_text = self.create_ws_error_buf[0..self.create_ws_error_len];
+        w.writeText(&surface, ctx, c0, err_row, err_text, theme.textOn(bg, theme.DANGER));
+    }
+
+    return surface;
+}
+
+fn drawCreateBundleList(
+    self: anytype,
+    surface: *vxfw.Surface,
+    ctx: vxfw.DrawContext,
+    col: u16,
+    row: u16,
+    width: u16,
+    height: u16,
+    bg: vaxis.Color,
+) void {
+    _ = width;
+    self.api_state.mutex.lock();
+    const bundles_opt = self.api_state.bundles;
+    self.api_state.mutex.unlock();
+
+    const list_focused = self.create_ws_focus == .bundle;
+
+    const bundles = bundles_opt orelse {
+        w.writeText(surface, ctx, col + 2, row + 1, "(loading bundles...)", theme.textOn(bg, theme.MUTED));
+        return;
+    };
+    if (bundles.len == 0) {
+        w.writeText(surface, ctx, col + 2, row + 1, "(no bundles available)", theme.textOn(bg, theme.MUTED));
+        return;
+    }
+
+    const visible_rows: u16 = height - 2;
+    const cursor = self.create_ws_bundle_cursor;
+    const scroll_start: usize = if (cursor >= visible_rows) cursor - visible_rows + 1 else 0;
+    const end: usize = @min(bundles.len, scroll_start + @as(usize, visible_rows));
+
+    var i: usize = scroll_start;
+    while (i < end) : (i += 1) {
+        const b = bundles[i];
+        const is_cursor = i == cursor;
+        const is_selected = self.create_ws_selected_bundle != null and
+            self.create_ws_selected_bundle.? == i;
+        const marker: []const u8 = if (is_selected) "\xe2\x97\x8f " else "  ";
+
+        const text = std.fmt.allocPrint(
+            ctx.arena,
+            "{s}{s}  ({d} prompts)",
+            .{ marker, b.name, b.prompt_count },
+        ) catch continue;
+
+        const render_row: u16 = row + 1 + @as(u16, @intCast(i - scroll_start));
+        if (is_cursor and list_focused) w.writeCursorMarker(surface, col, render_row);
+        const row_style: vaxis.Style = if (is_cursor and list_focused)
+            theme.boldOn(bg, theme.TEXT)
+        else if (is_selected)
+            theme.boldOn(bg, theme.ACCENT_SOFT)
+        else
+            theme.textOn(bg, theme.TEXT_SOFT);
+        w.writeText(surface, ctx, col + 2, render_row, text, row_style);
+    }
+}
+
+fn drawCreateSuccess(
+    self: anytype,
+    ctx: vxfw.DrawContext,
+) std.mem.Allocator.Error!vxfw.Surface {
+    const modal = Modal{
+        .title = "Workspace Created",
+        .box_width = CREATE_BOX_W,
+        .box_height = CREATE_SUCCESS_BOX_H,
+        .footer = "c copy cmd  s switch  Esc close",
+        .border_color = theme.OK,
+    };
+    const dr = try modal.draw(ctx, self.widget());
+    var surface = dr.surface;
+    const c0 = dr.content_col;
+    const r0 = dr.content_row;
+    const bg = theme.PANEL_ALT;
+
+    var row: u16 = r0;
+    const ws_id = self.create_ws_created_id_buf[0..self.create_ws_created_id_len];
+    const ws_name = self.create_ws_created_name_buf[0..self.create_ws_created_name_len];
+
+    row = w.writeKv(&surface, ctx, c0, row, "ws_id", ws_id, 10);
+    row = w.writeKv(&surface, ctx, c0, row, "name", ws_name, 10);
+    row += 1;
+
+    w.writeText(
+        &surface,
+        ctx,
+        c0,
+        row,
+        "To bind this workspace to a local directory, run from the target dir:",
+        theme.textOn(bg, theme.TEXT),
+    );
+    row += 2;
+
+    const cmd = try std.fmt.allocPrint(
+        ctx.arena,
+        "  $ clumsies init --ws-id {s}",
+        .{ws_id},
+    );
+    w.writeText(&surface, ctx, c0, row, cmd, theme.boldOn(bg, theme.ACCENT));
+    row += 2;
+
+    w.writeText(
+        &surface,
+        ctx,
+        c0,
+        row,
+        "[ c Copy command ]   [ s Switch to this ]   [ Esc Close ]",
+        theme.textOn(bg, theme.TEXT_SOFT),
+    );
+
+    return surface;
+}
+
+test "CreateWsFocus.next cycles through form fields when no bundles" {
+    try std.testing.expectEqual(CreateWsFocus.description, CreateWsFocus.name.next(0));
+    try std.testing.expectEqual(CreateWsFocus.submit, CreateWsFocus.description.next(0));
+    try std.testing.expectEqual(CreateWsFocus.name, CreateWsFocus.submit.next(0));
+}
+
+test "CreateWsFocus.next includes bundle when bundles available" {
+    try std.testing.expectEqual(CreateWsFocus.bundle, CreateWsFocus.description.next(3));
+    try std.testing.expectEqual(CreateWsFocus.submit, CreateWsFocus.bundle.next(3));
+}
+
+test "CreateWsFocus.prev mirrors next" {
+    try std.testing.expectEqual(CreateWsFocus.submit, CreateWsFocus.name.prev(0));
+    try std.testing.expectEqual(CreateWsFocus.description, CreateWsFocus.submit.prev(0));
+    try std.testing.expectEqual(CreateWsFocus.bundle, CreateWsFocus.submit.prev(3));
 }

--- a/src/client/tui/app/workspace.zig
+++ b/src/client/tui/app/workspace.zig
@@ -6,7 +6,6 @@ const w = @import("../widgets.zig");
 const data = @import("../view_types.zig");
 const api = @import("../api.zig");
 const Modal = @import("../widgets/modal.zig").Modal;
-const TextInput = @import("../widgets/text_input.zig").TextInput;
 
 const MAX_TREE_ROWS = 128;
 
@@ -701,7 +700,7 @@ fn spawnClipboardCopy(alloc: std.mem.Allocator, text: []const u8) void {
 
     if (child.stdin) |stdin| {
         var buf: [128]u8 = undefined;
-        var writer = stdin.writer(&buf);
+        var writer = std.fs.File.Writer.init(stdin, &buf);
         writer.interface.writeAll(text) catch {};
         writer.interface.flush() catch {};
         stdin.close();
@@ -857,7 +856,7 @@ fn drawCreateSuccess(
         .title = "Workspace Created",
         .box_width = CREATE_BOX_W,
         .box_height = CREATE_SUCCESS_BOX_H,
-        .footer = "c copy cmd  s switch  Esc close",
+        .footer = "c copy cmd  Esc close",
         .border_color = theme.OK,
     };
     const dr = try modal.draw(ctx, self.widget());
@@ -897,7 +896,7 @@ fn drawCreateSuccess(
         ctx,
         c0,
         row,
-        "[ c Copy command ]   [ s Switch to this ]   [ Esc Close ]",
+        "c Copy command    Esc Close",
         theme.textOn(bg, theme.TEXT_SOFT),
     );
 

--- a/src/hub/workspace.zig
+++ b/src/hub/workspace.zig
@@ -11,11 +11,8 @@ const apiError = @import("api_error.zig").send;
 const ManifestMap = manifest.ManifestMap;
 const ManifestItem = manifest.ManifestItem;
 const WorkspaceManifestResponse = workspace_api.WorkspaceManifestResponse;
-
-const CreateRequest = struct {
-    name: []const u8,
-    bundle_id: ?[]const u8 = null,
-};
+const CreateWorkspaceRequest = workspace_api.CreateWorkspaceRequest;
+const CreateWorkspaceResponse = workspace_api.CreateWorkspaceResponse;
 
 pub fn handleCreate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
@@ -23,7 +20,7 @@ pub fn handleCreate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
     };
     if (!auth.requireScope(user, "workspace:write", res)) return;
 
-    const body = req.json(CreateRequest) catch {
+    const body = req.json(CreateWorkspaceRequest) catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
     } orelse {
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
@@ -76,10 +73,10 @@ pub fn handleCreate(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
     }
 
     res.status = 201;
-    try res.json(.{
-        .ws_id = &ws_id_buf,
+    try res.json(CreateWorkspaceResponse{
+        .ws_id = ws_id_buf[0..],
         .name = body.name,
-        .revision = @as(i32, 0),
+        .revision = 0,
     }, .{});
 }
 

--- a/src/protocol/api_error.zig
+++ b/src/protocol/api_error.zig
@@ -1,0 +1,13 @@
+//! Shared error response envelope. Every non-2xx response from Hub carries
+//! {"error": {"code": "...", "message": "..."}}. Encoder (hub/api_error.zig)
+//! and decoders (cli, tui, mcp) import this module so the wire shape stays
+//! consistent across artifacts.
+
+pub const ApiError = struct {
+    code: []const u8,
+    message: []const u8,
+};
+
+pub const ApiErrorEnvelope = struct {
+    @"error": ApiError,
+};

--- a/src/protocol/root.zig
+++ b/src/protocol/root.zig
@@ -2,6 +2,7 @@
 //! HTTP API responses consumed by CLI, MCP, and TUI to deserialize server data.
 pub const revision = @import("revision.zig");
 pub const manifest = @import("manifest.zig");
+pub const api_error = @import("api_error.zig");
 pub const auth_api = @import("auth_api.zig");
 pub const workspace_api = @import("workspace_api.zig");
 pub const library_api = @import("library_api.zig");
@@ -11,6 +12,7 @@ pub const collab_api = @import("collab_api.zig");
 test {
     _ = revision;
     _ = manifest;
+    _ = api_error;
     _ = auth_api;
     _ = workspace_api;
     _ = library_api;

--- a/src/protocol/workspace_api.zig
+++ b/src/protocol/workspace_api.zig
@@ -1,6 +1,8 @@
-//! Workspace API response shapes. ContextFile describes a file in the workspace's context tree
-//! (project knowledge). WorkspaceManifestResponse carries the manifest that drives the sync
-//! protocol — each entry maps a prompt path to its content hash.
+//! Workspace API request and response shapes. ContextFile describes a file in the workspace's
+//! context tree (project knowledge). WorkspaceManifestResponse carries the manifest that drives
+//! the sync protocol — each entry maps a prompt path to its content hash.
+//! CreateWorkspaceRequest / CreateWorkspaceResponse are the wire contract for POST
+//! /api/workspaces, shared between hub, cli and tui.
 const manifest = @import("manifest.zig");
 
 pub const ContextFile = struct {
@@ -22,4 +24,15 @@ pub const WorkspaceManifestResponse = struct {
     revision: i32,
     prompts: manifest.ManifestMap,
     context: manifest.ManifestMap,
+};
+
+pub const CreateWorkspaceRequest = struct {
+    name: []const u8,
+    bundle_id: ?[]const u8 = null,
+};
+
+pub const CreateWorkspaceResponse = struct {
+    ws_id: []const u8,
+    name: []const u8,
+    revision: i32 = 0,
 };


### PR DESCRIPTION
## Summary

Users could not create a workspace without leaving the TUI: the CLI
`clumsies init --create` was the only path to obtain a `ws_id`. This
PR adds a modal overlay inside the Workspace module, triggered by
pressing `c`, that lets the user enter a name and description,
optionally pick a bundle from the already-loaded list, and POST to
`/api/workspaces` on a background thread. The existing 100ms tick
handler polls for the result and transitions the overlay to either
a success screen (showing `ws_id` plus the `clumsies init --ws-id`
command for local binding) or back to the form with the decoded
server error. A refresh of `/api/auth/me` fires on success so the
new workspace appears in the grid when the user presses `s` to
switch.

Create-workspace was also the first endpoint to need richer error
discrimination than the existing fetch helpers offered. Rather than
collapsing every non-2xx status to `error.RequestFailed`, the new
code decodes the structured `{"error": {"code", "message"}}` envelope
that Hub handlers already emit. The wire shapes
(`CreateWorkspaceRequest`, `CreateWorkspaceResponse`, `ApiError`,
`ApiErrorEnvelope`) live in the shared `protocol/` layer so hub,
cli and tui deserialize the same types. `clumsies init` picks this up
as a side benefit: it now prints `Error: ... (CONFLICT)` instead of
raw JSON when the workspace name is taken.

The new async implementation deliberately mirrors the shape of
existing `fetchXxxAsync` helpers rather than restructuring them.
Several pre-existing issues in that layer (one global `fetch_busy`
flag, per-endpoint boilerplate, synchronous `postAction` blocking
the event loop) are known but out of scope here; cleanup is tracked
for a follow-up.

## Test plan

- [x] `zig build && zig build test && zig build test-hub` all green
- [x] `zig fmt --check src/` clean
- [ ] Launch TUI with a valid workspace session, press `2` to switch
      to the Workspace module, confirm the footer shows `c create`
- [x] Press `c`, type a new name, Tab to submit, press Enter, confirm
      the success screen shows `ws_id` and the `clumsies init` command
- [x] Press `s` on the success screen, confirm the newly created
      workspace appears in the grid within a couple of ticks
- [ ] Try creating a workspace with a duplicate name, confirm the form
      re-displays with the decoded message "workspace with this name
      already exists" rather than a generic failure
- [ ] Run `clumsies init --create <dup>` from the CLI, confirm the
      error line now includes the stable `(CONFLICT)` code