### PR TITLE
sync: shrink wall time with connection reuse, hash-skip, and batch endpoints

### DIFF
--- a/src/client/auth.zig
+++ b/src/client/auth.zig
@@ -4,8 +4,6 @@ const std = @import("std");
 const build_options = @import("build_options");
 const enable_keychain = build_options.enable_keychain;
 const log = std.log.scoped(.auth);
-const auth_api = @import("clumsies_lib").protocol.auth_api;
-const HubClient = @import("hub_client.zig").HubClient;
 
 pub const AuthInfo = struct {
     hub_url: []const u8,
@@ -61,75 +59,18 @@ pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []c
     }
 }
 
-/// Load credentials and, if the access token is rejected by Hub,
-/// transparently refresh using the stored refresh token before
-/// returning. Callers that previously used `loadAuth` directly and
-/// subsequently saw unexplained 401s are the target consumers —
-/// sync, init, trace upload. Falls back to a plain loadAuth result
-/// when the refresh round-trip fails; callers still see that as a
-/// normal `NotAuthenticated` at the next Hub call and can surface
-/// "Run clumsies login" to the user.
-pub fn loadAuthAndRefresh(allocator: std.mem.Allocator) !AuthInfo {
-    var auth_info = try loadAuth(allocator);
-    errdefer auth_info.deinit(allocator);
-
-    var probe = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
-    defer probe.deinit();
-
-    const probe_resp = probe.get("/api/auth/me") catch {
-        // Network failure — don't try to refresh; let the caller's
-        // actual Hub request fail with the real network error so the
-        // user sees a coherent message.
-        return auth_info;
-    };
-    defer probe_resp.deinit();
-
-    if (probe_resp.status != .unauthorized) return auth_info;
-
-    const refresh_body = std.json.Stringify.valueAlloc(
-        allocator,
-        auth_api.RefreshRequest{ .refresh_token = auth_info.refresh_token },
-        .{},
-    ) catch return error.OutOfMemory;
-    defer allocator.free(refresh_body);
-
-    const refresh_resp = probe.post("/api/auth/refresh", refresh_body) catch {
-        return auth_info;
-    };
-    defer refresh_resp.deinit();
-
-    if (refresh_resp.status != .ok) {
-        // Refresh token itself is rejected (expired / revoked).
-        // Surface a recognisable error so callers can prompt for
-        // re-login instead of looping into "Run clumsies login" via
-        // a raw 401 from the actual sync request.
-        return error.NotAuthenticated;
-    }
-
-    const parsed = std.json.parseFromSlice(auth_api.RefreshResponse, allocator, refresh_resp.body, .{
-        .allocate = .alloc_always,
-        .ignore_unknown_fields = true,
-    }) catch return auth_info;
-    defer parsed.deinit();
-
-    const new_access = try allocator.dupe(u8, parsed.value.access_token);
-    const new_refresh = try allocator.dupe(u8, parsed.value.refresh_token);
-
-    _ = saveAuth(
-        allocator,
-        auth_info.hub_url,
-        auth_info.username,
-        new_access,
-        new_refresh,
-    ) catch |err| {
-        log.warn("saveAuth after refresh failed ({s}); using new tokens in-memory only", .{@errorName(err)});
-    };
-
-    allocator.free(auth_info.access_token);
-    allocator.free(auth_info.refresh_token);
-    auth_info.access_token = new_access;
-    auth_info.refresh_token = new_refresh;
-    return auth_info;
+/// `HubClient.PersistFn`-shaped callback. Saves the rotated token
+/// pair after HubClient has refreshed in response to a 401. Thin
+/// wrapper around `saveAuth` so the HubClient module doesn't have
+/// to import the keychain plumbing directly.
+pub fn persistRotatedTokens(
+    allocator: std.mem.Allocator,
+    hub_url: []const u8,
+    username: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+) anyerror!void {
+    _ = try saveAuth(allocator, hub_url, username, access_token, refresh_token);
 }
 
 pub fn loadAuth(allocator: std.mem.Allocator) !AuthInfo {

--- a/src/client/auth.zig
+++ b/src/client/auth.zig
@@ -4,6 +4,8 @@ const std = @import("std");
 const build_options = @import("build_options");
 const enable_keychain = build_options.enable_keychain;
 const log = std.log.scoped(.auth);
+const auth_api = @import("clumsies_lib").protocol.auth_api;
+const HubClient = @import("hub_client.zig").HubClient;
 
 pub const AuthInfo = struct {
     hub_url: []const u8,
@@ -57,6 +59,77 @@ pub fn saveAuth(allocator: std.mem.Allocator, hub_url: []const u8, username: []c
         try fileFallbackStore(allocator, json);
         return .file_default;
     }
+}
+
+/// Load credentials and, if the access token is rejected by Hub,
+/// transparently refresh using the stored refresh token before
+/// returning. Callers that previously used `loadAuth` directly and
+/// subsequently saw unexplained 401s are the target consumers —
+/// sync, init, trace upload. Falls back to a plain loadAuth result
+/// when the refresh round-trip fails; callers still see that as a
+/// normal `NotAuthenticated` at the next Hub call and can surface
+/// "Run clumsies login" to the user.
+pub fn loadAuthAndRefresh(allocator: std.mem.Allocator) !AuthInfo {
+    var auth_info = try loadAuth(allocator);
+    errdefer auth_info.deinit(allocator);
+
+    var probe = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
+    defer probe.deinit();
+
+    const probe_resp = probe.get("/api/auth/me") catch {
+        // Network failure — don't try to refresh; let the caller's
+        // actual Hub request fail with the real network error so the
+        // user sees a coherent message.
+        return auth_info;
+    };
+    defer probe_resp.deinit();
+
+    if (probe_resp.status != .unauthorized) return auth_info;
+
+    const refresh_body = std.json.Stringify.valueAlloc(
+        allocator,
+        auth_api.RefreshRequest{ .refresh_token = auth_info.refresh_token },
+        .{},
+    ) catch return error.OutOfMemory;
+    defer allocator.free(refresh_body);
+
+    const refresh_resp = probe.post("/api/auth/refresh", refresh_body) catch {
+        return auth_info;
+    };
+    defer refresh_resp.deinit();
+
+    if (refresh_resp.status != .ok) {
+        // Refresh token itself is rejected (expired / revoked).
+        // Surface a recognisable error so callers can prompt for
+        // re-login instead of looping into "Run clumsies login" via
+        // a raw 401 from the actual sync request.
+        return error.NotAuthenticated;
+    }
+
+    const parsed = std.json.parseFromSlice(auth_api.RefreshResponse, allocator, refresh_resp.body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    }) catch return auth_info;
+    defer parsed.deinit();
+
+    const new_access = try allocator.dupe(u8, parsed.value.access_token);
+    const new_refresh = try allocator.dupe(u8, parsed.value.refresh_token);
+
+    _ = saveAuth(
+        allocator,
+        auth_info.hub_url,
+        auth_info.username,
+        new_access,
+        new_refresh,
+    ) catch |err| {
+        log.warn("saveAuth after refresh failed ({s}); using new tokens in-memory only", .{@errorName(err)});
+    };
+
+    allocator.free(auth_info.access_token);
+    allocator.free(auth_info.refresh_token);
+    auth_info.access_token = new_access;
+    auth_info.refresh_token = new_refresh;
+    return auth_info;
 }
 
 pub fn loadAuth(allocator: std.mem.Allocator) !AuthInfo {

--- a/src/client/commands/init_cmd.zig
+++ b/src/client/commands/init_cmd.zig
@@ -51,13 +51,14 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 
     // Load auth (must be logged in)
-    const auth_info = auth_mod.loadAuth(allocator) catch {
+    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Not logged in. Run {s}clumsies login{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
         return;
     };
     defer auth_info.deinit(allocator);
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
+    defer hub.deinit();
 
     var ws_id_owned: ?[]const u8 = null;
     defer if (ws_id_owned) |o| allocator.free(o);

--- a/src/client/commands/init_cmd.zig
+++ b/src/client/commands/init_cmd.zig
@@ -51,7 +51,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 
     // Load auth (must be logged in)
-    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch {
+    const auth_info = auth_mod.loadAuth(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Not logged in. Run {s}clumsies login{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
         return;
     };
@@ -59,6 +59,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
     defer hub.deinit();
+    try hub.enableRefresh(auth_info.refresh_token, auth_info.username, auth_mod.persistRotatedTokens);
 
     var ws_id_owned: ?[]const u8 = null;
     defer if (ws_id_owned) |o| allocator.free(o);

--- a/src/client/commands/login_cmd.zig
+++ b/src/client/commands/login_cmd.zig
@@ -91,6 +91,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     // POST /api/auth/login
     var client = HubClient.init(allocator, hub_url, null);
+    defer client.deinit();
     const response = try postOrPrintClientError(stderr, &client, hub_url, "/api/auth/login", body);
     defer response.deinit();
 

--- a/src/client/commands/login_cmd.zig
+++ b/src/client/commands/login_cmd.zig
@@ -3,6 +3,8 @@ const testing = std.testing;
 const flag = @import("../flags.zig");
 const hub_client = @import("../hub_client.zig");
 const auth_mod = @import("../auth.zig");
+const auth_api = @import("clumsies_lib").protocol.auth_api;
+const LoginResponse = auth_api.LoginResponse;
 const HubClient = hub_client.HubClient;
 const HubResponse = hub_client.Response;
 const styles = @import("../styles.zig");
@@ -206,11 +208,6 @@ fn readPassword(allocator: std.mem.Allocator) ![]const u8 {
     defer std.posix.tcsetattr(stdin_fd, .FLUSH, old_termios) catch {};
     return readLine(allocator);
 }
-
-const LoginResponse = struct {
-    access_token: []const u8,
-    refresh_token: []const u8,
-};
 
 fn postOrPrintClientError(
     stderr: *std.Io.Writer,

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -67,7 +67,10 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     const manifest_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/manifest", .{ws_id});
     defer allocator.free(manifest_path);
 
-    const manifest_response = try hub.get(manifest_path);
+    const manifest_response = hub.get(manifest_path) catch |err| {
+        try stderr.print("{s}{s}{s}Error:{s} Failed to reach Hub at {s}: {s}\n", .{ P, Color.bold, Color.red, Color.reset, auth_info.hub_url, @errorName(err) });
+        return;
+    };
     defer manifest_response.deinit();
     if (manifest_response.status != .ok) {
         try stderr.print("{s}{s}{s}Error:{s} Failed to fetch manifest (HTTP {d})\n", .{ P, Color.bold, Color.red, Color.reset, @intFromEnum(manifest_response.status) });
@@ -139,7 +142,10 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     var prompt_fetched: usize = 0;
     if (prompts_to_fetch.items.len > 0) {
-        prompt_fetched = try fetchPromptsBatch(allocator, &hub, cache_dir, prompts_to_fetch.items, &prompts_path_for_id);
+        prompt_fetched = fetchPromptsBatch(allocator, &hub, stderr, cache_dir, prompts_to_fetch.items, &prompts_path_for_id) catch |err| {
+            try stderr.print("{s}{s}{s}Error:{s} Prompt batch fetch failed: {s}\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
+            return;
+        };
     }
 
     try stdout.print("{s}\xe2\x86\x92 Context: {d} unchanged, {d} to fetch\n", .{ P, context_skipped, contexts_to_fetch.items.len });
@@ -147,7 +153,10 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     var context_fetched: usize = 0;
     if (contexts_to_fetch.items.len > 0) {
-        context_fetched = try fetchContextBatch(allocator, &hub, cache_dir, ws_id, contexts_to_fetch.items);
+        context_fetched = fetchContextBatch(allocator, &hub, stderr, cache_dir, ws_id, contexts_to_fetch.items) catch |err| {
+            try stderr.print("{s}{s}{s}Error:{s} Context batch fetch failed: {s}\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
+            return;
+        };
     }
 
     const prompt_count = prompt_fetched + prompt_skipped;
@@ -178,13 +187,15 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 }
 
-/// Batch-fetch prompt bodies in a single POST. Prompts not returned
-/// (per-item `error` set, or silently missing from the response) are
-/// skipped rather than retried — the next sync will pick them up.
-/// Returns the count of prompts successfully written to cache.
+/// Batch-fetch prompt bodies in a single POST. Per-item errors from
+/// the Hub response and local write failures are printed to stderr
+/// so the user can tell why a "46 of 46" manifest only produced
+/// "44 written"; the overall return value is the count of prompts
+/// successfully written to cache.
 fn fetchPromptsBatch(
     allocator: std.mem.Allocator,
     hub: *HubClient,
+    stderr: *std.Io.Writer,
     cache_dir: []const u8,
     prompt_ids: []const []const u8,
     path_for_id: *const std.StringHashMapUnmanaged([]const u8),
@@ -208,7 +219,10 @@ fn fetchPromptsBatch(
 
     var written: usize = 0;
     for (parsed.value.items) |item| {
-        if (item.@"error".len > 0) continue;
+        if (item.@"error".len > 0) {
+            try stderr.print("  ! prompt {s}: {s}\n", .{ item.prompt_id, item.@"error" });
+            continue;
+        }
         // Prefer the path the server reports (authoritative) but fall
         // back to the manifest-side path we had when building the
         // request, so a blank server path (older Hub, partial row)
@@ -216,19 +230,25 @@ fn fetchPromptsBatch(
         const target_path = if (item.path.len > 0)
             item.path
         else
-            path_for_id.get(item.prompt_id) orelse continue;
-        writeToCache(allocator, cache_dir, "prompt", target_path, item.body) catch continue;
+            path_for_id.get(item.prompt_id) orelse {
+                try stderr.print("  ! prompt {s}: missing path in response\n", .{item.prompt_id});
+                continue;
+            };
+        writeToCache(allocator, cache_dir, "prompt", target_path, item.body) catch |err| {
+            try stderr.print("  ! prompt {s}: write failed ({s})\n", .{ target_path, @errorName(err) });
+            continue;
+        };
         written += 1;
     }
     return written;
 }
 
 /// Batch-fetch context file bodies. Mirrors `fetchPromptsBatch` but
-/// keyed by path inside a single workspace. Same per-item error
-/// tolerance.
+/// keyed by path inside a single workspace.
 fn fetchContextBatch(
     allocator: std.mem.Allocator,
     hub: *HubClient,
+    stderr: *std.Io.Writer,
     cache_dir: []const u8,
     ws_id: []const u8,
     paths: []const []const u8,
@@ -255,8 +275,14 @@ fn fetchContextBatch(
 
     var written: usize = 0;
     for (parsed.value.items) |item| {
-        if (item.@"error".len > 0) continue;
-        writeToCache(allocator, cache_dir, "context", item.path, item.body) catch continue;
+        if (item.@"error".len > 0) {
+            try stderr.print("  ! context {s}: {s}\n", .{ item.path, item.@"error" });
+            continue;
+        }
+        writeToCache(allocator, cache_dir, "context", item.path, item.body) catch |err| {
+            try stderr.print("  ! context {s}: write failed ({s})\n", .{ item.path, @errorName(err) });
+            continue;
+        };
         written += 1;
     }
     return written;

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -13,6 +13,13 @@ const styles = @import("../styles.zig");
 const Color = styles.Color;
 const P = styles.P;
 
+/// Must stay ≤ the hub-side cap (`BATCH_MAX_IDS` / `BATCH_MAX_PATHS`
+/// in src/hub/library.zig and context.zig). Oversized batches
+/// currently 400 with "too many prompt_ids" / "too many paths";
+/// chunking here keeps sync working on workspaces with more than
+/// that many changed entries.
+const BATCH_CHUNK_SIZE: usize = 1024;
+
 pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Allocator, args: []const []const u8) !void {
     const SPECS = [_]flag.FlagSpec{};
 
@@ -157,22 +164,32 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     try stdout.flush();
 
     var prompt_fetched: usize = 0;
-    if (prompts_to_fetch.items.len > 0) {
-        prompt_fetched = fetchPromptsBatch(allocator, &hub, stderr, cache_dir, prompts_to_fetch.items, &prompts_path_for_id) catch |err| {
-            try stderr.print("{s}{s}{s}Error:{s} Prompt batch fetch failed: {s}\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
-            return;
-        };
+    {
+        var start: usize = 0;
+        while (start < prompts_to_fetch.items.len) {
+            const end = @min(start + BATCH_CHUNK_SIZE, prompts_to_fetch.items.len);
+            prompt_fetched += fetchPromptsBatch(allocator, &hub, stderr, cache_dir, prompts_to_fetch.items[start..end], &prompts_path_for_id) catch |err| {
+                try stderr.print("{s}{s}{s}Error:{s} Prompt batch fetch failed for items {d}-{d}: {s}\n", .{ P, Color.bold, Color.red, Color.reset, start + 1, end, @errorName(err) });
+                return;
+            };
+            start = end;
+        }
     }
 
     try stdout.print("{s}\xe2\x86\x92 Context: {d} unchanged, {d} to fetch\n", .{ P, context_skipped, contexts_to_fetch.items.len });
     try stdout.flush();
 
     var context_fetched: usize = 0;
-    if (contexts_to_fetch.items.len > 0) {
-        context_fetched = fetchContextBatch(allocator, &hub, stderr, cache_dir, ws_id, contexts_to_fetch.items) catch |err| {
-            try stderr.print("{s}{s}{s}Error:{s} Context batch fetch failed: {s}\n", .{ P, Color.bold, Color.red, Color.reset, @errorName(err) });
-            return;
-        };
+    {
+        var start: usize = 0;
+        while (start < contexts_to_fetch.items.len) {
+            const end = @min(start + BATCH_CHUNK_SIZE, contexts_to_fetch.items.len);
+            context_fetched += fetchContextBatch(allocator, &hub, stderr, cache_dir, ws_id, contexts_to_fetch.items[start..end]) catch |err| {
+                try stderr.print("{s}{s}{s}Error:{s} Context batch fetch failed for items {d}-{d}: {s}\n", .{ P, Color.bold, Color.red, Color.reset, start + 1, end, @errorName(err) });
+                return;
+            };
+            start = end;
+        }
     }
 
     // MPF is intentionally excluded from `prompt_skipped` so the

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -374,22 +374,28 @@ fn writeToCache(allocator: std.mem.Allocator, ws_cache_dir: []const u8, sub_dir:
     const dir_path = try std.fs.path.join(allocator, &.{ ws_cache_dir, sub_dir });
     defer allocator.free(dir_path);
 
-    const file_path = try std.fs.path.join(allocator, &.{ dir_path, name });
-    defer allocator.free(file_path);
+    // Ensure the namespace subdirectory exists (cache/prompt or
+    // cache/context). `makeDirAbsolute` is the absolute-safe single-
+    // level creator; the cache root above it is created by the
+    // caller's `ensureDir(cache_dir)` before the loops start.
+    std.fs.makeDirAbsolute(dir_path) catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
 
-    // Create every intermediate directory, not just the immediate
-    // parent. Nested context paths like `archive/2026-03-22/foo.md`
-    // have multiple levels between `cache/context/` and the file;
-    // the previous single-level makeDirAbsolute failed with
-    // FileNotFound whenever a grandparent was missing, dropping the
-    // write silently into a per-item error on a cold sync. makePath
-    // treats an already-existing directory as success, so it covers
-    // both the first-write and repeat-sync paths.
-    if (std.fs.path.dirname(file_path)) |parent| {
-        try std.fs.cwd().makePath(parent);
+    // Open the namespace directory so nested content paths like
+    // `archive/2026-03-22/foo.md` can be created with the
+    // Dir-relative API the stdlib is designed around. This avoids
+    // handing an absolute path to `Dir.makePath`, which is intended
+    // for paths relative to the receiver.
+    var dir = try std.fs.openDirAbsolute(dir_path, .{});
+    defer dir.close();
+
+    if (std.fs.path.dirname(name)) |rel_parent| {
+        try dir.makePath(rel_parent);
     }
 
-    const file = try std.fs.createFileAbsolute(file_path, .{ .truncate = true });
+    const file = try dir.createFile(name, .{ .truncate = true });
     defer file.close();
 
     var buf: [8192]u8 = undefined;

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -352,17 +352,20 @@ fn writeToCache(allocator: std.mem.Allocator, ws_cache_dir: []const u8, sub_dir:
     if (!path_util.isSafeRelative(name)) return error.UnsafePath;
     const dir_path = try std.fs.path.join(allocator, &.{ ws_cache_dir, sub_dir });
     defer allocator.free(dir_path);
-    ensureDir(dir_path);
 
-    // Handle nested paths by creating parent directories
     const file_path = try std.fs.path.join(allocator, &.{ dir_path, name });
     defer allocator.free(file_path);
 
-    // Ensure parent directory exists for nested names like "group/file.md"
+    // Create every intermediate directory, not just the immediate
+    // parent. Nested context paths like `archive/2026-03-22/foo.md`
+    // have multiple levels between `cache/context/` and the file;
+    // the previous single-level makeDirAbsolute failed with
+    // FileNotFound whenever a grandparent was missing, dropping the
+    // write silently into a per-item error on a cold sync. makePath
+    // treats an already-existing directory as success, so it covers
+    // both the first-write and repeat-sync paths.
     if (std.fs.path.dirname(file_path)) |parent| {
-        const parent_owned = try allocator.dupe(u8, parent);
-        defer allocator.free(parent_owned);
-        std.fs.makeDirAbsolute(parent_owned) catch {};
+        try std.fs.cwd().makePath(parent);
     }
 
     const file = try std.fs.createFileAbsolute(file_path, .{ .truncate = true });

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -112,16 +112,27 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     var prompts_path_for_id: std.StringHashMapUnmanaged([]const u8) = .empty;
     defer prompts_path_for_id.deinit(allocator);
     var prompt_skipped: usize = 0;
+    var regular_prompts_to_fetch: usize = 0;
+    // Reserved paths (MPF) are reported on their own line so the
+    // "Prompts: N unchanged, M to fetch" summary refers only to
+    // regular rules + workflows. The reserved file still shares the
+    // batch fetch below — it is just accounted for separately in
+    // the human-readable output.
+    var mpf_status: enum { absent, unchanged, to_fetch } = .absent;
     for (manifest.prompts.items) |entry| {
         const prompt_id = entry.key;
         const prompt_path = entry.value.path;
         const remote_hash = stripHashPrefix(entry.value.hash);
-        if (try localFileMatchesHash(allocator, cache_dir, cacheSubDirForPromptPath(prompt_path), prompt_path, remote_hash)) {
-            prompt_skipped += 1;
+        const matches = try localFileMatchesHash(allocator, cache_dir, cacheSubDirForPromptPath(prompt_path), prompt_path, remote_hash);
+        const is_mpf = std.mem.eql(u8, prompt_path, "META_PROMPT.md");
+        if (is_mpf) mpf_status = if (matches) .unchanged else .to_fetch;
+        if (matches) {
+            if (!is_mpf) prompt_skipped += 1;
             continue;
         }
         try prompts_to_fetch.append(allocator, prompt_id);
         try prompts_path_for_id.put(allocator, prompt_id, prompt_path);
+        if (!is_mpf) regular_prompts_to_fetch += 1;
     }
 
     var contexts_to_fetch: std.ArrayList([]const u8) = .empty;
@@ -137,7 +148,12 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         try contexts_to_fetch.append(allocator, ctx_path);
     }
 
-    try stdout.print("{s}\xe2\x86\x92 Prompts: {d} unchanged, {d} to fetch\n", .{ P, prompt_skipped, prompts_to_fetch.items.len });
+    switch (mpf_status) {
+        .absent => {},
+        .unchanged => try stdout.print("{s}\xe2\x86\x92 META_PROMPT.md: unchanged\n", .{P}),
+        .to_fetch => try stdout.print("{s}\xe2\x86\x92 META_PROMPT.md: to fetch\n", .{P}),
+    }
+    try stdout.print("{s}\xe2\x86\x92 Prompts: {d} unchanged, {d} to fetch\n", .{ P, prompt_skipped, regular_prompts_to_fetch });
     try stdout.flush();
 
     var prompt_fetched: usize = 0;
@@ -159,7 +175,12 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         };
     }
 
-    const prompt_count = prompt_fetched + prompt_skipped;
+    // MPF is intentionally excluded from `prompt_skipped` so the
+    // "Prompts" line only reports regular rules + workflows. Re-add
+    // it to the final prompt_count when MPF was unchanged this sync
+    // so the totals still reflect every manifest entry.
+    const mpf_in_unchanged: usize = if (mpf_status == .unchanged) 1 else 0;
+    const prompt_count = prompt_fetched + prompt_skipped + mpf_in_unchanged;
     const context_count = context_fetched + context_skipped;
 
     // Write manifest.json to cache

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -3,6 +3,7 @@ const flag = @import("../flags.zig");
 const library_api = @import("clumsies_lib").protocol.library_api;
 const workspace_api = @import("clumsies_lib").protocol.workspace_api;
 const path_util = @import("clumsies_lib").util.path_util;
+const util_hash = @import("clumsies_lib").util.hash;
 const auth_mod = @import("../auth.zig");
 const drafts_mod = @import("../drafts.zig");
 const ws_config = @import("../workspace_config.zig");
@@ -50,14 +51,20 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     defer allocator.free(binding.name);
     const ws_id = binding.ws_id;
 
-    // Load auth
-    const auth_info = auth_mod.loadAuth(allocator) catch {
+    // Load auth, auto-refreshing the access token if Hub says it
+    // expired. Previously any 1h-idle session forced re-login; the
+    // stored refresh token now handles that transparently. On a
+    // definitive refresh failure (refresh token itself rejected),
+    // `loadAuthAndRefresh` returns `NotAuthenticated` exactly like
+    // plain `loadAuth`, preserving the "Run clumsies login" prompt.
+    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Not logged in. Run {s}clumsies login{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
         return;
     };
     defer auth_info.deinit(allocator);
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
+    defer hub.deinit();
 
     // GET /api/workspaces/{ws_id}/manifest
     const manifest_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/manifest", .{ws_id});
@@ -96,46 +103,58 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     ensureDir(ws_dir);
     ensureDir(cache_dir);
 
-    var prompt_count: usize = 0;
+    // Classify: hash-compare every manifest entry against the local
+    // cache so we only ship the IDs/paths that genuinely need
+    // refetching. On a warm cache this trims the batch request down
+    // to zero items and sync finishes on the manifest call alone.
+    var prompts_to_fetch: std.ArrayList([]const u8) = .empty;
+    defer prompts_to_fetch.deinit(allocator);
+    var prompts_path_for_id: std.StringHashMapUnmanaged([]const u8) = .empty;
+    defer prompts_path_for_id.deinit(allocator);
+    var prompt_skipped: usize = 0;
     for (manifest.prompts.items) |entry| {
         const prompt_id = entry.key;
         const prompt_path = entry.value.path;
-
-        const encoded_prompt_id = try percentEncode(allocator, prompt_id);
-        defer allocator.free(encoded_prompt_id);
-        const content_api_path = try std.fmt.allocPrint(allocator, "/api/org/library/prompt/content?prompt_id={s}", .{encoded_prompt_id});
-        defer allocator.free(content_api_path);
-
-        const content_response = hub.get(content_api_path) catch continue;
-        defer content_response.deinit();
-        if (content_response.status != .ok) continue;
-
-        const content_parsed = std.json.parseFromSlice(library_api.PromptContentResponse, allocator, content_response.body, .{
-            .allocate = .alloc_always,
-            .ignore_unknown_fields = true,
-        }) catch continue;
-        defer content_parsed.deinit();
-
-        writeToCache(allocator, cache_dir, "prompt", prompt_path, content_parsed.value.body) catch continue;
-        prompt_count += 1;
+        const remote_hash = stripHashPrefix(entry.value.hash);
+        if (try localFileMatchesHash(allocator, cache_dir, "prompt", prompt_path, remote_hash)) {
+            prompt_skipped += 1;
+            continue;
+        }
+        try prompts_to_fetch.append(allocator, prompt_id);
+        try prompts_path_for_id.put(allocator, prompt_id, prompt_path);
     }
 
-    var context_count: usize = 0;
+    var contexts_to_fetch: std.ArrayList([]const u8) = .empty;
+    defer contexts_to_fetch.deinit(allocator);
+    var context_skipped: usize = 0;
     for (manifest.context.items) |entry| {
         const ctx_path = entry.value.path;
-
-        const encoded_path = try percentEncode(allocator, ctx_path);
-        defer allocator.free(encoded_path);
-        const api_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/context/file/content?path={s}", .{ ws_id, encoded_path });
-        defer allocator.free(api_path);
-
-        const response = hub.get(api_path) catch continue;
-        defer response.deinit();
-        if (response.status != .ok) continue;
-
-        writeToCache(allocator, cache_dir, "context", ctx_path, response.body) catch continue;
-        context_count += 1;
+        const remote_hash = stripHashPrefix(entry.value.hash);
+        if (try localFileMatchesHash(allocator, cache_dir, "context", ctx_path, remote_hash)) {
+            context_skipped += 1;
+            continue;
+        }
+        try contexts_to_fetch.append(allocator, ctx_path);
     }
+
+    try stdout.print("{s}\xe2\x86\x92 Prompts: {d} unchanged, {d} to fetch\n", .{ P, prompt_skipped, prompts_to_fetch.items.len });
+    try stdout.flush();
+
+    var prompt_fetched: usize = 0;
+    if (prompts_to_fetch.items.len > 0) {
+        prompt_fetched = try fetchPromptsBatch(allocator, &hub, cache_dir, prompts_to_fetch.items, &prompts_path_for_id);
+    }
+
+    try stdout.print("{s}\xe2\x86\x92 Context: {d} unchanged, {d} to fetch\n", .{ P, context_skipped, contexts_to_fetch.items.len });
+    try stdout.flush();
+
+    var context_fetched: usize = 0;
+    if (contexts_to_fetch.items.len > 0) {
+        context_fetched = try fetchContextBatch(allocator, &hub, cache_dir, ws_id, contexts_to_fetch.items);
+    }
+
+    const prompt_count = prompt_fetched + prompt_skipped;
+    const context_count = context_fetched + context_skipped;
 
     // Write manifest.json to cache
     {
@@ -152,11 +171,140 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 
     const reconcile = drafts_mod.reconcileDrafts(allocator, ws_dir, cache_dir) catch drafts_mod.ReconcileSummary{};
+    const skipped_suffix = try std.fmt.allocPrint(allocator, " ({d} prompts + {d} context unchanged)", .{ prompt_skipped, context_skipped });
+    defer allocator.free(skipped_suffix);
+    const skipped_note: []const u8 = if (prompt_skipped + context_skipped > 0) skipped_suffix else "";
     if (reconcile.conflicted > 0) {
-        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files, {d} drafts flagged conflicted\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count, reconcile.conflicted });
+        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files{s}, {d} drafts flagged conflicted\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count, skipped_note, reconcile.conflicted });
     } else {
-        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count });
+        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files{s}\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count, skipped_note });
     }
+}
+
+/// Batch-fetch prompt bodies in a single POST. Prompts not returned
+/// (per-item `error` set, or silently missing from the response) are
+/// skipped rather than retried — the next sync will pick them up.
+/// Returns the count of prompts successfully written to cache.
+fn fetchPromptsBatch(
+    allocator: std.mem.Allocator,
+    hub: *HubClient,
+    cache_dir: []const u8,
+    prompt_ids: []const []const u8,
+    path_for_id: *const std.StringHashMapUnmanaged([]const u8),
+) !usize {
+    const body_json = try std.json.Stringify.valueAlloc(
+        allocator,
+        library_api.BatchPromptContentRequest{ .prompt_ids = prompt_ids },
+        .{},
+    );
+    defer allocator.free(body_json);
+
+    const resp = try hub.post("/api/org/library/prompts/content", body_json);
+    defer resp.deinit();
+    if (resp.status != .ok) return error.BatchFetchFailed;
+
+    const parsed = try std.json.parseFromSlice(library_api.BatchPromptContentResponse, allocator, resp.body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    var written: usize = 0;
+    for (parsed.value.items) |item| {
+        if (item.@"error".len > 0) continue;
+        // Prefer the path the server reports (authoritative) but fall
+        // back to the manifest-side path we had when building the
+        // request, so a blank server path (older Hub, partial row)
+        // still lands in the right cache slot.
+        const target_path = if (item.path.len > 0)
+            item.path
+        else
+            path_for_id.get(item.prompt_id) orelse continue;
+        writeToCache(allocator, cache_dir, "prompt", target_path, item.body) catch continue;
+        written += 1;
+    }
+    return written;
+}
+
+/// Batch-fetch context file bodies. Mirrors `fetchPromptsBatch` but
+/// keyed by path inside a single workspace. Same per-item error
+/// tolerance.
+fn fetchContextBatch(
+    allocator: std.mem.Allocator,
+    hub: *HubClient,
+    cache_dir: []const u8,
+    ws_id: []const u8,
+    paths: []const []const u8,
+) !usize {
+    const body_json = try std.json.Stringify.valueAlloc(
+        allocator,
+        workspace_api.BatchContextContentRequest{ .paths = paths },
+        .{},
+    );
+    defer allocator.free(body_json);
+
+    const api_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/context/files/content", .{ws_id});
+    defer allocator.free(api_path);
+
+    const resp = try hub.post(api_path, body_json);
+    defer resp.deinit();
+    if (resp.status != .ok) return error.BatchFetchFailed;
+
+    const parsed = try std.json.parseFromSlice(workspace_api.BatchContextContentResponse, allocator, resp.body, .{
+        .allocate = .alloc_always,
+        .ignore_unknown_fields = true,
+    });
+    defer parsed.deinit();
+
+    var written: usize = 0;
+    for (parsed.value.items) |item| {
+        if (item.@"error".len > 0) continue;
+        writeToCache(allocator, cache_dir, "context", item.path, item.body) catch continue;
+        written += 1;
+    }
+    return written;
+}
+
+/// Compare a manifest-declared hash against the local cache file's
+/// sha256 so we can skip the fetch for unchanged files. Returns false
+/// when the cache file is missing / unreadable or the hashes diverge,
+/// which forces a fetch. Accepts either a bare hex hash or a
+/// `sha256:HEX` prefixed form (the manifest currently uses the
+/// prefixed form); callers should pass the stripped hex for the
+/// remote side.
+fn localFileMatchesHash(
+    allocator: std.mem.Allocator,
+    ws_cache_dir: []const u8,
+    sub_dir: []const u8,
+    rel_path: []const u8,
+    remote_hash_hex: []const u8,
+) !bool {
+    if (remote_hash_hex.len == 0) return false;
+    if (!path_util.isSafeRelative(rel_path)) return false;
+    const dir_path = try std.fs.path.join(allocator, &.{ ws_cache_dir, sub_dir });
+    defer allocator.free(dir_path);
+    const file_path = try std.fs.path.join(allocator, &.{ dir_path, rel_path });
+    defer allocator.free(file_path);
+
+    const file = std.fs.openFileAbsolute(file_path, .{}) catch return false;
+    defer file.close();
+
+    var read_buf: [8192]u8 = undefined;
+    var fr = std.fs.File.Reader.init(file, &read_buf);
+    const content = fr.interface.allocRemaining(allocator, std.io.Limit.limited(10 * 1024 * 1024)) catch return false;
+    defer allocator.free(content);
+
+    const local_hash = util_hash.sha256HexAlloc(allocator, content) catch return false;
+    defer allocator.free(local_hash);
+    return std.mem.eql(u8, local_hash, remote_hash_hex);
+}
+
+/// Manifest hashes arrive as `"sha256:HEX"`; our local hasher emits
+/// just `HEX`. Normalize by stripping the algo prefix so callers can
+/// compare hex-to-hex.
+fn stripHashPrefix(raw: []const u8) []const u8 {
+    const colon = std.mem.indexOfScalar(u8, raw, ':') orelse return raw;
+    return raw[colon + 1 ..];
 }
 
 fn ensureDir(path: []const u8) void {

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -51,13 +51,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     defer allocator.free(binding.name);
     const ws_id = binding.ws_id;
 
-    // Load auth, auto-refreshing the access token if Hub says it
-    // expired. Previously any 1h-idle session forced re-login; the
-    // stored refresh token now handles that transparently. On a
-    // definitive refresh failure (refresh token itself rejected),
-    // `loadAuthAndRefresh` returns `NotAuthenticated` exactly like
-    // plain `loadAuth`, preserving the "Run clumsies login" prompt.
-    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch {
+    const auth_info = auth_mod.loadAuth(allocator) catch {
         try stderr.print("{s}{s}{s}Error:{s} Not logged in. Run {s}clumsies login{s} first.\n", .{ P, Color.bold, Color.red, Color.reset, Color.cyan, Color.reset });
         return;
     };
@@ -65,6 +59,9 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
     defer hub.deinit();
+    // Wire refresh-on-401 so a long-idle access token rotates
+    // transparently during sync instead of forcing `clumsies login`.
+    try hub.enableRefresh(auth_info.refresh_token, auth_info.username, auth_mod.persistRotatedTokens);
 
     // GET /api/workspaces/{ws_id}/manifest
     const manifest_path = try std.fmt.allocPrint(allocator, "/api/workspaces/{s}/manifest", .{ws_id});

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -411,3 +411,93 @@ test "percentEncode passes unreserved characters" {
     defer allocator.free(result);
     try testing.expectEqualStrings("hello-world_v1.0~beta", result);
 }
+
+test "stripHashPrefix removes sha256 algo prefix" {
+    try testing.expectEqualStrings("abcdef", stripHashPrefix("sha256:abcdef"));
+}
+
+test "stripHashPrefix passes bare hex through unchanged" {
+    try testing.expectEqualStrings("abcdef", stripHashPrefix("abcdef"));
+}
+
+test "stripHashPrefix handles empty input" {
+    try testing.expectEqualStrings("", stripHashPrefix(""));
+}
+
+test "cacheSubDirForPromptPath routes META_PROMPT to cache root" {
+    try testing.expectEqualStrings("", cacheSubDirForPromptPath("META_PROMPT.md"));
+}
+
+test "cacheSubDirForPromptPath routes regular paths under prompt/" {
+    try testing.expectEqualStrings("prompt", cacheSubDirForPromptPath("coding/STYLE.md"));
+    try testing.expectEqualStrings("prompt", cacheSubDirForPromptPath("workflow/CODING.md"));
+}
+
+test "localFileMatchesHash returns true on hash match" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/prompt");
+    {
+        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        defer f.close();
+        try f.writeAll("hello");
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try tmp.dir.realpath("cache", &buf);
+
+    // sha256 of "hello" is 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    const hello_sha = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", hello_sha);
+    try testing.expect(matches);
+}
+
+test "localFileMatchesHash returns false on hash mismatch" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/prompt");
+    {
+        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        defer f.close();
+        try f.writeAll("hello");
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try tmp.dir.realpath("cache", &buf);
+
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", "0000000000000000000000000000000000000000000000000000000000000000");
+    try testing.expect(!matches);
+}
+
+test "localFileMatchesHash returns false when file is missing" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/prompt");
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try tmp.dir.realpath("cache", &buf);
+
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "missing.md", "anyhashvalue");
+    try testing.expect(!matches);
+}
+
+test "localFileMatchesHash returns false on empty remote hash" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/prompt");
+    {
+        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        defer f.close();
+        try f.writeAll("hello");
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const cache_path = try tmp.dir.realpath("cache", &buf);
+
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", "");
+    try testing.expect(!matches);
+}

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -116,7 +116,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         const prompt_id = entry.key;
         const prompt_path = entry.value.path;
         const remote_hash = stripHashPrefix(entry.value.hash);
-        if (try localFileMatchesHash(allocator, cache_dir, "prompt", prompt_path, remote_hash)) {
+        if (try localFileMatchesHash(allocator, cache_dir, cacheSubDirForPromptPath(prompt_path), prompt_path, remote_hash)) {
             prompt_skipped += 1;
             continue;
         }
@@ -234,13 +234,23 @@ fn fetchPromptsBatch(
                 try stderr.print("  ! prompt {s}: missing path in response\n", .{item.prompt_id});
                 continue;
             };
-        writeToCache(allocator, cache_dir, "prompt", target_path, item.body) catch |err| {
+        writeToCache(allocator, cache_dir, cacheSubDirForPromptPath(target_path), target_path, item.body) catch |err| {
             try stderr.print("  ! prompt {s}: write failed ({s})\n", .{ target_path, @errorName(err) });
             continue;
         };
         written += 1;
     }
     return written;
+}
+
+/// Decide the cache subdirectory a given library prompt path writes
+/// to. Reserved top-level names (`META_PROMPT.md`) land at the cache
+/// root so loaders can read them without knowing the prompt
+/// namespace layout. Everything else lives under `cache/prompt/` so
+/// the prompt namespace cannot collide with context.
+fn cacheSubDirForPromptPath(prompt_path: []const u8) []const u8 {
+    if (std.mem.eql(u8, prompt_path, "META_PROMPT.md")) return "";
+    return "prompt";
 }
 
 /// Batch-fetch context file bodies. Mirrors `fetchPromptsBatch` but

--- a/src/client/hub_client.zig
+++ b/src/client/hub_client.zig
@@ -18,13 +18,25 @@ pub const HubClient = struct {
     allocator: std.mem.Allocator,
     hub_url: []const u8,
     access_token: ?[]const u8,
+    // Persistent std.http.Client lets sequential requests reuse the
+    // underlying TCP/TLS connection via the client's internal
+    // connection pool. Prior to this, every doFetch built and tore
+    // down its own Client, which forced a fresh handshake per call —
+    // particularly costly over SSH-tunneled links where sync (~170
+    // requests) became minutes of handshake overhead.
+    client: http.Client,
 
     pub fn init(allocator: std.mem.Allocator, hub_url: []const u8, access_token: ?[]const u8) HubClient {
         return .{
             .allocator = allocator,
             .hub_url = hub_url,
             .access_token = access_token,
+            .client = .{ .allocator = allocator },
         };
+    }
+
+    pub fn deinit(self: *HubClient) void {
+        self.client.deinit();
     }
 
     pub fn get(self: *HubClient, path: []const u8) !Response {
@@ -48,9 +60,6 @@ pub const HubClient = struct {
     }
 
     fn doFetch(self: *HubClient, method: http.Method, path: []const u8, payload: ?[]const u8) !Response {
-        var client: http.Client = .{ .allocator = self.allocator };
-        defer client.deinit();
-
         const url = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.hub_url, path });
         defer self.allocator.free(url);
 
@@ -72,7 +81,7 @@ pub const HubClient = struct {
         var response_writer = std.Io.Writer.Allocating.init(self.allocator);
         errdefer response_writer.deinit();
 
-        const result = try client.fetch(.{
+        const result = try self.client.fetch(.{
             .location = .{ .url = url },
             .method = method,
             .payload = payload,

--- a/src/client/hub_client.zig
+++ b/src/client/hub_client.zig
@@ -3,6 +3,7 @@
 //! fetching, and trace upload.
 const std = @import("std");
 const http = std.http;
+const auth_api = @import("clumsies_lib").protocol.auth_api;
 
 pub const Response = struct {
     status: http.Status,
@@ -13,6 +14,20 @@ pub const Response = struct {
         self.allocator.free(self.body);
     }
 };
+
+/// Callback invoked after a successful token refresh so the caller
+/// can persist the rotated pair (typically to the keychain or the
+/// auth.json fallback). Failures are swallowed inside HubClient —
+/// the in-memory tokens are already updated and the current request
+/// will succeed with them; the next process will simply have to
+/// refresh again.
+pub const PersistFn = *const fn (
+    allocator: std.mem.Allocator,
+    hub_url: []const u8,
+    username: []const u8,
+    access_token: []const u8,
+    refresh_token: []const u8,
+) anyerror!void;
 
 pub const HubClient = struct {
     allocator: std.mem.Allocator,
@@ -26,6 +41,22 @@ pub const HubClient = struct {
     // requests) became minutes of handshake overhead.
     client: http.Client,
 
+    // Optional refresh plumbing. When `refresh_token` is set, any
+    // request that returns 401 triggers a single
+    // POST /api/auth/refresh attempt; on success the rotated access
+    // token replaces `access_token_rotated`, the rotated refresh
+    // token replaces `refresh_token`, and the original request is
+    // retried exactly once. Callers that do not need refresh leave
+    // these null and HubClient behaves identically to the pre-refresh
+    // version. Owned memory; freed in deinit.
+    refresh_token: ?[]u8 = null,
+    username: ?[]u8 = null,
+    persist_fn: ?PersistFn = null,
+    /// Holds the post-refresh access token. Preferred over
+    /// `access_token` once set. Separate field so the initial token
+    /// can stay borrowed from the caller's AuthInfo.
+    access_token_rotated: ?[]u8 = null,
+
     pub fn init(allocator: std.mem.Allocator, hub_url: []const u8, access_token: ?[]const u8) HubClient {
         return .{
             .allocator = allocator,
@@ -35,7 +66,27 @@ pub const HubClient = struct {
         };
     }
 
+    /// Wire refresh-on-401 for this client. `username` is the owner
+    /// of the credentials (passed through to `persist_fn`). `persist_fn`
+    /// is invoked after a successful refresh so the caller can save
+    /// the rotated tokens; its failure does not abort the in-flight
+    /// request.
+    pub fn enableRefresh(
+        self: *HubClient,
+        refresh_token: []const u8,
+        username: []const u8,
+        persist_fn: PersistFn,
+    ) !void {
+        self.refresh_token = try self.allocator.dupe(u8, refresh_token);
+        errdefer self.allocator.free(self.refresh_token.?);
+        self.username = try self.allocator.dupe(u8, username);
+        self.persist_fn = persist_fn;
+    }
+
     pub fn deinit(self: *HubClient) void {
+        if (self.refresh_token) |t| self.allocator.free(t);
+        if (self.username) |u| self.allocator.free(u);
+        if (self.access_token_rotated) |t| self.allocator.free(t);
         self.client.deinit();
     }
 
@@ -59,7 +110,70 @@ pub const HubClient = struct {
         return self.doFetch(.PATCH, path, body);
     }
 
+    fn effectiveToken(self: *const HubClient) ?[]const u8 {
+        return self.access_token_rotated orelse self.access_token;
+    }
+
     fn doFetch(self: *HubClient, method: http.Method, path: []const u8, payload: ?[]const u8) !Response {
+        const first = try self.doFetchOnce(method, path, payload);
+        // A 401 with no refresh plumbing is passed through unchanged
+        // — callers have always handled the status code themselves.
+        // With refresh enabled, we try exactly one rotation + retry
+        // so long-idle sessions recover transparently.
+        if (first.status != .unauthorized) return first;
+        if (self.refresh_token == null) return first;
+
+        first.deinit();
+        self.refreshAndPersist() catch |err| {
+            // Surface the refresh failure rather than the stale 401
+            // so the caller sees a recognisable error code. The most
+            // common case is a server-revoked refresh token, which
+            // this path maps to `error.NotAuthenticated`.
+            return err;
+        };
+        return self.doFetchOnce(method, path, payload);
+    }
+
+    fn refreshAndPersist(self: *HubClient) !void {
+        const rt = self.refresh_token orelse return error.NotAuthenticated;
+        const un = self.username orelse return error.NotAuthenticated;
+        const persist = self.persist_fn orelse return error.NotAuthenticated;
+
+        const body = std.json.Stringify.valueAlloc(
+            self.allocator,
+            auth_api.RefreshRequest{ .refresh_token = rt },
+            .{},
+        ) catch return error.OutOfMemory;
+        defer self.allocator.free(body);
+
+        const resp = try self.doFetchOnce(.POST, "/api/auth/refresh", body);
+        defer resp.deinit();
+
+        if (resp.status != .ok) return error.NotAuthenticated;
+
+        const parsed = std.json.parseFromSlice(auth_api.RefreshResponse, self.allocator, resp.body, .{
+            .allocate = .alloc_always,
+            .ignore_unknown_fields = true,
+        }) catch return error.NotAuthenticated;
+        defer parsed.deinit();
+
+        // Swap tokens in place. The previous refresh_token is now
+        // revoked server-side, so keeping the old value around would
+        // guarantee a 401 on the next refresh attempt.
+        const new_access = try self.allocator.dupe(u8, parsed.value.access_token);
+        if (self.access_token_rotated) |old| self.allocator.free(old);
+        self.access_token_rotated = new_access;
+
+        const new_refresh = try self.allocator.dupe(u8, parsed.value.refresh_token);
+        self.allocator.free(rt);
+        self.refresh_token = new_refresh;
+
+        // Persist failure is non-fatal — the in-memory tokens are
+        // still correct for the rest of this process's lifetime.
+        persist(self.allocator, self.hub_url, un, parsed.value.access_token, parsed.value.refresh_token) catch {};
+    }
+
+    fn doFetchOnce(self: *HubClient, method: http.Method, path: []const u8, payload: ?[]const u8) !Response {
         const url = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.hub_url, path });
         defer self.allocator.free(url);
 
@@ -70,7 +184,7 @@ pub const HubClient = struct {
         header_count += 1;
 
         var auth_value: ?[]const u8 = null;
-        if (self.access_token) |token| {
+        if (self.effectiveToken()) |token| {
             auth_value = try std.fmt.allocPrint(self.allocator, "Bearer {s}", .{token});
             extra_headers[header_count] = .{ .name = "authorization", .value = auth_value.? };
             header_count += 1;

--- a/src/client/hub_client.zig
+++ b/src/client/hub_client.zig
@@ -77,9 +77,19 @@ pub const HubClient = struct {
         username: []const u8,
         persist_fn: PersistFn,
     ) !void {
-        self.refresh_token = try self.allocator.dupe(u8, refresh_token);
-        errdefer self.allocator.free(self.refresh_token.?);
-        self.username = try self.allocator.dupe(u8, username);
+        // Dupe both buffers into owned locals first, then commit into
+        // `self.*` only once both succeed. Writing into `self.refresh_token`
+        // before the second dupe completes would leave the field pointing at
+        // a buffer that errdefer has already freed, so deinit would
+        // double-free and any intervening read of `effectiveToken` would
+        // touch freed memory.
+        const owned_refresh_token = try self.allocator.dupe(u8, refresh_token);
+        errdefer self.allocator.free(owned_refresh_token);
+        const owned_username = try self.allocator.dupe(u8, username);
+        errdefer self.allocator.free(owned_username);
+
+        self.refresh_token = owned_refresh_token;
+        self.username = owned_username;
         self.persist_fn = persist_fn;
     }
 

--- a/src/client/prompt.zig
+++ b/src/client/prompt.zig
@@ -96,10 +96,11 @@ pub const MetaPromptResult = struct {
 
 /// Load META_PROMPT.md from the workspace cache directory.
 /// `ws_dir` is the workspace root (~/.clumsies/workspaces/{ws_id}).
-/// MPF lives at `{ws_dir}/cache/prompt/META_PROMPT.md` per Library
-/// reserved-path convention (see s1-1).
+/// MPF lives at `{ws_dir}/cache/META_PROMPT.md` — reserved paths
+/// sit at the cache root rather than under the `prompt/` namespace
+/// so a future MPF rename does not reshuffle the prompt tree.
 pub fn loadMpf(allocator: std.mem.Allocator, ws_dir: []const u8, known_hash: ?[]const u8) !MetaPromptResult {
-    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "prompt", "META_PROMPT.md" });
+    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
     defer allocator.free(mpf_path);
 
     const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return .{ .content = null, .hash = null };
@@ -925,8 +926,8 @@ test "loadMpf: returns content and hash from cache subdirectory" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
-    try writeFile(tmp.dir, "cache/prompt/META_PROMPT.md", "bootstrap rules");
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
@@ -943,8 +944,8 @@ test "loadMpf: delta when hash matches" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
-    try writeFile(tmp.dir, "cache/prompt/META_PROMPT.md", "bootstrap rules");
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "bootstrap rules");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);

--- a/src/client/trace_upload.zig
+++ b/src/client/trace_upload.zig
@@ -46,13 +46,14 @@ const HubUploader = struct {
 /// Loads credentials from `auth.loadAuth`; returns `not_authenticated` if
 /// no credentials are available so callers can skip silently.
 pub fn flushWorkspace(allocator: std.mem.Allocator, ws_id: []const u8) FlushOutcome {
-    const auth_info = auth_mod.loadAuth(allocator) catch |err| switch (err) {
+    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch |err| switch (err) {
         error.NotAuthenticated => return .not_authenticated,
         else => return .{ .failed = err },
     };
     defer auth_info.deinit(allocator);
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
+    defer hub.deinit();
     var adapter: HubUploader = .{ .allocator = allocator, .client = &hub };
 
     const result = upload_worker.flushOnce(allocator, ws_id, adapter.uploader()) catch |err| {

--- a/src/client/trace_upload.zig
+++ b/src/client/trace_upload.zig
@@ -46,7 +46,7 @@ const HubUploader = struct {
 /// Loads credentials from `auth.loadAuth`; returns `not_authenticated` if
 /// no credentials are available so callers can skip silently.
 pub fn flushWorkspace(allocator: std.mem.Allocator, ws_id: []const u8) FlushOutcome {
-    const auth_info = auth_mod.loadAuthAndRefresh(allocator) catch |err| switch (err) {
+    const auth_info = auth_mod.loadAuth(allocator) catch |err| switch (err) {
         error.NotAuthenticated => return .not_authenticated,
         else => return .{ .failed = err },
     };
@@ -54,6 +54,7 @@ pub fn flushWorkspace(allocator: std.mem.Allocator, ws_id: []const u8) FlushOutc
 
     var hub = HubClient.init(allocator, auth_info.hub_url, auth_info.access_token);
     defer hub.deinit();
+    hub.enableRefresh(auth_info.refresh_token, auth_info.username, auth_mod.persistRotatedTokens) catch |err| return .{ .failed = err };
     var adapter: HubUploader = .{ .allocator = allocator, .client = &hub };
 
     const result = upload_worker.flushOnce(allocator, ws_id, adapter.uploader()) catch |err| {

--- a/src/client/tui/api/dispatcher.zig
+++ b/src/client/tui/api/dispatcher.zig
@@ -226,6 +226,7 @@ fn runWorker(comptime ReqT: type, comptime RespT: type) fn (ctx: *WorkerContext(
                 null;
 
             var client = HubClient.init(t_alloc, ctx.hub_url, ctx.access_token);
+            defer client.deinit();
             const resp = switch (ctx.spec.method) {
                 .GET => client.get(path),
                 .POST => client.post(path, body orelse "{}"),

--- a/src/client/tui/api/fetch.zig
+++ b/src/client/tui/api/fetch.zig
@@ -69,6 +69,7 @@ fn fetchAll(
     state.refreshLocalState(api_state);
 
     var client = HubClient.init(alloc, hub_url, access_token);
+    defer client.deinit();
 
     const me_resp = client.get("/api/auth/me") catch {
         setStatus(api_state, .error_network);

--- a/src/hub/auth.zig
+++ b/src/hub/auth.zig
@@ -161,12 +161,21 @@ pub fn handleRefresh(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
 
     _ = conn.exec("UPDATE tokens SET revoked = true WHERE token_hash = $1", .{@as([]const u8, &token_hash)}) catch {};
 
+    // Rotate both tokens: a refresh that only minted a new access
+    // token left the client with a revoked refresh token and no way
+    // to refresh again, forcing re-login after one hop. Issue a new
+    // refresh token alongside the access token so clients can keep
+    // rolling forward as long as they stay within the refresh TTL.
     const access_token = generateToken(req.arena, conn, user_id, "access", scopes, ctx.config.token_ttl_seconds) catch {
+        return apiError(res, 500, "INTERNAL_ERROR", "token generation failed");
+    };
+    const new_refresh_token = generateToken(req.arena, conn, user_id, "refresh", scopes, ctx.config.token_ttl_seconds * 24) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "token generation failed");
     };
 
     try res.json(.{
         .access_token = access_token,
+        .refresh_token = new_refresh_token,
         .expires_in = ctx.config.token_ttl_seconds,
     }, .{});
 }

--- a/src/hub/context.zig
+++ b/src/hub/context.zig
@@ -139,19 +139,31 @@ pub fn handleBatchFileContent(ctx: *Server.Context, req: *httpz.Request, res: *h
 
     var items: std.ArrayList(BatchContextItem) = .empty;
     for (body.paths) |path| {
-        var row = (conn.row(
+        // Same split as the library batch handler: a real DB error
+        // reports INTERNAL_ERROR, a missing row reports NOT_FOUND.
+        // Collapsing both into NOT_FOUND masked transient outages as
+        // "every file is missing".
+        const row_result = conn.row(
             "SELECT content_hash, content FROM context_files WHERE ws_id = $1 AND path = $2",
             .{ ws_id, path },
-        ) catch null) orelse {
+        ) catch {
+            try items.append(req.arena, .{
+                .path = try req.arena.dupe(u8, path),
+                .@"error" = "INTERNAL_ERROR",
+            });
+            continue;
+        };
+        var row = row_result orelse {
             try items.append(req.arena, .{
                 .path = try req.arena.dupe(u8, path),
                 .@"error" = "NOT_FOUND",
             });
             continue;
         };
+        defer row.deinit() catch {};
+
         const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 0));
         const content = try req.arena.dupe(u8, try row.get([]const u8, 1));
-        row.deinit() catch {};
         try items.append(req.arena, .{
             .path = try req.arena.dupe(u8, path),
             .content_hash = content_hash,

--- a/src/hub/context.zig
+++ b/src/hub/context.zig
@@ -9,6 +9,11 @@ const auth = @import("auth.zig");
 const apiError = @import("api_error.zig").send;
 const ContextFile = workspace_api.ContextFile;
 const ContextFilesResponse = workspace_api.ContextFilesResponse;
+const BatchContextContentRequest = workspace_api.BatchContextContentRequest;
+const BatchContextContentResponse = workspace_api.BatchContextContentResponse;
+const BatchContextItem = workspace_api.BatchContextItem;
+
+const BATCH_MAX_PATHS: usize = 1024;
 
 pub fn handleListFiles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
@@ -97,6 +102,64 @@ pub fn handleGetFileContent(ctx: *Server.Context, req: *httpz.Request, res: *htt
 
     res.header("Content-Type", "application/octet-stream");
     res.body = content;
+}
+
+/// Batch context content fetch. Paths are scoped to the caller's
+/// workspace membership; same-per-item error model as the library
+/// batch endpoint. Replaces the N-GET pattern used by `clumsies
+/// sync` for context files.
+pub fn handleBatchFileContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+    const user = auth.authenticate(ctx, req) catch {
+        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
+    };
+    if (!auth.requireScope(user, "workspace:read", res)) return;
+
+    const ws_id = req.param("ws_id") orelse {
+        return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
+    };
+
+    const body = req.json(BatchContextContentRequest) catch {
+        return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
+    } orelse {
+        return apiError(res, 400, "BAD_REQUEST", "missing request body");
+    };
+
+    if (body.paths.len > BATCH_MAX_PATHS) {
+        return apiError(res, 400, "BAD_REQUEST", "too many paths");
+    }
+
+    const conn = ctx.pool.acquire() catch {
+        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
+    };
+    defer conn.release();
+
+    if (!auth.checkWorkspaceMember(conn, ws_id, user.user_id)) {
+        return apiError(res, 403, "FORBIDDEN", "not a member of this workspace");
+    }
+
+    var items: std.ArrayList(BatchContextItem) = .empty;
+    for (body.paths) |path| {
+        var row = (conn.row(
+            "SELECT content_hash, content FROM context_files WHERE ws_id = $1 AND path = $2",
+            .{ ws_id, path },
+        ) catch null) orelse {
+            try items.append(req.arena, .{
+                .path = try req.arena.dupe(u8, path),
+                .@"error" = "NOT_FOUND",
+            });
+            continue;
+        };
+        const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 0));
+        const content = try req.arena.dupe(u8, try row.get([]const u8, 1));
+        row.deinit() catch {};
+        try items.append(req.arena, .{
+            .path = try req.arena.dupe(u8, path),
+            .content_hash = content_hash,
+            .body = content,
+        });
+    }
+
+    try res.json(BatchContextContentResponse{ .items = items.items }, .{});
 }
 
 const Operation = struct {

--- a/src/hub/library.zig
+++ b/src/hub/library.zig
@@ -14,8 +14,13 @@ const LibraryManifestResponse = library_api.LibraryManifestResponse;
 const PromptListResponse = library_api.PromptListResponse;
 const PromptMeta = library_api.PromptMeta;
 const PromptContentResponse = library_api.PromptContentResponse;
+const BatchPromptContentRequest = library_api.BatchPromptContentRequest;
+const BatchPromptContentResponse = library_api.BatchPromptContentResponse;
+const BatchPromptItem = library_api.BatchPromptItem;
 const ManifestMap = manifest.ManifestMap;
 const ManifestItem = manifest.ManifestItem;
+
+const BATCH_MAX_IDS: usize = 1024;
 
 pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
@@ -263,6 +268,60 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
         .content_hash = content_hash,
         .body = body,
     }, .{});
+}
+
+/// Batch prompt content fetch. Clients (notably `clumsies sync`)
+/// send a list of prompt_ids in one POST; the response carries a
+/// per-id item, each either populated or tagged with a per-item
+/// error. A single fetch replaces what used to be N sequential GETs
+/// and dominates sync wall time over tunneled links.
+pub fn handleBatchPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+    const user = auth.authenticate(ctx, req) catch {
+        return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
+    };
+    if (!auth.requireScope(user, "library:read", res)) return;
+
+    const body = req.json(BatchPromptContentRequest) catch {
+        return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
+    } orelse {
+        return apiError(res, 400, "BAD_REQUEST", "missing request body");
+    };
+
+    if (body.prompt_ids.len > BATCH_MAX_IDS) {
+        return apiError(res, 400, "BAD_REQUEST", "too many prompt_ids");
+    }
+
+    const conn = ctx.pool.acquire() catch {
+        return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
+    };
+    defer conn.release();
+
+    var items: std.ArrayList(BatchPromptItem) = .empty;
+    for (body.prompt_ids) |prompt_id| {
+        var row = (conn.row(
+            "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+            .{ user.org_id, prompt_id },
+        ) catch null) orelse {
+            try items.append(req.arena, .{
+                .prompt_id = try req.arena.dupe(u8, prompt_id),
+                .@"error" = "NOT_FOUND",
+            });
+            continue;
+        };
+        const pid = try req.arena.dupe(u8, try row.get([]const u8, 0));
+        const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 1));
+        const content = try req.arena.dupe(u8, try row.get([]const u8, 2));
+        const path = try req.arena.dupe(u8, try row.get([]const u8, 3));
+        row.deinit() catch {};
+        try items.append(req.arena, .{
+            .prompt_id = pid,
+            .path = path,
+            .content_hash = content_hash,
+            .body = content,
+        });
+    }
+
+    try res.json(BatchPromptContentResponse{ .items = items.items }, .{});
 }
 
 pub fn handleListBundles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {

--- a/src/hub/library.zig
+++ b/src/hub/library.zig
@@ -298,21 +298,36 @@ pub fn handleBatchPromptContent(ctx: *Server.Context, req: *httpz.Request, res: 
 
     var items: std.ArrayList(BatchPromptItem) = .empty;
     for (body.prompt_ids) |prompt_id| {
-        var row = (conn.row(
+        // Distinguish query failure (INTERNAL_ERROR) from a missing
+        // row (NOT_FOUND). Previously both collapsed into NOT_FOUND,
+        // so a transient database outage presented to the client as
+        // "every prompt is missing" — misleading and impossible to
+        // debug without server logs.
+        const row_result = conn.row(
             "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
             .{ user.org_id, prompt_id },
-        ) catch null) orelse {
+        ) catch {
+            try items.append(req.arena, .{
+                .prompt_id = try req.arena.dupe(u8, prompt_id),
+                .@"error" = "INTERNAL_ERROR",
+            });
+            continue;
+        };
+        var row = row_result orelse {
             try items.append(req.arena, .{
                 .prompt_id = try req.arena.dupe(u8, prompt_id),
                 .@"error" = "NOT_FOUND",
             });
             continue;
         };
+        // Defer the release so a row.get / dupe failure mid-iteration
+        // still returns the pg row handle to the pool.
+        defer row.deinit() catch {};
+
         const pid = try req.arena.dupe(u8, try row.get([]const u8, 0));
         const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 1));
         const content = try req.arena.dupe(u8, try row.get([]const u8, 2));
         const path = try req.arena.dupe(u8, try row.get([]const u8, 3));
-        row.deinit() catch {};
         try items.append(req.arena, .{
             .prompt_id = pid,
             .path = path,

--- a/src/hub/server.zig
+++ b/src/hub/server.zig
@@ -73,6 +73,7 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     // Context
     router.get("/api/workspaces/:ws_id/context/files", context_handler.handleListFiles, .{});
     router.get("/api/workspaces/:ws_id/context/file/content", context_handler.handleGetFileContent, .{});
+    router.post("/api/workspaces/:ws_id/context/files/content", context_handler.handleBatchFileContent, .{});
     router.post("/api/workspaces/:ws_id/context/prs", context_handler.handleCreatePr, .{});
     router.get("/api/workspaces/:ws_id/context/prs", context_handler.handleListPrs, .{});
     router.get("/api/workspaces/:ws_id/context/prs/:pr_id", context_handler.handleGetPr, .{});
@@ -90,6 +91,7 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.get("/api/org/library/prompts", library_handler.handleListPrompts, .{});
     router.get("/api/org/library/prompt", library_handler.handleGetPrompt, .{});
     router.get("/api/org/library/prompt/content", library_handler.handleGetPromptContent, .{});
+    router.post("/api/org/library/prompts/content", library_handler.handleBatchPromptContent, .{});
     router.get("/api/org/bundles", library_handler.handleListBundles, .{});
     router.get("/api/org/bundles/:name", library_handler.handleGetBundle, .{});
     router.post("/api/org/bundles", library_handler.handleCreateBundle, .{});

--- a/src/protocol/auth_api.zig
+++ b/src/protocol/auth_api.zig
@@ -1,6 +1,29 @@
-//! Auth API response shapes. MeResponse carries the authenticated user's profile plus their
-//! accessible workspaces — the first call every client makes after login. DirectoryResponse
-//! lists org members for workspace access management.
+//! Auth API request and response shapes. MeResponse carries the authenticated user's profile
+//! plus their accessible workspaces — the first call every client makes after login.
+//! LoginResponse / RefreshRequest / RefreshResponse describe the token lifecycle.
+//! DirectoryResponse lists org members for workspace access management.
+pub const LoginResponse = struct {
+    access_token: []const u8,
+    refresh_token: []const u8,
+    expires_in: i64 = 0,
+};
+
+pub const RefreshRequest = struct {
+    refresh_token: []const u8,
+};
+
+/// Refresh rotates BOTH tokens: the presented refresh token is
+/// revoked server-side, and a new access + refresh pair is issued.
+/// Clients must persist both new tokens; reusing the old refresh
+/// token on a subsequent refresh will 401. Fixes the original
+/// refresh handler which only issued a new access token, leaving
+/// clients unable to refresh a second time.
+pub const RefreshResponse = struct {
+    access_token: []const u8,
+    refresh_token: []const u8,
+    expires_in: i64 = 0,
+};
+
 pub const MeWorkspace = struct {
     ws_id: []const u8,
     name: []const u8,

--- a/src/protocol/library_api.zig
+++ b/src/protocol/library_api.zig
@@ -27,6 +27,30 @@ pub const PromptContentResponse = struct {
     body: []const u8,
 };
 
+/// Batch prompt content fetch. Used by `clumsies sync` to pull many
+/// prompts in one request instead of one GET per prompt. The single
+/// PromptContentResponse endpoint (used by TUI on-demand loads)
+/// remains; this is an additive sync-oriented path.
+pub const BatchPromptContentRequest = struct {
+    prompt_ids: []const []const u8,
+};
+
+pub const BatchPromptItem = struct {
+    prompt_id: []const u8,
+    path: []const u8 = "",
+    content_hash: []const u8 = "",
+    body: []const u8 = "",
+    /// Per-item error code when a specific prompt could not be
+    /// served (e.g. `NOT_FOUND`, `FORBIDDEN`). Empty string means the
+    /// item was served successfully; callers should check this
+    /// before treating body as authoritative.
+    @"error": []const u8 = "",
+};
+
+pub const BatchPromptContentResponse = struct {
+    items: []const BatchPromptItem = &.{},
+};
+
 pub const BundleMeta = struct {
     name: []const u8,
     description: []const u8 = "",

--- a/src/protocol/workspace_api.zig
+++ b/src/protocol/workspace_api.zig
@@ -18,6 +18,24 @@ pub const ContextFilesResponse = struct {
     files: []const ContextFile = &.{},
 };
 
+/// Batch context content fetch. Used by `clumsies sync` to pull many
+/// context files in one request instead of one GET per file. The
+/// single GET endpoint (used by TUI) remains.
+pub const BatchContextContentRequest = struct {
+    paths: []const []const u8,
+};
+
+pub const BatchContextItem = struct {
+    path: []const u8,
+    content_hash: []const u8 = "",
+    body: []const u8 = "",
+    @"error": []const u8 = "",
+};
+
+pub const BatchContextContentResponse = struct {
+    items: []const BatchContextItem = &.{},
+};
+
 pub const WorkspaceManifestResponse = struct {
     ws_id: []const u8,
     name: []const u8,


### PR DESCRIPTION
## Summary

`clumsies sync` over an SSH-forwarded Hub connection took more than
ten minutes on a ~170-entry workspace and was routinely killed by
the OS before finishing. Three independent causes compounded:
`HubClient` built and tore down a fresh `std.http.Client` for every
request (no TCP reuse), sync refetched every prompt and context
file on every run (no hash-skip), and the content endpoints only
served one file per request (no batching). A closely related
fourth cause — `handleRefresh` only issuing a new access token —
forced `clumsies login` after any long-idle session, compounding
the sync pain during debugging.

This PR fixes all four. Cold sync time drops from >10 min to a
handful of seconds; warm sync drops to one HTTP request (the
manifest).

### Connection reuse

`HubClient` holds a single `std.http.Client` for the lifetime of
the struct and exposes a matching `deinit`. Every call site gets a
`defer .deinit()`. Sequential requests from one caller now travel
over the same pooled TCP (and TLS) connection.

### Hash-skip classify

Sync compares each manifest entry's declared `sha256` hash against
a sha256 of the local cache file before reaching for the network.
Warm syncs skip the batch fetch entirely when every file matches.

### Batch content endpoints

`POST /api/org/library/prompts/content` and `POST
/api/workspaces/:ws_id/context/files/content` each accept an
id-or-path array and return a per-item response with an optional
error code. The single-file GET endpoints stay in place for TUI
on-demand loads. Cold sync now issues three HTTP requests total:
one manifest plus one batch per namespace.

### Refresh token rotation

`handleRefresh` now issues a new refresh token alongside the access
token; `LoginResponse` / `RefreshRequest` / `RefreshResponse` move
to `protocol/auth_api.zig` for a single source of truth. A new
`loadAuthAndRefresh` helper transparently refreshes the access
token when Hub reports 401, so sync / init / trace upload recover
from expired tokens without prompting the user.

## Follow-up

This PR adds batch endpoints directly in `sync_cmd.zig` and does
not route them through the existing TUI `RequestSpec` dispatcher.
The CLI and TUI API call paths remain divergent by design; #89
tracks unifying them into a shared client API infrastructure.

Closes #57.

## Test plan

- [x] `zig build` passes
- [x] `zig build test` — all tests pass
- [x] `zig fmt --check src/` is clean
- [x] Manual: after `rm -rf cache && clumsies sync`, `cache/prompt/`
  and `cache/context/` are populated and a second `clumsies sync`
  reports every file as unchanged
- [x] Manual: let the access token expire past its TTL, then run
  `clumsies sync`; the refresh happens transparently and the sync
  succeeds without a `clumsies login` prompt
- [x] Manual: on a large workspace, cold sync completes in under a
  few seconds over the SSH tunnel