### PR TITLE
tui: split monolithic widgets.zig into component files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ https://github.com/user-attachments/assets/3ae8473c-dac1-45b5-8a72-6ad21906f235
 
 **CLI.** Your local command surface. Login, workspace binding, cache sync, adapter install/remove, attestation flush, and TUI entry point.
 
-**MCP runtime.** How agents talk to clumsies. Exposes `memory.setup`, `memory.search`, `memory.load`, `memory.refer`, and `memory.submit` — each call automatically produces an attestation event.
+**MCP runtime.** How agents talk to clumsies. Exposes `memory.setup`, `memory.search`, `memory.load`, `memory.refer`, `memory.submit`, and `memory.reject` — each call automatically produces an attestation event. Agents can also propose changes via `context.propose_create/update/rename/delete` (workspace context) and `prompt.propose_create/update/rename/delete` (library rules).
 
 **Adapter layer.** Bridges your rules to agent runtimes without vendor lock-in. Currently supports Claude Code and Codex. Cursor, Windsurf, Copilot, Cline, Kimi Code, Qwen Code, and OpenCode coming soon.
 

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -18,8 +18,8 @@ const util_hash = @import("clumsies_lib").util.hash;
 
 const tree = @import("tree.zig");
 const attestation_reader = @import("attestation_reader.zig");
-const Modal = @import("widgets/modal.zig").Modal;
-const TextInput = @import("widgets/text_input.zig").TextInput;
+const Modal = w.Modal;
+const TextInput = w.TextInput;
 const TableRow = @import("table_row.zig").TableRow;
 const Column = @import("table_row.zig").Column;
 

