### PR TITLE
client: align path conventions with library model

### DIFF
--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -24,7 +24,7 @@ pub fn renderImportedWorkflowSkills(
     const cache_dir = workspace_config.getCachePath(allocator, binding.ws_id) catch return allocator.alloc(model.RenderedAsset, 0);
     defer allocator.free(cache_dir);
 
-    const workflow_root = try std.fs.path.join(allocator, &.{ cache_dir, "workflow" });
+    const workflow_root = try std.fs.path.join(allocator, &.{ cache_dir, "prompt", "workflow" });
     defer allocator.free(workflow_root);
 
     var workflow_dir = std.fs.openDirAbsolute(workflow_root, .{ .iterate = true }) catch |err| switch (err) {

--- a/src/client/commands/setup_cmd.zig
+++ b/src/client/commands/setup_cmd.zig
@@ -20,7 +20,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     if (cache_path) |cp| {
         defer allocator.free(cp);
-        const mpf_path = std.fs.path.join(allocator, &.{ cp, "META_PROMPT.md" }) catch return;
+        const mpf_path = std.fs.path.join(allocator, &.{ cp, "prompt", "META_PROMPT.md" }) catch return;
         defer allocator.free(mpf_path);
 
         const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return;

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -116,7 +116,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         }) catch continue;
         defer content_parsed.deinit();
 
-        writeToCache(allocator, cache_dir, "", prompt_path, content_parsed.value.body) catch continue;
+        writeToCache(allocator, cache_dir, "prompt", prompt_path, content_parsed.value.body) catch continue;
         prompt_count += 1;
     }
 

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -570,8 +570,8 @@ test "loadIndex: parses prompt and context entries" {
         \\    {
         \\      "category": "prompt",
         \\      "prompt_id": "p-style",
-        \\      "current_path": "rule/coding/STYLE.md",
-        \\      "draft_path": "rule/coding/STYLE.md",
+        \\      "current_path": "coding/STYLE.md",
+        \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "modify",
         \\      "base_hash": "sha256:abc",
         \\      "status": "editing"
@@ -597,7 +597,7 @@ test "loadIndex: parses prompt and context entries" {
 
     try testing.expectEqual(@as(usize, 2), index.entries.items.len);
 
-    const prompt_entry = index.findByCurrentPath(.prompt, "rule/coding/STYLE.md").?;
+    const prompt_entry = index.findByCurrentPath(.prompt, "coding/STYLE.md").?;
     try testing.expectEqual(DraftOperation.modify, prompt_entry.operation);
     try testing.expectEqualStrings("p-style", prompt_entry.prompt_id.?);
 
@@ -638,13 +638,13 @@ test "readDraftFile: reads from drafts/{category}/{draft_path}" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("drafts/prompt/rule/coding");
-    try writeFile(tmp.dir, "drafts/prompt/rule/coding/STYLE.md", "draft override content");
+    try tmp.dir.makePath("drafts/prompt/coding");
+    try writeFile(tmp.dir, "drafts/prompt/coding/STYLE.md", "draft override content");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    const content = try readDraftFile(testing.allocator, root, .prompt, "rule/coding/STYLE.md");
+    const content = try readDraftFile(testing.allocator, root, .prompt, "coding/STYLE.md");
     defer testing.allocator.free(content);
 
     try testing.expectEqualStrings("draft override content", content);
@@ -660,20 +660,20 @@ test "createDraft: writes file and index entry round-trip" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/coding/STYLE.md",
-        .current_path = "rule/coding/STYLE.md",
+        .draft_path = "coding/STYLE.md",
+        .current_path = "coding/STYLE.md",
         .base_hash = "sha256:abc",
         .prompt_id = "p-style",
     }, "# STYLE modified\n");
 
-    const content = try readDraftFile(testing.allocator, root, .prompt, "rule/coding/STYLE.md");
+    const content = try readDraftFile(testing.allocator, root, .prompt, "coding/STYLE.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("# STYLE modified\n", content);
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
     try testing.expectEqual(@as(usize, 1), index.entries.items.len);
-    const entry = index.findByCurrentPath(.prompt, "rule/coding/STYLE.md").?;
+    const entry = index.findByCurrentPath(.prompt, "coding/STYLE.md").?;
     try testing.expectEqual(DraftOperation.modify, entry.operation);
     try testing.expectEqualStrings("p-style", entry.prompt_id.?);
     try testing.expectEqualStrings("sha256:abc", entry.base_hash.?);
@@ -710,16 +710,16 @@ test "createDraft: delete operation does not write a content file" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .delete,
-        .draft_path = "rule/old/UNUSED.md",
-        .current_path = "rule/old/UNUSED.md",
+        .draft_path = "old/UNUSED.md",
+        .current_path = "old/UNUSED.md",
         .prompt_id = "p-unused",
     }, "");
 
