### PR TITLE
adapter: drop dead stats skill from claude-code bundle

### DIFF
--- a/assets/adapters/claude-code/runtime/skills/search/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/search/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search
-description: Discover available prompts in .prompts/
+description: Discover available prompts in the Library
 argument-hint: "[-k rule|workflow|context] [-g group]"
 user-invocable: true
 ---

--- a/assets/adapters/claude-code/runtime/skills/stats/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/stats/SKILL.md
@@ -1,8 +1,0 @@
----
-name: stats
-description: Show prompt usage statistics from trace data
-argument-hint: "[--scope workspace|prompt|diff] [-p prompt-id] [--time daily|weekly]"
-user-invocable: true
-allowed-tools: Bash
----
-!`clumsies stats $ARGUMENTS`

--- a/build.zig
+++ b/build.zig
@@ -284,10 +284,6 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/claude-code/runtime/skills/search/SKILL.md",
     ));
-    options.addOption([]const u8, "adapter_claude_code_runtime_skill_stats", readSourceAsset(
-        b,
-        "assets/adapters/claude-code/runtime/skills/stats/SKILL.md",
-    ));
 }
 
 fn readSourceAsset(b: *std.Build, relative_path: []const u8) []const u8 {

--- a/src/client/adapter/packages/claude_code.zig
+++ b/src/client/adapter/packages/claude_code.zig
@@ -89,15 +89,6 @@ pub fn renderRuntimeAssets(
         .file_mode = 0o644,
         .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_search),
     });
-    try assets.append(allocator, .{
-        .resource_id = "claude-code.skills.stats",
-        .resource_kind = "plain_file",
-        .relative_path = try scopedRelativePath(allocator, scope, "skills/stats/SKILL.md"),
-        .ownership = "exclusive",
-        .label = "Claude Code stats skill",
-        .file_mode = 0o644,
-        .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_stats),
-    });
 
     if (scope == .workspace) {
         const skills_root_absolute = try std.fs.path.join(allocator, &.{ target_root, ".claude", "skills" });


### PR DESCRIPTION
## Summary

adapter install for Claude Code shipped a /stats slash command
whose SKILL.md invoked `clumsies stats $ARGUMENTS` via Bash, but
the `clumsies stats` CLI subcommand was removed during the hub-
client command collapse. Running /stats in Claude Code fails with
command-not-found. The skill also has no MCP tool counterpart
(memory.setup/search/load/refer are the only exposed tools).

Remove the stats SKILL.md template, its build.zig readSourceAsset
entry, and the RenderedAsset block from claude_code.zig. Update
the search SKILL.md description to point at the Library instead
of the deprecated .prompts/ location.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` passes
- [x] `zig fmt --check src/` clean
- [ ] Manual: run `clumsies adapt` for Claude Code, confirm `.claude/skills/stats/` is no longer created