--- a/src/client/tui/app/analysis.zig
+++ b/src/client/tui/app/analysis.zig
@@ -41,7 +41,7 @@ pub fn drawPrompts(
     insights: *const data.AnalysisData,
     available: bool,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const border_color = w.focusBorder(self.analysis_focus == .prompts);
+    const border_color = theme.focusBorder(self.analysis_focus == .prompts);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
@@ -218,7 +218,7 @@ pub fn drawMembers(
     insights: *const data.AnalysisData,
     available: bool,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const border_color = w.focusBorder(self.analysis_focus == .members);
+    const border_color = theme.focusBorder(self.analysis_focus == .members);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);

--- a/src/client/tui/app/dashboard.zig
+++ b/src/client/tui/app/dashboard.zig
@@ -4,7 +4,7 @@ const vxfw = vaxis.vxfw;
 const theme = @import("../theme.zig");
 const w = @import("../widgets.zig");
 const attestation_reader = @import("../attestation_reader.zig");
-const Modal = @import("../widgets/modal.zig").Modal;
+const Modal = w.Modal;
 
 pub fn drawRoot(
     self: anytype,
@@ -34,7 +34,7 @@ pub fn drawChart(
     scope_label: []const u8,
     active_session_count: usize,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const border_color = w.focusBorder(self.analysis_focus == .chart);
+    const border_color = theme.focusBorder(self.analysis_focus == .chart);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
@@ -127,7 +127,7 @@ pub fn drawInputs(
     visible_inputs: []const attestation_reader.InputEvent,
     scope_label: []const u8,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const border_color = w.focusBorder(self.analysis_focus == .inputs);
+    const border_color = theme.focusBorder(self.analysis_focus == .inputs);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);

--- a/src/client/tui/app/library.zig
+++ b/src/client/tui/app/library.zig
@@ -28,7 +28,7 @@ pub fn drawListPanel(
 ) std.mem.Allocator.Error!vxfw.Surface {
     const size = ctx.max.size();
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
-    const border_color = w.focusBorder(!self.detail_focus_content);
+    const border_color = theme.focusBorder(!self.detail_focus_content);
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
 
@@ -394,19 +394,14 @@ pub fn syncLibraryWidgets(self: anytype) void {
                 (std.fmt.allocPrint(self.viewAllocator(), "{s} *", .{row_text}) catch row_text)
             else
                 row_text;
-            const row_fg = if (draft_status_opt) |s|
-                theme.draftStatusColor(s)
-            else if (row_sel)
-                theme.TEXT
-            else
-                theme.TEXT_SOFT;
+            const row_style = w.draftRowStyle(row_sel, draft_status_opt);
             self.library_table_cols[i] = .{
                 .{ .text = labeled_text, .flex = 1 },
                 .{ .text = pr_label, .flex = 0, .min_width = 2, .alignment = .right },
             };
             self.library_table_rows[i] = .{
                 .columns = &self.library_table_cols[i],
-                .style = if (row_sel) theme.boldOn(theme.PANEL, row_fg) else theme.textOn(theme.PANEL, row_fg),
+                .style = row_style,
                 .gap = 2,
                 .padding_left = 0,
             };

--- a/src/client/tui/app/prompt_detail.zig
+++ b/src/client/tui/app/prompt_detail.zig
@@ -40,7 +40,7 @@ pub fn drawEmbeddedEmpty(
     ctx: vxfw.DrawContext,
 ) std.mem.Allocator.Error!vxfw.Surface {
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-    const border_color = w.focusBorder(self.detail_focus_content);
+    const border_color = theme.focusBorder(self.detail_focus_content);
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
     w.writeText(&surface, ctx, 2, 0, "Detail", theme.boldOn(theme.PANEL, theme.TEXT));
@@ -56,7 +56,7 @@ pub fn drawEmbedded(
     const body = try buildPromptDetailBody(self, ctx, prompt, embedded_layout);
 
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-    const border_color = w.focusBorder(self.detail_focus_content);
+    const border_color = theme.focusBorder(self.detail_focus_content);
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
     try fillPromptDetailSurface(&surface, ctx, prompt, embedded_layout, body);
@@ -266,15 +266,15 @@ fn writePromptMetaOnPanelChrome(
     // beside a file that is genuinely new. Show `(new)` instead,
     // mirroring the workspace context panel convention.
     if (prompt.revision == 0 and prompt.content_hash.len == 0 and prompt.updated.len == 0) {
-        _ = writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
+        _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
         return;
     }
 
     const full = try formatPromptMeta(ctx.arena, prompt, true);
-    if (writeHeaderRightIfFits(surface, ctx, 0, min_col, full, theme.fg(theme.MUTED))) return;
+    if (w.writeHeaderRightIfFits(surface, ctx, 0, min_col, full, theme.fg(theme.MUTED))) return;
 
     const compact = try formatPromptMeta(ctx.arena, prompt, false);
-    _ = writeHeaderRightIfFits(surface, ctx, 0, min_col, compact, theme.fg(theme.MUTED));
+    _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, compact, theme.fg(theme.MUTED));
 }
 
 fn formatPromptMeta(
@@ -302,22 +302,6 @@ fn formatPromptMeta(
         "rev{d} pr{d} c{d} {s}",
         .{ prompt.revision, prompt.open_pr_count, prompt.constraint_count, updated },
     );
-}
-
-fn writeHeaderRightIfFits(
-    surface: *vxfw.Surface,
-    ctx: vxfw.DrawContext,
-    row: u16,
-    min_col: u16,
-    text: []const u8,
-    style: vaxis.Style,
-) bool {
-    const width: u16 = @intCast(ctx.stringWidth(text));
-    if (width == 0 or width >= surface.size.width) return false;
-    const start_col = surface.size.width - width - 1;
-    if (start_col <= min_col) return false;
-    w.writeText(surface, ctx, start_col, row, text, style);
-    return true;
 }
 
 fn handlePrDiffEvent(

--- a/src/client/tui/app/settings.zig
+++ b/src/client/tui/app/settings.zig
@@ -14,7 +14,7 @@ pub fn drawSettings(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Erro
     w.fillSurface(&root, theme.PANEL);
 
     const sidebar_w: u16 = 18;
-    const sidebar_border = w.focusBorder(self.settings_focus == .sidebar);
+    const sidebar_border = theme.focusBorder(self.settings_focus == .sidebar);
     var sidebar = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = sidebar_w, .height = size.height });
     w.fillSurface(&sidebar, theme.PANEL);
     w.drawBorder(&sidebar, sidebar_border, theme.PANEL);
@@ -109,7 +109,7 @@ fn drawSettingsAccount(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.E
 
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
     w.fillSurface(&surface, theme.PANEL);
-    w.drawBorder(&surface, w.focusBorder(focused), theme.PANEL);
+    w.drawBorder(&surface, theme.focusBorder(focused), theme.PANEL);
     w.writeText(&surface, ctx, 2, 0, "Account", theme.boldOn(theme.PANEL, theme.TEXT));
 
     var row: u16 = 2;
@@ -213,7 +213,7 @@ fn drawSettingsOrg(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Error
     const focused = self.settings_focus == .content;
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
     w.fillSurface(&surface, theme.PANEL);
-    w.drawBorder(&surface, w.focusBorder(focused), theme.PANEL);
+    w.drawBorder(&surface, theme.focusBorder(focused), theme.PANEL);
     w.writeText(&surface, ctx, 2, 0, "Organization", theme.boldOn(theme.PANEL, theme.TEXT));
 
     var row: u16 = 2;
@@ -277,7 +277,7 @@ fn drawSettingsToken(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Err
     const t: data.TokenInfo = .{ .scopes = &.{}, .expires = "\xe2\x80\x94" };
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
     w.fillSurface(&surface, theme.PANEL);
-    w.drawBorder(&surface, w.focusBorder(focused), theme.PANEL);
+    w.drawBorder(&surface, theme.focusBorder(focused), theme.PANEL);
     w.writeText(&surface, ctx, 2, 0, "Token", theme.boldOn(theme.PANEL, theme.TEXT));
 
     var row: u16 = 2;

--- a/src/client/tui/app/workspace.zig
+++ b/src/client/tui/app/workspace.zig
@@ -7,7 +7,7 @@ const data = @import("../view_types.zig");
 const api = @import("../api.zig");
 const drafts_mod = @import("../../drafts.zig");
 const prompt_detail = @import("prompt_detail.zig");
-const Modal = @import("../widgets/modal.zig").Modal;
+const Modal = w.Modal;
 
 const MAX_TREE_ROWS = 128;
 
@@ -80,7 +80,7 @@ pub fn drawStatus(
     const grid_rows: u16 = (ws_count + cols - 1) / cols;
     const bar_h: u16 = 1 + grid_rows + 1;
 
-    const bar_border = w.focusBorder(self.ws_focus == .bar);
+    const bar_border = theme.focusBorder(self.ws_focus == .bar);
     var bar = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = size.width, .height = bar_h });
     w.fillSurface(&bar, theme.PANEL);
     w.drawBorder(&bar, bar_border, theme.PANEL);
@@ -141,7 +141,7 @@ pub fn drawList(
     live_ws: ?api.model.WsDetail,
     lib_prompts: []const data.PromptEntry,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const list_border = w.focusBorder(self.ws_focus == .list);
+    const list_border = theme.focusBorder(self.ws_focus == .list);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, list_border, theme.PANEL);
@@ -217,18 +217,8 @@ pub fn drawList(
                 const m = marker_info orelse break :blk null;
                 break :blk self.draftStatusFor(m.category, m.path);
             };
-            const row_fg = if (draft_status) |s|
-                theme.draftStatusColor(s)
-            else if (sel)
-                theme.TEXT
-            else
-                theme.TEXT_SOFT;
-            const row_style = if (sel) theme.boldOn(theme.PANEL, row_fg) else theme.fg(row_fg);
-            w.writeText(&surface, ctx, row_col, kv_row, rendered, row_style);
-            if (draft_status != null) {
-                const nw: u16 = @intCast(ctx.stringWidth(rendered));
-                w.writeText(&surface, ctx, row_col + nw + 1, kv_row, "*", row_style);
-            }
+            const row_style = w.draftRowStyle(sel, draft_status);
+            w.writeDraftMarker(&surface, ctx, row_col, kv_row, rendered, draft_status != null, row_style);
         }
         kv_row += 1;
     }
@@ -242,7 +232,7 @@ pub fn drawDetail(
     args: DetailArgs,
 ) std.mem.Allocator.Error!vxfw.Surface {
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-    const content_border = w.focusBorder(self.ws_focus == .content);
+    const content_border = theme.focusBorder(self.ws_focus == .content);
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, content_border, theme.PANEL);
 
@@ -321,10 +311,10 @@ fn writeWsMetaOnHeader(
                     "{s}  {s}  {s}",
                     .{ hash7, f.author, updated_short },
                 );
-                _ = writeHeaderRightIfFits(surface, ctx, 0, min_col, meta, theme.fg(theme.MUTED));
+                _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, meta, theme.fg(theme.MUTED));
             } else if (args.context_sel_path != null) {
                 // Virtual row: local create-op draft, no hub metadata.
-                _ = writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
+                _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
             }
         },
         .prompts => {
@@ -332,7 +322,7 @@ fn writeWsMetaOnHeader(
                 if (idx >= ws_d.ws_prompts.len) return;
                 const p = &ws_d.ws_prompts[idx];
                 const hash7 = hashBadge(p.content_hash);
-                _ = writeHeaderRightIfFits(surface, ctx, 0, min_col, hash7, theme.fg(theme.MUTED));
+                _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, hash7, theme.fg(theme.MUTED));
             }
         },
     }
@@ -346,22 +336,6 @@ fn hashBadge(raw: []const u8) []const u8 {
     const start = if (colon) |c| c + 1 else 0;
     const slice = raw[start..];
     return slice[0..@min(7, slice.len)];
-}
-
-fn writeHeaderRightIfFits(
-    surface: *vxfw.Surface,
-    ctx: vxfw.DrawContext,
-    row: u16,
-    min_col: u16,
-    text: []const u8,
-    style: vaxis.Style,
-) bool {
-    const width: u16 = @intCast(ctx.stringWidth(text));
-    if (width == 0 or width >= surface.size.width) return false;
-    const start_col = surface.size.width - width - 1;
-    if (start_col <= min_col) return false;
-    w.writeText(surface, ctx, start_col, row, text, style);
-    return true;
 }
 
 fn drawDirSelected(

--- a/src/client/tui/theme.zig
+++ b/src/client/tui/theme.zig
@@ -107,3 +107,7 @@ pub fn blank(bg: vaxis.Color) vaxis.Cell {
         .style = .{ .fg = TEXT, .bg = bg },
     };
 }
+
+pub fn focusBorder(has_focus: bool) vaxis.Color {
+    return if (has_focus) ACCENT else BORDER;
+}

--- a/src/client/tui/widgets.zig
+++ b/src/client/tui/widgets.zig
@@ -3,592 +3,64 @@ const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 const theme = @import("theme.zig");
 
-// Braille charts are redrawn frequently, so we keep a static UTF-8 lookup
-// table for U+2800..U+28FF instead of encoding and duplicating a grapheme
-// for every rendered cell on each draw.
-const braille_utf8_table = initBrailleUtf8Table();
-
-fn initBrailleUtf8Table() [256][3]u8 {
-    var table: [256][3]u8 = undefined;
-    for (0..table.len) |i| {
-        const cp: u21 = 0x2800 + @as(u21, @intCast(i));
-        // The braille block always encodes to three UTF-8 bytes. Assemble
-        // them directly so comptime table generation stays simple and avoids
-        // hitting std.unicode's branch quota during builds.
-        table[i] = .{
-            @as(u8, 0xe0) | @as(u8, @intCast(cp >> 12)),
-            @as(u8, 0x80) | @as(u8, @intCast((cp >> 6) & 0x3f)),
-            @as(u8, 0x80) | @as(u8, @intCast(cp & 0x3f)),
-        };
-    }
-    return table;
-}
-
-fn brailleGrapheme(cp: u21) []const u8 {
-    const idx: usize = @intCast(cp - 0x2800);
-    return braille_utf8_table[idx][0..];
-}
-
-fn sampleInterpolatedValue(trend: []const f32, sample_x: f32) f32 {
-    if (trend.len == 0) return 0;
-    if (trend.len == 1) return trend[0];
-
-    const max_x = @as(f32, @floatFromInt(trend.len - 1));
-    const clamped_x = std.math.clamp(sample_x, 0.0, max_x);
-    const left_x = @floor(clamped_x);
-    const left_idx: usize = @intFromFloat(left_x);
-    const right_idx = @min(left_idx + 1, trend.len - 1);
-    const t = clamped_x - left_x;
-
-    return trend[left_idx] * (1.0 - t) + trend[right_idx] * t;
-}
-
-const ChartScale = struct {
-    min_val: f32,
-    max_val: f32,
-};
-
-fn transformChartValue(value: f32) f32 {
-    return @sqrt(@max(value, 0.0));
-}
-
-fn quantileSorted(values: []const f32, q: f32) f32 {
-    if (values.len == 0) return 0;
-    if (values.len == 1) return values[0];
-
-    const clamped_q = std.math.clamp(q, 0.0, 1.0);
-    const scaled_idx = clamped_q * @as(f32, @floatFromInt(values.len - 1));
-    const left_idx: usize = @intFromFloat(@floor(scaled_idx));
-    const right_idx = @min(left_idx + 1, values.len - 1);
-    const t = scaled_idx - @as(f32, @floatFromInt(left_idx));
-
-    return values[left_idx] * (1.0 - t) + values[right_idx] * t;
-}
-
-fn resolveChartScale(trend: []const f32) ChartScale {
-    if (trend.len == 0) return .{ .min_val = 0, .max_val = 1 };
-
-    var sorted_samples: [256]f32 = undefined;
-    const sample_count = @min(trend.len, sorted_samples.len);
-    if (sample_count == 0) return .{ .min_val = 0, .max_val = 1 };
-
-    for (0..sample_count) |i| {
-        const src_idx = if (sample_count == trend.len or sample_count == 1)
-            i
-        else
-            i * (trend.len - 1) / (sample_count - 1);
-        sorted_samples[i] = transformChartValue(trend[src_idx]);
-    }
-
-    std.mem.sort(f32, sorted_samples[0..sample_count], {}, struct {
-        fn lessThan(_: void, a: f32, b: f32) bool {
-            return a < b;
-        }
-    }.lessThan);
-
-    const min_sample = sorted_samples[0];
-    const max_sample = sorted_samples[sample_count - 1];
-    const lower_q = quantileSorted(sorted_samples[0..sample_count], 0.12);
-    const upper_q = quantileSorted(sorted_samples[0..sample_count], 0.88);
-    const center = (lower_q + upper_q) * 0.5;
-    const robust_span = @max(upper_q - lower_q, 0.35);
-
-    // Use a robust band instead of raw min/max so one burst does not flatten
-    // the rest of the minute, while still leaving some headroom for spikes.
-    const lower_pad = @max(robust_span * 0.35, (lower_q - min_sample) * 0.5, 0.12);
-    const upper_pad = @max(robust_span * 0.45, (max_sample - upper_q) * 0.4, 0.25);
-
-    var min_val = @max(lower_q - lower_pad, 0.0);
-    var max_val = upper_q + upper_pad;
-
-    const min_display_span = @max(robust_span * 1.4, 0.9);
-    if (max_val - min_val < min_display_span) {
-        const half_span = min_display_span * 0.5;
-        min_val = @max(center - half_span, 0.0);
-        max_val = center + half_span;
-    }
-
-    if (max_val - min_val < 0.1) {
-        max_val = min_val + 0.1;
-    }
-
-    return .{ .min_val = min_val, .max_val = max_val };
-}
-
-fn chartDotY(value: f32, min_val: f32, max_val: f32, rows: u32) u32 {
-    const span = @max(max_val - min_val, 0.001);
-    const ratio = std.math.clamp((value - min_val) / span, 0.0, 1.0);
-    const max_row = @as(f32, @floatFromInt(rows - 1));
-    return @intFromFloat(@round((1.0 - ratio) * max_row));
-}
-
-// Fill entire surface buffer with a background color.
-pub fn fillSurface(surface: *vxfw.Surface, bg: vaxis.Color) void {
-    @memset(surface.buffer, theme.blank(bg));
-}
-
-// Paint a full-width band on a single row with a background color.
-pub fn paintBand(surface: *vxfw.Surface, row: u16, bg: vaxis.Color, fg: vaxis.Color) void {
-    for (0..surface.size.width) |col| {
-        surface.writeCell(@intCast(col), row, .{
-            .char = .{ .grapheme = " ", .width = 1 },
-            .style = .{ .fg = fg, .bg = bg },
-        });
-    }
-}
-
-// Draw a rounded border (╭╮╰╯─│) around the entire surface.
-pub fn drawBorder(surface: *vxfw.Surface, fg: vaxis.Color, bg: vaxis.Color) void {
-    const right = surface.size.width -| 1;
-    const bottom = surface.size.height -| 1;
-    const s = vaxis.Style{ .fg = fg, .bg = bg };
-
-    surface.writeCell(0, 0, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = s });
-    surface.writeCell(right, 0, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = s });
-    surface.writeCell(right, bottom, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = s });
-    surface.writeCell(0, bottom, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = s });
-
-    var col: u16 = 1;
-    while (col < right) : (col += 1) {
-        surface.writeCell(col, 0, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
-        surface.writeCell(col, bottom, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
-    }
-    var row: u16 = 1;
-    while (row < bottom) : (row += 1) {
-        surface.writeCell(0, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
-        surface.writeCell(right, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
-    }
-}
-
-// Write text at (col, row) using grapheme-aware width.
-pub fn writeText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8, s: vaxis.Style) void {
-    var cursor = col;
-    var iter = ctx.graphemeIterator(text);
-    while (iter.next()) |grapheme| {
-        if (cursor >= surface.size.width or row >= surface.size.height) break;
-        const bytes = grapheme.bytes(text);
-        if (std.mem.eql(u8, bytes, "\n")) break;
-        const width: u16 = @intCast(ctx.stringWidth(bytes));
-        if (width == 0 or cursor + width > surface.size.width) break;
-        surface.writeCell(cursor, row, .{
-            .char = .{ .grapheme = bytes, .width = @intCast(width) },
-            .style = s,
-        });
-        cursor += width;
-    }
-}
-
-// Write text right-aligned on a given row.
-pub fn writeRightText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, text: []const u8, s: vaxis.Style) void {
-    const width: u16 = @intCast(ctx.stringWidth(text));
-    if (width >= surface.size.width) return;
-    writeText(surface, ctx, surface.size.width - width - 1, row, text, s);
-}
-
-// Horizontal key-value pair: key in MUTED, value in TEXT.
-// key_width is the fixed column width for the key (left-aligned, padded).
-// Returns the next available row (row + 1).
-pub fn writeKv(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, key: []const u8, value: []const u8, key_width: u16) u16 {
-    writeText(surface, ctx, col, row, key, theme.fg(theme.MUTED));
-    writeText(surface, ctx, col + key_width + 1, row, value, theme.fg(theme.TEXT));
-    return row + 1;
-}
-
-// Section header: bold accent text, used before vertical KV groups.
-// Returns the next available row (row + 1).
-pub fn writeSectionHeader(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8) u16 {
-    writeText(surface, ctx, col, row, text, theme.fgBold(theme.ACCENT));
-    return row + 1;
-}
-
-// Draw a filled badge (pill) with background. Returns the column after the badge.
-pub fn drawFilledBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, fg: vaxis.Color, bg: vaxis.Color) u16 {
-    const width = @as(u16, @intCast(ctx.stringWidth(text))) + 2;
-    for (0..width) |offset| {
-        if (col + offset >= surface.size.width) break;
-        surface.writeCell(@intCast(col + offset), row, .{
-            .char = .{ .grapheme = " ", .width = 1 },
-            .style = .{ .fg = fg, .bg = bg },
-        });
-    }
-    writeText(surface, ctx, col + 1, row, text, .{ .fg = fg, .bg = bg, .bold = true });
-    return col + width;
-}
-
-// Draw a tab-style badge: selected = gold bg, unselected = panel_alt bg.
-pub fn drawTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
-    return drawFilledBadge(
-        surface,
-        ctx,
-        row,
-        col,
-        text,
-        if (selected) theme.PANEL else theme.TEXT_SOFT,
-        if (selected) theme.MINT else theme.PANEL_ALT,
-    );
-}
-
-// Draw an inner tab badge (smaller emphasis): selected = gold, unselected = panel_alt.
-pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
-    return drawFilledBadge(
-        surface,
-        ctx,
-        row,
-        col,
-        text,
-        if (selected) theme.PANEL else theme.TEXT_SOFT,
-        if (selected) theme.GOLD else theme.PANEL_ALT,
-    );
-}
-
-// Draw a braille area chart with gradient coloring (btop-style).
-// Area is filled from the data line down to the bottom, creating
-// a solid "mountain" shape. Gradient: ACCENT_SOFT (bottom) → OK (top).
-pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const f32, x: u16, y: u16, width: u16, height: u16) void {
-    if (width == 0 or height == 0 or trend.len == 0) return;
-
-    const scale = resolveChartScale(trend);
-
-    const braille_h: u32 = @as(u32, height) * 4;
-    const cols: u32 = @min(@as(u32, width) * 2, 512);
-    const rows: u32 = @min(braille_h, 128);
-
-    var dots: [512][128]bool = undefined;
-    for (&dots) |*r| @memset(r, false);
-
-    // Sample a continuous curve across the discrete buckets so the chart
-    // reads as a local activity wave rather than a stack of isolated bars.
-    for (0..cols) |col_idx| {
-        const sample_x = if (cols > 1)
-            @as(f32, @floatFromInt(col_idx)) *
-                @as(f32, @floatFromInt(trend.len - 1)) /
-                @as(f32, @floatFromInt(cols - 1))
-        else
-            0.0;
-        const val = sampleInterpolatedValue(trend, sample_x);
-        const dot_y = chartDotY(transformChartValue(val), scale.min_val, scale.max_val, rows);
-
-        // Fill from dot_y down to bottom (area fill)
-        var fill_y = dot_y;
-        while (fill_y < rows) : (fill_y += 1) {
-            dots[col_idx][fill_y] = true;
-        }
-    }
-
-    // Render braille characters with vertical gradient
-    const char_cols = (cols + 1) / 2;
-    const char_rows = (rows + 3) / 4;
-
-    for (0..char_rows) |cr| {
-        for (0..char_cols) |cc| {
-            var cp: u21 = 0x2800;
-            const dx = cc * 2;
-            const dy = cr * 4;
-
-            if (dx < cols) {
-                if (dy + 0 < rows and dots[dx][dy + 0]) cp |= 0x01;
-                if (dy + 1 < rows and dots[dx][dy + 1]) cp |= 0x02;
-                if (dy + 2 < rows and dots[dx][dy + 2]) cp |= 0x04;
-                if (dy + 3 < rows and dots[dx][dy + 3]) cp |= 0x40;
-            }
-            if (dx + 1 < cols) {
-                if (dy + 0 < rows and dots[dx + 1][dy + 0]) cp |= 0x08;
-                if (dy + 1 < rows and dots[dx + 1][dy + 1]) cp |= 0x10;
-                if (dy + 2 < rows and dots[dx + 1][dy + 2]) cp |= 0x20;
-                if (dy + 3 < rows and dots[dx + 1][dy + 3]) cp |= 0x80;
-            }
-
-            if (cp == 0x2800) continue;
-
-            // Vertical gradient: top rows = ACCENT (deep amber), bottom rows = ACCENT_SOFT (light amber)
-            const vert_t: f32 = if (char_rows > 1) 1.0 - @as(f32, @floatFromInt(cr)) / @as(f32, @floatFromInt(char_rows - 1)) else 0.5;
-            const color = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, vert_t);
-
-            const col: u16 = x + @as(u16, @intCast(cc));
-            const row: u16 = y + @as(u16, @intCast(cr));
-            if (col < surface.size.width and row < surface.size.height) {
-                surface.writeCell(col, row, .{
-                    .char = .{ .grapheme = brailleGrapheme(cp), .width = 1 },
-                    .style = .{ .fg = color, .bg = theme.PANEL },
-                });
-            }
-        }
-    }
-}
-
-test "brailleGrapheme uses stable utf8 lookups" {
-    try std.testing.expectEqualStrings("\xe2\xa0\x81", brailleGrapheme(0x2801));
-    try std.testing.expectEqualStrings("\xe2\xa3\xbf", brailleGrapheme(0x28ff));
-}
-
-test "sampleInterpolatedValue blends neighboring buckets" {
-    const trend = [_]f32{ 0, 10, 0 };
-    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 0.5), 0.001);
-    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 1.5), 0.001);
-}
-
-test "resolveChartScale keeps steady low activity off the bottom edge" {
-    const trend = [_]f32{ 1, 1, 1, 1, 1 };
-    const scale = resolveChartScale(&trend);
-    const dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
-
-    try std.testing.expect(dot_y > 1);
-    try std.testing.expect(dot_y < 6);
-}
-
-test "resolveChartScale preserves low-band motion when a spike arrives" {
-    const trend = [_]f32{ 1, 1, 1, 1, 100 };
-    const scale = resolveChartScale(&trend);
-    const low_dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
-    const spike_dot_y = chartDotY(transformChartValue(100), scale.min_val, scale.max_val, 8);
-
-    try std.testing.expect(low_dot_y < 7);
-    try std.testing.expectEqual(@as(u32, 0), spike_dot_y);
-}
-
-test "chartDotY maps higher values toward the top" {
-    try std.testing.expectEqual(@as(u32, 7), chartDotY(0, 0, 10, 8));
-    try std.testing.expectEqual(@as(u32, 0), chartDotY(10, 0, 10, 8));
-}
-
-// Initialize ScrollBars for selectable lists. draw_cursor is set to true
-// so that j/k keys trigger nextItem/prevItem (cursor movement) rather
-// than bare viewport scrolling. However, draw_cursor=true also activates
-// a buggy rendering path in libvaxis 0.5.1 that clips the selected row
-// to zero width (see applyCursorOverlay for the full explanation).
-//
-// The rendering workaround: each draw*() call-site temporarily sets
-// draw_cursor=false via defer before Panel.draw(), then calls
-// applyCursorOverlay() to paint the ▌ indicator as a z_index=1 overlay.
-// This decouples event handling (needs draw_cursor=true) from rendering
-// (needs draw_cursor=false to avoid the bug).
-//
-// Upstream fix: https://github.com/rockorager/libvaxis/pull/256
-pub fn initCursorScrollBars(background: vaxis.Color) vxfw.ScrollBars {
-    return .{
-        .scroll_view = .{
-            .children = .{ .slice = &.{} },
-            .wheel_scroll = 1,
-            .draw_cursor = true,
-        },
-        .draw_horizontal_scrollbar = false,
-        .vertical_scrollbar_thumb = .{
-            .char = .{ .grapheme = "▐", .width = 1 },
-            .style = .{ .fg = theme.BORDER, .bg = background },
-        },
-        .vertical_scrollbar_hover_thumb = .{
-            .char = .{ .grapheme = "█", .width = 1 },
-            .style = .{ .fg = theme.GOLD, .bg = background },
-        },
-        .vertical_scrollbar_drag_thumb = .{
-            .char = .{ .grapheme = "█", .width = 1 },
-            .style = .{ .fg = theme.ACCENT, .bg = background },
-        },
-    };
-}
-
-// Initialize ScrollBars without cursor (for content scrolling).
-pub fn initPlainScrollBars(background: vaxis.Color, wheel_scroll: u8) vxfw.ScrollBars {
-    return .{
-        .scroll_view = .{
-            .children = .{ .slice = &.{} },
-            .wheel_scroll = wheel_scroll,
-        },
-        .draw_horizontal_scrollbar = false,
-        .vertical_scrollbar_thumb = .{
-            .char = .{ .grapheme = "▐", .width = 1 },
-            .style = .{ .fg = theme.BORDER, .bg = background },
-        },
-        .vertical_scrollbar_hover_thumb = .{
-            .char = .{ .grapheme = "█", .width = 1 },
-            .style = .{ .fg = theme.GOLD, .bg = background },
-        },
-        .vertical_scrollbar_drag_thumb = .{
-            .char = .{ .grapheme = "█", .width = 1 },
-            .style = .{ .fg = theme.ACCENT, .bg = background },
-        },
-    };
-}
-
-// Wraps an already-rendered Surface into a Widget for passing to containers.
-pub const SurfaceWidget = struct {
-    surface: vxfw.Surface,
-    widget_ref: vxfw.Widget,
-
-    pub fn widget(self: *const SurfaceWidget) vxfw.Widget {
-        return .{
-            .userdata = @constCast(self),
-            .drawFn = typeErasedDrawFn,
-        };
-    }
-
-    fn typeErasedDrawFn(ptr: *anyopaque, _: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const self: *const SurfaceWidget = @ptrCast(@alignCast(ptr));
-        var surface = self.surface;
-        surface.widget = self.widget_ref;
-        return surface;
-    }
-};
-
-// Wraps a widget reference with stable identity for containers that need it.
-pub const WidgetBox = struct {
-    widget_ref: vxfw.Widget,
-
-    pub fn widget(self: *const WidgetBox) vxfw.Widget {
-        return .{
-            .userdata = @constCast(self),
-            .drawFn = typeErasedDrawFn,
-        };
-    }
-
-    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const self: *const WidgetBox = @ptrCast(@alignCast(ptr));
-        var surface = try self.widget_ref.draw(ctx);
-        surface.widget = self.widget();
-        return surface;
-    }
-};
-
-// Reusable bordered panel with title, subtitle, padding, and child widget.
-pub const Panel = struct {
-    owner: vxfw.Widget,
-    title: []const u8,
-    subtitle: []const u8 = "",
-    background: vaxis.Color,
-    border_color: vaxis.Color,
-    child: vxfw.Widget,
-    padding: Padding = .{},
-
-    pub const Padding = struct {
-        left: u16 = 0,
-        right: u16 = 0,
-        top: u16 = 0,
-        bottom: u16 = 0,
-    };
-
-    pub fn draw(self: *const Panel, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
-        const size = ctx.max.size();
-        var surface = try vxfw.Surface.init(ctx.arena, self.owner, size);
-        fillSurface(&surface, self.background);
-        drawBorder(&surface, self.border_color, self.background);
-
-        // Title takes priority. Subtitle only renders if enough space
-        // remains after title + 2 cell gap. Prevents overlap on narrow panels.
-        const title_w: u16 = @intCast(ctx.stringWidth(self.title));
-        writeText(&surface, ctx, 2, 0, self.title, theme.boldOn(self.background, theme.TEXT));
-        if (self.subtitle.len > 0) {
-            const sub_w: u16 = @intCast(ctx.stringWidth(self.subtitle));
-            const title_end = 2 + title_w + 2;
-            const sub_start = size.width -| sub_w -| 1;
-            if (sub_start > title_end) {
-                writeRightText(&surface, ctx, 0, self.subtitle, theme.textOn(self.background, theme.MUTED));
-            }
-        }
-
-        const inner_width = size.width -| 2 -| self.padding.left -| self.padding.right;
-        const inner_height = size.height -| 2 -| self.padding.top -| self.padding.bottom;
-        const child_ctx = ctx.withConstraints(
-            .{ .width = inner_width, .height = inner_height },
-            .{ .width = inner_width, .height = inner_height },
-        );
-        const child_surface = try self.child.draw(child_ctx);
-        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
-        children[0] = .{
-            .origin = .{
-                .row = 1 + self.padding.top,
-                .col = 1 + self.padding.left,
-            },
-            .surface = child_surface,
-        };
-        surface.children = children;
-        return surface;
-    }
-};
-
-// Render a ▌ cursor indicator on a Panel surface at the ScrollView's
-// selected row. This is our workaround for a libvaxis rendering bug.
-//
-// The problem: ScrollView.draw_cursor wraps the selected row in a
-// cursor_surf with width=2, then places the text child at col=2 inside
-// it. During compositing, Window.initChild clamps the text window to
-// max_width = parent_width(2) - x_off(2) = 0. The text is invisible.
-// Only the ▌ at col=0 of cursor_surf survives.
-//
-// The fix PR has been open since 2025-10-13 with no review:
-// https://github.com/rockorager/libvaxis/pull/256
-//
-// Our workaround: keep draw_cursor=false so ScrollView never creates
-// the buggy cursor_surf. Instead, after Panel.draw() produces the
-// final surface (with ScrollBars content as z_index=0 children), we
-// append a 1×1 ▌ surface at z_index=1. vxfw's Surface.render sorts
-// children by z_index before drawing, so our overlay paints on top of
-// the list content at the exact row of the selected item.
-//
-// This approach does not touch ScrollView internals. It reads two
-// public fields (scroll_view.cursor for the selected index and
-// scroll_view.scroll.top for the viewport offset) to compute the
-// visible row, then composites via the standard SubSurface z_index
-// mechanism.
-//
-// TODO: Remove this workaround when libvaxis merges PR #256 and we
-// update the dependency. Re-enable draw_cursor in initCursorScrollBars
-// and delete the applyCursorOverlay calls in app.zig.
-//
-// Constraints: Panel must have a 1-cell border (content starts at
-// col=1, row=1). Each ScrollView child must be exactly 1 row tall
-// (softwrap=false single-line Text).
-pub fn applyCursorOverlay(
-    ctx: vxfw.DrawContext,
-    surface: *vxfw.Surface,
-    scroll_view: *const vxfw.ScrollView,
-    bg: vaxis.Color,
-) std.mem.Allocator.Error!vxfw.Surface {
-    const cursor_pos = scroll_view.cursor;
-    const scroll_top = scroll_view.scroll.top;
-    if (cursor_pos < scroll_top) return surface.*;
-
-    const visible_row = cursor_pos - scroll_top;
-    const target_row: i17 = @intCast(1 + visible_row);
-
-    if (target_row >= surface.size.height -| 1) return surface.*;
-
-    const cursor_buf = try ctx.arena.alloc(vaxis.Cell, 1);
-    cursor_buf[0] = .{
-        .char = .{ .grapheme = "▌", .width = 1 },
-        .style = .{ .fg = theme.ACCENT_SOFT, .bg = bg },
-    };
-    const cursor_surface: vxfw.Surface = .{
-        .size = .{ .width = 1, .height = 1 },
-        .widget = surface.widget,
-        .buffer = cursor_buf,
-        .children = &.{},
-    };
-
-    const old_children = surface.children;
-    const new_children = try ctx.arena.alloc(vxfw.SubSurface, old_children.len + 1);
-    @memcpy(new_children[0..old_children.len], old_children);
-    new_children[old_children.len] = .{
-        .origin = .{ .col = 1, .row = target_row },
-        .surface = cursor_surface,
-        .z_index = 1,
-    };
-    surface.children = new_children;
-
-    return surface.*;
-}
+const draw = @import("widgets/draw.zig");
+const chart = @import("widgets/chart.zig");
+const badge = @import("widgets/badge.zig");
+const panel = @import("widgets/panel.zig");
+const fixed_split = @import("widgets/fixed_split.zig");
+const cursor = @import("widgets/cursor.zig");
+const empty_state = @import("widgets/empty_state.zig");
+const modal_mod = @import("widgets/modal.zig");
+const text_input = @import("widgets/text_input.zig");
+
+pub const fillSurface = draw.fillSurface;
+pub const paintBand = draw.paintBand;
+pub const drawBorder = draw.drawBorder;
+pub const writeText = draw.writeText;
+pub const writeRightText = draw.writeRightText;
+pub const writeHeaderRightIfFits = draw.writeHeaderRightIfFits;
+pub const writeKv = draw.writeKv;
+pub const writeSectionHeader = draw.writeSectionHeader;
+pub const writeCursorMarker = draw.writeCursorMarker;
+
+pub const drawBrailleAreaChart = chart.drawBrailleAreaChart;
+
+pub const Badge = badge.Badge;
+pub const badgeTopLevel = badge.badgeTopLevel;
+pub const badgeInnerTab = badge.badgeInnerTab;
+pub const drawFilledBadge = badge.drawFilledBadge;
+pub const drawTabBadge = badge.drawTabBadge;
+pub const drawInnerTabBadge = badge.drawInnerTabBadge;
+
+pub const SurfaceWidget = panel.SurfaceWidget;
+pub const WidgetBox = panel.WidgetBox;
+pub const Panel = panel.Panel;
+
+pub const splitHorizontal = fixed_split.splitHorizontal;
+pub const FixedSplit = fixed_split.FixedSplit;
+
+pub const initCursorScrollBars = cursor.initCursorScrollBars;
+pub const initPlainScrollBars = cursor.initPlainScrollBars;
+pub const applyCursorOverlay = cursor.applyCursorOverlay;
+pub const cursorDown = cursor.cursorDown;
+pub const cursorUp = cursor.cursorUp;
+pub const handleCursorKeys = cursor.handleCursorKeys;
+pub const handleGridKeys = cursor.handleGridKeys;
+
+pub const EmptyState = empty_state.EmptyState;
+pub const drawEmptyState = empty_state.drawEmptyState;
+
+pub const Anchor = modal_mod.Anchor;
+pub const Modal = modal_mod.Modal;
+
+pub const TextInputResult = text_input.TextInputResult;
+pub const TextInput = text_input.TextInput;
 
 pub fn countLines(text: []const u8) usize {
     if (text.len == 0) return 0;
     return 1 + std.mem.count(u8, text, "\n");
 }
 