-    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "rule/old/UNUSED.md"));
+    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "old/UNUSED.md"));
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
-    const entry = index.findByCurrentPath(.prompt, "rule/old/UNUSED.md").?;
+    const entry = index.findByCurrentPath(.prompt, "old/UNUSED.md").?;
     try testing.expectEqual(DraftOperation.delete, entry.operation);
 }
 
@@ -754,13 +754,13 @@ test "discardDraft: removes entry and file" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .create,
-        .draft_path = "rule/new/FRESH.md",
+        .draft_path = "new/FRESH.md",
         .local_temp_id = "local-1",
     }, "# FRESH\n");
 
-    try discardDraft(testing.allocator, root, .prompt, "rule/new/FRESH.md");
+    try discardDraft(testing.allocator, root, .prompt, "new/FRESH.md");
 
-    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "rule/new/FRESH.md"));
+    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "new/FRESH.md"));
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
@@ -787,25 +787,25 @@ test "setDraftStatus: transitions editing to ready and back" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/x/Y.md",
-        .current_path = "rule/x/Y.md",
+        .draft_path = "x/Y.md",
+        .current_path = "x/Y.md",
         .prompt_id = "p-y",
     }, "draft body\n");
 
-    try setDraftStatus(testing.allocator, root, .prompt, "rule/x/Y.md", .ready);
+    try setDraftStatus(testing.allocator, root, .prompt, "x/Y.md", .ready);
 
     {
         var index = try loadIndex(testing.allocator, root);
         defer index.deinit(testing.allocator);
-        const entry = index.findByCurrentPath(.prompt, "rule/x/Y.md").?;
+        const entry = index.findByCurrentPath(.prompt, "x/Y.md").?;
         try testing.expectEqual(DraftStatus.ready, entry.status);
     }
 
-    try setDraftStatus(testing.allocator, root, .prompt, "rule/x/Y.md", .editing);
+    try setDraftStatus(testing.allocator, root, .prompt, "x/Y.md", .editing);
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
-    const entry = index.findByCurrentPath(.prompt, "rule/x/Y.md").?;
+    const entry = index.findByCurrentPath(.prompt, "x/Y.md").?;
     try testing.expectEqual(DraftStatus.editing, entry.status);
 }
 
@@ -831,14 +831,14 @@ test "reconcileDrafts: leaves matching base_hash untouched" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/A.md",
-        .current_path = "rule/A.md",
+        .draft_path = "coding/A.md",
+        .current_path = "coding/A.md",
         .prompt_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/A.md", seed);
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/A.md", seed);
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -863,14 +863,14 @@ test "reconcileDrafts: marks conflicted when cache drifted" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/A.md",
-        .current_path = "rule/A.md",
+        .draft_path = "coding/A.md",
+        .current_path = "coding/A.md",
         .prompt_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/A.md", "v2 body (someone else merged)\n");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/A.md", "v2 body (someone else merged)\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -893,7 +893,7 @@ test "reconcileDrafts: skips create-operation drafts" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .create,
