### PR TITLE
adapter: free uniqueSlug result in workflow skill builder

### DIFF
--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -54,6 +54,7 @@ pub fn renderImportedWorkflowSkills(
         const base_slug = try workflowSlugFromFilename(allocator, filename);
         defer allocator.free(base_slug);
         const slug = try uniqueSlug(allocator, &slug_counts, base_slug);
+        defer allocator.free(slug);
 
         const relative_id = try std.fmt.allocPrint(allocator, "workflow:{s}", .{entry.path});
         defer allocator.free(relative_id);


### PR DESCRIPTION
## Summary

`clumsies adapt` leaked one allocation per workflow prompt under the
workspace cache. GPA debug mode reported `memory address 0x... leaked`
at `uniqueSlug → allocator.dupe` for each prompt before adapt could
report its normal result.

uniqueSlug always returns a fresh allocation (allocPrint when
disambiguating a duplicate base, dupe when the base is unique).
renderImportedWorkflowSkills stored the slug without freeing. Defer
the free at the call site.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] `zig fmt --check src/` clean
- [ ] Manual: run `clumsies adapt` in debug build, confirm GPA no longer prints leak backtraces for uniqueSlug