-/// Format a server timestamp (ISO-8601 or Postgres `YYYY-MM-DD HH:MM:SS.uuuuuu+zz`)
-/// as a compact `YYYY-MM-DD HH:MM` for TUI row display. Shared by the
-/// prompt metadata badge, PR list rows, PR comment headers, and the
-/// workspace context/prompts panel header so all timestamps in the
-/// UI render in one consistent shape. Falls back to the trimmed raw
-/// string when the input is shorter than a date, and to the date
-/// portion alone when there is no time component.
 pub fn formatShortTimestamp(arena: std.mem.Allocator, raw: []const u8) std.mem.Allocator.Error![]const u8 {
     const trimmed = std.mem.trim(u8, raw, " \t\r\n");
     if (trimmed.len < 10) return arena.dupe(u8, trimmed);
@@ -598,248 +70,66 @@ pub fn formatShortTimestamp(arena: std.mem.Allocator, raw: []const u8) std.mem.A
     return arena.dupe(u8, trimmed[0..10]);
 }
 
-/// Create a horizontal two-column layout. Left column is `left_width` cells;
-/// right column fills the rest, separated by a 1-cell gap.
-pub fn splitHorizontal(
-    ctx: vxfw.DrawContext,
-    owner: vxfw.Widget,
-    bg: vaxis.Color,
-    left: vxfw.Surface,
-    right: vxfw.Surface,
-    left_width: u16,
-) std.mem.Allocator.Error!vxfw.Surface {
-    const size = ctx.max.size();
-    var root = try vxfw.Surface.init(ctx.arena, owner, size);
-    fillSurface(&root, bg);
-    const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-    children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = left };
-    children[1] = .{ .origin = .{ .row = 0, .col = @as(i17, @intCast(left_width)) + 1 }, .surface = right };
-    root.children = children;
-    return root;
+pub fn draftRowStyle(selected: bool, draft_status: anytype) vaxis.Style {
+    const fg = if (draft_status != null)
+        theme.draftStatusColor(draft_status.?)
+    else if (selected)
+        theme.TEXT
+    else
+        theme.TEXT_SOFT;
+    return if (selected) theme.boldOn(theme.PANEL, fg) else theme.fg(fg);
 }
 