-        .draft_path = "rule/new.md",
+        .draft_path = "coding/NEW.md",
     }, "brand new\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
@@ -919,15 +919,15 @@ test "reconcileDrafts: leaves terminal states sticky" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/A.md",
-        .current_path = "rule/A.md",
+        .draft_path = "coding/A.md",
+        .current_path = "coding/A.md",
         .prompt_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
-    try setDraftStatus(testing.allocator, root, .prompt, "rule/A.md", .merged);
+    try setDraftStatus(testing.allocator, root, .prompt, "coding/A.md", .merged);
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/A.md", "totally different body\n");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/A.md", "totally different body\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -950,8 +950,8 @@ test "index serialization: multiple entries survive round-trip" {
     try createDraft(testing.allocator, root, .{
         .category = .prompt,
         .operation = .modify,
-        .draft_path = "rule/a/A.md",
-        .current_path = "rule/a/A.md",
+        .draft_path = "a/A.md",
+        .current_path = "a/A.md",
         .prompt_id = "p-a",
         .base_hash = "sha256:aaa",
     }, "a\n");

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -334,7 +334,7 @@ pub fn reconcileDrafts(
         const cur = entry.current_path orelse continue;
 
         const rel_dir: []const u8 = switch (entry.category) {
-            .prompt => "",
+            .prompt => "prompt",
             .context => "context",
         };
         const cache_path = try std.fs.path.join(allocator, &.{ cache_dir, rel_dir, cur });
@@ -837,8 +837,8 @@ test "reconcileDrafts: leaves matching base_hash untouched" {
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/A.md", seed);
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/A.md", seed);
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -869,8 +869,8 @@ test "reconcileDrafts: marks conflicted when cache drifted" {
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/A.md", "v2 body (someone else merged)\n");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/A.md", "v2 body (someone else merged)\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -926,8 +926,8 @@ test "reconcileDrafts: leaves terminal states sticky" {
     }, seed);
     try setDraftStatus(testing.allocator, root, .prompt, "rule/A.md", .merged);
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/A.md", "totally different body\n");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/A.md", "totally different body\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -14,8 +14,8 @@ const setup_schema =
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"knownHash\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const search_schema =
-    "{\"name\":\"" ++ tool_names.search ++ "\",\"title\":\"Search\",\"description\":\"Discover available rules, workflows, and context. Returns fresh metadata from the workspace.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\",\"context\"]},\"group\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
+    "{\"name\":\"" ++ tool_names.search ++ "\",\"title\":\"Search\",\"description\":\"Discover available rules and workflows. Returns fresh metadata from the workspace.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\"]},\"group\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const load_schema =
     "{\"name\":\"" ++ tool_names.load ++ "\",\"title\":\"Load\",\"description\":\"Load prompt content by ids. Returns delta based on knownHashes. Rule/Workflow content includes a refer reminder.\"," ++
@@ -251,7 +251,6 @@ fn parsePromptKind(value: std.json.Value) !?workspace_prompt.PromptKind {
 
     if (std.mem.eql(u8, str, "rule")) return .rule;
     if (std.mem.eql(u8, str, "workflow")) return .workflow;
-    if (std.mem.eql(u8, str, "context")) return .context;
     return error.InvalidParams;
 }
 

--- a/src/client/prompt.zig
+++ b/src/client/prompt.zig
@@ -19,7 +19,6 @@ fn displayNameFromFilename(filename: []const u8) []const u8 {
 pub const PromptKind = enum {
     rule,
     workflow,
-    context,
 };
 
 pub const SetupPriority = enum(u8) {
@@ -74,7 +73,7 @@ pub const LoadResult = struct {
 
 fn priorityForKind(kind: PromptKind) SetupPriority {
     return switch (kind) {
-        .rule, .workflow, .context => .normal,
+        .rule, .workflow => .normal,
     };
 }
 
@@ -82,7 +81,6 @@ pub fn kindToString(kind: PromptKind) []const u8 {
     return switch (kind) {
         .rule => "rule",
         .workflow => "workflow",
-        .context => "context",
     };
 }
 
@@ -222,10 +220,10 @@ pub fn deinitPromptItems(allocator: std.mem.Allocator, items: *std.ArrayList(Pro
 }
 
 fn kindFromPath(path: []const u8) ?PromptKind {
-    if (std.mem.startsWith(u8, path, "rule/")) return .rule;
+    if (std.mem.eql(u8, path, "META_PROMPT.md")) return null;
+    if (std.mem.eql(u8, path, "PIN.md")) return null;
     if (std.mem.startsWith(u8, path, "workflow/")) return .workflow;
-    if (std.mem.startsWith(u8, path, "context/")) return .context;
-    return null;
+    return .rule;
 }
 
 fn groupFromPath(path: []const u8) ?[]const u8 {

--- a/src/client/prompt.zig
+++ b/src/client/prompt.zig
@@ -227,10 +227,15 @@ fn kindFromPath(path: []const u8) ?PromptKind {
 }
 
 fn groupFromPath(path: []const u8) ?[]const u8 {
-    const slash = std.mem.indexOfScalar(u8, path, '/') orelse return null;
-    const after_kind = path[slash + 1 ..];
-    const next_slash = std.mem.indexOfScalar(u8, after_kind, '/') orelse return null;
-    return after_kind[0..next_slash];
+    if (std.mem.eql(u8, path, "META_PROMPT.md")) return null;
+    if (std.mem.eql(u8, path, "PIN.md")) return null;
+    const first_slash = std.mem.indexOfScalar(u8, path, '/') orelse return null;
+    if (std.mem.startsWith(u8, path, "workflow/")) {
+        const after_kind = path[first_slash + 1 ..];
+        const next_slash = std.mem.indexOfScalar(u8, after_kind, '/') orelse return null;
+        return after_kind[0..next_slash];
+    }
+    return path[0..first_slash];
 }
 
 fn matchesGroup(item_group: []const u8, filter: []const u8) bool {
@@ -595,7 +600,7 @@ test "loadManifest: parses prompts and context entries" {
         \\{
         \\  "revision": 7,
         \\  "prompts": {
-        \\    "p-1": {"path": "rule/coding/STYLE.md", "hash": "sha256:abc"},
+        \\    "p-1": {"path": "coding/STYLE.md", "hash": "sha256:abc"},
         \\    "p-2": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:def"}
         \\  },
         \\  "context": {
@@ -614,7 +619,7 @@ test "loadManifest: parses prompts and context entries" {
     try testing.expectEqual(@as(usize, 1), manifest.context.count());
 
     const p1 = manifest.prompts.get("p-1").?;
-    try testing.expectEqualStrings("rule/coding/STYLE.md", p1.path);
+    try testing.expectEqualStrings("coding/STYLE.md", p1.path);
     try testing.expectEqualStrings("sha256:abc", p1.hash);
 
     const c1 = manifest.context.get("c-1").?;
@@ -639,16 +644,19 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/rule/coding");
-    try tmp.dir.makePath("cache/prompt/workflow/cmd");
-    try writeFile(tmp.dir, "cache/prompt/rule/coding/STYLE.md", "style");
-    try writeFile(tmp.dir, "cache/prompt/workflow/cmd/COMMIT.md", "commit");
+    try tmp.dir.makePath("cache/prompt/pedagogy");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try tmp.dir.makePath("cache/prompt/workflow");
+    try writeFile(tmp.dir, "cache/prompt/pedagogy/TEACHING.md", "teaching");
+    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style");
+    try writeFile(tmp.dir, "cache/prompt/workflow/COMMIT.md", "commit");
 
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
-        \\    "p-commit": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:2"}
+        \\    "p-teach": {"path": "pedagogy/TEACHING.md", "hash": "sha256:1"},
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:2"},
+        \\    "p-commit": {"path": "workflow/COMMIT.md", "hash": "sha256:3"}
         \\  }
         \\}
     );
@@ -659,25 +667,38 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     var items = try discoverSearchable(testing.allocator, root, null, null);
     defer deinitPromptItems(testing.allocator, &items);
 
-    try testing.expectEqual(@as(usize, 2), items.items.len);
+    try testing.expectEqual(@as(usize, 3), items.items.len);
 
+    var found_teach = false;
     var found_style = false;
     var found_commit = false;
     for (items.items) |item| {
+        if (std.mem.eql(u8, item.id, "p-teach")) {
+            found_teach = true;
+            try testing.expectEqual(PromptKind.rule, item.kind);
+            try testing.expectEqualStrings("pedagogy/TEACHING.md", item.path);
+            try testing.expectEqualStrings("pedagogy", item.group.?);
+        }
         if (std.mem.eql(u8, item.id, "p-style")) {
             found_style = true;
             try testing.expectEqual(PromptKind.rule, item.kind);
-            try testing.expectEqualStrings("rule/coding/STYLE.md", item.path);
+            try testing.expectEqualStrings("coding/STYLE.md", item.path);
             try testing.expectEqualStrings("coding", item.group.?);
         }
         if (std.mem.eql(u8, item.id, "p-commit")) {
             found_commit = true;
             try testing.expectEqual(PromptKind.workflow, item.kind);
-            try testing.expectEqualStrings("cmd", item.group.?);
+            try testing.expect(item.group == null);
         }
     }
+    try testing.expect(found_teach);
     try testing.expect(found_style);
     try testing.expect(found_commit);
+
+    var coding_filtered = try discoverSearchable(testing.allocator, root, null, "coding");
+    defer deinitPromptItems(testing.allocator, &coding_filtered);
+    try testing.expectEqual(@as(usize, 1), coding_filtered.items.len);
+    try testing.expectEqualStrings("p-style", coding_filtered.items[0].id);
 }
 
 test "discoverSearchable: kind filter narrows results" {
@@ -687,7 +708,7 @@ test "discoverSearchable: kind filter narrows results" {
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:1"},
         \\    "p-commit": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:2"}
         \\  }
         \\}
@@ -703,15 +724,15 @@ test "discoverSearchable: kind filter narrows results" {
     try testing.expectEqualStrings("p-style", rules.items[0].id);
 }
 
-test "discoverSearchable: group filter matches first path component after kind" {
+test "discoverSearchable: group filter matches first path component" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-1": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"},
-        \\    "p-2": {"path": "rule/zig/NAMING.md", "hash": "sha256:2"}
+        \\    "p-1": {"path": "coding/STYLE.md", "hash": "sha256:1"},
+        \\    "p-2": {"path": "zig/NAMING.md", "hash": "sha256:2"}
         \\  }
         \\}
     );
@@ -734,7 +755,7 @@ test "discoverSearchable: META_PROMPT.md is excluded" {
         \\{
         \\  "prompts": {
         \\    "p-mpf": {"path": "META_PROMPT.md", "hash": "sha256:abc"},
-        \\    "p-style": {"path": "rule/coding/STYLE.md", "hash": "sha256:1"}
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:1"}
         \\  }
         \\}
     );
@@ -753,13 +774,13 @@ test "loadPrompts: looks up by hub prompt_id and reads cache file" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
     );
@@ -780,13 +801,13 @@ test "loadPrompts: known hash matches returns delta with no content" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
     );
@@ -820,19 +841,19 @@ test "loadPrompts: draft content overrides cache when indexed" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "cache content");
 
-    try tmp.dir.makePath("drafts/prompt/rule");
-    try writeFile(tmp.dir, "drafts/prompt/rule/STYLE.md", "draft override");
+    try tmp.dir.makePath("drafts/prompt/coding");
+    try writeFile(tmp.dir, "drafts/prompt/coding/STYLE.md", "draft override");
     try writeFile(tmp.dir, "drafts/index.json",
         \\{
         \\  "drafts": [
         \\    {
         \\      "category": "prompt",
         \\      "prompt_id": "p-style",
-        \\      "current_path": "rule/STYLE.md",
-        \\      "draft_path": "rule/STYLE.md",
+        \\      "current_path": "coding/STYLE.md",
+        \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "modify",
         \\      "base_hash": "sha256:original",
         \\      "status": "editing"
@@ -844,7 +865,7 @@ test "loadPrompts: draft content overrides cache when indexed" {
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
     );
@@ -866,8 +887,8 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/rule");
-    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/prompt/coding");
+    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "cache content");
 
     try tmp.dir.makePath("drafts");
     try writeFile(tmp.dir, "drafts/index.json",
@@ -876,8 +897,8 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
         \\    {
         \\      "category": "prompt",
         \\      "prompt_id": "p-style",
-        \\      "current_path": "rule/STYLE.md",
-        \\      "draft_path": "rule/STYLE.md",
+        \\      "current_path": "coding/STYLE.md",
+        \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "delete",
         \\      "base_hash": "sha256:original",
         \\      "status": "editing"
@@ -889,7 +910,7 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
     try writeTestManifest(tmp.dir,
         \\{
         \\  "prompts": {
-        \\    "p-style": {"path": "rule/STYLE.md", "hash": "sha256:zzz"}
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
     );

--- a/src/client/prompt.zig
+++ b/src/client/prompt.zig
@@ -96,10 +96,10 @@ pub const MetaPromptResult = struct {
 
 /// Load META_PROMPT.md from the workspace cache directory.
 /// `ws_dir` is the workspace root (~/.clumsies/workspaces/{ws_id}).
-/// MPF lives at `{ws_dir}/cache/META_PROMPT.md` per Library reserved-path
-/// convention (see s1-1).
+/// MPF lives at `{ws_dir}/cache/prompt/META_PROMPT.md` per Library
+/// reserved-path convention (see s1-1).
 pub fn loadMpf(allocator: std.mem.Allocator, ws_dir: []const u8, known_hash: ?[]const u8) !MetaPromptResult {
-    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
+    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "prompt", "META_PROMPT.md" });
     defer allocator.free(mpf_path);
 
     const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return .{ .content = null, .hash = null };
@@ -388,7 +388,7 @@ pub fn loadPrompts(
 fn readCacheFileAlloc(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
     if (!path_util.isSafeRelative(rel_path)) return error.UnsafeCachePath;
 
-    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", rel_path });
+    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "prompt", rel_path });
     defer allocator.free(abs_path);
 
     const file = try std.fs.openFileAbsolute(abs_path, .{});
@@ -639,10 +639,10 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/rule/coding");
-    try tmp.dir.makePath("cache/workflow/cmd");
-    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style");
-    try writeFile(tmp.dir, "cache/workflow/cmd/COMMIT.md", "commit");
+    try tmp.dir.makePath("cache/prompt/rule/coding");
+    try tmp.dir.makePath("cache/prompt/workflow/cmd");
+    try writeFile(tmp.dir, "cache/prompt/rule/coding/STYLE.md", "style");
+    try writeFile(tmp.dir, "cache/prompt/workflow/cmd/COMMIT.md", "commit");
 
     try writeTestManifest(tmp.dir,
         \\{
@@ -753,8 +753,8 @@ test "loadPrompts: looks up by hub prompt_id and reads cache file" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
@@ -780,8 +780,8 @@ test "loadPrompts: known hash matches returns delta with no content" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
@@ -820,8 +820,8 @@ test "loadPrompts: draft content overrides cache when indexed" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "cache content");
 
     try tmp.dir.makePath("drafts/prompt/rule");
     try writeFile(tmp.dir, "drafts/prompt/rule/STYLE.md", "draft override");
@@ -866,8 +866,8 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/rule");
-    try writeFile(tmp.dir, "cache/rule/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/prompt/rule");
+    try writeFile(tmp.dir, "cache/prompt/rule/STYLE.md", "cache content");
 
     try tmp.dir.makePath("drafts");
     try writeFile(tmp.dir, "drafts/index.json",
@@ -904,8 +904,8 @@ test "loadMpf: returns content and hash from cache subdirectory" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache");
-    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
+    try tmp.dir.makePath("cache/prompt");
+    try writeFile(tmp.dir, "cache/prompt/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
@@ -922,8 +922,8 @@ test "loadMpf: delta when hash matches" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache");
-    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
+    try tmp.dir.makePath("cache/prompt");
+    try writeFile(tmp.dir, "cache/prompt/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);

--- a/src/client/tui/view_types.zig
+++ b/src/client/tui/view_types.zig
@@ -213,13 +213,12 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
     .{ .name = "pr:merge", .description = "Accept/reject pull requests" },
 };
 
-// Derives kind short label from path prefix.
-// e.g. "rule/..." -> "rule", "workflow/..." -> "wf"
+// Derives kind short label from path prefix. Rule is the default kind;
+// workflow/ is the only explicit prefix. Reserved top-level paths (META_PROMPT.md,
+// PIN.md) produce an empty label since they are not searchable prompts.
 pub fn kindFromPath(path: []const u8) []const u8 {
-    if (std.mem.indexOfScalar(u8, path, '/')) |idx| {
-        const category = path[0..idx];
-        if (std.mem.eql(u8, category, "rule")) return "rule";
-        if (std.mem.eql(u8, category, "workflow")) return "wf";
-    }
-    return "";
+    if (std.mem.eql(u8, path, "META_PROMPT.md")) return "";
+    if (std.mem.eql(u8, path, "PIN.md")) return "";
+    if (std.mem.startsWith(u8, path, "workflow/")) return "wf";
+    return "rule";
 }


### PR DESCRIPTION
## Summary

`memory.search` and `memory.load` silently dropped every prompt
whose path didn't carry a `rule/` prefix. Libraries that use the
current path convention (no `rule/` prefix; paths like
`coding/STYLE.md`) rendered both tools unusable — search returned
an empty set, load errored `UnknownPromptId` for every id. Cache
layout was also asymmetric: Library prompts landed directly at
`cache/{prompt_path}` while workspace context files landed at
`cache/context/{ctx_path}`, so a Library path starting with
`context/` would collide with the context namespace on disk.

This PR tightens both.

### Path classification

`kindFromPath` now returns `.workflow` for paths under `workflow/`,
`null` for reserved top-level names (`META_PROMPT.md`, `PIN.md`),
and `.rule` for everything else. Rule is the default kind; no
explicit prefix is required. The unreachable `PromptKind.context`
variant is removed along with the `"context"` option in the
`memory.search` tool schema and parser.

### Cache layout

Library prompts move to `cache/prompt/` as a sibling of
`cache/context/`. The two namespaces are now symmetric and
collision-free by construction. Every cache consumer (sync, setup,
the adapter workflow scan, draft reconciliation, MPF load, and the
unit tests) is updated to join `prompt/` into the path. Existing
on-disk caches become stale and are regenerated on the next
`clumsies sync`.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` — all tests pass (fixtures migrated to new layout)
- [x] `zig fmt --check src/` is clean
- [x] Manual: after resync, `cache/prompt/` and `cache/context/` appear as sibling directories, `cache/prompt/META_PROMPT.md` is present, `cache/prompt/workflow/<name>.md` is present
- [ ] Manual: in a fresh session, `memory.search` returns all rules and workflows; `memory.load` succeeds for every id; `memory.refer` writes a trace event