-/// Create a vertical two-row layout. Top section is `top_height` rows;
-/// bottom section fills the rest.
-pub fn splitVertical(
-    ctx: vxfw.DrawContext,
-    owner: vxfw.Widget,
-    bg: vaxis.Color,
-    top: vxfw.Surface,
-    bottom: vxfw.Surface,
-    top_height: u16,
-) std.mem.Allocator.Error!vxfw.Surface {
-    const size = ctx.max.size();
-    var root = try vxfw.Surface.init(ctx.arena, owner, size);
-    fillSurface(&root, bg);
-    const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
-    children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = top };
-    children[1] = .{ .origin = .{ .row = @as(i17, @intCast(top_height)), .col = 0 }, .surface = bottom };
-    root.children = children;
-    return root;
-}
-
-/// Draw the ▌ cursor marker at (col, row) on an existing surface.
-pub fn writeCursorMarker(surface: *vxfw.Surface, col: u16, row: u16) void {
-    if (col >= surface.size.width or row >= surface.size.height) return;
-    surface.writeCell(col, row, .{
-        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
-        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
-    });
-}
-
-/// Move cursor down by one. Returns true if the event was consumed.
-pub fn cursorDown(cursor: *usize, count: usize, ctx: *vxfw.EventContext) bool {
-    if (count > 0 and cursor.* + 1 < count) {
-        cursor.* += 1;
-        ctx.consumeAndRedraw();
-        return true;
-    }
-    return false;
-}
-
-/// Move cursor up by one. Returns true if the event was consumed.
-pub fn cursorUp(cursor: *usize, ctx: *vxfw.EventContext) bool {
-    if (cursor.* > 0) {
-        cursor.* -= 1;
-        ctx.consumeAndRedraw();
-        return true;
-    }
-    return false;
-}
-
-/// Handle j/↓ and k/↑ keys for list cursor navigation.
-/// Returns true if the event was consumed.
-pub fn handleCursorKeys(key: vaxis.Key, cursor: *usize, count: usize, ctx: *vxfw.EventContext) bool {
-    if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{}))
-        return cursorDown(cursor, count, ctx);
-    if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{}))
-        return cursorUp(cursor, ctx);
-    return false;
-}
-
-/// Handle h/j/k/l + arrow keys for 2D grid cursor navigation.
-/// Returns true if the event was consumed.
-pub fn handleGridKeys(key: vaxis.Key, cursor: *usize, count: usize, cols: u16, ctx: *vxfw.EventContext) bool {
-    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
-        if (cursor.* + 1 < count) {
-            cursor.* += 1;
-            ctx.consumeAndRedraw();
-            return true;
-        }
-        return false;
-    }
-    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
-        if (cursor.* > 0) {
-            cursor.* -= 1;
-            ctx.consumeAndRedraw();
-            return true;
-        }
-        return false;
-    }
-    if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
-        if (cursor.* + cols < count) {
-            cursor.* += cols;
-            ctx.consumeAndRedraw();
-            return true;
-        }
-        return false;
-    }
-    if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
-        if (cursor.* >= cols) {
-            cursor.* -= cols;
-            ctx.consumeAndRedraw();
-            return true;
-        }
-        return false;
-    }
-    return false;
-}
-
-/// Return the border color for a panel based on whether it has focus.
-pub fn focusBorder(has_focus: bool) vaxis.Color {
-    return if (has_focus) theme.ACCENT else theme.BORDER;
-}
-
-/// Render a row of tab badges. Returns the column after the last badge.
-pub fn drawTabBar(
-    surface: *vxfw.Surface,
-    ctx: vxfw.DrawContext,
-    row: u16,
-    start_col: u16,
-    labels: []const []const u8,
-    selected: usize,
-    comptime style: enum { top_level, inner },
-) u16 {
-    var col = start_col;
-    for (labels, 0..) |label, i| {
-        col = switch (style) {
-            .top_level => drawTabBadge(surface, ctx, row, col, label, i == selected),
-            .inner => drawInnerTabBadge(surface, ctx, row, col, label, i == selected),
-        };
-    }
-    return col;
-}
-
-const api_state = @import("api/state.zig");
-
-/// Draw a gradient activity bar using █ characters. Width is proportional to
-/// value/max_value. Color lerps from ACCENT_SOFT to ACCENT across the bar.
-/// Always draws at least 1 cell when value > 0.
-pub fn drawActivityBar(
-    surface: *vxfw.Surface,
-    col: u16,
-    row: u16,
-    value: u32,
-    max_value: u32,
-    width: u16,
-) void {
-    if (value == 0 or width == 0 or max_value == 0) return;
-    const bar_w_raw: u16 = @intCast(@as(u32, width) * value / max_value);
-    const bar_w: u16 = if (bar_w_raw == 0) 1 else @min(bar_w_raw, width);
-    for (0..bar_w) |offset| {
-        const bc = col + @as(u16, @intCast(offset));
-        if (bc >= surface.size.width) break;
-        const t: f32 = if (bar_w > 1)
-            @as(f32, @floatFromInt(offset)) / @as(f32, @floatFromInt(bar_w - 1))
-        else
-            0.5;
-        surface.writeCell(bc, row, .{
-            .char = .{ .grapheme = "\xe2\x96\x88", .width = 1 },
-            .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
-        });
-    }
-}
-
-/// Draw a heatmap grid using ▪ characters. Color intensity represents value.
-/// values are laid out row-major with `cols` items per row. Cells are spaced
-/// 2 columns apart for visual breathing room.
-pub fn drawHeatmap(
-    surface: *vxfw.Surface,
-    col: u16,
-    start_row: u16,
-    values: []const u16,
-    cols: u16,
-    max_value: u16,
-) void {
-    if (cols == 0) return;
-    const max_f: f32 = @floatFromInt(@max(max_value, 1));
-    for (values, 0..) |value, i| {
-        const grid_col: u16 = @intCast(i % cols);
-        const grid_row: u16 = @intCast(i / cols);
-        const x = col + grid_col * 2;
-        const y = start_row + grid_row;
-        if (x >= surface.size.width or y >= surface.size.height) continue;
-        const fg = if (value == 0)
-            theme.rgb(0xffe8b8)
-        else
-            theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, @as(f32, @floatFromInt(value)) / max_f);
-        surface.writeCell(x, y, .{
-            .char = .{ .grapheme = "\xe2\x96\xa0", .width = 1 },
-            .style = .{ .fg = fg, .bg = theme.PANEL },
-        });
-    }
-}
-
-/// Write an empty-state message based on the API connection status.
-/// Produces messages like "Loading prompts..." or "Not authenticated."
-pub fn drawEmptyState(
+pub fn writeDraftMarker(
     surface: *vxfw.Surface,
     ctx: vxfw.DrawContext,
     col: u16,
     row: u16,
-    status: api_state.ConnectionStatus,
-    entity_name: []const u8,
+    name: []const u8,
+    has_draft: bool,
+    style: vaxis.Style,
 ) void {
-    const msg: []const u8 = switch (status) {
-        .connecting => blk: {
-            break :blk std.fmt.allocPrint(ctx.arena, "Loading {s}...", .{entity_name}) catch "Loading...";
-        },
-        .error_auth => "Not authenticated. Run clumsies login.",
-        .error_network => "Hub unavailable. Check clumsies-hub.",
-        .disconnected => "Not connected to hub.",
-        .connected => blk: {
-            break :blk std.fmt.allocPrint(ctx.arena, "No {s} loaded.", .{entity_name}) catch "No data loaded.";
-        },
-    };
-    writeText(surface, ctx, col, row, msg, .{ .fg = theme.MUTED, .bg = theme.PANEL });
-}
-
-test "writeCursorMarker does not crash on out-of-bounds" {
-    const alloc = std.testing.allocator;
-    var surface = try vxfw.Surface.init(alloc, undefined, .{ .width = 2, .height = 2 });
-    defer alloc.free(surface.buffer);
-    // In-bounds: should write without panic
-    writeCursorMarker(&surface, 0, 0);
-    // Out-of-bounds: should be a no-op
-    writeCursorMarker(&surface, 5, 5);
+    writeText(surface, ctx, col, row, name, style);
+    if (has_draft) {
+        const nw: u16 = @intCast(ctx.stringWidth(name));
+        writeText(surface, ctx, col + nw + 1, row, "*", style);
+    }
 }
 
 test "focusBorder returns ACCENT when focused" {
-    try std.testing.expectEqual(theme.ACCENT, focusBorder(true));
-    try std.testing.expectEqual(theme.BORDER, focusBorder(false));
+    try std.testing.expectEqual(theme.ACCENT, theme.focusBorder(true));
+    try std.testing.expectEqual(theme.BORDER, theme.focusBorder(false));
+}
+
+test "draftRowStyle uses draft color when draft present" {
+    const DraftStatus = @import("../drafts.zig").DraftStatus;
+    const style = draftRowStyle(true, @as(?DraftStatus, .editing));
+    try std.testing.expectEqual(theme.WARN, style.fg);
+    try std.testing.expectEqual(theme.PANEL, style.bg);
+    try std.testing.expect(style.bold);
+}
+
+test "draftRowStyle uses TEXT when selected without draft" {
+    const style = draftRowStyle(true, @as(?@import("../drafts.zig").DraftStatus, null));
+    try std.testing.expectEqual(theme.TEXT, style.fg);
+    try std.testing.expect(style.bold);
+}
+
+test "draftRowStyle uses TEXT_SOFT when unselected without draft" {
+    const style = draftRowStyle(false, @as(?@import("../drafts.zig").DraftStatus, null));
+    try std.testing.expectEqual(theme.TEXT_SOFT, style.fg);
+    try std.testing.expect(!style.bold);
 }
 
 test {
+    _ = @import("widgets/draw.zig");
+    _ = @import("widgets/chart.zig");
+    _ = @import("widgets/badge.zig");
+    _ = @import("widgets/panel.zig");
+    _ = @import("widgets/fixed_split.zig");
+    _ = @import("widgets/cursor.zig");
+    _ = @import("widgets/empty_state.zig");
     _ = @import("widgets/modal.zig");
     _ = @import("widgets/text_input.zig");
+    _ = @import("widgets/diff_viewer.zig");
 }

--- a/src/client/tui/widgets/badge.zig
+++ b/src/client/tui/widgets/badge.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+
+// Draw a filled badge (pill) with background. Returns the column after the badge.
+pub const Badge = struct {
+    text: []const u8,
+    fg: vaxis.Color,
+    bg: vaxis.Color,
+    bold: bool = true,
+
+    pub fn widget(self: *const Badge) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = badgeTypeErasedDrawFn,
+        };
+    }
+
+    /// Width in cells: text + 1 cell padding on each side.
+    pub fn width(self: *const Badge, ctx: vxfw.DrawContext) u16 {
+        return @as(u16, @intCast(ctx.stringWidth(self.text))) + 2;
+    }
+
+    fn badgeTypeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const Badge = @ptrCast(@alignCast(ptr));
+        const text_w: u16 = @intCast(ctx.stringWidth(self.text));
+        const badge_w = text_w + 2;
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = badge_w, .height = 1 });
+        const style: vaxis.Style = .{ .fg = self.fg, .bg = self.bg, .bold = self.bold };
+        for (0..badge_w) |c| {
+            surface.writeCell(@intCast(c), 0, .{
+                .char = .{ .grapheme = " ", .width = 1 },
+                .style = style,
+            });
+        }
+        d.writeText(&surface, ctx, 1, 0, self.text, style);
+        return surface;
+    }
+};
+
+pub fn badgeTopLevel(text: []const u8, selected: bool) Badge {
+    return .{
+        .text = text,
+        .fg = if (selected) theme.PANEL else theme.TEXT_SOFT,
+        .bg = if (selected) theme.MINT else theme.PANEL_ALT,
+    };
+}
+
+pub fn badgeInnerTab(text: []const u8, selected: bool) Badge {
+    return .{
+        .text = text,
+        .fg = if (selected) theme.PANEL else theme.TEXT_SOFT,
+        .bg = if (selected) theme.GOLD else theme.PANEL_ALT,
+    };
+}
+
+/// Draw a filled badge directly onto a surface. Returns the column after the badge.
+pub fn drawFilledBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, fg: vaxis.Color, bg: vaxis.Color) u16 {
+    const width = @as(u16, @intCast(ctx.stringWidth(text))) + 2;
+    for (0..width) |offset| {
+        if (col + offset >= surface.size.width) break;
+        surface.writeCell(@intCast(col + offset), row, .{
+            .char = .{ .grapheme = " ", .width = 1 },
+            .style = .{ .fg = fg, .bg = bg },
+        });
+    }
+    d.writeText(surface, ctx, col + 1, row, text, .{ .fg = fg, .bg = bg, .bold = true });
+    return col + width;
+}
+
+pub fn drawTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
+    const b = badgeTopLevel(text, selected);
+    return drawFilledBadge(surface, ctx, row, col, b.text, b.fg, b.bg);
+}
+
+pub fn drawInnerTabBadge(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, col: u16, text: []const u8, selected: bool) u16 {
+    const b = badgeInnerTab(text, selected);
+    return drawFilledBadge(surface, ctx, row, col, b.text, b.fg, b.bg);
+}
+
+test "badgeTopLevel uses MINT bg when selected" {
+    const sel = badgeTopLevel("test", true);
+    try std.testing.expectEqual(theme.MINT, sel.bg);
+    try std.testing.expectEqual(theme.PANEL, sel.fg);
+    const unsel = badgeTopLevel("test", false);
+    try std.testing.expectEqual(theme.PANEL_ALT, unsel.bg);
+    try std.testing.expectEqual(theme.TEXT_SOFT, unsel.fg);
+}
+
+test "badgeInnerTab uses GOLD bg when selected" {
+    const sel = badgeInnerTab("tab", true);
+    try std.testing.expectEqual(theme.GOLD, sel.bg);
+    const unsel = badgeInnerTab("tab", false);
+    try std.testing.expectEqual(theme.PANEL_ALT, unsel.bg);
+}

--- a/src/client/tui/widgets/chart.zig
+++ b/src/client/tui/widgets/chart.zig
@@ -1,0 +1,233 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+
+// Braille charts are redrawn frequently, so we keep a static UTF-8 lookup
+// table for U+2800..U+28FF instead of encoding and duplicating a grapheme
+// for every rendered cell on each draw.
+const braille_utf8_table = initBrailleUtf8Table();
+
+fn initBrailleUtf8Table() [256][3]u8 {
+    var table: [256][3]u8 = undefined;
+    for (0..table.len) |i| {
+        const cp: u21 = 0x2800 + @as(u21, @intCast(i));
+        // The braille block always encodes to three UTF-8 bytes. Assemble
+        // them directly so comptime table generation stays simple and avoids
+        // hitting std.unicode's branch quota during builds.
+        table[i] = .{
+            @as(u8, 0xe0) | @as(u8, @intCast(cp >> 12)),
+            @as(u8, 0x80) | @as(u8, @intCast((cp >> 6) & 0x3f)),
+            @as(u8, 0x80) | @as(u8, @intCast(cp & 0x3f)),
+        };
+    }
+    return table;
+}
+
+fn brailleGrapheme(cp: u21) []const u8 {
+    const idx: usize = @intCast(cp - 0x2800);
+    return braille_utf8_table[idx][0..];
+}
+
+fn sampleInterpolatedValue(trend: []const f32, sample_x: f32) f32 {
+    if (trend.len == 0) return 0;
+    if (trend.len == 1) return trend[0];
+
+    const max_x = @as(f32, @floatFromInt(trend.len - 1));
+    const clamped_x = std.math.clamp(sample_x, 0.0, max_x);
+    const left_x = @floor(clamped_x);
+    const left_idx: usize = @intFromFloat(left_x);
+    const right_idx = @min(left_idx + 1, trend.len - 1);
+    const t = clamped_x - left_x;
+
+    return trend[left_idx] * (1.0 - t) + trend[right_idx] * t;
+}
+
+const ChartScale = struct {
+    min_val: f32,
+    max_val: f32,
+};
+
+fn transformChartValue(value: f32) f32 {
+    return @sqrt(@max(value, 0.0));
+}
+
+fn quantileSorted(values: []const f32, q: f32) f32 {
+    if (values.len == 0) return 0;
+    if (values.len == 1) return values[0];
+
+    const clamped_q = std.math.clamp(q, 0.0, 1.0);
+    const scaled_idx = clamped_q * @as(f32, @floatFromInt(values.len - 1));
+    const left_idx: usize = @intFromFloat(@floor(scaled_idx));
+    const right_idx = @min(left_idx + 1, values.len - 1);
+    const t = scaled_idx - @as(f32, @floatFromInt(left_idx));
+
+    return values[left_idx] * (1.0 - t) + values[right_idx] * t;
+}
+
+fn resolveChartScale(trend: []const f32) ChartScale {
+    if (trend.len == 0) return .{ .min_val = 0, .max_val = 1 };
+
+    var sorted_samples: [256]f32 = undefined;
+    const sample_count = @min(trend.len, sorted_samples.len);
+    if (sample_count == 0) return .{ .min_val = 0, .max_val = 1 };
+
+    for (0..sample_count) |i| {
+        const src_idx = if (sample_count == trend.len or sample_count == 1)
+            i
+        else
+            i * (trend.len - 1) / (sample_count - 1);
+        sorted_samples[i] = transformChartValue(trend[src_idx]);
+    }
+
+    std.mem.sort(f32, sorted_samples[0..sample_count], {}, struct {
+        fn lessThan(_: void, a: f32, b: f32) bool {
+            return a < b;
+        }
+    }.lessThan);
+
+    const min_sample = sorted_samples[0];
+    const max_sample = sorted_samples[sample_count - 1];
+    const lower_q = quantileSorted(sorted_samples[0..sample_count], 0.12);
+    const upper_q = quantileSorted(sorted_samples[0..sample_count], 0.88);
+    const center = (lower_q + upper_q) * 0.5;
+    const robust_span = @max(upper_q - lower_q, 0.35);
+
+    // Use a robust band instead of raw min/max so one burst does not flatten
+    // the rest of the minute, while still leaving some headroom for spikes.
+    const lower_pad = @max(robust_span * 0.35, (lower_q - min_sample) * 0.5, 0.12);
+    const upper_pad = @max(robust_span * 0.45, (max_sample - upper_q) * 0.4, 0.25);
+
+    var min_val = @max(lower_q - lower_pad, 0.0);
+    var max_val = upper_q + upper_pad;
+
+    const min_display_span = @max(robust_span * 1.4, 0.9);
+    if (max_val - min_val < min_display_span) {
+        const half_span = min_display_span * 0.5;
+        min_val = @max(center - half_span, 0.0);
+        max_val = center + half_span;
+    }
+
+    if (max_val - min_val < 0.1) {
+        max_val = min_val + 0.1;
+    }
+
+    return .{ .min_val = min_val, .max_val = max_val };
+}
+
+fn chartDotY(value: f32, min_val: f32, max_val: f32, rows: u32) u32 {
+    const span = @max(max_val - min_val, 0.001);
+    const ratio = std.math.clamp((value - min_val) / span, 0.0, 1.0);
+    const max_row = @as(f32, @floatFromInt(rows - 1));
+    return @intFromFloat(@round((1.0 - ratio) * max_row));
+}
+
+// Draw a braille area chart with gradient coloring (btop-style).
+// Area is filled from the data line down to the bottom, creating
+// a solid "mountain" shape. Gradient: ACCENT_SOFT (bottom) → OK (top).
+pub fn drawBrailleAreaChart(surface: *vxfw.Surface, trend: []const f32, x: u16, y: u16, width: u16, height: u16) void {
+    if (width == 0 or height == 0 or trend.len == 0) return;
+
+    const scale = resolveChartScale(trend);
+
+    const braille_h: u32 = @as(u32, height) * 4;
+    const cols: u32 = @min(@as(u32, width) * 2, 512);
+    const rows: u32 = @min(braille_h, 128);
+
+    var dots: [512][128]bool = undefined;
+    for (&dots) |*r| @memset(r, false);
+
+    // Sample a continuous curve across the discrete buckets so the chart
+    // reads as a local activity wave rather than a stack of isolated bars.
+    for (0..cols) |col_idx| {
+        const sample_x = if (cols > 1)
+            @as(f32, @floatFromInt(col_idx)) *
+                @as(f32, @floatFromInt(trend.len - 1)) /
+                @as(f32, @floatFromInt(cols - 1))
+        else
+            0.0;
+        const val = sampleInterpolatedValue(trend, sample_x);
+        const dot_y = chartDotY(transformChartValue(val), scale.min_val, scale.max_val, rows);
+
+        // Fill from dot_y down to bottom (area fill)
+        var fill_y = dot_y;
+        while (fill_y < rows) : (fill_y += 1) {
+            dots[col_idx][fill_y] = true;
+        }
+    }
+
+    // Render braille characters with vertical gradient
+    const char_cols = (cols + 1) / 2;
+    const char_rows = (rows + 3) / 4;
+
+    for (0..char_rows) |cr| {
+        for (0..char_cols) |cc| {
+            var cp: u21 = 0x2800;
+            const dx = cc * 2;
+            const dy = cr * 4;
+
+            if (dx < cols) {
+                if (dy + 0 < rows and dots[dx][dy + 0]) cp |= 0x01;
+                if (dy + 1 < rows and dots[dx][dy + 1]) cp |= 0x02;
+                if (dy + 2 < rows and dots[dx][dy + 2]) cp |= 0x04;
+                if (dy + 3 < rows and dots[dx][dy + 3]) cp |= 0x40;
+            }
+            if (dx + 1 < cols) {
+                if (dy + 0 < rows and dots[dx + 1][dy + 0]) cp |= 0x08;
+                if (dy + 1 < rows and dots[dx + 1][dy + 1]) cp |= 0x10;
+                if (dy + 2 < rows and dots[dx + 1][dy + 2]) cp |= 0x20;
+                if (dy + 3 < rows and dots[dx + 1][dy + 3]) cp |= 0x80;
+            }
+
+            if (cp == 0x2800) continue;
+
+            // Vertical gradient: top rows = ACCENT (deep amber), bottom rows = ACCENT_SOFT (light amber)
+            const vert_t: f32 = if (char_rows > 1) 1.0 - @as(f32, @floatFromInt(cr)) / @as(f32, @floatFromInt(char_rows - 1)) else 0.5;
+            const color = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, vert_t);
+
+            const col: u16 = x + @as(u16, @intCast(cc));
+            const row: u16 = y + @as(u16, @intCast(cr));
+            if (col < surface.size.width and row < surface.size.height) {
+                surface.writeCell(col, row, .{
+                    .char = .{ .grapheme = brailleGrapheme(cp), .width = 1 },
+                    .style = .{ .fg = color, .bg = theme.PANEL },
+                });
+            }
+        }
+    }
+}
+
+test "brailleGrapheme uses stable utf8 lookups" {
+    try std.testing.expectEqualStrings("\xe2\xa0\x81", brailleGrapheme(0x2801));
+    try std.testing.expectEqualStrings("\xe2\xa3\xbf", brailleGrapheme(0x28ff));
+}
+
+test "sampleInterpolatedValue blends neighboring buckets" {
+    const trend = [_]f32{ 0, 10, 0 };
+    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 0.5), 0.001);
+    try std.testing.expectApproxEqAbs(@as(f32, 5), sampleInterpolatedValue(&trend, 1.5), 0.001);
+}
+
+test "resolveChartScale keeps steady low activity off the bottom edge" {
+    const trend = [_]f32{ 1, 1, 1, 1, 1 };
+    const scale = resolveChartScale(&trend);
+    const dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
+
+    try std.testing.expect(dot_y > 1);
+    try std.testing.expect(dot_y < 6);
+}
+
+test "resolveChartScale preserves low-band motion when a spike arrives" {
+    const trend = [_]f32{ 1, 1, 1, 1, 100 };
+    const scale = resolveChartScale(&trend);
+    const low_dot_y = chartDotY(transformChartValue(1), scale.min_val, scale.max_val, 8);
+    const spike_dot_y = chartDotY(transformChartValue(100), scale.min_val, scale.max_val, 8);
+
+    try std.testing.expect(low_dot_y < 7);
+    try std.testing.expectEqual(@as(u32, 0), spike_dot_y);
+}
+
+test "chartDotY maps higher values toward the top" {
+    try std.testing.expectEqual(@as(u32, 7), chartDotY(0, 0, 10, 8));
+    try std.testing.expectEqual(@as(u32, 0), chartDotY(10, 0, 10, 8));
+}

--- a/src/client/tui/widgets/cursor.zig
+++ b/src/client/tui/widgets/cursor.zig
@@ -106,9 +106,9 @@ pub fn applyCursorOverlay(
     if (cursor_pos < scroll_top) return surface.*;
 
     const visible_row = cursor_pos - scroll_top;
-    const target_row: i17 = @intCast(1 + visible_row);
+    const target_u16: u16 = @intCast(1 + visible_row);
 
-    if (target_row >= surface.size.height -| 1) return surface.*;
+    if (target_u16 >= surface.size.height -| 1) return surface.*;
 
     const cursor_buf = try ctx.arena.alloc(vaxis.Cell, 1);
     cursor_buf[0] = .{
@@ -126,7 +126,7 @@ pub fn applyCursorOverlay(
     const new_children = try ctx.arena.alloc(vxfw.SubSurface, old_children.len + 1);
     @memcpy(new_children[0..old_children.len], old_children);
     new_children[old_children.len] = .{
-        .origin = .{ .col = 1, .row = target_row },
+        .origin = .{ .col = 1, .row = @as(i17, @intCast(target_u16)) },
         .surface = cursor_surface,
         .z_index = 1,
     };

--- a/src/client/tui/widgets/cursor.zig
+++ b/src/client/tui/widgets/cursor.zig
@@ -1,0 +1,214 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+
+// Initialize ScrollBars for selectable lists. draw_cursor is set to true
+// so that j/k keys trigger nextItem/prevItem (cursor movement) rather
+// than bare viewport scrolling. However, draw_cursor=true also activates
+// a buggy rendering path in libvaxis 0.5.1 that clips the selected row
+// to zero width (see applyCursorOverlay for the full explanation).
+//
+// The rendering workaround: each draw*() call-site temporarily sets
+// draw_cursor=false via defer before Panel.draw(), then calls
+// applyCursorOverlay() to paint the indicator as a z_index=1 overlay.
+// This decouples event handling (needs draw_cursor=true) from rendering
+// (needs draw_cursor=false to avoid the bug).
+//
+// Upstream fix: https://github.com/rockorager/libvaxis/pull/256
+pub fn initCursorScrollBars(background: vaxis.Color) vxfw.ScrollBars {
+    return .{
+        .scroll_view = .{
+            .children = .{ .slice = &.{} },
+            .wheel_scroll = 1,
+            .draw_cursor = true,
+        },
+        .draw_horizontal_scrollbar = false,
+        .vertical_scrollbar_thumb = .{
+            .char = .{ .grapheme = "▐", .width = 1 },
+            .style = .{ .fg = theme.BORDER, .bg = background },
+        },
+        .vertical_scrollbar_hover_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.GOLD, .bg = background },
+        },
+        .vertical_scrollbar_drag_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.ACCENT, .bg = background },
+        },
+    };
+}
+
+// Initialize ScrollBars without cursor (for content scrolling).
+pub fn initPlainScrollBars(background: vaxis.Color, wheel_scroll: u8) vxfw.ScrollBars {
+    return .{
+        .scroll_view = .{
+            .children = .{ .slice = &.{} },
+            .wheel_scroll = wheel_scroll,
+        },
+        .draw_horizontal_scrollbar = false,
+        .vertical_scrollbar_thumb = .{
+            .char = .{ .grapheme = "▐", .width = 1 },
+            .style = .{ .fg = theme.BORDER, .bg = background },
+        },
+        .vertical_scrollbar_hover_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.GOLD, .bg = background },
+        },
+        .vertical_scrollbar_drag_thumb = .{
+            .char = .{ .grapheme = "█", .width = 1 },
+            .style = .{ .fg = theme.ACCENT, .bg = background },
+        },
+    };
+}
+
+// Render a cursor indicator on a Panel surface at the ScrollView's
+// selected row. This is our workaround for a libvaxis rendering bug.
+//
+// The problem: ScrollView.draw_cursor wraps the selected row in a
+// cursor_surf with width=2, then places the text child at col=2 inside
+// it. During compositing, Window.initChild clamps the text window to
+// max_width = parent_width(2) - x_off(2) = 0. The text is invisible.
+// Only the indicator at col=0 of cursor_surf survives.
+//
+// The fix PR has been open since 2025-10-13 with no review:
+// https://github.com/rockorager/libvaxis/pull/256
+//
+// Our workaround: keep draw_cursor=false so ScrollView never creates
+// the buggy cursor_surf. Instead, after Panel.draw() produces the
+// final surface (with ScrollBars content as z_index=0 children), we
+// append a 1x1 surface at z_index=1. vxfw's Surface.render sorts
+// children by z_index before drawing, so our overlay paints on top of
+// the list content at the exact row of the selected item.
+//
+// This approach does not touch ScrollView internals. It reads two
+// public fields (scroll_view.cursor for the selected index and
+// scroll_view.scroll.top for the viewport offset) to compute the
+// visible row, then composites via the standard SubSurface z_index
+// mechanism.
+//
+// TODO: Remove this workaround when libvaxis merges PR #256 and we
+// update the dependency. Re-enable draw_cursor in initCursorScrollBars
+// and delete the applyCursorOverlay calls in app.zig.
+//
+// Constraints: Panel must have a 1-cell border (content starts at
+// col=1, row=1). Each ScrollView child must be exactly 1 row tall
+// (softwrap=false single-line Text).
+pub fn applyCursorOverlay(
+    ctx: vxfw.DrawContext,
+    surface: *vxfw.Surface,
+    scroll_view: *const vxfw.ScrollView,
+    bg: vaxis.Color,
+) std.mem.Allocator.Error!vxfw.Surface {
+    const cursor_pos = scroll_view.cursor;
+    const scroll_top = scroll_view.scroll.top;
+    if (cursor_pos < scroll_top) return surface.*;
+
+    const visible_row = cursor_pos - scroll_top;
+    const target_row: i17 = @intCast(1 + visible_row);
+
+    if (target_row >= surface.size.height -| 1) return surface.*;
+
+    const cursor_buf = try ctx.arena.alloc(vaxis.Cell, 1);
+    cursor_buf[0] = .{
+        .char = .{ .grapheme = "▌", .width = 1 },
+        .style = .{ .fg = theme.ACCENT_SOFT, .bg = bg },
+    };
+    const cursor_surface: vxfw.Surface = .{
+        .size = .{ .width = 1, .height = 1 },
+        .widget = surface.widget,
+        .buffer = cursor_buf,
+        .children = &.{},
+    };
+
+    const old_children = surface.children;
+    const new_children = try ctx.arena.alloc(vxfw.SubSurface, old_children.len + 1);
+    @memcpy(new_children[0..old_children.len], old_children);
+    new_children[old_children.len] = .{
+        .origin = .{ .col = 1, .row = target_row },
+        .surface = cursor_surface,
+        .z_index = 1,
+    };
+    surface.children = new_children;
+
+    return surface.*;
+}
+
+/// Move cursor down by one. Returns true if the event was consumed.
+pub fn cursorDown(cursor: *usize, count: usize, ctx: *vxfw.EventContext) bool {
+    if (count > 0 and cursor.* + 1 < count) {
+        cursor.* += 1;
+        ctx.consumeAndRedraw();
+        return true;
+    }
+    return false;
+}
+
+/// Move cursor up by one. Returns true if the event was consumed.
+pub fn cursorUp(cursor: *usize, ctx: *vxfw.EventContext) bool {
+    if (cursor.* > 0) {
+        cursor.* -= 1;
+        ctx.consumeAndRedraw();
+        return true;
+    }
+    return false;
+}
+
+/// Handle j/Down and k/Up keys for list cursor navigation.
+/// Returns true if the event was consumed.
+pub fn handleCursorKeys(key: vaxis.Key, cursor: *usize, count: usize, ctx: *vxfw.EventContext) bool {
+    if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{}))
+        return cursorDown(cursor, count, ctx);
+    if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{}))
+        return cursorUp(cursor, ctx);
+    return false;
+}
+
+/// Handle h/j/k/l + arrow keys for 2D grid cursor navigation.
+/// Returns true if the event was consumed.
+pub fn handleGridKeys(key: vaxis.Key, cursor: *usize, count: usize, cols: u16, ctx: *vxfw.EventContext) bool {
+    if (key.matches('l', .{}) or key.matches(vaxis.Key.right, .{})) {
+        if (cursor.* + 1 < count) {
+            cursor.* += 1;
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        return false;
+    }
+    if (key.matches('h', .{}) or key.matches(vaxis.Key.left, .{})) {
+        if (cursor.* > 0) {
+            cursor.* -= 1;
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        return false;
+    }
+    if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
+        if (cursor.* + cols < count) {
+            cursor.* += cols;
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        return false;
+    }
+    if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
+        if (cursor.* >= cols) {
+            cursor.* -= cols;
+            ctx.consumeAndRedraw();
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+test "writeCursorMarker does not crash on out-of-bounds" {
+    const alloc = std.testing.allocator;
+    var surface = try vxfw.Surface.init(alloc, undefined, .{ .width = 2, .height = 2 });
+    defer alloc.free(surface.buffer);
+    // In-bounds: should write without panic
+    d.writeCursorMarker(&surface, 0, 0);
+    // Out-of-bounds: should be a no-op
+    d.writeCursorMarker(&surface, 5, 5);
+}

--- a/src/client/tui/widgets/draw.zig
+++ b/src/client/tui/widgets/draw.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+
+// Fill entire surface buffer with a background color.
+pub fn fillSurface(surface: *vxfw.Surface, bg: vaxis.Color) void {
+    @memset(surface.buffer, theme.blank(bg));
+}
+
+// Paint a full-width band on a single row with a background color.
+pub fn paintBand(surface: *vxfw.Surface, row: u16, bg: vaxis.Color, fg: vaxis.Color) void {
+    for (0..surface.size.width) |col| {
+        surface.writeCell(@intCast(col), row, .{
+            .char = .{ .grapheme = " ", .width = 1 },
+            .style = .{ .fg = fg, .bg = bg },
+        });
+    }
+}
+
+// Draw a rounded border (╭╮╰╯─│) around the entire surface.
+pub fn drawBorder(surface: *vxfw.Surface, fg: vaxis.Color, bg: vaxis.Color) void {
+    const right = surface.size.width -| 1;
+    const bottom = surface.size.height -| 1;
+    const s = vaxis.Style{ .fg = fg, .bg = bg };
+
+    surface.writeCell(0, 0, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = s });
+    surface.writeCell(right, 0, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = s });
+    surface.writeCell(right, bottom, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = s });
+    surface.writeCell(0, bottom, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = s });
+
+    var col: u16 = 1;
+    while (col < right) : (col += 1) {
+        surface.writeCell(col, 0, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+        surface.writeCell(col, bottom, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = s });
+    }
+    var row: u16 = 1;
+    while (row < bottom) : (row += 1) {
+        surface.writeCell(0, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+        surface.writeCell(right, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = s });
+    }
+}
+
+// Write text at (col, row) using grapheme-aware width.
+pub fn writeText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8, s: vaxis.Style) void {
+    var cursor = col;
+    var iter = ctx.graphemeIterator(text);
+    while (iter.next()) |grapheme| {
+        if (cursor >= surface.size.width or row >= surface.size.height) break;
+        const bytes = grapheme.bytes(text);
+        if (std.mem.eql(u8, bytes, "\n")) break;
+        const width: u16 = @intCast(ctx.stringWidth(bytes));
+        if (width == 0 or cursor + width > surface.size.width) break;
+        surface.writeCell(cursor, row, .{
+            .char = .{ .grapheme = bytes, .width = @intCast(width) },
+            .style = s,
+        });
+        cursor += width;
+    }
+}
+
+// Write text right-aligned on a given row.
+pub fn writeRightText(surface: *vxfw.Surface, ctx: vxfw.DrawContext, row: u16, text: []const u8, s: vaxis.Style) void {
+    const width: u16 = @intCast(ctx.stringWidth(text));
+    if (width >= surface.size.width) return;
+    writeText(surface, ctx, surface.size.width - width - 1, row, text, s);
+}
+
+/// Write right-aligned text if it fits without overlapping min_col.
+/// Returns true if the text was written.
+pub fn writeHeaderRightIfFits(
+    surface: *vxfw.Surface,
+    ctx: vxfw.DrawContext,
+    row: u16,
+    min_col: u16,
+    text: []const u8,
+    style: vaxis.Style,
+) bool {
+    const width: u16 = @intCast(ctx.stringWidth(text));
+    if (width == 0 or width >= surface.size.width) return false;
+    const start_col = surface.size.width - width - 1;
+    if (start_col <= min_col) return false;
+    writeText(surface, ctx, start_col, row, text, style);
+    return true;
+}
+
+// Horizontal key-value pair: key in MUTED, value in TEXT.
+// key_width is the fixed column width for the key (left-aligned, padded).
+// Returns the next available row (row + 1).
+pub fn writeKv(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, key: []const u8, value: []const u8, key_width: u16) u16 {
+    writeText(surface, ctx, col, row, key, theme.fg(theme.MUTED));
+    writeText(surface, ctx, col + key_width + 1, row, value, theme.fg(theme.TEXT));
+    return row + 1;
+}
+
+// Section header: bold accent text, used before vertical KV groups.
+// Returns the next available row (row + 1).
+pub fn writeSectionHeader(surface: *vxfw.Surface, ctx: vxfw.DrawContext, col: u16, row: u16, text: []const u8) u16 {
+    writeText(surface, ctx, col, row, text, theme.fgBold(theme.ACCENT));
+    return row + 1;
+}
+
+/// Draw the ▌ cursor marker at (col, row) on an existing surface.
+pub fn writeCursorMarker(surface: *vxfw.Surface, col: u16, row: u16) void {
+    if (col >= surface.size.width or row >= surface.size.height) return;
+    surface.writeCell(col, row, .{
+        .char = .{ .grapheme = "\xe2\x96\x8c", .width = 1 },
+        .style = .{ .fg = theme.ACCENT_SOFT, .bg = theme.PANEL },
+    });
+}

--- a/src/client/tui/widgets/empty_state.zig
+++ b/src/client/tui/widgets/empty_state.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+const api_state = @import("../api/state.zig");
+
+pub const EmptyState = struct {
+    status: api_state.ConnectionStatus,
+    entity_name: []const u8,
+
+    pub fn widget(self: *const EmptyState) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = emptyStateTypeErasedDrawFn,
+        };
+    }
+
+    fn emptyStateTypeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const EmptyState = @ptrCast(@alignCast(ptr));
+        const msg = self.message(ctx.arena);
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        d.fillSurface(&surface, theme.PANEL);
+        d.writeText(&surface, ctx, 2, 1, msg, .{ .fg = theme.MUTED, .bg = theme.PANEL });
+        return surface;
+    }
+
+    pub fn message(self: *const EmptyState, arena: std.mem.Allocator) []const u8 {
+        return switch (self.status) {
+            .connecting => std.fmt.allocPrint(arena, "Loading {s}...", .{self.entity_name}) catch "Loading...",
+            .error_auth => "Not authenticated. Run clumsies login.",
+            .error_network => "Hub unavailable. Check clumsies-hub.",
+            .disconnected => "Not connected to hub.",
+            .connected => std.fmt.allocPrint(arena, "No {s} loaded.", .{self.entity_name}) catch "No data loaded.",
+        };
+    }
+};
+
+/// Backward-compatible draw helper. Delegates to EmptyState widget.
+pub fn drawEmptyState(
+    surface: *vxfw.Surface,
+    ctx: vxfw.DrawContext,
+    col: u16,
+    row: u16,
+    status: api_state.ConnectionStatus,
+    entity_name: []const u8,
+) void {
+    const es: EmptyState = .{ .status = status, .entity_name = entity_name };
+    const msg = es.message(ctx.arena);
+    d.writeText(surface, ctx, col, row, msg, .{ .fg = theme.MUTED, .bg = theme.PANEL });
+}

--- a/src/client/tui/widgets/fixed_split.zig
+++ b/src/client/tui/widgets/fixed_split.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
-const theme = @import("../theme.zig");
 const d = @import("draw.zig");
 
 /// Create a horizontal two-column layout. Left column is `left_width` cells;

--- a/src/client/tui/widgets/fixed_split.zig
+++ b/src/client/tui/widgets/fixed_split.zig
@@ -1,0 +1,81 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+
+/// Create a horizontal two-column layout. Left column is `left_width` cells;
+/// right column fills the rest, separated by a 1-cell gap.
+pub fn splitHorizontal(
+    ctx: vxfw.DrawContext,
+    owner: vxfw.Widget,
+    bg: vaxis.Color,
+    left: vxfw.Surface,
+    right: vxfw.Surface,
+    left_width: u16,
+) std.mem.Allocator.Error!vxfw.Surface {
+    const size = ctx.max.size();
+    var root = try vxfw.Surface.init(ctx.arena, owner, size);
+    d.fillSurface(&root, bg);
+    const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+    children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = left };
+    children[1] = .{ .origin = .{ .row = 0, .col = @as(i17, @intCast(left_width)) + 1 }, .surface = right };
+    root.children = children;
+    return root;
+}
+
+pub const FixedSplit = struct {
+    primary: vxfw.Widget,
+    secondary: vxfw.Widget,
+    split_at: u16,
+    direction: enum { horizontal, vertical },
+    background: vaxis.Color,
+
+    pub fn widget(self: *const FixedSplit) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = fixedSplitTypeErasedDrawFn,
+        };
+    }
+
+    fn fixedSplitTypeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const FixedSplit = @ptrCast(@alignCast(ptr));
+        const size = ctx.max.size();
+        var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        d.fillSurface(&root, self.background);
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
+        switch (self.direction) {
+            .horizontal => {
+                const left_ctx = ctx.withConstraints(
+                    .{ .width = 0, .height = 0 },
+                    .{ .width = self.split_at, .height = size.height },
+                );
+                const right_col: i17 = @as(i17, @intCast(self.split_at)) + 1;
+                const right_w = size.width -| @as(u16, @intCast(right_col));
+                const right_ctx = ctx.withConstraints(
+                    .{ .width = 0, .height = 0 },
+                    .{ .width = right_w, .height = size.height },
+                );
+                children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.primary.draw(left_ctx) };
+                children[1] = .{ .origin = .{ .row = 0, .col = right_col }, .surface = try self.secondary.draw(right_ctx) };
+            },
+            .vertical => {
+                const top_ctx = ctx.withConstraints(
+                    .{ .width = 0, .height = 0 },
+                    .{ .width = size.width, .height = self.split_at },
+                );
+                const bot_row: i17 = @as(i17, @intCast(self.split_at)) + 1;
+                const bot_h = size.height -| @as(u16, @intCast(bot_row));
+                const bot_ctx = ctx.withConstraints(
+                    .{ .width = 0, .height = 0 },
+                    .{ .width = size.width, .height = bot_h },
+                );
+                children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = try self.primary.draw(top_ctx) };
+                children[1] = .{ .origin = .{ .row = bot_row, .col = 0 }, .surface = try self.secondary.draw(bot_ctx) };
+            },
+        }
+        root.children = children;
+        return root;
+    }
+};

--- a/src/client/tui/widgets/modal.zig
+++ b/src/client/tui/widgets/modal.zig
@@ -1,17 +1,11 @@
-//! Modal widget: a centered (or anchored) overlay dialog with border, title,
-//! and footer. Renders a dimmed full-screen backdrop with a foreground box.
-//! Callers write content into the returned inner surface area.
 const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 const theme = @import("../theme.zig");
-const w = @import("../widgets.zig");
+const d = @import("draw.zig");
 
 pub const Anchor = enum { center, bottom_right };
 
-/// Modal overlay configuration. After calling `draw()`, write content into the
-/// returned surface starting at (content_col, content_row) — these are the
-/// absolute coordinates of the first usable cell inside the box.
 pub const Modal = struct {
     title: []const u8,
     box_width: u16,
@@ -20,8 +14,6 @@ pub const Modal = struct {
     footer: []const u8 = "",
     anchor: Anchor = .center,
 
-    /// Result of draw(): the full overlay surface plus the coordinates where
-    /// callers should start writing content.
     pub const DrawResult = struct {
         surface: vxfw.Surface,
         content_col: u16,
@@ -31,7 +23,7 @@ pub const Modal = struct {
     pub fn draw(self: *const Modal, ctx: vxfw.DrawContext, owner: vxfw.Widget) std.mem.Allocator.Error!DrawResult {
         const size = ctx.max.size();
         var surface = try vxfw.Surface.init(ctx.arena, owner, size);
-        w.fillSurface(&surface, theme.PANEL);
+        d.fillSurface(&surface, theme.PANEL);
 
         const start_col: u16 = switch (self.anchor) {
             .center => (size.width -| self.box_width) / 2,
@@ -42,7 +34,6 @@ pub const Modal = struct {
             .bottom_right => size.height -| self.box_height -| 1,
         };
 
-        // Fill box background
         var row: u16 = 0;
         while (row < self.box_height) : (row += 1) {
             var col: u16 = 0;
@@ -54,7 +45,6 @@ pub const Modal = struct {
             }
         }
 
-        // Rounded border
         const s = vaxis.Style{ .fg = self.border_color, .bg = theme.PANEL_ALT };
         surface.writeCell(start_col, start_row, .{ .char = .{ .grapheme = "\xe2\x95\xad", .width = 1 }, .style = s });
         surface.writeCell(start_col + self.box_width - 1, start_row, .{ .char = .{ .grapheme = "\xe2\x95\xae", .width = 1 }, .style = s });
@@ -71,13 +61,11 @@ pub const Modal = struct {
             surface.writeCell(start_col + self.box_width - 1, start_row + r, .{ .char = .{ .grapheme = "\xe2\x94\x82", .width = 1 }, .style = s });
         }
 
-        // Title
         const title_text = try std.fmt.allocPrint(ctx.arena, " {s} ", .{self.title});
-        w.writeText(&surface, ctx, start_col + 2, start_row, title_text, theme.boldOn(theme.PANEL_ALT, self.border_color));
+        d.writeText(&surface, ctx, start_col + 2, start_row, title_text, theme.boldOn(theme.PANEL_ALT, self.border_color));
 
-        // Footer
         if (self.footer.len > 0) {
-            w.writeText(&surface, ctx, start_col + 2, start_row + self.box_height - 1, self.footer, theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT));
+            d.writeText(&surface, ctx, start_col + 2, start_row + self.box_height - 1, self.footer, theme.textOn(theme.PANEL_ALT, theme.TEXT_SOFT));
         }
 
         return .{

--- a/src/client/tui/widgets/panel.zig
+++ b/src/client/tui/widgets/panel.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+
+// Wraps an already-rendered Surface into a Widget for passing to containers.
+pub const SurfaceWidget = struct {
+    surface: vxfw.Surface,
+    widget_ref: vxfw.Widget,
+
+    pub fn widget(self: *const SurfaceWidget) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, _: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const SurfaceWidget = @ptrCast(@alignCast(ptr));
+        var surface = self.surface;
+        surface.widget = self.widget_ref;
+        return surface;
+    }
+};
+
+// Wraps a widget reference with stable identity for containers that need it.
+pub const WidgetBox = struct {
+    widget_ref: vxfw.Widget,
+
+    pub fn widget(self: *const WidgetBox) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const WidgetBox = @ptrCast(@alignCast(ptr));
+        var surface = try self.widget_ref.draw(ctx);
+        surface.widget = self.widget();
+        return surface;
+    }
+};
+
+// Reusable bordered panel with title, subtitle, padding, and child widget.
+pub const Panel = struct {
+    title: []const u8,
+    subtitle: []const u8 = "",
+    background: vaxis.Color,
+    border_color: vaxis.Color,
+    child: vxfw.Widget,
+    padding: Padding = .{},
+
+    pub const Padding = struct {
+        left: u16 = 0,
+        right: u16 = 0,
+        top: u16 = 0,
+        bottom: u16 = 0,
+    };
+
+    pub fn widget(self: *const Panel) vxfw.Widget {
+        return .{
+            .userdata = @constCast(self),
+            .drawFn = typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *const Panel = @ptrCast(@alignCast(ptr));
+        return draw(self, ctx);
+    }
+
+    fn draw(self: *const Panel, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const size = ctx.max.size();
+        var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+        d.fillSurface(&surface, self.background);
+        d.drawBorder(&surface, self.border_color, self.background);
+
+        // Title takes priority. Subtitle only renders if enough space
+        // remains after title + 2 cell gap. Prevents overlap on narrow panels.
+        const title_w: u16 = @intCast(ctx.stringWidth(self.title));
+        d.writeText(&surface, ctx, 2, 0, self.title, theme.boldOn(self.background, theme.TEXT));
+        if (self.subtitle.len > 0) {
+            const sub_w: u16 = @intCast(ctx.stringWidth(self.subtitle));
+            const title_end = 2 + title_w + 2;
+            const sub_start = size.width -| sub_w -| 1;
+            if (sub_start > title_end) {
+                d.writeRightText(&surface, ctx, 0, self.subtitle, theme.textOn(self.background, theme.MUTED));
+            }
+        }
+
+        const inner_width = size.width -| 2 -| self.padding.left -| self.padding.right;
+        const inner_height = size.height -| 2 -| self.padding.top -| self.padding.bottom;
+        const child_ctx = ctx.withConstraints(
+            .{ .width = inner_width, .height = inner_height },
+            .{ .width = inner_width, .height = inner_height },
+        );
+        const child_surface = try self.child.draw(child_ctx);
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        children[0] = .{
+            .origin = .{
+                .row = 1 + self.padding.top,
+                .col = 1 + self.padding.left,
+            },
+            .surface = child_surface,
+        };
+        surface.children = children;
+        return surface;
+    }
+};

--- a/src/client/tui/widgets/text_input.zig
+++ b/src/client/tui/widgets/text_input.zig
@@ -1,17 +1,14 @@
-//! TextInput widget: single-line text entry with cursor indicator.
-//! Handles character input, backspace, and reports Enter/Esc to the caller
-//! via the Result enum. Follows the vxfw Widget protocol.
 const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 const theme = @import("../theme.zig");
-const w = @import("../widgets.zig");
+const d = @import("draw.zig");
 
-pub const Result = enum {
-    consumed, // Character appended or deleted
-    submit, // Enter pressed
-    cancel, // Esc pressed
-    ignored, // Unrecognized key
+pub const TextInputResult = enum {
+    consumed,
+    submit,
+    cancel,
+    ignored,
 };
 
 pub const TextInput = struct {
@@ -19,9 +16,7 @@ pub const TextInput = struct {
     len: *usize,
     bg: vaxis.Color = theme.PANEL_ALT,
 
-    /// Process a key press. Returns what happened so the caller can act on
-    /// submit/cancel without needing to re-check the key.
-    pub fn handleKey(self: *TextInput, key: vaxis.Key) Result {
+    pub fn handleKey(self: *TextInput, key: vaxis.Key) TextInputResult {
         if (key.matches(vaxis.Key.enter, .{})) return .submit;
         if (key.matches(vaxis.Key.escape, .{})) return .cancel;
         if (key.matches(vaxis.Key.backspace, .{})) {
@@ -44,8 +39,6 @@ pub const TextInput = struct {
         return .ignored;
     }
 
-    /// Render the input text + cursor underscore at (col, row) on the surface.
-    /// Scrolls the visible window if text overflows the available width.
     pub fn drawOnSurface(
         self: *const TextInput,
         surface: *vxfw.Surface,
@@ -59,10 +52,9 @@ pub const TextInput = struct {
         const visible_start = if (text.len > max_visible) text.len - max_visible else 0;
         const visible = text[visible_start..];
         const display = std.fmt.allocPrint(ctx.arena, "{s}_", .{visible}) catch return;
-        w.writeText(surface, ctx, col, row, display, .{ .fg = theme.TEXT, .bg = self.bg });
+        d.writeText(surface, ctx, col, row, display, .{ .fg = theme.TEXT, .bg = self.bg });
     }
 
-    /// Clear the input buffer.
     pub fn clear(self: *TextInput) void {
         self.len.* = 0;
     }
@@ -73,7 +65,7 @@ test "TextInput handleKey appends printable characters" {
     var len: usize = 0;
     var input = TextInput{ .buf = &buf, .len = &len };
     const key_a = vaxis.Key{ .codepoint = 'a' };
-    try std.testing.expectEqual(Result.consumed, input.handleKey(key_a));
+    try std.testing.expectEqual(TextInputResult.consumed, input.handleKey(key_a));
     try std.testing.expectEqual(@as(usize, 1), len);
     try std.testing.expectEqual(@as(u8, 'a'), buf[0]);
 }
@@ -83,7 +75,7 @@ test "TextInput handleKey reports submit on Enter" {
     var len: usize = 0;
     var input = TextInput{ .buf = &buf, .len = &len };
     const key_enter = vaxis.Key{ .codepoint = vaxis.Key.enter };
-    try std.testing.expectEqual(Result.submit, input.handleKey(key_enter));
+    try std.testing.expectEqual(TextInputResult.submit, input.handleKey(key_enter));
 }
 
 test "TextInput handleKey reports cancel on Esc" {
@@ -91,7 +83,7 @@ test "TextInput handleKey reports cancel on Esc" {
     var len: usize = 0;
     var input = TextInput{ .buf = &buf, .len = &len };
     const key_esc = vaxis.Key{ .codepoint = vaxis.Key.escape };
-    try std.testing.expectEqual(Result.cancel, input.handleKey(key_esc));
+    try std.testing.expectEqual(TextInputResult.cancel, input.handleKey(key_esc));
 }
 
 test "TextInput clear resets length" {


### PR DESCRIPTION
## Summary

Split `widgets.zig` (which mixed drawing primitives, widget structs, domain
helpers, and chart rendering in one file) into individual component files
under `widgets/`, with `widgets.zig` as a re-export surface. Each component
(Badge, Panel, Modal, TextInput, FixedSplit, EmptyState, chart, cursor)
now owns its own file and imports only the draw primitives it needs.

Remove unused `widget()` + `typeErasedDrawFn` boilerplate from Modal and
TextInput (zero callers), restore `Modal.draw(ctx, owner)` pattern. Move
`focusBorder` to `theme.zig`. Extract `draftRowStyle`, `writeDraftMarker`,
and `writeHeaderRightIfFits` as shared helpers, unifying the duplicated
master-detail UI primitives between library and workspace panels. Delete
dead code (drawTabBar, drawActivityBar, drawHeatmap, splitVertical). Add
unit tests for Badge, draftRowStyle, and writeHeaderRightIfFits.

Also update README to list `memory.reject` and propose tools in the MCP
runtime description.

Closes #82.

## Test plan

- [ ] `zig build && zig build test` pass
- [ ] Visual TUI verification: all panels render correctly (workspace list, library tree, prompt detail, settings, dashboard chart)
- [ ] Modal overlays work (create workspace, PR composer, help overlay)
- [ ] TextInput fields work (workspace name input, bundle selection)