### PR TITLE
rename: replace domain concept "prompt" with "rule" across the full stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ https://github.com/user-attachments/assets/3ae8473c-dac1-45b5-8a72-6ad21906f235
 
 ## What is in the repo
 
-**Hub server.** The single source of truth. Manages prompt libraries, workspace manifests, context, collaboration workflows, and attestation aggregation — all behind a REST API that every client talks to.
+**Hub server.** The single source of truth. Manages rule libraries, workspace manifests, context, collaboration workflows, and attestation aggregation — all behind a REST API that every client talks to.
 
 **CLI.** Your local command surface. Login, workspace binding, cache sync, adapter install/remove, attestation flush, and TUI entry point.
 
-**MCP runtime.** How agents talk to clumsies. Exposes `memory.setup`, `memory.search`, `memory.load`, `memory.refer`, `memory.submit`, and `memory.reject` — each call automatically produces an attestation event. Agents can also propose changes via `context.propose_create/update/rename/delete` (workspace context) and `prompt.propose_create/update/rename/delete` (library rules).
+**MCP runtime.** How agents talk to clumsies. Exposes `memory.setup`, `memory.search`, `memory.load`, `memory.refer`, `memory.submit`, and `memory.reject` — each call automatically produces an attestation event. Agents can also propose changes via `context.propose_create/update/rename/delete` (workspace context) and `rule.propose_create/update/rename/delete` (library rules).
 
 **Adapter layer.** Bridges your rules to agent runtimes without vendor lock-in. Currently supports Claude Code and Codex. Cursor, Windsurf, Copilot, Cline, Kimi Code, Qwen Code, and OpenCode coming soon.
 

--- a/assets/adapters/claude-code/runtime/skills/search/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/search/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: search
-description: Discover available prompts in the Library
+description: Discover available rules in the Library
 argument-hint: "[-k rule|workflow|context] [-g group]"
 user-invocable: true
 ---
-Call the `memory.search` MCP tool to discover available prompts.
+Call the `memory.search` MCP tool to discover available rules.
 
 $ARGUMENTS

--- a/assets/adapters/codex/runtime/skills/search/SKILL.md
+++ b/assets/adapters/codex/runtime/skills/search/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: search
-description: Discover available prompts in the Library
+description: Discover available rules in the Library
 argument-hint: "[-k rule|workflow|context] [-g group]"
 user-invocable: true
 ---
-Call the `memory.search` MCP tool to discover available prompts.
+Call the `memory.search` MCP tool to discover available rules.
 
 $ARGUMENTS

--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -1,4 +1,4 @@
-//! Workflow skill import. Scans the workspace's cached workflow prompts and generates SKILL.md
+//! Workflow skill import. Scans the workspace's cached workflow rules and generates SKILL.md
 //! files that agent hooks can invoke as slash commands (e.g., /commit, /review-pr).
 const model = @import("model.zig");
 const std = @import("std");

--- a/src/client/attestation.zig
+++ b/src/client/attestation.zig
@@ -36,10 +36,10 @@ pub const AttestationEvent = struct {
         context_propose_update: ProposeUpdatePayload,
         context_propose_rename: ProposeRenamePayload,
         context_propose_delete: ProposeDeletePayload,
-        prompt_propose_create: ProposeCreatePayload,
-        prompt_propose_update: ProposeUpdatePayload,
-        prompt_propose_rename: ProposeRenamePayload,
-        prompt_propose_delete: ProposeDeletePayload,
+        rule_propose_create: ProposeCreatePayload,
+        rule_propose_update: ProposeUpdatePayload,
+        rule_propose_rename: ProposeRenamePayload,
+        rule_propose_delete: ProposeDeletePayload,
     };
 
     pub const UserPromptPayload = struct {
@@ -48,13 +48,13 @@ pub const AttestationEvent = struct {
     };
 
     pub const LoadPayload = struct {
-        prompt_id: []const u8,
-        prompt_hash: []const u8,
+        rule_id: []const u8,
+        rule_hash: []const u8,
     };
 
     pub const ReferPayload = struct {
-        prompt_id: []const u8,
-        prompt_hash: ?[]const u8 = null,
+        rule_id: []const u8,
+        rule_hash: ?[]const u8 = null,
         constraint_id: []const u8,
         reason: ?[]const u8 = null,
     };
@@ -99,10 +99,10 @@ pub fn payloadTypeTag(payload: AttestationEvent.Payload) []const u8 {
         .context_propose_update => "context_propose_update",
         .context_propose_rename => "context_propose_rename",
         .context_propose_delete => "context_propose_delete",
-        .prompt_propose_create => "prompt_propose_create",
-        .prompt_propose_update => "prompt_propose_update",
-        .prompt_propose_rename => "prompt_propose_rename",
-        .prompt_propose_delete => "prompt_propose_delete",
+        .rule_propose_create => "rule_propose_create",
+        .rule_propose_update => "rule_propose_update",
+        .rule_propose_rename => "rule_propose_rename",
+        .rule_propose_delete => "rule_propose_delete",
     };
 }
 
@@ -212,12 +212,12 @@ fn serializeAttestationEvent(allocator: std.mem.Allocator, event: AttestationEve
             try writeOptionalString(allocator, &buf, "content_hash", p.content_hash);
         },
         .load => |p| {
-            try writeOptionalString(allocator, &buf, "prompt_id", p.prompt_id);
-            try writeOptionalString(allocator, &buf, "prompt_hash", p.prompt_hash);
+            try writeOptionalString(allocator, &buf, "rule_id", p.rule_id);
+            try writeOptionalString(allocator, &buf, "rule_hash", p.rule_hash);
         },
         .refer => |p| {
-            try writeOptionalString(allocator, &buf, "prompt_id", p.prompt_id);
-            try writeOptionalString(allocator, &buf, "prompt_hash", p.prompt_hash);
+            try writeOptionalString(allocator, &buf, "rule_id", p.rule_id);
+            try writeOptionalString(allocator, &buf, "rule_hash", p.rule_hash);
             try writeOptionalString(allocator, &buf, "constraint_id", p.constraint_id);
             try writeOptionalString(allocator, &buf, "reason", p.reason);
         },
@@ -242,18 +242,18 @@ fn serializeAttestationEvent(allocator: std.mem.Allocator, event: AttestationEve
         .context_propose_delete => |p| {
             try writeOptionalString(allocator, &buf, "context_id", p.id);
         },
-        .prompt_propose_create => |p| {
+        .rule_propose_create => |p| {
             try writeOptionalString(allocator, &buf, "path", p.path);
         },
-        .prompt_propose_update => |p| {
-            try writeOptionalString(allocator, &buf, "prompt_id", p.id);
+        .rule_propose_update => |p| {
+            try writeOptionalString(allocator, &buf, "rule_id", p.id);
         },
-        .prompt_propose_rename => |p| {
-            try writeOptionalString(allocator, &buf, "prompt_id", p.id);
+        .rule_propose_rename => |p| {
+            try writeOptionalString(allocator, &buf, "rule_id", p.id);
             try writeOptionalString(allocator, &buf, "new_path", p.new_path);
         },
-        .prompt_propose_delete => |p| {
-            try writeOptionalString(allocator, &buf, "prompt_id", p.id);
+        .rule_propose_delete => |p| {
+            try writeOptionalString(allocator, &buf, "rule_id", p.id);
         },
     }
 
@@ -282,7 +282,7 @@ test "serializeAttestationEvent: refer event with all fields" {
         .ts = 1743753000000,
         .payload = .{
             .refer = .{
-                .prompt_id = "p-550e8400",
+                .rule_id = "p-550e8400",
                 .constraint_id = "c-2",
                 .reason = "applying style",
             },
@@ -295,7 +295,7 @@ test "serializeAttestationEvent: refer event with all fields" {
     try testing.expect(std.mem.indexOf(u8, line, "\"event_id\":3") != null);
     try testing.expect(std.mem.indexOf(u8, line, "\"type\":\"refer\"") != null);
     try testing.expect(std.mem.indexOf(u8, line, "\"timestamp\":1743753000000") != null);
-    try testing.expect(std.mem.indexOf(u8, line, "\"prompt_id\":\"p-550e8400\"") != null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"rule_id\":\"p-550e8400\"") != null);
     try testing.expect(std.mem.indexOf(u8, line, "\"constraint_id\":\"c-2\"") != null);
     try testing.expect(std.mem.indexOf(u8, line, "\"reason\":\"applying style\"") != null);
     try testing.expect(std.mem.endsWith(u8, line, "}\n"));
@@ -311,7 +311,7 @@ test "serializeAttestationEvent: setup omits payload fields" {
     };
     const line = try serializeAttestationEvent(testing.allocator, event);
     defer testing.allocator.free(line);
-    try testing.expect(std.mem.indexOf(u8, line, "\"prompt_id\"") == null);
+    try testing.expect(std.mem.indexOf(u8, line, "\"rule_id\"") == null);
     try testing.expect(std.mem.indexOf(u8, line, "\"constraint_id\"") == null);
     try testing.expect(std.mem.indexOf(u8, line, "\"type\":\"setup\"") != null);
 }

--- a/src/client/commands/adapt_cmd.zig
+++ b/src/client/commands/adapt_cmd.zig
@@ -107,9 +107,9 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
                 );
                 return;
             }
-            const prompt = try std.fmt.allocPrint(allocator, "A {s} adapter install is already active here. Apply an update?", .{pkg.display_name});
-            defer allocator.free(prompt);
-            is_update = try adapter.ui.promptYesNo(stdout, allocator, prompt, true);
+            const rule = try std.fmt.allocPrint(allocator, "A {s} adapter install is already active here. Apply an update?", .{pkg.display_name});
+            defer allocator.free(rule);
+            is_update = try adapter.ui.promptYesNo(stdout, allocator, rule, true);
             if (!is_update) {
                 try stdout.print("{s}{s}Cancelled.{s} No files were written.\n", .{ P, Color.dim, Color.reset });
                 return;
@@ -216,8 +216,8 @@ fn chooseScope(
         count += 1;
     }
 
-    const prompt = "Where should Clumsies be installed?";
-    const index = try adapter.ui.promptChoice(stdout, allocator, prompt, choices[0..count], 0);
+    const rule = "Where should Clumsies be installed?";
+    const index = try adapter.ui.promptChoice(stdout, allocator, rule, choices[0..count], 0);
 
     return if (workspace_target_root_opt != null and index == 0) .workspace else .user;
 }

--- a/src/client/commands/adapter_cli.zig
+++ b/src/client/commands/adapter_cli.zig
@@ -52,7 +52,7 @@ pub fn defaultPackageOrPrint(stderr: *std.Io.Writer) ?adapter.packages.AdapterPa
 pub fn choosePackage(
     stdout: *std.Io.Writer,
     allocator: std.mem.Allocator,
-    prompt: []const u8,
+    rule: []const u8,
 ) !adapter.packages.AdapterPackage {
     const all_packages = adapter.packages.all();
     if (all_packages.len == 0) return error.NoAdapterPackages;
@@ -68,7 +68,7 @@ pub fn choosePackage(
         };
     }
 
-    const index = try adapter.ui.promptChoice(stdout, allocator, prompt, choices, 0);
+    const index = try adapter.ui.promptChoice(stdout, allocator, rule, choices, 0);
     return all_packages[index];
 }
 

--- a/src/client/commands/adapter_cli.zig
+++ b/src/client/commands/adapter_cli.zig
@@ -52,7 +52,7 @@ pub fn defaultPackageOrPrint(stderr: *std.Io.Writer) ?adapter.packages.AdapterPa
 pub fn choosePackage(
     stdout: *std.Io.Writer,
     allocator: std.mem.Allocator,
-    rule: []const u8,
+    prompt: []const u8,
 ) !adapter.packages.AdapterPackage {
     const all_packages = adapter.packages.all();
     if (all_packages.len == 0) return error.NoAdapterPackages;
@@ -68,7 +68,7 @@ pub fn choosePackage(
         };
     }
 
-    const index = try adapter.ui.promptChoice(stdout, allocator, rule, choices, 0);
+    const index = try adapter.ui.promptChoice(stdout, allocator, prompt, choices, 0);
     return all_packages[index];
 }
 

--- a/src/client/commands/attestation_append_cmd.zig
+++ b/src/client/commands/attestation_append_cmd.zig
@@ -106,9 +106,9 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     else if (std.mem.eql(u8, event_type, "search"))
         .search
     else if (std.mem.eql(u8, event_type, "load"))
-        .search // CLI hook doesn't carry prompt_id; fallback to void variant
+        .search // CLI hook doesn't carry rule_id; fallback to void variant
     else if (std.mem.eql(u8, event_type, "refer"))
-        .search // CLI hook doesn't carry prompt_id/constraint_id; fallback to void variant
+        .search // CLI hook doesn't carry rule_id/constraint_id; fallback to void variant
     else if (std.mem.eql(u8, event_type, "agent_report"))
         .search // CLI hook doesn't carry summary; fallback to void variant
     else

--- a/src/client/commands/login_cmd.zig
+++ b/src/client/commands/login_cmd.zig
@@ -70,7 +70,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     };
     defer allocator.free(hub_url);
 
-    // Get username: from flag or rule interactively
+    // Get username: from flag or prompt interactively
     const username_from_prompt: ?[]const u8 = if (result.value(1) != null) null else blk: {
         try stderr.print("{s}Username: ", .{P});
         try stderr.flush();

--- a/src/client/commands/login_cmd.zig
+++ b/src/client/commands/login_cmd.zig
@@ -70,7 +70,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     };
     defer allocator.free(hub_url);
 
-    // Get username: from flag or prompt interactively
+    // Get username: from flag or rule interactively
     const username_from_prompt: ?[]const u8 = if (result.value(1) != null) null else blk: {
         try stderr.print("{s}Username: ", .{P});
         try stderr.flush();

--- a/src/client/commands/setup_cmd.zig
+++ b/src/client/commands/setup_cmd.zig
@@ -20,7 +20,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     if (cache_path) |cp| {
         defer allocator.free(cp);
-        const mpf_path = std.fs.path.join(allocator, &.{ cp, "prompt", "META_PROMPT.md" }) catch return;
+        const mpf_path = std.fs.path.join(allocator, &.{ cp, "rule", "META_PROMPT.md" }) catch return;
         defer allocator.free(mpf_path);
 
         const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return;

--- a/src/client/commands/setup_cmd.zig
+++ b/src/client/commands/setup_cmd.zig
@@ -20,7 +20,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     if (cache_path) |cp| {
         defer allocator.free(cp);
-        const mpf_path = std.fs.path.join(allocator, &.{ cp, "rule", "META_PROMPT.md" }) catch return;
+        const mpf_path = std.fs.path.join(allocator, &.{ cp, "META_PROMPT.md" }) catch return;
         defer allocator.free(mpf_path);
 
         const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return;

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -15,7 +15,7 @@ const P = styles.P;
 
 /// Must stay ≤ the hub-side cap (`BATCH_MAX_IDS` / `BATCH_MAX_PATHS`
 /// in src/hub/library.zig and context.zig). Oversized batches
-/// currently 400 with "too many prompt_ids" / "too many paths";
+/// currently 400 with "too many rule_ids" / "too many paths";
 /// chunking here keeps sync working on workspaces with more than
 /// that many changed entries.
 const BATCH_CHUNK_SIZE: usize = 1024;
@@ -126,8 +126,8 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     // batch fetch below — it is just accounted for separately in
     // the human-readable output.
     var mpf_status: enum { absent, unchanged, to_fetch } = .absent;
-    for (manifest.prompts.items) |entry| {
-        const prompt_id = entry.key;
+    for (manifest.rules.items) |entry| {
+        const rule_id = entry.key;
         const prompt_path = entry.value.path;
         const remote_hash = stripHashPrefix(entry.value.hash);
         const matches = try localFileMatchesHash(allocator, cache_dir, cacheSubDirForPromptPath(prompt_path), prompt_path, remote_hash);
@@ -137,8 +137,8 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
             if (!is_mpf) prompt_skipped += 1;
             continue;
         }
-        try prompts_to_fetch.append(allocator, prompt_id);
-        try prompts_path_for_id.put(allocator, prompt_id, prompt_path);
+        try prompts_to_fetch.append(allocator, rule_id);
+        try prompts_path_for_id.put(allocator, rule_id, prompt_path);
         if (!is_mpf) regular_prompts_to_fetch += 1;
     }
 
@@ -194,10 +194,10 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 
     // MPF is intentionally excluded from `prompt_skipped` so the
     // "Prompts" line only reports regular rules + workflows. Re-add
-    // it to the final prompt_count when MPF was unchanged this sync
+    // it to the final rule_count when MPF was unchanged this sync
     // so the totals still reflect every manifest entry.
     const mpf_in_unchanged: usize = if (mpf_status == .unchanged) 1 else 0;
-    const prompt_count = prompt_fetched + prompt_skipped + mpf_in_unchanged;
+    const rule_count = prompt_fetched + prompt_skipped + mpf_in_unchanged;
     const context_count = context_fetched + context_skipped;
 
     // Write manifest.json to cache
@@ -215,41 +215,41 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 
     const reconcile = drafts_mod.reconcileDrafts(allocator, ws_dir, cache_dir) catch drafts_mod.ReconcileSummary{};
-    const skipped_suffix = try std.fmt.allocPrint(allocator, " ({d} prompts + {d} context unchanged)", .{ prompt_skipped, context_skipped });
+    const skipped_suffix = try std.fmt.allocPrint(allocator, " ({d} rules + {d} context unchanged)", .{ prompt_skipped, context_skipped });
     defer allocator.free(skipped_suffix);
     const skipped_note: []const u8 = if (prompt_skipped + context_skipped > 0) skipped_suffix else "";
     if (reconcile.conflicted > 0) {
-        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files{s}, {d} drafts flagged conflicted\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count, skipped_note, reconcile.conflicted });
+        try stdout.print("{s}{s}{s}Synced:{s} {d} rules, {d} context files{s}, {d} drafts flagged conflicted\n", .{ P, Color.bold, Color.green, Color.reset, rule_count, context_count, skipped_note, reconcile.conflicted });
     } else {
-        try stdout.print("{s}{s}{s}Synced:{s} {d} prompts, {d} context files{s}\n", .{ P, Color.bold, Color.green, Color.reset, prompt_count, context_count, skipped_note });
+        try stdout.print("{s}{s}{s}Synced:{s} {d} rules, {d} context files{s}\n", .{ P, Color.bold, Color.green, Color.reset, rule_count, context_count, skipped_note });
     }
 }
 
-/// Batch-fetch prompt bodies in a single POST. Per-item errors from
+/// Batch-fetch rule bodies in a single POST. Per-item errors from
 /// the Hub response and local write failures are printed to stderr
 /// so the user can tell why a "46 of 46" manifest only produced
-/// "44 written"; the overall return value is the count of prompts
+/// "44 written"; the overall return value is the count of rules
 /// successfully written to cache.
 fn fetchPromptsBatch(
     allocator: std.mem.Allocator,
     hub: *HubClient,
     stderr: *std.Io.Writer,
     cache_dir: []const u8,
-    prompt_ids: []const []const u8,
+    rule_ids: []const []const u8,
     path_for_id: *const std.StringHashMapUnmanaged([]const u8),
 ) !usize {
     const body_json = try std.json.Stringify.valueAlloc(
         allocator,
-        library_api.BatchPromptContentRequest{ .prompt_ids = prompt_ids },
+        library_api.BatchRuleContentRequest{ .rule_ids = rule_ids },
         .{},
     );
     defer allocator.free(body_json);
 
-    const resp = try hub.post("/api/org/library/prompts/content", body_json);
+    const resp = try hub.post("/api/org/library/rules/content", body_json);
     defer resp.deinit();
     if (resp.status != .ok) return error.BatchFetchFailed;
 
-    const parsed = try std.json.parseFromSlice(library_api.BatchPromptContentResponse, allocator, resp.body, .{
+    const parsed = try std.json.parseFromSlice(library_api.BatchRuleContentResponse, allocator, resp.body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     });
@@ -258,7 +258,7 @@ fn fetchPromptsBatch(
     var written: usize = 0;
     for (parsed.value.items) |item| {
         if (item.@"error".len > 0) {
-            try stderr.print("  ! prompt {s}: {s}\n", .{ item.prompt_id, item.@"error" });
+            try stderr.print("  ! rule {s}: {s}\n", .{ item.rule_id, item.@"error" });
             continue;
         }
         // Prefer the path the server reports (authoritative) but fall
@@ -268,12 +268,12 @@ fn fetchPromptsBatch(
         const target_path = if (item.path.len > 0)
             item.path
         else
-            path_for_id.get(item.prompt_id) orelse {
-                try stderr.print("  ! prompt {s}: missing path in response\n", .{item.prompt_id});
+            path_for_id.get(item.rule_id) orelse {
+                try stderr.print("  ! rule {s}: missing path in response\n", .{item.rule_id});
                 continue;
             };
         writeToCache(allocator, cache_dir, cacheSubDirForPromptPath(target_path), target_path, item.body) catch |err| {
-            try stderr.print("  ! prompt {s}: write failed ({s})\n", .{ target_path, @errorName(err) });
+            try stderr.print("  ! rule {s}: write failed ({s})\n", .{ target_path, @errorName(err) });
             continue;
         };
         written += 1;
@@ -281,14 +281,14 @@ fn fetchPromptsBatch(
     return written;
 }
 
-/// Decide the cache subdirectory a given library prompt path writes
+/// Decide the cache subdirectory a given library rule path writes
 /// to. Reserved top-level names (`META_PROMPT.md`) land at the cache
-/// root so loaders can read them without knowing the prompt
-/// namespace layout. Everything else lives under `cache/prompt/` so
-/// the prompt namespace cannot collide with context.
+/// root so loaders can read them without knowing the rule
+/// namespace layout. Everything else lives under `cache/rule/` so
+/// the rule namespace cannot collide with context.
 fn cacheSubDirForPromptPath(prompt_path: []const u8) []const u8 {
     if (std.mem.eql(u8, prompt_path, "META_PROMPT.md")) return "";
-    return "prompt";
+    return "rule";
 }
 
 /// Batch-fetch context file bodies. Mirrors `fetchPromptsBatch` but
@@ -391,7 +391,7 @@ fn writeToCache(allocator: std.mem.Allocator, ws_cache_dir: []const u8, sub_dir:
     const dir_path = try std.fs.path.join(allocator, &.{ ws_cache_dir, sub_dir });
     defer allocator.free(dir_path);
 
-    // Ensure the namespace subdirectory exists (cache/prompt or
+    // Ensure the namespace subdirectory exists (cache/rule or
     // cache/context). `makeDirAbsolute` is the absolute-safe single-
     // level creator; the cache root above it is created by the
     // caller's `ensureDir(cache_dir)` before the loops start.
@@ -439,7 +439,7 @@ fn percentEncode(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
 
 fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}Usage: {s}clumsies sync{s}\n", .{ P, Color.cyan, Color.reset });
-    try out.print("{s}Sync workspace prompts and context files from Hub to local cache.\n", .{P});
+    try out.print("{s}Sync workspace rules and context files from Hub to local cache.\n", .{P});
     try out.print("{s}Requires workspace binding (run {s}clumsies init{s} first).\n", .{ P, Color.cyan, Color.reset });
 }
 
@@ -475,18 +475,18 @@ test "cacheSubDirForPromptPath routes META_PROMPT to cache root" {
     try testing.expectEqualStrings("", cacheSubDirForPromptPath("META_PROMPT.md"));
 }
 
-test "cacheSubDirForPromptPath routes regular paths under prompt/" {
-    try testing.expectEqualStrings("prompt", cacheSubDirForPromptPath("coding/STYLE.md"));
-    try testing.expectEqualStrings("prompt", cacheSubDirForPromptPath("workflow/CODING.md"));
+test "cacheSubDirForPromptPath routes regular paths under rule/" {
+    try testing.expectEqualStrings("rule", cacheSubDirForPromptPath("coding/STYLE.md"));
+    try testing.expectEqualStrings("rule", cacheSubDirForPromptPath("workflow/CODING.md"));
 }
 
 test "localFileMatchesHash returns true on hash match" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
+    try tmp.dir.makePath("cache/rule");
     {
-        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        const f = try tmp.dir.createFile("cache/rule/file.md", .{});
         defer f.close();
         try f.writeAll("hello");
     }
@@ -496,7 +496,7 @@ test "localFileMatchesHash returns true on hash match" {
 
     // sha256 of "hello" is 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     const hello_sha = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
-    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", hello_sha);
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "rule", "file.md", hello_sha);
     try testing.expect(matches);
 }
 
@@ -504,9 +504,9 @@ test "localFileMatchesHash returns false on hash mismatch" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
+    try tmp.dir.makePath("cache/rule");
     {
-        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        const f = try tmp.dir.createFile("cache/rule/file.md", .{});
         defer f.close();
         try f.writeAll("hello");
     }
@@ -514,7 +514,7 @@ test "localFileMatchesHash returns false on hash mismatch" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const cache_path = try tmp.dir.realpath("cache", &buf);
 
-    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", "0000000000000000000000000000000000000000000000000000000000000000");
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "rule", "file.md", "0000000000000000000000000000000000000000000000000000000000000000");
     try testing.expect(!matches);
 }
 
@@ -522,12 +522,12 @@ test "localFileMatchesHash returns false when file is missing" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
+    try tmp.dir.makePath("cache/rule");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const cache_path = try tmp.dir.realpath("cache", &buf);
 
-    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "missing.md", "anyhashvalue");
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "rule", "missing.md", "anyhashvalue");
     try testing.expect(!matches);
 }
 
@@ -535,9 +535,9 @@ test "localFileMatchesHash returns false on empty remote hash" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt");
+    try tmp.dir.makePath("cache/rule");
     {
-        const f = try tmp.dir.createFile("cache/prompt/file.md", .{});
+        const f = try tmp.dir.createFile("cache/rule/file.md", .{});
         defer f.close();
         try f.writeAll("hello");
     }
@@ -545,6 +545,6 @@ test "localFileMatchesHash returns false on empty remote hash" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const cache_path = try tmp.dir.realpath("cache", &buf);
 
-    const matches = try localFileMatchesHash(testing.allocator, cache_path, "prompt", "file.md", "");
+    const matches = try localFileMatchesHash(testing.allocator, cache_path, "rule", "file.md", "");
     try testing.expect(!matches);
 }

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -1,5 +1,5 @@
-//! Local drafts: tracks in-progress edits to prompts and context files per workspace. When a
-//! user modifies a Library prompt locally (creating a "local edit"), the draft is stored under
+//! Local drafts: tracks in-progress edits to rules and context files per workspace. When a
+//! user modifies a Library rule locally (creating a "local edit"), the draft is stored under
 //! ~/.clumsies/workspaces/{ws_id}/drafts/ with an index mapping original paths to draft files.
 const std = @import("std");
 const testing = std.testing;
@@ -7,12 +7,12 @@ const path_util = @import("clumsies_lib").util.path_util;
 const util_hash = @import("clumsies_lib").util.hash;
 
 pub const DraftCategory = enum {
-    prompt,
+    rule,
     context,
 
     fn toString(self: DraftCategory) []const u8 {
         return switch (self) {
-            .prompt => "prompt",
+            .rule => "rule",
             .context => "context",
         };
     }
@@ -36,7 +36,7 @@ pub const DraftStatus = enum {
 
 pub const DraftEntry = struct {
     category: DraftCategory,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     context_id: ?[]const u8 = null,
     local_temp_id: ?[]const u8 = null,
     current_path: ?[]const u8 = null,
@@ -115,8 +115,8 @@ pub fn loadIndex(allocator: std.mem.Allocator, ws_dir: []const u8) !DraftsIndex 
 
 fn parseEntry(obj: std.json.ObjectMap) ?DraftEntry {
     const category_str = stringField(obj, "category") orelse return null;
-    const category: DraftCategory = if (std.mem.eql(u8, category_str, "prompt"))
-        .prompt
+    const category: DraftCategory = if (std.mem.eql(u8, category_str, "rule"))
+        .rule
     else if (std.mem.eql(u8, category_str, "context"))
         .context
     else
@@ -154,7 +154,7 @@ fn parseEntry(obj: std.json.ObjectMap) ?DraftEntry {
 
     return .{
         .category = category,
-        .prompt_id = stringField(obj, "prompt_id"),
+        .rule_id = stringField(obj, "rule_id"),
         .context_id = stringField(obj, "context_id"),
         .local_temp_id = stringField(obj, "local_temp_id"),
         .current_path = stringField(obj, "current_path"),
@@ -205,7 +205,7 @@ pub const CreateDraftParams = struct {
     draft_path: []const u8,
     current_path: ?[]const u8 = null,
     base_hash: ?[]const u8 = null,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     context_id: ?[]const u8 = null,
     local_temp_id: ?[]const u8 = null,
     description: ?[]const u8 = null,
@@ -240,7 +240,7 @@ pub fn createDraft(
 
     const new_entry = DraftEntry{
         .category = params.category,
-        .prompt_id = params.prompt_id,
+        .rule_id = params.rule_id,
         .context_id = params.context_id,
         .local_temp_id = params.local_temp_id,
         .current_path = params.current_path,
@@ -338,7 +338,7 @@ pub fn reconcileDrafts(
         const cur = entry.current_path orelse continue;
 
         const rel_dir: []const u8 = switch (entry.category) {
-            .prompt => "prompt",
+            .rule => "rule",
             .context => "context",
         };
         const cache_path = try std.fs.path.join(allocator, &.{ cache_dir, rel_dir, cur });
@@ -465,7 +465,7 @@ fn serializeIndex(allocator: std.mem.Allocator, entries: []const DraftEntry) ![]
         if (i > 0) try buf.appendSlice(allocator, ",");
         try buf.appendSlice(allocator, "\n    {");
         try writeStringField(allocator, &buf, "category", entry.category.toString(), true);
-        try writeOptStringField(allocator, &buf, "prompt_id", entry.prompt_id);
+        try writeOptStringField(allocator, &buf, "rule_id", entry.rule_id);
         try writeOptStringField(allocator, &buf, "context_id", entry.context_id);
         try writeOptStringField(allocator, &buf, "local_temp_id", entry.local_temp_id);
         try writeOptStringField(allocator, &buf, "current_path", entry.current_path);
@@ -564,7 +564,7 @@ test "loadIndex: missing file returns empty index" {
     try testing.expectEqual(@as(usize, 0), index.entries.items.len);
 }
 
-test "loadIndex: parses prompt and context entries" {
+test "loadIndex: parses rule and context entries" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -573,8 +573,8 @@ test "loadIndex: parses prompt and context entries" {
         \\{
         \\  "drafts": [
         \\    {
-        \\      "category": "prompt",
-        \\      "prompt_id": "p-style",
+        \\      "category": "rule",
+        \\      "rule_id": "p-style",
         \\      "current_path": "coding/STYLE.md",
         \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "modify",
@@ -602,9 +602,9 @@ test "loadIndex: parses prompt and context entries" {
 
     try testing.expectEqual(@as(usize, 2), index.entries.items.len);
 
-    const prompt_entry = index.findByCurrentPath(.prompt, "coding/STYLE.md").?;
-    try testing.expectEqual(DraftOperation.modify, prompt_entry.operation);
-    try testing.expectEqualStrings("p-style", prompt_entry.prompt_id.?);
+    const rule_entry = index.findByCurrentPath(.rule, "coding/STYLE.md").?;
+    try testing.expectEqual(DraftOperation.modify, rule_entry.operation);
+    try testing.expectEqualStrings("p-style", rule_entry.rule_id.?);
 
     const ctx_entry = index.findByCurrentPath(.context, "spec/API.md").?;
     try testing.expectEqual(DraftCategory.context, ctx_entry.category);
@@ -636,20 +636,20 @@ test "findByCurrentPath: returns null for unknown path" {
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
 
-    try testing.expect(index.findByCurrentPath(.prompt, "anything") == null);
+    try testing.expect(index.findByCurrentPath(.rule, "anything") == null);
 }
 
 test "readDraftFile: reads from drafts/{category}/{draft_path}" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("drafts/prompt/coding");
-    try writeFile(tmp.dir, "drafts/prompt/coding/STYLE.md", "draft override content");
+    try tmp.dir.makePath("drafts/rule/coding");
+    try writeFile(tmp.dir, "drafts/rule/coding/STYLE.md", "draft override content");
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    const content = try readDraftFile(testing.allocator, root, .prompt, "coding/STYLE.md");
+    const content = try readDraftFile(testing.allocator, root, .rule, "coding/STYLE.md");
     defer testing.allocator.free(content);
 
     try testing.expectEqualStrings("draft override content", content);
@@ -663,24 +663,24 @@ test "createDraft: writes file and index entry round-trip" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "coding/STYLE.md",
         .current_path = "coding/STYLE.md",
         .base_hash = "sha256:abc",
-        .prompt_id = "p-style",
+        .rule_id = "p-style",
     }, "# STYLE modified\n");
 
-    const content = try readDraftFile(testing.allocator, root, .prompt, "coding/STYLE.md");
+    const content = try readDraftFile(testing.allocator, root, .rule, "coding/STYLE.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("# STYLE modified\n", content);
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
     try testing.expectEqual(@as(usize, 1), index.entries.items.len);
-    const entry = index.findByCurrentPath(.prompt, "coding/STYLE.md").?;
+    const entry = index.findByCurrentPath(.rule, "coding/STYLE.md").?;
     try testing.expectEqual(DraftOperation.modify, entry.operation);
-    try testing.expectEqualStrings("p-style", entry.prompt_id.?);
+    try testing.expectEqualStrings("p-style", entry.rule_id.?);
     try testing.expectEqualStrings("sha256:abc", entry.base_hash.?);
     try testing.expectEqual(DraftStatus.editing, entry.status);
 }
@@ -713,18 +713,18 @@ test "createDraft: delete operation does not write a content file" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .delete,
         .draft_path = "old/UNUSED.md",
         .current_path = "old/UNUSED.md",
-        .prompt_id = "p-unused",
+        .rule_id = "p-unused",
     }, "");
 
-    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "old/UNUSED.md"));
+    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .rule, "old/UNUSED.md"));
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
-    const entry = index.findByCurrentPath(.prompt, "old/UNUSED.md").?;
+    const entry = index.findByCurrentPath(.rule, "old/UNUSED.md").?;
     try testing.expectEqual(DraftOperation.delete, entry.operation);
 }
 
@@ -757,15 +757,15 @@ test "discardDraft: removes entry and file" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .create,
         .draft_path = "new/FRESH.md",
         .local_temp_id = "local-1",
     }, "# FRESH\n");
 
-    try discardDraft(testing.allocator, root, .prompt, "new/FRESH.md");
+    try discardDraft(testing.allocator, root, .rule, "new/FRESH.md");
 
-    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .prompt, "new/FRESH.md"));
+    try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .rule, "new/FRESH.md"));
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
@@ -779,7 +779,7 @@ test "discardDraft: idempotent when draft is absent" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    try discardDraft(testing.allocator, root, .prompt, "never/existed.md");
+    try discardDraft(testing.allocator, root, .rule, "never/existed.md");
 }
 
 test "setDraftStatus: transitions editing to ready and back" {
@@ -790,27 +790,27 @@ test "setDraftStatus: transitions editing to ready and back" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "x/Y.md",
         .current_path = "x/Y.md",
-        .prompt_id = "p-y",
+        .rule_id = "p-y",
     }, "draft body\n");
 
-    try setDraftStatus(testing.allocator, root, .prompt, "x/Y.md", .ready);
+    try setDraftStatus(testing.allocator, root, .rule, "x/Y.md", .ready);
 
     {
         var index = try loadIndex(testing.allocator, root);
         defer index.deinit(testing.allocator);
-        const entry = index.findByCurrentPath(.prompt, "x/Y.md").?;
+        const entry = index.findByCurrentPath(.rule, "x/Y.md").?;
         try testing.expectEqual(DraftStatus.ready, entry.status);
     }
 
-    try setDraftStatus(testing.allocator, root, .prompt, "x/Y.md", .editing);
+    try setDraftStatus(testing.allocator, root, .rule, "x/Y.md", .editing);
 
     var index = try loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
-    const entry = index.findByCurrentPath(.prompt, "x/Y.md").?;
+    const entry = index.findByCurrentPath(.rule, "x/Y.md").?;
     try testing.expectEqual(DraftStatus.editing, entry.status);
 }
 
@@ -821,7 +821,7 @@ test "setDraftStatus: returns DraftNotFound for missing draft" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    try testing.expectError(error.DraftNotFound, setDraftStatus(testing.allocator, root, .prompt, "nope.md", .ready));
+    try testing.expectError(error.DraftNotFound, setDraftStatus(testing.allocator, root, .rule, "nope.md", .ready));
 }
 
 test "reconcileDrafts: leaves matching base_hash untouched" {
@@ -834,16 +834,16 @@ test "reconcileDrafts: leaves matching base_hash untouched" {
     const seed = "hello world\n";
     const seed_hash = util_hash.contentHash(seed);
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "coding/A.md",
         .current_path = "coding/A.md",
-        .prompt_id = "p-a",
+        .rule_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/A.md", seed);
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/A.md", seed);
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -866,16 +866,16 @@ test "reconcileDrafts: marks conflicted when cache drifted" {
     const seed = "v1 body\n";
     const seed_hash = util_hash.contentHash(seed);
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "coding/A.md",
         .current_path = "coding/A.md",
-        .prompt_id = "p-a",
+        .rule_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/A.md", "v2 body (someone else merged)\n");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/A.md", "v2 body (someone else merged)\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -896,7 +896,7 @@ test "reconcileDrafts: skips create-operation drafts" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .create,
         .draft_path = "coding/NEW.md",
     }, "brand new\n");
@@ -922,17 +922,17 @@ test "reconcileDrafts: leaves terminal states sticky" {
     const seed = "merged body\n";
     const seed_hash = util_hash.contentHash(seed);
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "coding/A.md",
         .current_path = "coding/A.md",
-        .prompt_id = "p-a",
+        .rule_id = "p-a",
         .base_hash = seed_hash[0..],
     }, seed);
-    try setDraftStatus(testing.allocator, root, .prompt, "coding/A.md", .merged);
+    try setDraftStatus(testing.allocator, root, .rule, "coding/A.md", .merged);
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/A.md", "totally different body\n");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/A.md", "totally different body\n");
 
     const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
     defer testing.allocator.free(cache_dir);
@@ -953,11 +953,11 @@ test "index serialization: multiple entries survive round-trip" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     try createDraft(testing.allocator, root, .{
-        .category = .prompt,
+        .category = .rule,
         .operation = .modify,
         .draft_path = "a/A.md",
         .current_path = "a/A.md",
-        .prompt_id = "p-a",
+        .rule_id = "p-a",
         .base_hash = "sha256:aaa",
     }, "a\n");
     try createDraft(testing.allocator, root, .{

--- a/src/client/main.zig
+++ b/src/client/main.zig
@@ -218,7 +218,7 @@ test {
     _ = @import("batch_upload.zig");
     _ = @import("drafts.zig");
     _ = @import("flags.zig");
-    _ = @import("prompt.zig");
+    _ = @import("rule.zig");
     _ = @import("session_marker.zig");
     _ = @import("attestation.zig");
     _ = @import("workspace_config.zig");

--- a/src/client/mcp/tool_names.zig
+++ b/src/client/mcp/tool_names.zig
@@ -1,5 +1,5 @@
 //! MCP tool name constants (memory.setup/search/load/refer/submit/reject,
-//! context.propose_*/prompt.propose_*). Shared by tools.zig (dispatch),
+//! context.propose_*/rule.propose_*). Shared by tools.zig (dispatch),
 //! tool_result.zig (refer reminder text), and server.zig (instruction string)
 //! to keep tool identity consistent across the protocol.
 pub const setup = "memory.setup";
@@ -14,7 +14,7 @@ pub const context_propose_update = "context.propose_update";
 pub const context_propose_rename = "context.propose_rename";
 pub const context_propose_delete = "context.propose_delete";
 
-pub const prompt_propose_create = "prompt.propose_create";
-pub const prompt_propose_update = "prompt.propose_update";
-pub const prompt_propose_rename = "prompt.propose_rename";
-pub const prompt_propose_delete = "prompt.propose_delete";
+pub const rule_propose_create = "rule.propose_create";
+pub const rule_propose_update = "rule.propose_update";
+pub const rule_propose_rename = "rule.propose_rename";
+pub const rule_propose_delete = "rule.propose_delete";

--- a/src/client/mcp/tool_result.zig
+++ b/src/client/mcp/tool_result.zig
@@ -28,7 +28,7 @@ pub fn buildErrorResult(allocator: std.mem.Allocator, message: []const u8) ![]u8
     );
 }
 
-pub fn serializePromptList(
+pub fn serializeRuleList(
     allocator: std.mem.Allocator,
     items: []const workspace_rule.RuleItem,
 ) ![]u8 {
@@ -38,7 +38,7 @@ pub fn serializePromptList(
     try buf.appendSlice(allocator, "{\"items\":[");
     for (items, 0..) |item, idx| {
         if (idx > 0) try buf.append(allocator, ',');
-        try appendPromptMetadata(allocator, &buf, item);
+        try appendRuleMetadata(allocator, &buf, item);
     }
     try buf.appendSlice(allocator, "]}");
 
@@ -92,7 +92,7 @@ pub fn serializeLoadResultWithConstraints(
     return try buf.toOwnedSlice(allocator);
 }
 
-fn appendPromptMetadata(
+fn appendRuleMetadata(
     allocator: std.mem.Allocator,
     buf: *std.ArrayList(u8),
     item: workspace_rule.RuleItem,
@@ -218,12 +218,12 @@ test "buildErrorResult escapes special characters in message" {
     try std.testing.expect(std.mem.indexOf(u8, result, "\\nnewline") != null);
 }
 
-test "serializePromptList produces valid items array" {
+test "serializeRuleList produces valid items array" {
     const allocator = std.testing.allocator;
     const items = [_]workspace_rule.RuleItem{
         .{ .id = "p-1", .path = "rule/STYLE.md", .kind = .rule, .group = null, .hash = "abc123", .name = "STYLE", .priority = .normal },
     };
-    const result = try serializePromptList(allocator, &items);
+    const result = try serializeRuleList(allocator, &items);
     defer allocator.free(result);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"items\":[") != null);
     try std.testing.expect(std.mem.indexOf(u8, result, "\"id\":\"p-1\"") != null);

--- a/src/client/mcp/tool_result.zig
+++ b/src/client/mcp/tool_result.zig
@@ -1,9 +1,9 @@
 //! MCP tool response formatting. Builds the content envelope agents consume: success results
-//! include human-readable text + machine-readable structuredContent; loaded prompts include
+//! include human-readable text + machine-readable structuredContent; loaded rules include
 //! parsed constraint IDs for the agent to reference in memory.refer calls.
 const std = @import("std");
 const encoding = @import("clumsies_lib").util.encoding;
-const workspace_prompt = @import("../prompt.zig");
+const workspace_rule = @import("../rule.zig");
 const tool_names = @import("tool_names.zig");
 
 pub fn buildSuccessResult(allocator: std.mem.Allocator, structured_json: []const u8) ![]u8 {
@@ -30,7 +30,7 @@ pub fn buildErrorResult(allocator: std.mem.Allocator, message: []const u8) ![]u8
 
 pub fn serializePromptList(
     allocator: std.mem.Allocator,
-    items: []const workspace_prompt.PromptItem,
+    items: []const workspace_rule.RuleItem,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -47,7 +47,7 @@ pub fn serializePromptList(
 
 pub fn serializeLoadResultWithConstraints(
     allocator: std.mem.Allocator,
-    result: *workspace_prompt.LoadResult,
+    result: *workspace_rule.LoadResult,
     workspace_id: []const u8,
 ) ![]u8 {
     var buf: std.ArrayList(u8) = .empty;
@@ -61,10 +61,10 @@ pub fn serializeLoadResultWithConstraints(
         if (idx > 0) try buf.append(allocator, ',');
 
         if ((item.kind == .rule or item.kind == .workflow) and item.content != null) {
-            var parsed = try workspace_prompt.parseConstraints(allocator, item.content.?);
+            var parsed = try workspace_rule.parseConstraints(allocator, item.content.?);
             defer parsed.deinit(allocator);
 
-            try appendLoadedPromptWithConstraints(allocator, &buf, item, parsed.constraints.items);
+            try appendLoadedRuleWithConstraints(allocator, &buf, item, parsed.constraints.items);
 
             if (buf.items.len > 0 and buf.items[buf.items.len - 1] == '}') {
                 buf.items.len -= 1;
@@ -84,7 +84,7 @@ pub fn serializeLoadResultWithConstraints(
             }
             try buf.appendSlice(allocator, "]}");
         } else {
-            try appendLoadedPrompt(allocator, &buf, item);
+            try appendLoadedRule(allocator, &buf, item);
         }
     }
     try buf.appendSlice(allocator, "]}");
@@ -95,7 +95,7 @@ pub fn serializeLoadResultWithConstraints(
 fn appendPromptMetadata(
     allocator: std.mem.Allocator,
     buf: *std.ArrayList(u8),
-    item: workspace_prompt.PromptItem,
+    item: workspace_rule.RuleItem,
 ) !void {
     const esc_id = try encoding.jsonEscapeAlloc(allocator, item.id);
     defer allocator.free(esc_id);
@@ -106,7 +106,7 @@ fn appendPromptMetadata(
 
     try buf.writer(allocator).print(
         "{{\"id\":\"{s}\",\"kind\":\"{s}\",\"path\":\"{s}\",\"name\":\"{s}\",\"group\":",
-        .{ esc_id, workspace_prompt.kindToString(item.kind), esc_path, esc_name },
+        .{ esc_id, workspace_rule.kindToString(item.kind), esc_path, esc_name },
     );
     if (item.group) |group| {
         const esc_group = try encoding.jsonEscapeAlloc(allocator, group);
@@ -124,19 +124,19 @@ fn appendPromptMetadata(
     try buf.appendSlice(allocator, "}");
 }
 
-fn appendLoadedPrompt(
+fn appendLoadedRule(
     allocator: std.mem.Allocator,
     buf: *std.ArrayList(u8),
-    item: workspace_prompt.LoadedPrompt,
+    item: workspace_rule.LoadedRule,
 ) !void {
-    return appendLoadedPromptWithConstraints(allocator, buf, item, &.{});
+    return appendLoadedRuleWithConstraints(allocator, buf, item, &.{});
 }
 
-fn appendLoadedPromptWithConstraints(
+fn appendLoadedRuleWithConstraints(
     allocator: std.mem.Allocator,
     buf: *std.ArrayList(u8),
-    item: workspace_prompt.LoadedPrompt,
-    constraints: []const workspace_prompt.ParsedConstraint,
+    item: workspace_rule.LoadedRule,
+    constraints: []const workspace_rule.ParsedConstraint,
 ) !void {
     const esc_id = try encoding.jsonEscapeAlloc(allocator, item.id);
     defer allocator.free(esc_id);
@@ -147,7 +147,7 @@ fn appendLoadedPromptWithConstraints(
         "{{\"id\":\"{s}\",\"kind\":\"{s}\",\"path\":\"{s}\",\"changed\":{s},\"hash\":\"{s}\",\"hasDraft\":{s},",
         .{
             esc_id,
-            workspace_prompt.kindToString(item.kind),
+            workspace_rule.kindToString(item.kind),
             esc_path,
             if (item.changed) "true" else "false",
             item.hash,
@@ -175,7 +175,7 @@ fn appendLoadedPromptWithConstraints(
 
             const reminder = try std.fmt.allocPrint(
                 allocator,
-                "{s}\n\n---\n[clumsies] When you apply constraints from this prompt, include them in a single {s} call at the end of your response.\nrefs entry fields: promptId: {s}, promptHash: {s}, constraintId: pick from below\n{s}---",
+                "{s}\n\n---\n[clumsies] When you apply constraints from this rule, include them in a single {s} call at the end of your response.\nrefs entry fields: ruleId: {s}, ruleHash: {s}, constraintId: pick from below\n{s}---",
                 .{ content, tool_names.refer, item.id, item.hash, constraint_list },
             );
             defer allocator.free(reminder);
@@ -220,7 +220,7 @@ test "buildErrorResult escapes special characters in message" {
 
 test "serializePromptList produces valid items array" {
     const allocator = std.testing.allocator;
-    const items = [_]workspace_prompt.PromptItem{
+    const items = [_]workspace_rule.RuleItem{
         .{ .id = "p-1", .path = "rule/STYLE.md", .kind = .rule, .group = null, .hash = "abc123", .name = "STYLE", .priority = .normal },
     };
     const result = try serializePromptList(allocator, &items);

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -258,7 +258,7 @@ fn handleSearch(
 
     session.recordEvent(allocator, .search);
 
-    const structured = try tool_result.serializePromptList(allocator, items.items);
+    const structured = try tool_result.serializeRuleList(allocator, items.items);
     defer allocator.free(structured);
     return try tool_result.buildSuccessResult(allocator, structured);
 }

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -1,11 +1,11 @@
 //! MCP tool definitions and dispatch. Exposes tools to the agent:
-//! memory.setup/search/load/refer/submit and context.*/prompt.* propose
+//! memory.setup/search/load/refer/submit and context.*/rule.* propose
 //! operations. Each call generates an attestation event.
 const std = @import("std");
 const testing = std.testing;
 const encoding = @import("clumsies_lib").util.encoding;
 const util_hash = @import("clumsies_lib").util.hash;
-const workspace_prompt = @import("../prompt.zig");
+const workspace_rule = @import("../rule.zig");
 const drafts_mod = @import("../drafts.zig");
 const session_mod = @import("session.zig");
 const tool_names = @import("tool_names.zig");
@@ -13,7 +13,7 @@ const tool_result = @import("tool_result.zig");
 const attestation = @import("../attestation.zig");
 
 const setup_schema =
-    "{\"name\":\"" ++ tool_names.setup ++ "\",\"title\":\"Setup\",\"description\":\"Bootstrap the protocol. Returns workspace_id and meta-prompt content with usage instructions (delta based on knownHash).\"," ++
+    "{\"name\":\"" ++ tool_names.setup ++ "\",\"title\":\"Setup\",\"description\":\"Bootstrap the protocol. Returns workspace_id and meta-rule content with usage instructions (delta based on knownHash).\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"knownHash\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const search_schema =
@@ -21,12 +21,12 @@ const search_schema =
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\",\"context\"]},\"group\":{\"type\":\"string\"},\"query\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const load_schema =
-    "{\"name\":\"" ++ tool_names.load ++ "\",\"title\":\"Load\",\"description\":\"Load prompt content by ids. Returns delta based on knownHashes. Rule/Workflow content includes a refer reminder.\"," ++
+    "{\"name\":\"" ++ tool_names.load ++ "\",\"title\":\"Load\",\"description\":\"Load rule content by ids. Returns delta based on knownHashes. Rule/Workflow content includes a refer reminder.\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"ids\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"knownHashes\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"string\"}}},\"required\":[\"ids\"],\"additionalProperties\":false}}";
 
 const refer_schema =
-    "{\"name\":\"" ++ tool_names.refer ++ "\",\"title\":\"Refer\",\"description\":\"Declare constraint references from loaded prompts. Pass an array of refs, each with promptId and constraintId.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"refs\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"promptId\":{\"type\":\"string\"},\"promptHash\":{\"type\":\"string\"},\"constraintId\":{\"type\":\"string\"},\"reason\":{\"type\":\"string\"}},\"required\":[\"promptId\",\"constraintId\"]}}},\"required\":[\"refs\"],\"additionalProperties\":false}}";
+    "{\"name\":\"" ++ tool_names.refer ++ "\",\"title\":\"Refer\",\"description\":\"Declare constraint references from loaded rules. Pass an array of refs, each with ruleId and constraintId.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"refs\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"properties\":{\"ruleId\":{\"type\":\"string\"},\"ruleHash\":{\"type\":\"string\"},\"constraintId\":{\"type\":\"string\"},\"reason\":{\"type\":\"string\"}},\"required\":[\"ruleId\",\"constraintId\"]}}},\"required\":[\"refs\"],\"additionalProperties\":false}}";
 
 const submit_schema =
     "{\"name\":\"" ++ tool_names.submit ++ "\",\"title\":\"Submit\",\"description\":\"Submit your turn summary. Call this before finishing to close the current turn.\"," ++
@@ -38,7 +38,7 @@ const reject_schema =
 
 const propose_base_props = "\"path\":{\"type\":\"string\"},\"body\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}";
 const propose_id_ctx = "\"context_id\":{\"type\":\"string\"},\"body\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}";
-const propose_id_prompt = "\"prompt_id\":{\"type\":\"string\"},\"body\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}";
+const propose_id_rule = "\"rule_id\":{\"type\":\"string\"},\"body\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}";
 
 const context_propose_create_schema =
     "{\"name\":\"" ++ tool_names.context_propose_create ++ "\",\"title\":\"Propose Context Create\"," ++
@@ -60,25 +60,25 @@ const context_propose_delete_schema =
     "\"description\":\"Propose deleting a workspace context file. Creates a draft for user review.\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"context_id\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}},\"required\":[\"context_id\"],\"additionalProperties\":false}}";
 
-const prompt_propose_create_schema =
-    "{\"name\":\"" ++ tool_names.prompt_propose_create ++ "\",\"title\":\"Propose Prompt Create\"," ++
-    "\"description\":\"Propose creating a new Library prompt file. Creates a draft for user review.\"," ++
+const rule_propose_create_schema =
+    "{\"name\":\"" ++ tool_names.rule_propose_create ++ "\",\"title\":\"Propose Rule Create\"," ++
+    "\"description\":\"Propose creating a new Library rule file. Creates a draft for user review.\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{" ++ propose_base_props ++ "},\"required\":[\"path\",\"body\"],\"additionalProperties\":false}}";
 
-const prompt_propose_update_schema =
-    "{\"name\":\"" ++ tool_names.prompt_propose_update ++ "\",\"title\":\"Propose Prompt Update\"," ++
-    "\"description\":\"Propose updating an existing Library prompt. Creates a draft for user review.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{" ++ propose_id_prompt ++ "},\"required\":[\"prompt_id\",\"body\"],\"additionalProperties\":false}}";
+const rule_propose_update_schema =
+    "{\"name\":\"" ++ tool_names.rule_propose_update ++ "\",\"title\":\"Propose Rule Update\"," ++
+    "\"description\":\"Propose updating an existing Library rule. Creates a draft for user review.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{" ++ propose_id_rule ++ "},\"required\":[\"rule_id\",\"body\"],\"additionalProperties\":false}}";
 
-const prompt_propose_rename_schema =
-    "{\"name\":\"" ++ tool_names.prompt_propose_rename ++ "\",\"title\":\"Propose Prompt Rename\"," ++
-    "\"description\":\"Propose renaming a Library prompt file. Creates a draft for user review.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"prompt_id\":{\"type\":\"string\"},\"new_path\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}},\"required\":[\"prompt_id\",\"new_path\"],\"additionalProperties\":false}}";
+const rule_propose_rename_schema =
+    "{\"name\":\"" ++ tool_names.rule_propose_rename ++ "\",\"title\":\"Propose Rule Rename\"," ++
+    "\"description\":\"Propose renaming a Library rule file. Creates a draft for user review.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"rule_id\":{\"type\":\"string\"},\"new_path\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}},\"required\":[\"rule_id\",\"new_path\"],\"additionalProperties\":false}}";
 
-const prompt_propose_delete_schema =
-    "{\"name\":\"" ++ tool_names.prompt_propose_delete ++ "\",\"title\":\"Propose Prompt Delete\"," ++
-    "\"description\":\"Propose deleting a Library prompt. Creates a draft for user review.\"," ++
-    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"prompt_id\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}},\"required\":[\"prompt_id\"],\"additionalProperties\":false}}";
+const rule_propose_delete_schema =
+    "{\"name\":\"" ++ tool_names.rule_propose_delete ++ "\",\"title\":\"Propose Rule Delete\"," ++
+    "\"description\":\"Propose deleting a Library rule. Creates a draft for user review.\"," ++
+    "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"rule_id\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"}},\"required\":[\"rule_id\"],\"additionalProperties\":false}}";
 
 pub fn buildListResult(allocator: std.mem.Allocator) ![]u8 {
     return try allocator.dupe(
@@ -94,10 +94,10 @@ pub fn buildListResult(allocator: std.mem.Allocator) ![]u8 {
             context_propose_update_schema ++ "," ++
             context_propose_rename_schema ++ "," ++
             context_propose_delete_schema ++ "," ++
-            prompt_propose_create_schema ++ "," ++
-            prompt_propose_update_schema ++ "," ++
-            prompt_propose_rename_schema ++ "," ++
-            prompt_propose_delete_schema ++
+            rule_propose_create_schema ++ "," ++
+            rule_propose_update_schema ++ "," ++
+            rule_propose_rename_schema ++ "," ++
+            rule_propose_delete_schema ++
             "]}",
     );
 }
@@ -134,9 +134,9 @@ pub fn handleCall(
     }
     if (std.mem.eql(u8, name, tool_names.load)) {
         return handleLoad(allocator, workspace_root, session, args_obj) catch |err| switch (err) {
-            error.UnknownPromptId => try tool_result.buildErrorResult(
+            error.UnknownRuleId => try tool_result.buildErrorResult(
                 allocator,
-                "Unknown prompt id",
+                "Unknown rule id",
             ),
             else => return err,
         };
@@ -166,17 +166,17 @@ pub fn handleCall(
     }
 
     // Prompt propose operations
-    if (std.mem.eql(u8, name, tool_names.prompt_propose_create)) {
-        return handleProposeCreate(allocator, workspace_root, session, args_obj, .prompt) catch |err| proposeErr(allocator, err);
+    if (std.mem.eql(u8, name, tool_names.rule_propose_create)) {
+        return handleProposeCreate(allocator, workspace_root, session, args_obj, .rule) catch |err| proposeErr(allocator, err);
     }
-    if (std.mem.eql(u8, name, tool_names.prompt_propose_update)) {
-        return handleProposeUpdate(allocator, workspace_root, session, args_obj, .prompt) catch |err| proposeErr(allocator, err);
+    if (std.mem.eql(u8, name, tool_names.rule_propose_update)) {
+        return handleProposeUpdate(allocator, workspace_root, session, args_obj, .rule) catch |err| proposeErr(allocator, err);
     }
-    if (std.mem.eql(u8, name, tool_names.prompt_propose_rename)) {
-        return handleProposeRename(allocator, workspace_root, session, args_obj, .prompt) catch |err| proposeErr(allocator, err);
+    if (std.mem.eql(u8, name, tool_names.rule_propose_rename)) {
+        return handleProposeRename(allocator, workspace_root, session, args_obj, .rule) catch |err| proposeErr(allocator, err);
     }
-    if (std.mem.eql(u8, name, tool_names.prompt_propose_delete)) {
-        return handleProposeDelete(allocator, workspace_root, session, args_obj, .prompt) catch |err| proposeErr(allocator, err);
+    if (std.mem.eql(u8, name, tool_names.rule_propose_delete)) {
+        return handleProposeDelete(allocator, workspace_root, session, args_obj, .rule) catch |err| proposeErr(allocator, err);
     }
 
     return try tool_result.buildErrorResult(allocator, "Unknown tool");
@@ -193,7 +193,7 @@ fn handleSetup(
         else => null,
     } else null;
 
-    var mpf = try workspace_prompt.loadMpf(allocator, workspace_root, known_hash);
+    var mpf = try workspace_rule.loadMpf(allocator, workspace_root, known_hash);
     defer mpf.deinit(allocator);
 
     const esc_ws = try encoding.jsonEscapeAlloc(allocator, session.ws_id);
@@ -241,7 +241,7 @@ fn handleSearch(
     args_obj: std.json.ObjectMap,
 ) ![]u8 {
     const kind = if (args_obj.get("kind")) |value|
-        try parsePromptKind(value)
+        try parseRuleKind(value)
     else
         null;
     const group = if (args_obj.get("group")) |value| switch (value) {
@@ -253,8 +253,8 @@ fn handleSearch(
         else => return error.InvalidParams,
     } else null;
 
-    var items = try workspace_prompt.discoverSearchable(allocator, workspace_root, kind, group, query);
-    defer workspace_prompt.deinitPromptItems(allocator, &items);
+    var items = try workspace_rule.discoverSearchable(allocator, workspace_root, kind, group, query);
+    defer workspace_rule.deinitRuleItems(allocator, &items);
 
     session.recordEvent(allocator, .search);
 
@@ -275,7 +275,7 @@ fn handleLoad(
     var known = try parseKnownHashes(allocator, args_obj.get("knownHashes"));
     defer known.deinit(allocator);
 
-    var result = try workspace_prompt.loadPrompts(
+    var result = try workspace_rule.loadRules(
         allocator,
         workspace_root,
         ids.items,
@@ -284,7 +284,7 @@ fn handleLoad(
     defer result.deinit(allocator);
 
     for (result.items.items) |item| {
-        session.recordEvent(allocator, .{ .load = .{ .prompt_id = item.id, .prompt_hash = item.hash } });
+        session.recordEvent(allocator, .{ .load = .{ .rule_id = item.id, .rule_hash = item.hash } });
     }
 
     const structured = try tool_result.serializeLoadResultWithConstraints(
@@ -316,12 +316,12 @@ fn handleRefer(
             else => continue,
         };
 
-        const prompt_id = if (ref_obj.get("promptId")) |v| switch (v) {
+        const rule_id = if (ref_obj.get("ruleId")) |v| switch (v) {
             .string => |s| s,
             else => continue,
         } else continue;
 
-        const prompt_hash = if (ref_obj.get("promptHash")) |v| switch (v) {
+        const rule_hash = if (ref_obj.get("ruleHash")) |v| switch (v) {
             .string => |s| s,
             else => null,
         } else null;
@@ -337,8 +337,8 @@ fn handleRefer(
         } else null;
 
         session.recordEvent(allocator, .{ .refer = .{
-            .prompt_id = prompt_id,
-            .prompt_hash = prompt_hash,
+            .rule_id = rule_id,
+            .rule_hash = rule_hash,
             .constraint_id = constraint_id orelse continue,
             .reason = reason,
         } });
@@ -351,7 +351,7 @@ fn handleRefer(
     return try tool_result.buildSuccessResult(allocator, structured);
 }
 
-fn parsePromptKind(value: std.json.Value) !?workspace_prompt.PromptKind {
+fn parseRuleKind(value: std.json.Value) !?workspace_rule.RuleKind {
     const str = switch (value) {
         .string => |s| s,
         else => return error.InvalidParams,
@@ -400,8 +400,8 @@ fn parseStringList(
 fn parseKnownHashes(
     allocator: std.mem.Allocator,
     value_opt: ?std.json.Value,
-) !std.ArrayList(workspace_prompt.KnownHash) {
-    var known: std.ArrayList(workspace_prompt.KnownHash) = .empty;
+) !std.ArrayList(workspace_rule.KnownHash) {
+    var known: std.ArrayList(workspace_rule.KnownHash) = .empty;
     errdefer known.deinit(allocator);
 
     const value = value_opt orelse return known;
@@ -500,7 +500,7 @@ fn handleProposeCreate(
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_create = .{ .path = path } },
-        .prompt => .{ .prompt_propose_create = .{ .path = path } },
+        .rule => .{ .rule_propose_create = .{ .path = path } },
     };
     session.recordEvent(allocator, payload);
 
@@ -516,24 +516,24 @@ fn handleProposeUpdate(
 ) ![]u8 {
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
-        .prompt => requiredString(args, "prompt_id") orelse return error.InvalidParams,
+        .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const body = requiredString(args, "body") orelse return error.InvalidParams;
     if (body.len == 0) return error.InvalidParams;
     const description = optionalString(args, "description");
 
-    var manifest = try workspace_prompt.loadManifest(allocator, workspace_root);
+    var manifest = try workspace_rule.loadManifest(allocator, workspace_root);
     defer manifest.deinit(allocator);
 
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
-        .prompt => manifest.prompts.get(id) orelse return error.FileNotFound,
+        .rule => manifest.rules.get(id) orelse return error.FileNotFound,
     };
 
     const cache_content = switch (category) {
-        .context => try workspace_prompt.readContextCacheFile(allocator, workspace_root, m_entry.path),
-        .prompt => try readPromptCacheFile(allocator, workspace_root, m_entry.path),
+        .context => try workspace_rule.readContextCacheFile(allocator, workspace_root, m_entry.path),
+        .rule => try readRuleCacheFile(allocator, workspace_root, m_entry.path),
     };
     defer allocator.free(cache_content);
 
@@ -545,14 +545,14 @@ fn handleProposeUpdate(
         .draft_path = m_entry.path,
         .current_path = m_entry.path,
         .base_hash = base_hash[0..],
-        .prompt_id = if (category == .prompt) id else null,
+        .rule_id = if (category == .rule) id else null,
         .context_id = if (category == .context) id else null,
         .description = description,
     }, body);
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_update = .{ .id = id } },
-        .prompt => .{ .prompt_propose_update = .{ .id = id } },
+        .rule => .{ .rule_propose_update = .{ .id = id } },
     };
     session.recordEvent(allocator, payload);
 
@@ -568,24 +568,24 @@ fn handleProposeRename(
 ) ![]u8 {
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
-        .prompt => requiredString(args, "prompt_id") orelse return error.InvalidParams,
+        .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const new_path = requiredString(args, "new_path") orelse return error.InvalidParams;
     if (new_path.len == 0) return error.InvalidParams;
     const description = optionalString(args, "description");
 
-    var manifest = try workspace_prompt.loadManifest(allocator, workspace_root);
+    var manifest = try workspace_rule.loadManifest(allocator, workspace_root);
     defer manifest.deinit(allocator);
 
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
-        .prompt => manifest.prompts.get(id) orelse return error.FileNotFound,
+        .rule => manifest.rules.get(id) orelse return error.FileNotFound,
     };
 
     const cache_content = switch (category) {
-        .context => try workspace_prompt.readContextCacheFile(allocator, workspace_root, m_entry.path),
-        .prompt => try readPromptCacheFile(allocator, workspace_root, m_entry.path),
+        .context => try workspace_rule.readContextCacheFile(allocator, workspace_root, m_entry.path),
+        .rule => try readRuleCacheFile(allocator, workspace_root, m_entry.path),
     };
     defer allocator.free(cache_content);
 
@@ -597,14 +597,14 @@ fn handleProposeRename(
         .draft_path = new_path,
         .current_path = m_entry.path,
         .base_hash = base_hash[0..],
-        .prompt_id = if (category == .prompt) id else null,
+        .rule_id = if (category == .rule) id else null,
         .context_id = if (category == .context) id else null,
         .description = description,
     }, "");
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_rename = .{ .id = id, .new_path = new_path } },
-        .prompt => .{ .prompt_propose_rename = .{ .id = id, .new_path = new_path } },
+        .rule => .{ .rule_propose_rename = .{ .id = id, .new_path = new_path } },
     };
     session.recordEvent(allocator, payload);
 
@@ -620,17 +620,17 @@ fn handleProposeDelete(
 ) ![]u8 {
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
-        .prompt => requiredString(args, "prompt_id") orelse return error.InvalidParams,
+        .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const description = optionalString(args, "description");
 
-    var manifest = try workspace_prompt.loadManifest(allocator, workspace_root);
+    var manifest = try workspace_rule.loadManifest(allocator, workspace_root);
     defer manifest.deinit(allocator);
 
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
-        .prompt => manifest.prompts.get(id) orelse return error.FileNotFound,
+        .rule => manifest.rules.get(id) orelse return error.FileNotFound,
     };
 
     try drafts_mod.createDraft(allocator, workspace_root, .{
@@ -638,14 +638,14 @@ fn handleProposeDelete(
         .operation = .delete,
         .draft_path = m_entry.path,
         .current_path = m_entry.path,
-        .prompt_id = if (category == .prompt) id else null,
+        .rule_id = if (category == .rule) id else null,
         .context_id = if (category == .context) id else null,
         .description = description,
     }, "");
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_delete = .{ .id = id } },
-        .prompt => .{ .prompt_propose_delete = .{ .id = id } },
+        .rule => .{ .rule_propose_delete = .{ .id = id } },
     };
     session.recordEvent(allocator, payload);
 
@@ -664,8 +664,8 @@ fn optionalString(obj: std.json.ObjectMap, key: []const u8) ?[]const u8 {
     return requiredString(obj, key);
 }
 
-fn readPromptCacheFile(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
-    return workspace_prompt.readPromptCacheFile(allocator, ws_dir, rel_path);
+fn readRuleCacheFile(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
+    return workspace_rule.readRuleCacheFile(allocator, ws_dir, rel_path);
 }
 
 fn buildOkDraftPath(allocator: std.mem.Allocator, draft_path: []const u8) ![]u8 {
@@ -689,10 +689,10 @@ test "buildListResult: exposes all memory and propose tools" {
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.context_propose_update ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.context_propose_rename ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.context_propose_delete ++ "\"") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.prompt_propose_create ++ "\"") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.prompt_propose_update ++ "\"") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.prompt_propose_rename ++ "\"") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.prompt_propose_delete ++ "\"") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.rule_propose_create ++ "\"") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.rule_propose_update ++ "\"") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.rule_propose_rename ++ "\"") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.rule_propose_delete ++ "\"") != null);
 
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.begin\"") == null);
     try testing.expect(std.mem.indexOf(u8, result, "\"memory.complete\"") == null);
@@ -702,7 +702,7 @@ test "buildListResult: exposes all memory and propose tools" {
 }
 
 // The next three tests exercise full handleCall flows against
-// synthetic .prompts fixtures. They were added before the test
+// synthetic .rules fixtures. They were added before the test
 // aggregator was wired into client/main.zig, so they never ran — and
 // silently drifted out of sync with handleCall's actual response
 // format. Skipping them keeps CI honest while the mismatch is

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -1,7 +1,7 @@
-//! Prompt resolution engine. Resolves prompts from the workspace cache (synced from Hub via
+//! Rule resolution engine. Resolves rules from the workspace cache (synced from Hub via
 //! manifest) with draft overlay support. Handles discovery (listing by kind/group), content
 //! loading (drafts override cache), and constraint parsing (extracting atomic tracking units
-//! from prompt markdown for the refer protocol).
+//! from rule markdown for the refer protocol).
 const std = @import("std");
 const testing = std.testing;
 const util_hash = @import("clumsies_lib").util.hash;
@@ -10,13 +10,13 @@ const path_util = @import("clumsies_lib").util.path_util;
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
-/// Strip file extension from a prompt filename to get the display name.
+/// Strip file extension from a rule filename to get the display name.
 fn displayNameFromFilename(filename: []const u8) []const u8 {
     const ext_idx = std.mem.lastIndexOfScalar(u8, filename, '.');
     return if (ext_idx) |idx| filename[0..idx] else filename;
 }
 
-pub const PromptKind = enum {
+pub const RuleKind = enum {
     rule,
     workflow,
     context,
@@ -27,9 +27,9 @@ pub const SetupPriority = enum(u8) {
     normal,
 };
 
-pub const PromptItem = struct {
+pub const RuleItem = struct {
     id: []const u8,
-    kind: PromptKind,
+    kind: RuleKind,
     path: []const u8,
     name: []const u8,
     group: ?[]const u8,
@@ -43,9 +43,9 @@ pub const KnownHash = struct {
     hash: []const u8,
 };
 
-pub const LoadedPrompt = struct {
+pub const LoadedRule = struct {
     id: []const u8,
-    kind: PromptKind,
+    kind: RuleKind,
     path: []const u8,
     name: []const u8,
     group: ?[]const u8,
@@ -57,7 +57,7 @@ pub const LoadedPrompt = struct {
 };
 
 pub const LoadResult = struct {
-    items: std.ArrayList(LoadedPrompt) = .empty,
+    items: std.ArrayList(LoadedRule) = .empty,
 
     pub fn deinit(self: *LoadResult, allocator: std.mem.Allocator) void {
         for (self.items.items) |item| {
@@ -73,13 +73,13 @@ pub const LoadResult = struct {
     }
 };
 
-fn priorityForKind(kind: PromptKind) SetupPriority {
+fn priorityForKind(kind: RuleKind) SetupPriority {
     return switch (kind) {
         .rule, .workflow, .context => .normal,
     };
 }
 
-pub fn kindToString(kind: PromptKind) []const u8 {
+pub fn kindToString(kind: RuleKind) []const u8 {
     return switch (kind) {
         .rule => "rule",
         .workflow => "workflow",
@@ -100,8 +100,8 @@ pub const MetaPromptResult = struct {
 /// Load META_PROMPT.md from the workspace cache directory.
 /// `ws_dir` is the workspace root (~/.clumsies/workspaces/{ws_id}).
 /// MPF lives at `{ws_dir}/cache/META_PROMPT.md` — reserved paths
-/// sit at the cache root rather than under the `prompt/` namespace
-/// so a future MPF rename does not reshuffle the prompt tree.
+/// sit at the cache root rather than under the `rule/` namespace
+/// so a future MPF rename does not reshuffle the rule tree.
 pub fn loadMpf(allocator: std.mem.Allocator, ws_dir: []const u8, known_hash: ?[]const u8) !MetaPromptResult {
     const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
     defer allocator.free(mpf_path);
@@ -137,7 +137,7 @@ pub const ManifestEntry = struct {
 /// this struct; deinit drops the arena and invalidates all keys/values.
 pub const Manifest = struct {
     arena_state: *std.heap.ArenaAllocator,
-    prompts: std.StringHashMapUnmanaged(ManifestEntry) = .empty,
+    rules: std.StringHashMapUnmanaged(ManifestEntry) = .empty,
     context: std.StringHashMapUnmanaged(ManifestEntry) = .empty,
 
     pub fn deinit(self: *Manifest, allocator: std.mem.Allocator) void {
@@ -149,7 +149,7 @@ pub const Manifest = struct {
 /// Read `{ws_dir}/manifest.json` into an in-memory map. Returns an empty
 /// manifest (no error) if the file does not exist — that is the expected
 /// state before the first sync. Invalid JSON or a non-object top-level
-/// value returns `InvalidManifest`. Malformed prompts/context entries
+/// value returns `InvalidManifest`. Malformed rules/context entries
 /// inside an otherwise valid top-level object are silently skipped so a
 /// single bad row doesn't block discovery of the rest.
 pub fn loadManifest(allocator: std.mem.Allocator, ws_dir: []const u8) !Manifest {
@@ -176,8 +176,8 @@ pub fn loadManifest(allocator: std.mem.Allocator, ws_dir: []const u8) !Manifest 
     const parsed = std.json.parseFromSliceLeaky(std.json.Value, arena, content, .{}) catch return error.InvalidManifest;
     if (parsed != .object) return error.InvalidManifest;
 
-    if (parsed.object.get("prompts")) |prompts_val| {
-        try parseManifestSection(arena, &manifest.prompts, prompts_val);
+    if (parsed.object.get("rules")) |rules_val| {
+        try parseManifestSection(arena, &manifest.rules, rules_val);
     }
     if (parsed.object.get("context")) |context_val| {
         try parseManifestSection(arena, &manifest.context, context_val);
@@ -216,7 +216,7 @@ fn parseManifestSection(
     }
 }
 
-fn freePromptItem(allocator: std.mem.Allocator, item: PromptItem) void {
+fn freeRuleItem(allocator: std.mem.Allocator, item: RuleItem) void {
     allocator.free(item.id);
     allocator.free(item.path);
     allocator.free(item.name);
@@ -225,12 +225,12 @@ fn freePromptItem(allocator: std.mem.Allocator, item: PromptItem) void {
     if (item.description) |desc| allocator.free(desc);
 }
 
-pub fn deinitPromptItems(allocator: std.mem.Allocator, items: *std.ArrayList(PromptItem)) void {
-    for (items.items) |item| freePromptItem(allocator, item);
+pub fn deinitRuleItems(allocator: std.mem.Allocator, items: *std.ArrayList(RuleItem)) void {
+    for (items.items) |item| freeRuleItem(allocator, item);
     items.deinit(allocator);
 }
 
-fn kindFromPath(path: []const u8) ?PromptKind {
+fn kindFromPath(path: []const u8) ?RuleKind {
     if (std.mem.eql(u8, path, "META_PROMPT.md")) return null;
     if (std.mem.eql(u8, path, "PIN.md")) return null;
     if (std.mem.startsWith(u8, path, "workflow/")) return .workflow;
@@ -264,7 +264,7 @@ fn matchesQuery(haystack: []const u8, query: []const u8) bool {
     return false;
 }
 
-/// Discover prompts and context available for memory.search. Iterates the
+/// Discover rules and context available for memory.search. Iterates the
 /// local manifest, classifies each entry by path prefix or category, and
 /// applies optional kind/group filters. Reserved paths (META_PROMPT.md) are
 /// excluded. Context entries have kind = .context and group derived from
@@ -272,17 +272,17 @@ fn matchesQuery(haystack: []const u8, query: []const u8) bool {
 pub fn discoverSearchable(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
-    kind_filter: ?PromptKind,
+    kind_filter: ?RuleKind,
     group_filter: ?[]const u8,
     query_filter: ?[]const u8,
-) !std.ArrayList(PromptItem) {
-    var items: std.ArrayList(PromptItem) = .empty;
-    errdefer deinitPromptItems(allocator, &items);
+) !std.ArrayList(RuleItem) {
+    var items: std.ArrayList(RuleItem) = .empty;
+    errdefer deinitRuleItems(allocator, &items);
 
     var manifest = try loadManifest(allocator, ws_dir);
     defer manifest.deinit(allocator);
 
-    var it = manifest.prompts.iterator();
+    var it = manifest.rules.iterator();
     while (it.next()) |entry| {
         const m_entry = entry.value_ptr.*;
 
@@ -377,21 +377,21 @@ pub fn discoverSearchable(
         }
     }
 
-    std.mem.sort(PromptItem, items.items, {}, lessThanPromptItem);
+    std.mem.sort(RuleItem, items.items, {}, lessThanRuleItem);
     return items;
 }
 
-fn lessThanPromptItem(_: void, a: PromptItem, b: PromptItem) bool {
+fn lessThanRuleItem(_: void, a: RuleItem, b: RuleItem) bool {
     const prio_order = std.math.order(@intFromEnum(a.priority), @intFromEnum(b.priority));
     if (prio_order != .eq) return prio_order == .lt;
     return std.mem.order(u8, a.id, b.id) == .lt;
 }
 
-/// Load prompt content by hub-issued prompt_id. Resolves each id through
+/// Load rule content by hub-issued rule_id. Resolves each id through
 /// the local manifest, then consults drafts/index.json: an active draft
 /// with operation != "delete" wins over the cache copy. Unknown ids return
-/// `error.UnknownPromptId`. Drafts marked for deletion behave as NotFound.
-pub fn loadPrompts(
+/// `error.UnknownRuleId`. Drafts marked for deletion behave as NotFound.
+pub fn loadRules(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
     ids: []const []const u8,
@@ -421,20 +421,20 @@ pub fn loadPrompts(
             return err;
         };
 
-        const m_entry = manifest.prompts.get(id) orelse return error.UnknownPromptId;
-        const kind = kindFromPath(m_entry.path) orelse return error.UnknownPromptId;
+        const m_entry = manifest.rules.get(id) orelse return error.UnknownRuleId;
+        const kind = kindFromPath(m_entry.path) orelse return error.UnknownRuleId;
 
         const known_hash = knownHashFor(id, known);
         const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
 
-        const draft_entry = draft_index.findByCurrentPath(.prompt, m_entry.path);
+        const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
         if (draft_entry) |entry| {
-            if (entry.operation == .delete) return error.UnknownPromptId;
+            if (entry.operation == .delete) return error.UnknownRuleId;
         }
 
         const content = if (changed) blk: {
             if (draft_entry) |entry| {
-                break :blk try drafts.readDraftFile(allocator, ws_dir, .prompt, entry.draft_path);
+                break :blk try drafts.readDraftFile(allocator, ws_dir, .rule, entry.draft_path);
             }
             break :blk try readCacheFileAlloc(allocator, ws_dir, m_entry.path);
         } else null;
@@ -469,11 +469,11 @@ pub fn loadPrompts(
 
 fn readCacheFileAlloc(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
     if (!path_util.isSafeRelative(rel_path)) return error.UnsafeCachePath;
-    return readPromptCacheFile(allocator, ws_dir, rel_path);
+    return readRuleCacheFile(allocator, ws_dir, rel_path);
 }
 
-pub fn readPromptCacheFile(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
-    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "prompt", rel_path });
+pub fn readRuleCacheFile(allocator: std.mem.Allocator, ws_dir: []const u8, rel_path: []const u8) ![]const u8 {
+    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "rule", rel_path });
     defer allocator.free(abs_path);
 
     const file = try std.fs.openFileAbsolute(abs_path, .{});
@@ -539,7 +539,7 @@ fn computeTextHash(allocator: std.mem.Allocator, text: []const u8) ![]const u8 {
     return try allocator.dupe(u8, &hex);
 }
 
-/// Parse constraints from prompt content according to s2 format standard.
+/// Parse constraints from rule content according to s2 format standard.
 /// Rules: # = title (skip), ## = constraint region, list items within region
 /// are individual constraints, otherwise the whole region is one constraint.
 pub fn parseConstraints(allocator: std.mem.Allocator, content: []const u8) !ValidateResult {
@@ -686,14 +686,14 @@ fn writeTestManifest(dir: std.fs.Dir, json: []const u8) !void {
     try writeFile(dir, "manifest.json", json);
 }
 
-test "loadManifest: parses prompts and context entries" {
+test "loadManifest: parses rules and context entries" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeTestManifest(tmp.dir,
         \\{
         \\  "revision": 7,
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-1": {"path": "coding/STYLE.md", "hash": "sha256:abc"},
         \\    "p-2": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:def"}
         \\  },
@@ -709,10 +709,10 @@ test "loadManifest: parses prompts and context entries" {
     var manifest = try loadManifest(testing.allocator, root);
     defer manifest.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(usize, 2), manifest.prompts.count());
+    try testing.expectEqual(@as(usize, 2), manifest.rules.count());
     try testing.expectEqual(@as(usize, 1), manifest.context.count());
 
-    const p1 = manifest.prompts.get("p-1").?;
+    const p1 = manifest.rules.get("p-1").?;
     try testing.expectEqualStrings("coding/STYLE.md", p1.path);
     try testing.expectEqualStrings("sha256:abc", p1.hash);
 
@@ -730,24 +730,24 @@ test "loadManifest: missing file returns empty manifest" {
     var manifest = try loadManifest(testing.allocator, root);
     defer manifest.deinit(testing.allocator);
 
-    try testing.expectEqual(@as(usize, 0), manifest.prompts.count());
+    try testing.expectEqual(@as(usize, 0), manifest.rules.count());
     try testing.expectEqual(@as(usize, 0), manifest.context.count());
 }
 
-test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
+test "discoverSearchable: returns hub rule_ids classified by path prefix" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/pedagogy");
-    try tmp.dir.makePath("cache/prompt/coding");
-    try tmp.dir.makePath("cache/prompt/workflow");
-    try writeFile(tmp.dir, "cache/prompt/pedagogy/TEACHING.md", "teaching");
-    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style");
-    try writeFile(tmp.dir, "cache/prompt/workflow/COMMIT.md", "commit");
+    try tmp.dir.makePath("cache/rule/pedagogy");
+    try tmp.dir.makePath("cache/rule/coding");
+    try tmp.dir.makePath("cache/rule/workflow");
+    try writeFile(tmp.dir, "cache/rule/pedagogy/TEACHING.md", "teaching");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style");
+    try writeFile(tmp.dir, "cache/rule/workflow/COMMIT.md", "commit");
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-teach": {"path": "pedagogy/TEACHING.md", "hash": "sha256:1"},
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:2"},
         \\    "p-commit": {"path": "workflow/COMMIT.md", "hash": "sha256:3"}
@@ -759,7 +759,7 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     var items = try discoverSearchable(testing.allocator, root, null, null, null);
-    defer deinitPromptItems(testing.allocator, &items);
+    defer deinitRuleItems(testing.allocator, &items);
 
     try testing.expectEqual(@as(usize, 3), items.items.len);
 
@@ -769,19 +769,19 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     for (items.items) |item| {
         if (std.mem.eql(u8, item.id, "p-teach")) {
             found_teach = true;
-            try testing.expectEqual(PromptKind.rule, item.kind);
+            try testing.expectEqual(RuleKind.rule, item.kind);
             try testing.expectEqualStrings("pedagogy/TEACHING.md", item.path);
             try testing.expectEqualStrings("pedagogy", item.group.?);
         }
         if (std.mem.eql(u8, item.id, "p-style")) {
             found_style = true;
-            try testing.expectEqual(PromptKind.rule, item.kind);
+            try testing.expectEqual(RuleKind.rule, item.kind);
             try testing.expectEqualStrings("coding/STYLE.md", item.path);
             try testing.expectEqualStrings("coding", item.group.?);
         }
         if (std.mem.eql(u8, item.id, "p-commit")) {
             found_commit = true;
-            try testing.expectEqual(PromptKind.workflow, item.kind);
+            try testing.expectEqual(RuleKind.workflow, item.kind);
             try testing.expect(item.group == null);
         }
     }
@@ -790,7 +790,7 @@ test "discoverSearchable: returns hub prompt_ids classified by path prefix" {
     try testing.expect(found_commit);
 
     var coding_filtered = try discoverSearchable(testing.allocator, root, null, "coding", null);
-    defer deinitPromptItems(testing.allocator, &coding_filtered);
+    defer deinitRuleItems(testing.allocator, &coding_filtered);
     try testing.expectEqual(@as(usize, 1), coding_filtered.items.len);
     try testing.expectEqualStrings("p-style", coding_filtered.items[0].id);
 }
@@ -801,7 +801,7 @@ test "discoverSearchable: kind filter narrows results" {
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:1"},
         \\    "p-commit": {"path": "workflow/cmd/COMMIT.md", "hash": "sha256:2"}
         \\  }
@@ -812,7 +812,7 @@ test "discoverSearchable: kind filter narrows results" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     var rules = try discoverSearchable(testing.allocator, root, .rule, null, null);
-    defer deinitPromptItems(testing.allocator, &rules);
+    defer deinitRuleItems(testing.allocator, &rules);
 
     try testing.expectEqual(@as(usize, 1), rules.items.len);
     try testing.expectEqualStrings("p-style", rules.items[0].id);
@@ -824,7 +824,7 @@ test "discoverSearchable: group filter matches first path component" {
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-1": {"path": "coding/STYLE.md", "hash": "sha256:1"},
         \\    "p-2": {"path": "zig/NAMING.md", "hash": "sha256:2"}
         \\  }
@@ -835,7 +835,7 @@ test "discoverSearchable: group filter matches first path component" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     var zig_rules = try discoverSearchable(testing.allocator, root, .rule, "zig", null);
-    defer deinitPromptItems(testing.allocator, &zig_rules);
+    defer deinitRuleItems(testing.allocator, &zig_rules);
 
     try testing.expectEqual(@as(usize, 1), zig_rules.items.len);
     try testing.expectEqualStrings("p-2", zig_rules.items[0].id);
@@ -847,7 +847,7 @@ test "discoverSearchable: META_PROMPT.md is excluded" {
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-mpf": {"path": "META_PROMPT.md", "hash": "sha256:abc"},
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:1"}
         \\  }
@@ -858,22 +858,22 @@ test "discoverSearchable: META_PROMPT.md is excluded" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     var items = try discoverSearchable(testing.allocator, root, null, null, null);
-    defer deinitPromptItems(testing.allocator, &items);
+    defer deinitRuleItems(testing.allocator, &items);
 
     try testing.expectEqual(@as(usize, 1), items.items.len);
     try testing.expectEqualStrings("p-style", items.items[0].id);
 }
 
-test "loadPrompts: looks up by hub prompt_id and reads cache file" {
+test "loadRules: looks up by hub rule_id and reads cache file" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
@@ -882,7 +882,7 @@ test "loadPrompts: looks up by hub prompt_id and reads cache file" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &.{});
+    var result = try loadRules(testing.allocator, root, &.{"p-style"}, &.{});
     defer result.deinit(testing.allocator);
 
     try testing.expectEqual(@as(usize, 1), result.items.items.len);
@@ -891,16 +891,16 @@ test "loadPrompts: looks up by hub prompt_id and reads cache file" {
     try testing.expectEqualStrings("style content", result.items.items[0].content.?);
 }
 
-test "loadPrompts: known hash matches returns delta with no content" {
+test "loadRules: known hash matches returns delta with no content" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "style content");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style content");
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
@@ -910,42 +910,42 @@ test "loadPrompts: known hash matches returns delta with no content" {
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
     const known = [_]KnownHash{.{ .id = "p-style", .hash = "sha256:zzz" }};
-    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &known);
+    var result = try loadRules(testing.allocator, root, &.{"p-style"}, &known);
     defer result.deinit(testing.allocator);
 
     try testing.expect(!result.items.items[0].changed);
     try testing.expect(result.items.items[0].content == null);
 }
 
-test "loadPrompts: unknown id returns UnknownPromptId" {
+test "loadRules: unknown id returns UnknownRuleId" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
     try writeTestManifest(tmp.dir,
-        \\{"prompts": {}}
+        \\{"rules": {}}
     );
 
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"p-missing"}, &.{}));
+    try testing.expectError(error.UnknownRuleId, loadRules(testing.allocator, root, &.{"p-missing"}, &.{}));
 }
 
-test "loadPrompts: draft content overrides cache when indexed" {
+test "loadRules: draft content overrides cache when indexed" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "cache content");
 
-    try tmp.dir.makePath("drafts/prompt/coding");
-    try writeFile(tmp.dir, "drafts/prompt/coding/STYLE.md", "draft override");
+    try tmp.dir.makePath("drafts/rule/coding");
+    try writeFile(tmp.dir, "drafts/rule/coding/STYLE.md", "draft override");
     try writeFile(tmp.dir, "drafts/index.json",
         \\{
         \\  "drafts": [
         \\    {
-        \\      "category": "prompt",
-        \\      "prompt_id": "p-style",
+        \\      "category": "rule",
+        \\      "rule_id": "p-style",
         \\      "current_path": "coding/STYLE.md",
         \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "modify",
@@ -958,7 +958,7 @@ test "loadPrompts: draft content overrides cache when indexed" {
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
@@ -967,7 +967,7 @@ test "loadPrompts: draft content overrides cache when indexed" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    var result = try loadPrompts(testing.allocator, root, &.{"p-style"}, &.{});
+    var result = try loadRules(testing.allocator, root, &.{"p-style"}, &.{});
     defer result.deinit(testing.allocator);
 
     try testing.expectEqual(@as(usize, 1), result.items.items.len);
@@ -977,20 +977,20 @@ test "loadPrompts: draft content overrides cache when indexed" {
     try testing.expectEqualStrings("draft override", item.content.?);
 }
 
-test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
+test "loadRules: draft marked delete behaves as UnknownRuleId" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    try tmp.dir.makePath("cache/prompt/coding");
-    try writeFile(tmp.dir, "cache/prompt/coding/STYLE.md", "cache content");
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "cache content");
 
     try tmp.dir.makePath("drafts");
     try writeFile(tmp.dir, "drafts/index.json",
         \\{
         \\  "drafts": [
         \\    {
-        \\      "category": "prompt",
-        \\      "prompt_id": "p-style",
+        \\      "category": "rule",
+        \\      "rule_id": "p-style",
         \\      "current_path": "coding/STYLE.md",
         \\      "draft_path": "coding/STYLE.md",
         \\      "operation": "delete",
@@ -1003,7 +1003,7 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
 
     try writeTestManifest(tmp.dir,
         \\{
-        \\  "prompts": {
+        \\  "rules": {
         \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:zzz"}
         \\  }
         \\}
@@ -1012,7 +1012,7 @@ test "loadPrompts: draft marked delete behaves as UnknownPromptId" {
     var buf: [std.fs.max_path_bytes]u8 = undefined;
     const root = tmpDirAbsolutePath(&tmp, &buf);
 
-    try testing.expectError(error.UnknownPromptId, loadPrompts(testing.allocator, root, &.{"p-style"}, &.{}));
+    try testing.expectError(error.UnknownRuleId, loadRules(testing.allocator, root, &.{"p-style"}, &.{}));
 }
 
 test "loadMpf: returns content and hash from cache subdirectory" {

--- a/src/client/tui/api/cache.zig
+++ b/src/client/tui/api/cache.zig
@@ -174,13 +174,13 @@ test "CacheSlot with StringKey compares slice contents" {
 }
 
 test "CacheSlot composite struct key uses std.meta.eql when no eql method" {
-    const Key = struct { ws_id: u32, prompt_id: u32 };
+    const Key = struct { ws_id: u32, rule_id: u32 };
     var cache: CacheSlot(Key, u32) = .{};
 
-    cache.store(.{ .ws_id = 1, .prompt_id = 10 }, 1010);
-    try std.testing.expectEqual(@as(u32, 1010), cache.lookup(.{ .ws_id = 1, .prompt_id = 10 }).?);
-    try std.testing.expect(cache.lookup(.{ .ws_id = 1, .prompt_id = 11 }) == null);
-    try std.testing.expect(cache.lookup(.{ .ws_id = 2, .prompt_id = 10 }) == null);
+    cache.store(.{ .ws_id = 1, .rule_id = 10 }, 1010);
+    try std.testing.expectEqual(@as(u32, 1010), cache.lookup(.{ .ws_id = 1, .rule_id = 10 }).?);
+    try std.testing.expect(cache.lookup(.{ .ws_id = 1, .rule_id = 11 }) == null);
+    try std.testing.expect(cache.lookup(.{ .ws_id = 2, .rule_id = 10 }) == null);
 }
 
 test "CacheSlot isPopulated tracks lifecycle" {

--- a/src/client/tui/api/fetch.zig
+++ b/src/client/tui/api/fetch.zig
@@ -98,12 +98,12 @@ fn fetchAll(
         model.DirectoryData,
         parse.parseDirectory,
     );
-    const prompts_list = doFetchParse(
+    const rules_list = doFetchParse(
         &client,
         alloc,
-        "/api/org/library/prompts",
-        []const model.LibraryPrompt,
-        parse.parseLibraryPrompts,
+        "/api/org/library/rules",
+        []const model.LibraryRule,
+        parse.parseLibraryRules,
     );
     const org_stats = doFetchParse(
         &client,
@@ -123,7 +123,7 @@ fn fetchAll(
     api_state.mutex.lock();
     api_state.current_user = user;
     api_state.directory = directory;
-    api_state.prompts = prompts_list;
+    api_state.rules = rules_list;
     api_state.bundles = bundles;
     api_state.org_stats = org_stats;
     api_state.status = .connected;

--- a/src/client/tui/api/model.zig
+++ b/src/client/tui/api/model.zig
@@ -23,8 +23,8 @@ pub const DirectoryData = struct {
     members: []const DirectoryMember,
 };
 
-pub const LibraryPrompt = struct {
-    prompt_id: []const u8,
+pub const LibraryRule = struct {
+    rule_id: []const u8,
     path: []const u8,
     content_hash: []const u8,
     updated_at: []const u8,
@@ -38,10 +38,10 @@ pub const LibraryPrompt = struct {
 pub const BundleData = struct {
     name: []const u8,
     description: []const u8,
-    prompt_count: usize,
+    rule_count: usize,
 };
 
-pub const PromptPr = struct {
+pub const RulePr = struct {
     pr_id: []const u8,
     status: []const u8,
     description: []const u8,
@@ -50,8 +50,8 @@ pub const PromptPr = struct {
     operation_count: i32 = 0,
 };
 
-pub const PromptStats = struct {
-    prompt_id: []const u8,
+pub const RuleStats = struct {
+    rule_id: []const u8,
     refer_count: i64,
     active_constraint_count: i64,
     workspace_count: i64,
@@ -61,8 +61,8 @@ pub const PromptStats = struct {
     trend: []const i64 = &.{},
 };
 
-pub const UserPromptStats = struct {
-    prompt_id: []const u8,
+pub const UserRuleStats = struct {
+    rule_id: []const u8,
     refer_count: i64,
 };
 
@@ -73,20 +73,20 @@ pub const UserStats = struct {
     active_days: i64,
     last_referred_at: ?i64 = null,
     trend: []const i64 = &.{},
-    top_prompts: []const UserPromptStats = &.{},
+    top_rules: []const UserRuleStats = &.{},
 };
 
 pub const OrgStats = struct {
     total_refer_count: i64,
     workspace_count: i64,
-    prompt_count: i64,
+    rule_count: i64,
     constraint_count: i64 = 0,
     active_constraint_count: i64 = 0,
     idle_constraint_count: i64 = 0,
     signal_ratio: f64 = 0,
     last_event_at: ?i64 = null,
     trend: []const TrendPoint,
-    prompts: []const PromptStats = &.{},
+    rules: []const RuleStats = &.{},
     users: []const UserStats = &.{},
 };
 
@@ -98,7 +98,7 @@ pub const TrendPoint = struct {
 pub const WsDetail = struct {
     ws_id: []const u8,
     context_files: []const ContextFileData,
-    ws_prompts: []const WsPromptData,
+    ws_rules: []const WsRuleData,
 };
 
 pub const ContextFileData = struct {
@@ -110,8 +110,8 @@ pub const ContextFileData = struct {
     updated_at: []const u8 = "",
 };
 
-pub const WsPromptData = struct {
-    prompt_id: []const u8,
+pub const WsRuleData = struct {
+    rule_id: []const u8,
     content_hash: []const u8,
     path: []const u8 = "",
 };

--- a/src/client/tui/api/parse.zig
+++ b/src/client/tui/api/parse.zig
@@ -8,7 +8,7 @@ const data = @import("../view_types.zig");
 const model = @import("model.zig");
 
 pub fn parseComments(alloc: std.mem.Allocator, body: []const u8) ?[]const data.CommentEntry {
-    const parsed = std.json.parseFromSlice(collab_api.PromptPrCommentsResponse, alloc, body, .{
+    const parsed = std.json.parseFromSlice(collab_api.RulePrCommentsResponse, alloc, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     }) catch return null;
@@ -48,17 +48,17 @@ pub fn parseContextFiles(alloc: std.mem.Allocator, body: []const u8) ?[]const mo
     return list.toOwnedSlice(alloc) catch return null;
 }
 
-pub fn parseManifestPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const model.WsPromptData {
+pub fn parseManifestRules(alloc: std.mem.Allocator, body: []const u8) ?[]const model.WsRuleData {
     const parsed = std.json.parseFromSlice(workspace_api.WorkspaceManifestResponse, alloc, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     }) catch return null;
     defer parsed.deinit();
 
-    var list: std.ArrayList(model.WsPromptData) = .empty;
-    for (parsed.value.prompts.items) |entry| {
+    var list: std.ArrayList(model.WsRuleData) = .empty;
+    for (parsed.value.rules.items) |entry| {
         list.append(alloc, .{
-            .prompt_id = alloc.dupe(u8, entry.key) catch continue,
+            .rule_id = alloc.dupe(u8, entry.key) catch continue,
             .content_hash = alloc.dupe(u8, entry.value.hash) catch continue,
             .path = alloc.dupe(u8, entry.value.path) catch continue,
         }) catch continue;
@@ -112,17 +112,17 @@ pub fn parseDirectory(alloc: std.mem.Allocator, body: []const u8) ?model.Directo
     return .{ .members = members.items };
 }
 
-pub fn parseLibraryPrompts(alloc: std.mem.Allocator, body: []const u8) ?[]const model.LibraryPrompt {
-    const parsed = std.json.parseFromSlice(library_api.PromptListResponse, alloc, body, .{
+pub fn parseLibraryRules(alloc: std.mem.Allocator, body: []const u8) ?[]const model.LibraryRule {
+    const parsed = std.json.parseFromSlice(library_api.RuleListResponse, alloc, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     }) catch return null;
     defer parsed.deinit();
 
-    var list: std.ArrayList(model.LibraryPrompt) = .empty;
-    for (parsed.value.prompts) |p| {
+    var list: std.ArrayList(model.LibraryRule) = .empty;
+    for (parsed.value.rules) |p| {
         list.append(alloc, .{
-            .prompt_id = alloc.dupe(u8, p.prompt_id) catch continue,
+            .rule_id = alloc.dupe(u8, p.rule_id) catch continue,
             .path = alloc.dupe(u8, p.path) catch continue,
             .content_hash = alloc.dupe(u8, p.content_hash) catch continue,
             .updated_at = alloc.dupe(u8, p.updated_at) catch continue,
@@ -147,14 +147,14 @@ pub fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?model.OrgStats
         }) catch continue;
     }
 
-    var prompt_stats: std.ArrayList(model.PromptStats) = .empty;
-    for (v.prompts) |p| {
+    var rule_stats: std.ArrayList(model.RuleStats) = .empty;
+    for (v.rules) |p| {
         var trend_values: std.ArrayList(i64) = .empty;
         for (p.trend) |bucket| {
             trend_values.append(alloc, bucket) catch continue;
         }
-        prompt_stats.append(alloc, .{
-            .prompt_id = alloc.dupe(u8, p.prompt_id) catch continue,
+        rule_stats.append(alloc, .{
+            .rule_id = alloc.dupe(u8, p.rule_id) catch continue,
             .refer_count = p.refer_count,
             .active_constraint_count = p.active_constraint_count,
             .workspace_count = p.workspace_count,
@@ -172,10 +172,10 @@ pub fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?model.OrgStats
             trend_values.append(alloc, bucket) catch continue;
         }
 
-        var top_prompts: std.ArrayList(model.UserPromptStats) = .empty;
-        for (u.top_prompts) |tp| {
-            top_prompts.append(alloc, .{
-                .prompt_id = alloc.dupe(u8, tp.prompt_id) catch continue,
+        var top_rules: std.ArrayList(model.UserRuleStats) = .empty;
+        for (u.top_rules) |tp| {
+            top_rules.append(alloc, .{
+                .rule_id = alloc.dupe(u8, tp.rule_id) catch continue,
                 .refer_count = tp.refer_count,
             }) catch continue;
         }
@@ -187,21 +187,21 @@ pub fn parseOrgStats(alloc: std.mem.Allocator, body: []const u8) ?model.OrgStats
             .active_days = u.active_days,
             .last_referred_at = u.last_referred_at,
             .trend = trend_values.items,
-            .top_prompts = top_prompts.items,
+            .top_rules = top_rules.items,
         }) catch continue;
     }
 
     return .{
         .total_refer_count = v.total_refer_count,
         .workspace_count = v.workspace_count,
-        .prompt_count = v.prompt_count,
+        .rule_count = v.rule_count,
         .constraint_count = 0,
         .active_constraint_count = 0,
         .idle_constraint_count = 0,
         .signal_ratio = 0,
         .last_event_at = null,
         .trend = trend_list.items,
-        .prompts = prompt_stats.items,
+        .rules = rule_stats.items,
         .users = user_stats.items,
     };
 }
@@ -215,27 +215,27 @@ pub fn parseBundles(alloc: std.mem.Allocator, body: []const u8) ?[]const model.B
 
     var list: std.ArrayList(model.BundleData) = .empty;
     for (parsed.value.bundles) |b| {
-        const prompt_count: usize = if (b.prompt_count > 0)
-            @intCast(b.prompt_count)
+        const rule_count: usize = if (b.rule_count > 0)
+            @intCast(b.rule_count)
         else
-            b.prompt_ids.len;
+            b.rule_ids.len;
         list.append(alloc, .{
             .name = alloc.dupe(u8, b.name) catch continue,
             .description = alloc.dupe(u8, b.description) catch continue,
-            .prompt_count = prompt_count,
+            .rule_count = rule_count,
         }) catch continue;
     }
     return list.toOwnedSlice(alloc) catch return null;
 }
 
-pub fn parsePromptPrs(alloc: std.mem.Allocator, body: []const u8) ?[]const model.PromptPr {
-    const parsed = std.json.parseFromSlice(collab_api.PromptPrListResponse, alloc, body, .{
+pub fn parseRulePrs(alloc: std.mem.Allocator, body: []const u8) ?[]const model.RulePr {
+    const parsed = std.json.parseFromSlice(collab_api.RulePrListResponse, alloc, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     }) catch return null;
     defer parsed.deinit();
 
-    var list: std.ArrayList(model.PromptPr) = .empty;
+    var list: std.ArrayList(model.RulePr) = .empty;
     for (parsed.value.prs) |pr| {
         list.append(alloc, .{
             .pr_id = alloc.dupe(u8, pr.pr_id) catch continue,
@@ -272,13 +272,13 @@ test "parseContextFiles accepts content_hash from hub response" {
     try testing.expectEqualStrings("sha256:abc", files[0].hash);
 }
 
-test "prompt content response parsing ignores extra fields" {
+test "rule content response parsing ignores extra fields" {
     const testing = std.testing;
     const body =
-        \\{"prompt_id":"p-1","path":"rule/architecture/HUB_SINGLE_SOURCE.md","content_hash":"sha256:def","body":"hello"}
+        \\{"rule_id":"p-1","path":"rule/architecture/HUB_SINGLE_SOURCE.md","content_hash":"sha256:def","body":"hello"}
     ;
 
-    const parsed = try std.json.parseFromSlice(library_api.PromptContentResponse, testing.allocator, body, .{
+    const parsed = try std.json.parseFromSlice(library_api.RuleContentResponse, testing.allocator, body, .{
         .allocate = .alloc_always,
         .ignore_unknown_fields = true,
     });
@@ -287,26 +287,26 @@ test "prompt content response parsing ignores extra fields" {
     try testing.expectEqualStrings("hello", parsed.value.body);
 }
 
-test "parseManifestPrompts reads shared manifest schema" {
+test "parseManifestRules reads shared manifest schema" {
     const testing = std.testing;
     const body =
-        \\{"ws_id":"ws-1","name":"demo","revision":7,"prompts":{"p-1":{"path":"rule/coding/00_COMPATIBILITY.md","hash":"sha256:def"}},"context":{}}
+        \\{"ws_id":"ws-1","name":"demo","revision":7,"rules":{"p-1":{"path":"rule/coding/00_COMPATIBILITY.md","hash":"sha256:def"}},"context":{}}
     ;
 
-    const prompts = parseManifestPrompts(testing.allocator, body) orelse return error.TestUnexpectedResult;
+    const rules = parseManifestRules(testing.allocator, body) orelse return error.TestUnexpectedResult;
     defer {
-        for (prompts) |prompt| {
-            testing.allocator.free(prompt.prompt_id);
-            testing.allocator.free(prompt.content_hash);
-            testing.allocator.free(prompt.path);
+        for (rules) |rule| {
+            testing.allocator.free(rule.rule_id);
+            testing.allocator.free(rule.content_hash);
+            testing.allocator.free(rule.path);
         }
-        testing.allocator.free(prompts);
+        testing.allocator.free(rules);
     }
 
-    try testing.expectEqual(@as(usize, 1), prompts.len);
-    try testing.expectEqualStrings("p-1", prompts[0].prompt_id);
-    try testing.expectEqualStrings("sha256:def", prompts[0].content_hash);
-    try testing.expectEqualStrings("rule/coding/00_COMPATIBILITY.md", prompts[0].path);
+    try testing.expectEqual(@as(usize, 1), rules.len);
+    try testing.expectEqualStrings("p-1", rules[0].rule_id);
+    try testing.expectEqualStrings("sha256:def", rules[0].content_hash);
+    try testing.expectEqualStrings("rule/coding/00_COMPATIBILITY.md", rules[0].path);
 }
 
 test "parseComments reads wrapped comments response" {
@@ -331,10 +331,10 @@ test "parseComments reads wrapped comments response" {
     try testing.expectEqualStrings("looks good", comments[0].body);
 }
 
-test "parseBundles uses prompt_count when server provides it" {
+test "parseBundles uses rule_count when server provides it" {
     const testing = std.testing;
     const body =
-        \\{"bundles":[{"name":"core","description":"Core prompts","updated_at":"2026-04-16T00:00:00Z","prompt_count":3}]}
+        \\{"bundles":[{"name":"core","description":"Core rules","updated_at":"2026-04-16T00:00:00Z","rule_count":3}]}
     ;
 
     const bundles = parseBundles(testing.allocator, body) orelse return error.TestUnexpectedResult;
@@ -347,5 +347,5 @@ test "parseBundles uses prompt_count when server provides it" {
     }
 
     try testing.expectEqual(@as(usize, 1), bundles.len);
-    try testing.expectEqual(@as(usize, 3), bundles[0].prompt_count);
+    try testing.expectEqual(@as(usize, 3), bundles[0].rule_count);
 }

--- a/src/client/tui/api/specs.zig
+++ b/src/client/tui/api/specs.zig
@@ -31,37 +31,37 @@ pub const create_workspace = dispatcher.RequestSpec(
 };
 
 pub const PathParams = struct { path: []const u8 };
-pub const PromptPrsParams = struct { prompt_id: []const u8 };
+pub const RulePrsParams = struct { rule_id: []const u8 };
 pub const WsContextContentParams = struct { ws_id: []const u8, path: []const u8 };
 pub const WsIdParams = struct { ws_id: []const u8 };
 pub const PrIdParams = struct { pr_id: []const u8 };
 
-pub const PromptPrsPayload = state.PromptPrsPayload;
+pub const RulePrsPayload = state.RulePrsPayload;
 pub const WsContextFilesPayload = state.WsContextFilesPayload;
 pub const WsManifestPayload = state.WsManifestPayload;
 pub const WsContextContentPayload = state.WsContextContentPayload;
 pub const PrCommentsPayload = state.PrCommentsPayload;
-pub const CreatePromptPrResponse = state.CreatePromptPrResponse;
+pub const CreateRulePrResponse = state.CreateRulePrResponse;
 pub const CreateContextPrResponse = state.CreateContextPrResponse;
 
-/// Parameters for creating a prompt PR with a single operation.
+/// Parameters for creating a rule PR with a single operation.
 /// Mirrors CreateContextPrParams so the composer submit path is
 /// symmetric across the two categories. Multi-op PRs remain a
 /// follow-up; the composer UI submits one draft at a time. Which
 /// fields must be non-null depends on `operation_type` (per
-/// s1-5 §2.2): modify/rename/delete carry `prompt_id`, create
+/// s1-5 §2.2): modify/rename/delete carry `rule_id`, create
 /// carries `path`, only modify/rename carry `base_hash`. The body
 /// builder enforces this and omits fields the hub does not want.
-pub const CreatePromptPrParams = struct {
+pub const CreateRulePrParams = struct {
     description: []const u8,
     operation_type: []const u8,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     path: ?[]const u8 = null,
     content: ?[]const u8 = null,
     base_hash: ?[]const u8 = null,
 };
 
-/// Parameters for creating a context PR. Mirrors the prompt PR shape
+/// Parameters for creating a context PR. Mirrors the rule PR shape
 /// but against a workspace-scoped endpoint. `context_id` identifies
 /// an existing file (modify/rename/delete); create-ops leave it null
 /// and populate `path` instead.
@@ -75,22 +75,22 @@ pub const CreateContextPrParams = struct {
     base_hash: ?[]const u8 = null,
 };
 
-pub const library_prompt_content = dispatcher.RequestSpec(
+pub const library_rule_content = dispatcher.RequestSpec(
     PathParams,
-    library_api.PromptContentResponse,
+    library_api.RuleContentResponse,
 ){
     .method = .GET,
-    .path_builder = promptContentPath,
-    .parse_ok = dispatcher.jsonParser(PathParams, library_api.PromptContentResponse),
+    .path_builder = ruleContentPath,
+    .parse_ok = dispatcher.jsonParser(PathParams, library_api.RuleContentResponse),
 };
 
-pub const library_prompt_prs = dispatcher.RequestSpec(
-    PromptPrsParams,
-    PromptPrsPayload,
+pub const library_rule_prs = dispatcher.RequestSpec(
+    RulePrsParams,
+    RulePrsPayload,
 ){
     .method = .GET,
-    .path_builder = promptPrsPath,
-    .parse_ok = parsePromptPrsPayload,
+    .path_builder = rulePrsPath,
+    .parse_ok = parseRulePrsPayload,
 };
 
 pub const workspace_context_content = dispatcher.RequestSpec(
@@ -122,11 +122,11 @@ pub const workspace_manifest = dispatcher.RequestSpec(
 
 pub const pr_detail = dispatcher.RequestSpec(
     PrIdParams,
-    collab_api.PromptPrDetailResponse,
+    collab_api.RulePrDetailResponse,
 ){
     .method = .GET,
     .path_builder = prDetailPath,
-    .parse_ok = dispatcher.jsonParser(PrIdParams, collab_api.PromptPrDetailResponse),
+    .parse_ok = dispatcher.jsonParser(PrIdParams, collab_api.RulePrDetailResponse),
 };
 
 pub const pr_comments = dispatcher.RequestSpec(
@@ -171,11 +171,11 @@ pub const pr_action = dispatcher.RequestSpec(PrActionParams, void){
     .parse_ok = dispatcher.parseVoid(PrActionParams),
 };
 
-pub const create_prompt_pr = dispatcher.RequestSpec(CreatePromptPrParams, CreatePromptPrResponse){
+pub const create_rule_pr = dispatcher.RequestSpec(CreateRulePrParams, CreateRulePrResponse){
     .method = .POST,
-    .path_builder = dispatcher.staticPath(CreatePromptPrParams, "/api/org/prompt-prs"),
-    .body_builder = createPromptPrBody,
-    .parse_ok = dispatcher.jsonParser(CreatePromptPrParams, CreatePromptPrResponse),
+    .path_builder = dispatcher.staticPath(CreateRulePrParams, "/api/org/rule-prs"),
+    .body_builder = createRulePrBody,
+    .parse_ok = dispatcher.jsonParser(CreateRulePrParams, CreateRulePrResponse),
 };
 
 pub const create_context_pr = dispatcher.RequestSpec(CreateContextPrParams, CreateContextPrResponse){
@@ -185,7 +185,7 @@ pub const create_context_pr = dispatcher.RequestSpec(CreateContextPrParams, Crea
     .parse_ok = dispatcher.jsonParser(CreateContextPrParams, CreateContextPrResponse),
 };
 
-fn createPromptPrBody(alloc: std.mem.Allocator, p: CreatePromptPrParams) anyerror![]const u8 {
+fn createRulePrBody(alloc: std.mem.Allocator, p: CreateRulePrParams) anyerror![]const u8 {
     // Every op-type field is optional on the wire — the hub tolerates
     // `"field": null` as equivalent to "field absent" (see
     // hub/collab.zig `Operation`), so emitting all fields keeps the
@@ -195,7 +195,7 @@ fn createPromptPrBody(alloc: std.mem.Allocator, p: CreatePromptPrParams) anyerro
     // just serializes the decision.
     const Op = struct {
         type: []const u8,
-        prompt_id: ?[]const u8 = null,
+        rule_id: ?[]const u8 = null,
         base_hash: ?[]const u8 = null,
         content: ?[]const u8 = null,
         path: ?[]const u8 = null,
@@ -207,7 +207,7 @@ fn createPromptPrBody(alloc: std.mem.Allocator, p: CreatePromptPrParams) anyerro
     };
     const ops = [_]Op{.{
         .type = p.operation_type,
-        .prompt_id = p.prompt_id,
+        .rule_id = p.rule_id,
         .base_hash = p.base_hash,
         .content = p.content,
         .path = p.path,
@@ -248,7 +248,7 @@ fn createContextPrBody(alloc: std.mem.Allocator, p: CreateContextPrParams) anyer
 }
 
 fn submitCommentPath(alloc: std.mem.Allocator, p: SubmitCommentParams) anyerror![]const u8 {
-    return std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{p.pr_id});
+    return std.fmt.allocPrint(alloc, "/api/org/rule-prs/{s}/comments", .{p.pr_id});
 }
 
 fn submitCommentBody(alloc: std.mem.Allocator, p: SubmitCommentParams) anyerror![]const u8 {
@@ -257,7 +257,7 @@ fn submitCommentBody(alloc: std.mem.Allocator, p: SubmitCommentParams) anyerror!
 }
 
 fn prActionPath(alloc: std.mem.Allocator, p: PrActionParams) anyerror![]const u8 {
-    return std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}", .{p.pr_id});
+    return std.fmt.allocPrint(alloc, "/api/org/rule-prs/{s}", .{p.pr_id});
 }
 
 fn prActionBody(alloc: std.mem.Allocator, p: PrActionParams) anyerror![]const u8 {
@@ -265,16 +265,16 @@ fn prActionBody(alloc: std.mem.Allocator, p: PrActionParams) anyerror![]const u8
     return std.json.Stringify.valueAlloc(alloc, Payload{ .action = p.action }, .{});
 }
 
-fn promptContentPath(alloc: std.mem.Allocator, p: PathParams) anyerror![]const u8 {
+fn ruleContentPath(alloc: std.mem.Allocator, p: PathParams) anyerror![]const u8 {
     const encoded = try std.fmt.allocPrint(alloc, "{f}", .{
         std.fmt.alt(std.Uri.Component{ .raw = p.path }, .formatQuery),
     });
     defer alloc.free(encoded);
-    return std.fmt.allocPrint(alloc, "/api/org/library/prompt/content?path={s}", .{encoded});
+    return std.fmt.allocPrint(alloc, "/api/org/library/rule/content?path={s}", .{encoded});
 }
 
-fn promptPrsPath(alloc: std.mem.Allocator, p: PromptPrsParams) anyerror![]const u8 {
-    return std.fmt.allocPrint(alloc, "/api/org/prompt-prs?prompt_id={s}", .{p.prompt_id});
+fn rulePrsPath(alloc: std.mem.Allocator, p: RulePrsParams) anyerror![]const u8 {
+    return std.fmt.allocPrint(alloc, "/api/org/rule-prs?rule_id={s}", .{p.rule_id});
 }
 
 fn wsContextContentPath(alloc: std.mem.Allocator, p: WsContextContentParams) anyerror![]const u8 {
@@ -294,25 +294,25 @@ fn wsManifestPath(alloc: std.mem.Allocator, p: WsIdParams) anyerror![]const u8 {
 }
 
 fn prDetailPath(alloc: std.mem.Allocator, p: PrIdParams) anyerror![]const u8 {
-    return std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}", .{p.pr_id});
+    return std.fmt.allocPrint(alloc, "/api/org/rule-prs/{s}", .{p.pr_id});
 }
 
 fn prCommentsPath(alloc: std.mem.Allocator, p: PrIdParams) anyerror![]const u8 {
-    return std.fmt.allocPrint(alloc, "/api/org/prompt-prs/{s}/comments", .{p.pr_id});
+    return std.fmt.allocPrint(alloc, "/api/org/rule-prs/{s}/comments", .{p.pr_id});
 }
 
-/// Wrap the existing `parse.parsePromptPrs` into the payload shape that
-/// carries the requested `prompt_id` alongside the parsed list. The
+/// Wrap the existing `parse.parseRulePrs` into the payload shape that
+/// carries the requested `rule_id` alongside the parsed list. The
 /// server response is a bare array, so the key is duped out of the
 /// request into the long-lived allocator before returning.
-fn parsePromptPrsPayload(
+fn parseRulePrsPayload(
     alloc: std.mem.Allocator,
-    req: PromptPrsParams,
+    req: RulePrsParams,
     body: []const u8,
-) anyerror!PromptPrsPayload {
-    const prs = parse.parsePromptPrs(alloc, body) orelse return error.ParseFailed;
+) anyerror!RulePrsPayload {
+    const prs = parse.parseRulePrs(alloc, body) orelse return error.ParseFailed;
     return .{
-        .prompt_id = try alloc.dupe(u8, req.prompt_id),
+        .rule_id = try alloc.dupe(u8, req.rule_id),
         .prs = prs,
     };
 }
@@ -334,10 +334,10 @@ fn parseWsManifestPayload(
     req: WsIdParams,
     body: []const u8,
 ) anyerror!WsManifestPayload {
-    const prompts = parse.parseManifestPrompts(alloc, body) orelse return error.ParseFailed;
+    const rules = parse.parseManifestRules(alloc, body) orelse return error.ParseFailed;
     return .{
         .ws_id = try alloc.dupe(u8, req.ws_id),
-        .prompts = prompts,
+        .rules = rules,
     };
 }
 

--- a/src/client/tui/api/state.zig
+++ b/src/client/tui/api/state.zig
@@ -29,9 +29,9 @@ pub const WsPathKey = struct {
 /// long-lived allocator and returns it alongside the parsed body, so
 /// the consumer can route the cache write against the request rather
 /// than against whatever the UI happens to select at consume time.
-pub const PromptPrsPayload = struct {
-    prompt_id: []const u8,
-    prs: []const model.PromptPr,
+pub const RulePrsPayload = struct {
+    rule_id: []const u8,
+    prs: []const model.RulePr,
 };
 
 pub const WsContextFilesPayload = struct {
@@ -41,7 +41,7 @@ pub const WsContextFilesPayload = struct {
 
 pub const WsManifestPayload = struct {
     ws_id: []const u8,
-    prompts: []const model.WsPromptData,
+    rules: []const model.WsRuleData,
 };
 
 pub const WsContextContentPayload = struct {
@@ -55,7 +55,7 @@ pub const PrCommentsPayload = struct {
     comments: []const data.CommentEntry,
 };
 
-pub const CreatePromptPrResponse = struct {
+pub const CreateRulePrResponse = struct {
     pr_id: []const u8,
     status: []const u8,
 };
@@ -81,22 +81,22 @@ pub const ApiState = struct {
     status: ConnectionStatus = .disconnected,
     current_user: ?model.UserData = null,
     directory: ?model.DirectoryData = null,
-    prompts: ?[]const model.LibraryPrompt = null,
+    rules: ?[]const model.LibraryRule = null,
     bundles: ?[]const model.BundleData = null,
     org_stats: ?model.OrgStats = null,
     local_stats: ?attestation_reader.LocalStats = null,
     drafts: ?[]const DraftEntry = null,
     active_sessions: ?[]const ActiveSession = null,
 
-    // Library prompt content, keyed by prompt path.
-    prompt_content_pending: request.PendingRequest(dispatcher.Result(library_api.PromptContentResponse)) = .{},
-    prompt_content_cache: cache.CacheSlot(cache.StringKey, library_api.PromptContentResponse) = .{},
+    // Library rule content, keyed by rule path.
+    rule_content_pending: request.PendingRequest(dispatcher.Result(library_api.RuleContentResponse)) = .{},
+    rule_content_cache: cache.CacheSlot(cache.StringKey, library_api.RuleContentResponse) = .{},
 
-    // Library prompt PR list. Pending result carries the prompt_id the
+    // Library rule PR list. Pending result carries the rule_id the
     // request was issued for so the consumer stores under the correct
-    // cache key even if the UI's prompt selection changed mid-flight.
-    prompt_prs_pending: request.PendingRequest(dispatcher.Result(PromptPrsPayload)) = .{},
-    prompt_prs_cache: cache.CacheSlot(cache.StringKey, []const model.PromptPr) = .{},
+    // cache key even if the UI's rule selection changed mid-flight.
+    rule_prs_pending: request.PendingRequest(dispatcher.Result(RulePrsPayload)) = .{},
+    rule_prs_cache: cache.CacheSlot(cache.StringKey, []const model.RulePr) = .{},
 
     // Workspace context file content, keyed by (ws_id, path). Payload
     // includes both halves of the key so the consumer routes the body
@@ -110,15 +110,15 @@ pub const ApiState = struct {
     ws_context_files_pending: request.PendingRequest(dispatcher.Result(WsContextFilesPayload)) = .{},
     ws_context_files_cache: cache.CacheSlot(cache.StringKey, []const model.ContextFileData) = .{},
     ws_manifest_pending: request.PendingRequest(dispatcher.Result(WsManifestPayload)) = .{},
-    ws_manifest_cache: cache.CacheSlot(cache.StringKey, []const model.WsPromptData) = .{},
+    ws_manifest_cache: cache.CacheSlot(cache.StringKey, []const model.WsRuleData) = .{},
 
     // Pr detail (compound): detail response + comments keyed by pr_id.
     // The detail response carries operations + attestation_summary; the consumer
     // computes the diff and picks the active operation against the cached
-    // prompt prs list. pr_detail response already echoes pr_id; comments
+    // rule prs list. pr_detail response already echoes pr_id; comments
     // wrap the bare list with a PrCommentsPayload.
-    pr_detail_pending: request.PendingRequest(dispatcher.Result(collab_api.PromptPrDetailResponse)) = .{},
-    pr_detail_cache: cache.CacheSlot(cache.StringKey, collab_api.PromptPrDetailResponse) = .{},
+    pr_detail_pending: request.PendingRequest(dispatcher.Result(collab_api.RulePrDetailResponse)) = .{},
+    pr_detail_cache: cache.CacheSlot(cache.StringKey, collab_api.RulePrDetailResponse) = .{},
     pr_comments_pending: request.PendingRequest(dispatcher.Result(PrCommentsPayload)) = .{},
     pr_comments_cache: cache.CacheSlot(cache.StringKey, []const data.CommentEntry) = .{},
 
@@ -127,12 +127,12 @@ pub const ApiState = struct {
     sign_out_pending: request.PendingRequest(dispatcher.Result(void)) = .{},
     submit_comment_pending: request.PendingRequest(dispatcher.Result(void)) = .{},
     pr_action_pending: request.PendingRequest(dispatcher.Result(void)) = .{},
-    create_prompt_pr_pending: request.PendingRequest(dispatcher.Result(CreatePromptPrResponse)) = .{},
+    create_rule_pr_pending: request.PendingRequest(dispatcher.Result(CreateRulePrResponse)) = .{},
     create_context_pr_pending: request.PendingRequest(dispatcher.Result(CreateContextPrResponse)) = .{},
     // Derived pr_detail view state, recomputed by consumers whenever
     // pr_detail_cache or pr_comments_cache changes. Kept here because
     // computing the diff on every draw would be wasteful; the consumer
-    // caches it once per (pr_id, active prompt_id) transition.
+    // caches it once per (pr_id, active rule_id) transition.
     pr_detail_id: ?[]const u8 = null,
     pr_detail_diff: ?[]const []const u8 = null,
     pr_detail_attestation_refers: u16 = 0,
@@ -144,7 +144,7 @@ pub const ApiState = struct {
     pr_detail_op_total: u16 = 0,
     hub_url: ?[]const u8 = null,
     access_token: ?[]const u8 = null,
-    /// True while the compound bootstrap fetch (/me + directory + prompts
+    /// True while the compound bootstrap fetch (/me + directory + rules
     /// + bundles + stats) is running. Prevents overlapping bootstrap
     /// triggers; does not gate any other endpoint, which now run
     /// independently via their own PendingRequest slots.
@@ -200,8 +200,8 @@ pub fn refreshLocalState(api_state: *ApiState) void {
 }
 
 pub fn invalidateOnDemandCaches(api_state: *ApiState) void {
-    api_state.prompt_prs_cache.invalidate();
-    api_state.prompt_content_cache.invalidate();
+    api_state.rule_prs_cache.invalidate();
+    api_state.rule_content_cache.invalidate();
     api_state.ws_context_content_cache.invalidate();
     api_state.ws_context_files_cache.invalidate();
     api_state.ws_manifest_cache.invalidate();
@@ -212,8 +212,8 @@ pub fn invalidateOnDemandCaches(api_state: *ApiState) void {
     // invalidation cannot repopulate the cache (with either a fresh
     // value or a remembered failure) for data the caller explicitly
     // declared stale.
-    api_state.prompt_prs_pending.cancel();
-    api_state.prompt_content_pending.cancel();
+    api_state.rule_prs_pending.cancel();
+    api_state.rule_content_pending.cancel();
     api_state.ws_context_content_pending.cancel();
     api_state.ws_context_files_pending.cancel();
     api_state.ws_manifest_pending.cancel();
@@ -239,18 +239,18 @@ pub fn invalidateOnDemandCaches(api_state: *ApiState) void {
 /// relative to `ws_id`.
 pub fn wsDetail(api_state: *ApiState, ws_id: []const u8) ?model.WsDetail {
     const files = api_state.ws_context_files_cache.lookup(.{ .value = ws_id }) orelse return null;
-    const prompts = api_state.ws_manifest_cache.lookup(.{ .value = ws_id }) orelse return null;
+    const rules = api_state.ws_manifest_cache.lookup(.{ .value = ws_id }) orelse return null;
     return .{
         .ws_id = ws_id,
         .context_files = files,
-        .ws_prompts = prompts,
+        .ws_rules = rules,
     };
 }
 
 /// Combined pr detail view: raw detail response + comments. Returns
 /// null when either half is still pending.
 pub const PrDetailView = struct {
-    detail: collab_api.PromptPrDetailResponse,
+    detail: collab_api.RulePrDetailResponse,
     comments: []const data.CommentEntry,
 };
 

--- a/src/client/tui/api/view_model.zig
+++ b/src/client/tui/api/view_model.zig
@@ -4,12 +4,12 @@ const attestation_reader = @import("../attestation_reader.zig");
 const model = @import("model.zig");
 const state = @import("state.zig");
 
-pub fn toPromptEntries(
+pub fn toRuleEntries(
     alloc: std.mem.Allocator,
-    prompts: []const model.LibraryPrompt,
-) []const data.PromptEntry {
-    var list: std.ArrayList(data.PromptEntry) = .empty;
-    for (prompts) |p| {
+    rules: []const model.LibraryRule,
+) []const data.RuleEntry {
+    var list: std.ArrayList(data.RuleEntry) = .empty;
+    for (rules) |p| {
         const refer_str = formatCount(alloc, p.refer_count) catch "";
         list.append(alloc, .{
             .path = p.path,
@@ -40,7 +40,7 @@ pub fn toBundleEntries(
     for (bundles) |b| {
         list.append(alloc, .{
             .name = b.name,
-            .count = @intCast(@min(b.prompt_count, std.math.maxInt(u16))),
+            .count = @intCast(@min(b.rule_count, std.math.maxInt(u16))),
         }) catch continue;
     }
     return list.toOwnedSlice(alloc) catch &.{};
@@ -48,8 +48,8 @@ pub fn toBundleEntries(
 
 pub fn toPrEntries(
     alloc: std.mem.Allocator,
-    prs: []const model.PromptPr,
-    prompt_path: []const u8,
+    prs: []const model.RulePr,
+    rule_path: []const u8,
     api_state: *state.ApiState,
 ) []const data.PullRequestEntry {
     var list: std.ArrayList(data.PullRequestEntry) = .empty;
@@ -79,7 +79,7 @@ pub fn toPrEntries(
 
         list.append(alloc, .{
             .id = pr.pr_id,
-            .prompt_name = prompt_path,
+            .rule_name = rule_path,
             .status = pr.status,
             .author = pr.author,
             .created = pr.created_at,
@@ -102,7 +102,7 @@ pub fn toPrEntries(
 pub fn analysisFromStats(
     alloc: std.mem.Allocator,
     stats: model.OrgStats,
-    library: ?[]const model.LibraryPrompt,
+    library: ?[]const model.LibraryRule,
     local: ?attestation_reader.LocalStats,
 ) data.AnalysisData {
     var trend: [30]u16 = .{0} ** 30;
@@ -123,15 +123,15 @@ pub fn analysisFromStats(
         refers_per_hour = @intCast(@min(@divTrunc(@max(last_day, 0), 24), std.math.maxInt(u16)));
     }
 
-    var prompts_list: std.ArrayList(data.AnalysisPrompt) = .empty;
-    for (stats.prompts) |ps| {
+    var rules_list: std.ArrayList(data.AnalysisRule) = .empty;
+    for (stats.rules) |ps| {
         const name = if (library) |lib| blk: {
             for (lib) |lp| {
-                if (std.mem.eql(u8, lp.prompt_id, ps.prompt_id))
+                if (std.mem.eql(u8, lp.rule_id, ps.rule_id))
                     break :blk lp.path;
             }
-            break :blk ps.prompt_id;
-        } else ps.prompt_id;
+            break :blk ps.rule_id;
+        } else ps.rule_id;
 
         const c_total: u8 = @intCast(@min(ps.active_constraint_count, 255));
         const c_idle: u8 = 0;
@@ -144,7 +144,7 @@ pub fn analysisFromStats(
             std.math.maxInt(u16),
         ));
 
-        prompts_list.append(alloc, .{
+        rules_list.append(alloc, .{
             .name = name,
             .constraint_count = c_total,
             .active_constraint_count = c_total,
@@ -161,12 +161,12 @@ pub fn analysisFromStats(
     }
 
     if (local) |l| {
-        const remapped_prompts: []const data.AnalysisPrompt = if (library) |lib| blk: {
-            var remapped: std.ArrayList(data.AnalysisPrompt) = .empty;
-            for (l.prompts) |p| {
+        const remapped_rules: []const data.AnalysisRule = if (library) |lib| blk: {
+            var remapped: std.ArrayList(data.AnalysisRule) = .empty;
+            for (l.rules) |p| {
                 var copy = p;
                 for (lib) |lp| {
-                    if (std.mem.eql(u8, lp.prompt_id, p.name)) {
+                    if (std.mem.eql(u8, lp.rule_id, p.name)) {
                         copy.name = lp.path;
                         break;
                     }
@@ -174,7 +174,7 @@ pub fn analysisFromStats(
                 remapped.append(alloc, copy) catch continue;
             }
             break :blk remapped.items;
-        } else l.prompts;
+        } else l.rules;
 
         var inputs_list: std.ArrayList(data.InputItem) = .empty;
         for (l.inputs) |iv| {
@@ -193,7 +193,7 @@ pub fn analysisFromStats(
             .today_delta_pct = 0,
             .last_event_minutes_ago = 0,
             .refer_trend = l.refer_trend,
-            .prompts = remapped_prompts,
+            .rules = remapped_rules,
             .members = toMemberStatss(alloc, stats.users, library),
             .models = &.{},
             .alerts = &.{},
@@ -210,7 +210,7 @@ pub fn analysisFromStats(
         .today_delta_pct = 0,
         .last_event_minutes_ago = 0,
         .refer_trend = trend,
-        .prompts = prompts_list.items,
+        .rules = rules_list.items,
         .members = toMemberStatss(alloc, stats.users, library),
         .models = &.{},
         .alerts = &.{},
@@ -243,13 +243,13 @@ fn trend30FromBuckets(source: []const i64) [30]u16 {
     return trend30;
 }
 
-test "toPromptEntries maps library prompts to view entries" {
+test "toRuleEntries maps library rules to view entries" {
     const alloc = std.testing.allocator;
-    const prompts = [_]model.LibraryPrompt{
-        .{ .prompt_id = "p1", .path = "rule/STYLE.md", .content_hash = "abc", .updated_at = "2025-01-01" },
-        .{ .prompt_id = "p2", .path = "workflow/COMMIT.md", .content_hash = "def", .updated_at = "2025-01-02", .refer_count = 1500 },
+    const rules = [_]model.LibraryRule{
+        .{ .rule_id = "p1", .path = "rule/STYLE.md", .content_hash = "abc", .updated_at = "2025-01-01" },
+        .{ .rule_id = "p2", .path = "workflow/COMMIT.md", .content_hash = "def", .updated_at = "2025-01-02", .refer_count = 1500 },
     };
-    const entries = toPromptEntries(alloc, &prompts);
+    const entries = toRuleEntries(alloc, &rules);
     defer {
         for (entries) |entry| alloc.free(entry.refer_count);
         alloc.free(entries);
@@ -266,7 +266,7 @@ test "toPromptEntries maps library prompts to view entries" {
 test "toBundleEntries maps bundle data to view entries" {
     const alloc = std.testing.allocator;
     const bundles = [_]model.BundleData{
-        .{ .name = "default", .description = "", .prompt_count = 5 },
+        .{ .name = "default", .description = "", .rule_count = 5 },
     };
     const entries = toBundleEntries(alloc, &bundles);
     defer alloc.free(entries);
@@ -307,26 +307,26 @@ test "trend30FromBuckets truncates long source to last 30" {
     try std.testing.expectEqual(@as(u16, 34), result[29]);
 }
 
-fn promptNameForId(library: ?[]const model.LibraryPrompt, prompt_id: []const u8) []const u8 {
+fn ruleNameForId(library: ?[]const model.LibraryRule, rule_id: []const u8) []const u8 {
     if (library) |lib| {
         for (lib) |lp| {
-            if (std.mem.eql(u8, lp.prompt_id, prompt_id)) return lp.path;
+            if (std.mem.eql(u8, lp.rule_id, rule_id)) return lp.path;
         }
     }
-    return prompt_id;
+    return rule_id;
 }
 
 fn toMemberStatss(
     alloc: std.mem.Allocator,
     members: []const model.UserStats,
-    library: ?[]const model.LibraryPrompt,
+    library: ?[]const model.LibraryRule,
 ) []const data.MemberStats {
     var list: std.ArrayList(data.MemberStats) = .empty;
     for (members) |m| {
-        var top_prompts: std.ArrayList(data.MemberPromptStat) = .empty;
-        for (m.top_prompts) |tp| {
-            top_prompts.append(alloc, .{
-                .name = promptNameForId(library, tp.prompt_id),
+        var top_rules: std.ArrayList(data.MemberRuleStat) = .empty;
+        for (m.top_rules) |tp| {
+            top_rules.append(alloc, .{
+                .name = ruleNameForId(library, tp.rule_id),
                 .refer_count = @intCast(@min(tp.refer_count, std.math.maxInt(u32))),
             }) catch continue;
         }
@@ -335,7 +335,7 @@ fn toMemberStatss(
             .refer_count = @intCast(@min(m.refer_count, std.math.maxInt(u32))),
             .active_days = @intCast(@min(m.active_days, 255)),
             .trend = trend30FromBuckets(m.trend),
-            .top_prompts = top_prompts.items,
+            .top_rules = top_rules.items,
             .models = &.{},
         }) catch continue;
     }

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -8,7 +8,7 @@ const api = @import("api.zig");
 const analysis_panel = @import("app/analysis.zig");
 const dashboard_panel = @import("app/dashboard.zig");
 const library_panel = @import("app/library.zig");
-const prompt_detail_panel = @import("app/prompt_detail.zig");
+const rule_detail_panel = @import("app/rule_detail.zig");
 const settings_panel = @import("app/settings.zig");
 const workspace_panel = @import("app/workspace.zig");
 const drafts_mod = @import("../drafts.zig");
@@ -25,17 +25,17 @@ const Column = @import("table_row.zig").Column;
 
 const WsTab = enum(u8) {
     context,
-    prompts,
+    rules,
 
     fn label(self: WsTab) []const u8 {
         return switch (self) {
             .context => "Context",
-            .prompts => "Prompts",
+            .rules => "Rules",
         };
     }
 };
 
-const ws_tabs = [_]WsTab{ .context, .prompts };
+const ws_tabs = [_]WsTab{ .context, .rules };
 
 const WsFocus = enum { bar, list, content };
 
@@ -129,14 +129,14 @@ pub const DraftTarget = struct {
     ws_id: []const u8,
     category: drafts_mod.DraftCategory,
     path: []const u8,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     context_id: ?[]const u8 = null,
 };
 
 pub const Dashboard = struct {
     api_state: *api.state.ApiState,
     selected_module: TopModule = .dashboard,
-    selected_prompt: usize = 0,
+    selected_rule: usize = 0,
     show_help: bool = false,
     show_settings: bool = false,
     show_confirm: bool = false,
@@ -160,7 +160,7 @@ pub const Dashboard = struct {
 
     content_scroll_bars: vxfw.ScrollBars,
 
-    // PR list within Prompt Detail
+    // PR list within Rule Detail
     pr_filter: PrFilter = .open,
     pr_scroll_bars: vxfw.ScrollBars,
     pr_widgets: [MAX_PR_ROWS * 2]vxfw.Widget = undefined,
@@ -206,17 +206,17 @@ pub const Dashboard = struct {
     ws_grid_cols: u16 = 3,
     ws_show_diff: bool = false,
     ws_context_tree: PathTreeState = .{},
-    ws_prompts_tree: PathTreeState = .{},
+    ws_rules_tree: PathTreeState = .{},
     // Workspace uses manual grid + cached visible rows, no ScrollBars
 
     // Dashboard / Analysis shared state
     analysis_scope_idx: usize = 0,
     breathing_phase: u8 = 0, // 0-20 for breathing animation cycle
-    analysis_focus: enum { chart, prompts, members, inputs } = .chart,
-    analysis_prompt_cursor: usize = 0,
+    analysis_focus: enum { chart, rules, members, inputs } = .chart,
+    analysis_rule_cursor: usize = 0,
     analysis_member_cursor: usize = 0,
     analysis_input_cursor: usize = 0,
-    analysis_expanded_prompt: ?usize = null,
+    analysis_expanded_rule: ?usize = null,
     analysis_show_member_detail: bool = false,
     analysis_show_input_detail: bool = false,
     dashboard_input_capacity: usize = 1,
@@ -232,17 +232,17 @@ pub const Dashboard = struct {
     // Drafts cache. Refreshed on startup and after every edit op so
     // list rows and the footer counter stay in sync with disk. Prompt
     // and context drafts live in separate maps because their path
-    // namespaces are distinct (library prompts are org-wide, context
+    // namespaces are distinct (library rules are org-wide, context
     // files are workspace-local).
     drafts_arena: std.heap.ArenaAllocator,
-    drafts_by_prompt_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
+    drafts_by_rule_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
     drafts_by_context_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
     /// Paths of local `operation=create` drafts per category. These do
-    /// not exist on the hub yet, so the server-side prompts /
+    /// not exist on the hub yet, so the server-side rules /
     /// context_files lists never carry them — the list renderers
     /// append these as virtual rows so the user can see (and edit)
     /// newly-created drafts before they are submitted.
-    drafts_create_prompt_paths: []const []const u8 = &.{},
+    drafts_create_rule_paths: []const []const u8 = &.{},
     drafts_create_context_paths: []const []const u8 = &.{},
     drafts_total: usize = 0,
     drafts_ready: usize = 0,
@@ -282,7 +282,7 @@ pub const Dashboard = struct {
     show_new_draft_form: bool = false,
     new_draft_path_buf: [128]u8 = .{0} ** 128,
     new_draft_path_len: usize = 0,
-    new_draft_category: drafts_mod.DraftCategory = .prompt,
+    new_draft_category: drafts_mod.DraftCategory = .rule,
 
     pub fn init(
         api_state: *api.state.ApiState,
@@ -310,7 +310,7 @@ pub const Dashboard = struct {
         const alloc = self.api_state.allocator();
         self.library_tree.deinit(alloc);
         self.ws_context_tree.deinit(alloc);
-        self.ws_prompts_tree.deinit(alloc);
+        self.ws_rules_tree.deinit(alloc);
     }
 
     pub fn widget(self: *Dashboard) vxfw.Widget {
@@ -338,7 +338,7 @@ pub const Dashboard = struct {
     pub fn currentWsTree(self: *Dashboard) *PathTreeState {
         return switch (self.ws_tab) {
             .context => &self.ws_context_tree,
-            .prompts => &self.ws_prompts_tree,
+            .rules => &self.ws_rules_tree,
         };
     }
 
@@ -610,7 +610,7 @@ pub const Dashboard = struct {
                     .dashboard => try dashboard_panel.handleModuleEvent(self, ctx, key, self.getAnalysisCounts().input_count),
                     .analysis => {
                         const counts = self.getAnalysisCounts();
-                        try analysis_panel.handleModuleEvent(self, ctx, key, counts.prompt_count, counts.member_count);
+                        try analysis_panel.handleModuleEvent(self, ctx, key, counts.rule_count, counts.member_count);
                     },
                 }
                 return;
@@ -634,8 +634,8 @@ pub const Dashboard = struct {
                     self.refreshDraftsCache();
                 }
                 _ = self.consumeCreateWsResult();
-                self.consumePromptContentResult();
-                self.consumePromptPrsResult();
+                self.consumeRuleContentResult();
+                self.consumeRulePrsResult();
                 self.consumeWsContextContentResult();
                 self.consumeWsContextFilesResult();
                 self.consumeWsManifestResult();
@@ -644,7 +644,7 @@ pub const Dashboard = struct {
                 self.consumeSignOutResult();
                 self.consumeSubmitCommentResult();
                 self.consumePrActionResult();
-                self.consumeCreatePromptPrResult();
+                self.consumeCreateRulePrResult();
                 self.consumeCreateContextPrResult();
                 ctx.redraw = true;
                 try ctx.tick(100, self.widget());
@@ -862,7 +862,7 @@ pub const Dashboard = struct {
                 .content => "j/k scroll  d toggle diff  e edit  D discard  m ready  p submit  Esc list  ? help",
             },
             .analysis => switch (self.analysis_focus) {
-                .prompts => "j/k move  Enter expand  Tab focus  ? help  q quit",
+                .rules => "j/k move  Enter expand  Tab focus  ? help  q quit",
                 .members => "j/k move  Enter detail  Tab focus  ? help  q quit",
                 else => "Tab focus  ? help  q quit",
             },
@@ -921,24 +921,24 @@ pub const Dashboard = struct {
 
         const size = ctx.max.size();
         const list_w: u16 = size.width / 3;
-        const prompts = self.getPrompts();
-        const create_paths = self.drafts_create_prompt_paths;
+        const rules = self.getRules();
+        const create_paths = self.drafts_create_rule_paths;
 
         const list_ctx = ctx.withConstraints(.{ .width = list_w, .height = size.height }, .{ .width = list_w, .height = size.height });
         const detail_w: u16 = size.width - list_w - 1;
         const detail_ctx = ctx.withConstraints(.{ .width = detail_w, .height = size.height }, .{ .width = detail_w, .height = size.height });
         const list_surface = try self.drawListPanel(list_ctx);
 
-        // selected_prompt >= prompts.len means a virtual (create-op
-        // draft) row. Clamping into `prompts` would render the last
-        // server prompt's header over a draft's body, which is what
+        // selected_rule >= rules.len means a virtual (create-op
+        // draft) row. Clamping into `rules` would render the last
+        // server rule's header over a draft's body, which is what
         // led to a mismatched title + stale rev/pr/c badge. Instead
-        // build a minimal PromptEntry stub for the virtual row so
+        // build a minimal RuleEntry stub for the virtual row so
         // the header stays in sync with the content.
-        var virtual_entry: data.PromptEntry = undefined;
-        const selected_entry: ?*const data.PromptEntry = blk: {
-            if (self.selected_prompt < prompts.len) break :blk &prompts[self.selected_prompt];
-            const k = self.selected_prompt - prompts.len;
+        var virtual_entry: data.RuleEntry = undefined;
+        const selected_entry: ?*const data.RuleEntry = blk: {
+            if (self.selected_rule < rules.len) break :blk &rules[self.selected_rule];
+            const k = self.selected_rule - rules.len;
             if (k >= create_paths.len) break :blk null;
             virtual_entry = .{
                 .path = create_paths[k],
@@ -961,9 +961,9 @@ pub const Dashboard = struct {
         };
 
         const detail_surface = if (selected_entry) |entry|
-            try prompt_detail_panel.drawEmbedded(self, detail_ctx, entry)
+            try rule_detail_panel.drawEmbedded(self, detail_ctx, entry)
         else
-            try prompt_detail_panel.drawEmbeddedEmpty(self, detail_ctx);
+            try rule_detail_panel.drawEmbeddedEmpty(self, detail_ctx);
         return library_panel.drawRoot(self, ctx, list_surface, detail_surface);
     }
 
@@ -975,13 +975,13 @@ pub const Dashboard = struct {
             bundles_list[self.library_bundle_filter - 1].name
         else
             "All";
-        const prompt_count: usize = blk: {
+        const rule_count: usize = blk: {
             self.api_state.mutex.lock();
             defer self.api_state.mutex.unlock();
-            if (self.api_state.prompts) |p| break :blk p.len;
+            if (self.api_state.rules) |p| break :blk p.len;
             break :blk 0;
         };
-        return library_panel.drawListPanel(self, ctx, bundle_label, prompt_count);
+        return library_panel.drawListPanel(self, ctx, bundle_label, rule_count);
     }
 
     // Workspace: top workspace bar + bottom master-detail (list | content).
@@ -1010,8 +1010,8 @@ pub const Dashboard = struct {
             api.state.wsDetail(self.api_state, ws_id)
         else
             null;
-        const lib_prompts: []const data.PromptEntry = if (self.ws_tab == .prompts) self.getPrompts() else &.{};
-        return workspace_panel.drawList(self, ctx, self.currentWsTree(), live_ws, lib_prompts);
+        const lib_rules: []const data.RuleEntry = if (self.ws_tab == .rules) self.getRules() else &.{};
+        return workspace_panel.drawList(self, ctx, self.currentWsTree(), live_ws, lib_rules);
     }
 
     /// ws_id of the currently-selected workspace, or null when the
@@ -1029,7 +1029,7 @@ pub const Dashboard = struct {
 
     pub fn resetWorkspaceTrees(self: *Dashboard) void {
         self.ws_context_tree.reset();
-        self.ws_prompts_tree.reset();
+        self.ws_rules_tree.reset();
         self.ws_list_sel = 0;
     }
 
@@ -1049,7 +1049,7 @@ pub const Dashboard = struct {
         return leaf;
     }
 
-    const ResolvedWsPrompt = struct {
+    const ResolvedWsRule = struct {
         idx: usize,
         path: []const u8,
     };
@@ -1058,84 +1058,84 @@ pub const Dashboard = struct {
         return self.api_state.ws_context_content_cache.lookup(.{ .ws_id = ws_id, .path = path });
     }
 
-    pub fn cachedPromptBody(self: *Dashboard, path: []const u8) ?[]const u8 {
-        const resp = self.api_state.prompt_content_cache.lookup(.{ .value = path }) orelse return null;
+    pub fn cachedRuleBody(self: *Dashboard, path: []const u8) ?[]const u8 {
+        const resp = self.api_state.rule_content_cache.lookup(.{ .value = path }) orelse return null;
         return resp.body;
     }
 
     pub fn invalidateRemoteDetailRequests(self: *Dashboard) void {
-        self.api_state.prompt_content_cache.invalidate();
-        self.api_state.prompt_prs_cache.invalidate();
+        self.api_state.rule_content_cache.invalidate();
+        self.api_state.rule_prs_cache.invalidate();
         self.api_state.ws_context_content_cache.invalidate();
     }
 
-    pub fn requestSelectedPromptDetail(self: *Dashboard) void {
-        const prompts = self.getPrompts();
-        if (self.selected_prompt >= prompts.len) return;
+    pub fn requestSelectedRuleDetail(self: *Dashboard) void {
+        const rules = self.getRules();
+        if (self.selected_rule >= rules.len) return;
 
-        const sel_path = prompts[self.selected_prompt].path;
+        const sel_path = rules[self.selected_rule].path;
         const key = api.cache.StringKey{ .value = sel_path };
 
-        if (self.api_state.prompt_content_cache.shouldDispatch(key)) {
+        if (self.api_state.rule_content_cache.shouldDispatch(key)) {
             api.specs.dispatchFromState(
                 api.specs.PathParams,
-                @import("clumsies_lib").protocol.library_api.PromptContentResponse,
-                api.specs.library_prompt_content,
-                &self.api_state.prompt_content_pending,
+                @import("clumsies_lib").protocol.library_api.RuleContentResponse,
+                api.specs.library_rule_content,
+                &self.api_state.rule_content_pending,
                 self.api_state,
                 .{ .path = sel_path },
             );
         }
 
-        if (self.api_state.prompt_prs_cache.shouldDispatch(key)) {
-            const prompt_id = self.lookupPromptId(sel_path) orelse return;
+        if (self.api_state.rule_prs_cache.shouldDispatch(key)) {
+            const rule_id = self.lookupRuleId(sel_path) orelse return;
             api.specs.dispatchFromState(
-                api.specs.PromptPrsParams,
-                api.specs.PromptPrsPayload,
-                api.specs.library_prompt_prs,
-                &self.api_state.prompt_prs_pending,
+                api.specs.RulePrsParams,
+                api.specs.RulePrsPayload,
+                api.specs.library_rule_prs,
+                &self.api_state.rule_prs_pending,
                 self.api_state,
-                .{ .prompt_id = prompt_id },
+                .{ .rule_id = rule_id },
             );
         }
     }
 
-    /// Look up the prompt_id that corresponds to `path` in the cached
-    /// library prompt list. Returns null if the library has not loaded
+    /// Look up the rule_id that corresponds to `path` in the cached
+    /// library rule list. Returns null if the library has not loaded
     /// yet or the path is unknown.
-    fn lookupPromptId(self: *Dashboard, path: []const u8) ?[]const u8 {
+    fn lookupRuleId(self: *Dashboard, path: []const u8) ?[]const u8 {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        const lib = self.api_state.prompts orelse return null;
+        const lib = self.api_state.rules orelse return null;
         for (lib) |lp| {
-            if (std.mem.eql(u8, lp.path, path)) return lp.prompt_id;
+            if (std.mem.eql(u8, lp.path, path)) return lp.rule_id;
         }
         return null;
     }
 
-    /// Inverse of `lookupPromptId`: given a prompt_id, return the path
-    /// that the prompt_prs cache is keyed by. Used by the prompt-prs
+    /// Inverse of `lookupRuleId`: given a rule_id, return the path
+    /// that the rule_prs cache is keyed by. Used by the rule-prs
     /// consumer so it can route a completed response against its
     /// request id rather than against the UI's current selection.
-    fn lookupPromptPath(self: *Dashboard, prompt_id: []const u8) ?[]const u8 {
+    fn lookupRulePath(self: *Dashboard, rule_id: []const u8) ?[]const u8 {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        const lib = self.api_state.prompts orelse return null;
+        const lib = self.api_state.rules orelse return null;
         for (lib) |lp| {
-            if (std.mem.eql(u8, lp.prompt_id, prompt_id)) return lp.path;
+            if (std.mem.eql(u8, lp.rule_id, rule_id)) return lp.path;
         }
         return null;
     }
 
-    /// Path of the currently selected library prompt, or null when no
-    /// prompt is in focus. Used by failure-caching in the on-demand
+    /// Path of the currently selected library rule, or null when no
+    /// rule is in focus. Used by failure-caching in the on-demand
     /// consumers, which do not have a request-scoped key to attribute
     /// the failure to and fall back to the current UI selection.
-    fn selectedPromptPath(self: *Dashboard) ?[]const u8 {
-        const prompts = self.getPrompts();
-        if (prompts.len == 0) return null;
-        const idx = @min(self.selected_prompt, prompts.len - 1);
-        return prompts[idx].path;
+    fn selectedRulePath(self: *Dashboard) ?[]const u8 {
+        const rules = self.getRules();
+        if (rules.len == 0) return null;
+        const idx = @min(self.selected_rule, rules.len - 1);
+        return rules[idx].path;
     }
 
     fn requestWorkspaceSelectionContent(self: *Dashboard, ws_d: *const api.model.WsDetail) void {
@@ -1157,34 +1157,34 @@ pub const Dashboard = struct {
                     .{ .ws_id = ws_d.ws_id, .path = file.path },
                 );
             },
-            .prompts => {
+            .rules => {
                 if (dir_sel != null) return;
-                const prompt_sel = self.resolveWsPromptSelection(ws_d) orelse return;
-                const key = api.cache.StringKey{ .value = prompt_sel.path };
-                if (!self.api_state.prompt_content_cache.shouldDispatch(key)) return;
+                const rule_sel = self.resolveWsRuleSelection(ws_d) orelse return;
+                const key = api.cache.StringKey{ .value = rule_sel.path };
+                if (!self.api_state.rule_content_cache.shouldDispatch(key)) return;
 
                 api.specs.dispatchFromState(
                     api.specs.PathParams,
-                    @import("clumsies_lib").protocol.library_api.PromptContentResponse,
-                    api.specs.library_prompt_content,
-                    &self.api_state.prompt_content_pending,
+                    @import("clumsies_lib").protocol.library_api.RuleContentResponse,
+                    api.specs.library_rule_content,
+                    &self.api_state.rule_content_pending,
                     self.api_state,
-                    .{ .path = prompt_sel.path },
+                    .{ .path = rule_sel.path },
                 );
             },
         }
     }
 
-    fn resolveWsPromptSelection(self: *Dashboard, ws_d: *const api.model.WsDetail) ?ResolvedWsPrompt {
+    fn resolveWsRuleSelection(self: *Dashboard, ws_d: *const api.model.WsDetail) ?ResolvedWsRule {
         const idx = self.currentWsTree().leafIndexAt(self.ws_list_sel) orelse return null;
-        if (idx >= ws_d.ws_prompts.len) return null;
-        const lib_prompts = self.getPrompts();
-        const wp = ws_d.ws_prompts[idx];
+        if (idx >= ws_d.ws_rules.len) return null;
+        const lib_rules = self.getRules();
+        const wp = ws_d.ws_rules[idx];
         const path = if (wp.path.len > 0)
             wp.path
-        else for (lib_prompts) |lp| {
+        else for (lib_rules) |lp| {
             if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
-        } else wp.prompt_id;
+        } else wp.rule_id;
         return .{ .idx = idx, .path = path };
     }
 
@@ -1203,8 +1203,8 @@ pub const Dashboard = struct {
             self.resolveWsContextSelection(&ws_d)
         else
             null;
-        const prompt_sel = if (live_ws) |ws_d|
-            self.resolveWsPromptSelection(&ws_d)
+        const rule_sel = if (live_ws) |ws_d|
+            self.resolveWsRuleSelection(&ws_d)
         else
             null;
         // context_sel_path is the unified identity for the context
@@ -1225,8 +1225,8 @@ pub const Dashboard = struct {
             .dir_sel = dir_sel,
             .context_sel = context_sel,
             .context_sel_path = context_sel_path,
-            .prompt_sel_idx = if (prompt_sel) |sel| sel.idx else null,
-            .prompt_sel_path = if (prompt_sel) |sel| sel.path else null,
+            .rule_sel_idx = if (rule_sel) |sel| sel.idx else null,
+            .rule_sel_path = if (rule_sel) |sel| sel.path else null,
         });
     }
 
@@ -1234,7 +1234,7 @@ pub const Dashboard = struct {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
         if (self.api_state.org_stats) |stats| {
-            return api.view_model.analysisFromStats(arena, stats, self.api_state.prompts, null);
+            return api.view_model.analysisFromStats(arena, stats, self.api_state.rules, null);
         }
         return null;
     }
@@ -1293,7 +1293,7 @@ pub const Dashboard = struct {
         return dashboard_panel.drawRoot(self, ctx, chart_surface, inputs_surface);
     }
 
-    // Analysis: aggregate prompt/member views and drill-downs.
+    // Analysis: aggregate rule/member views and drill-downs.
     fn drawAnalysis(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         var live_analysis = self.loadAnalysisData(ctx.arena);
         const analysis_available = live_analysis != null;
@@ -1306,7 +1306,7 @@ pub const Dashboard = struct {
             .today_delta_pct = 0,
             .last_event_minutes_ago = 0,
             .refer_trend = .{0} ** 30,
-            .prompts = &.{},
+            .rules = &.{},
             .members = &.{},
             .models = &.{},
             .alerts = &.{},
@@ -1389,18 +1389,18 @@ pub const Dashboard = struct {
         return count;
     }
 
-    pub fn getPrsForPrompt(self: *Dashboard, prompt_path: []const u8) []const data.PullRequestEntry {
-        const prs = self.api_state.prompt_prs_cache.lookup(.{ .value = prompt_path }) orelse return &.{};
+    pub fn getPrsForRule(self: *Dashboard, rule_path: []const u8) []const data.PullRequestEntry {
+        const prs = self.api_state.rule_prs_cache.lookup(.{ .value = rule_path }) orelse return &.{};
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        return api.view_model.toPrEntries(self.viewAllocator(), prs, prompt_path, self.api_state);
+        return api.view_model.toPrEntries(self.viewAllocator(), prs, rule_path, self.api_state);
     }
 
-    pub fn getPrompts(self: *Dashboard) []const data.PromptEntry {
+    pub fn getRules(self: *Dashboard) []const data.RuleEntry {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        if (self.api_state.prompts) |lp| {
-            return api.view_model.toPromptEntries(self.viewAllocator(), lp);
+        if (self.api_state.rules) |lp| {
+            return api.view_model.toRuleEntries(self.viewAllocator(), lp);
         }
         return &.{};
     }
@@ -1604,42 +1604,42 @@ pub const Dashboard = struct {
         return true;
     }
 
-    /// Pump the library prompt content pending slot: on .ok, stash the
+    /// Pump the library rule content pending slot: on .ok, stash the
     /// response in the cache keyed by path so subsequent draws can
     /// retrieve it synchronously. On any error outcome, record the
     /// failure against the selected path so widget sync does not
     /// re-dispatch on every tick; the next `invalidateOnDemandCaches`
-    /// or a navigation to a different prompt clears the marker.
-    fn consumePromptContentResult(self: *Dashboard) void {
-        const result = self.api_state.prompt_content_pending.consume() orelse return;
+    /// or a navigation to a different rule clears the marker.
+    fn consumeRuleContentResult(self: *Dashboard) void {
+        const result = self.api_state.rule_content_pending.consume() orelse return;
         switch (result) {
             .ok => |resp| {
-                self.api_state.prompt_content_cache.store(.{ .value = resp.path }, resp);
+                self.api_state.rule_content_cache.store(.{ .value = resp.path }, resp);
             },
             else => {
-                if (self.selectedPromptPath()) |path| {
-                    self.api_state.prompt_content_cache.markFailed(.{ .value = path });
+                if (self.selectedRulePath()) |path| {
+                    self.api_state.rule_content_cache.markFailed(.{ .value = path });
                 }
             },
         }
     }
 
-    /// Pump the library prompt PR list pending slot. Routes the cache
-    /// write against `payload.prompt_id` — the id the request was
-    /// issued for — rather than the current UI selection, so a prompt
+    /// Pump the library rule PR list pending slot. Routes the cache
+    /// write against `payload.rule_id` — the id the request was
+    /// issued for — rather than the current UI selection, so a rule
     /// switch mid-flight cannot store the list under the wrong path.
-    /// On error, mark the currently selected prompt as failed so the
+    /// On error, mark the currently selected rule as failed so the
     /// widget loop does not re-dispatch on every tick.
-    fn consumePromptPrsResult(self: *Dashboard) void {
-        const result = self.api_state.prompt_prs_pending.consume() orelse return;
+    fn consumeRulePrsResult(self: *Dashboard) void {
+        const result = self.api_state.rule_prs_pending.consume() orelse return;
         switch (result) {
             .ok => |payload| {
-                const path = self.lookupPromptPath(payload.prompt_id) orelse return;
-                self.api_state.prompt_prs_cache.store(.{ .value = path }, payload.prs);
+                const path = self.lookupRulePath(payload.rule_id) orelse return;
+                self.api_state.rule_prs_cache.store(.{ .value = path }, payload.prs);
             },
             else => {
-                if (self.selectedPromptPath()) |path| {
-                    self.api_state.prompt_prs_cache.markFailed(.{ .value = path });
+                if (self.selectedRulePath()) |path| {
+                    self.api_state.rule_prs_cache.markFailed(.{ .value = path });
                 }
             },
         }
@@ -1666,7 +1666,7 @@ pub const Dashboard = struct {
         const result = self.api_state.ws_manifest_pending.consume() orelse return;
         switch (result) {
             .ok => |payload| {
-                self.api_state.ws_manifest_cache.store(.{ .value = payload.ws_id }, payload.prompts);
+                self.api_state.ws_manifest_cache.store(.{ .value = payload.ws_id }, payload.rules);
             },
             else => {
                 if (self.activeWsId()) |ws_id| {
@@ -1710,13 +1710,13 @@ pub const Dashboard = struct {
         }
     }
 
-    /// pr_id of the currently-selected PR in the prompt-detail drill-
+    /// pr_id of the currently-selected PR in the rule-detail drill-
     /// down, or null when nothing is selected.
     fn activePrId(self: *Dashboard) ?[]const u8 {
-        const prompts = self.getPrompts();
-        const prompt_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-        if (prompts.len == 0) return null;
-        const prs = self.getPrsForPrompt(prompts[prompt_idx].path);
+        const rules = self.getRules();
+        const rule_idx = @min(self.selected_rule, if (rules.len > 0) rules.len - 1 else 0);
+        if (rules.len == 0) return null;
+        const prs = self.getPrsForRule(rules[rule_idx].path);
         if (prs.len == 0) return null;
         const pr_idx = @min(self.selected_pr_idx, prs.len - 1);
         return prs[pr_idx].id;
@@ -1724,26 +1724,26 @@ pub const Dashboard = struct {
 
     /// Recompute the 8 derived pr_detail_* fields from the just-fetched
     /// response. Picking the active operation requires the currently
-    /// cached library PR list so the op matching the selected prompt
+    /// cached library PR list so the op matching the selected rule
     /// is surfaced first.
     fn refreshPrDetailDerivedFields(
         self: *Dashboard,
         pr_id: []const u8,
-        resp: @import("clumsies_lib").protocol.collab_api.PromptPrDetailResponse,
+        resp: @import("clumsies_lib").protocol.collab_api.RulePrDetailResponse,
     ) void {
         const alloc = self.api_state.allocator();
 
-        const prompts = self.getPrompts();
-        const prompt_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-        const target_prompt_id: ?[]const u8 = if (prompts.len > 0)
-            self.lookupPromptId(prompts[prompt_idx].path)
+        const rules = self.getRules();
+        const rule_idx = @min(self.selected_rule, if (rules.len > 0) rules.len - 1 else 0);
+        const target_rule_id: ?[]const u8 = if (rules.len > 0)
+            self.lookupRuleId(rules[rule_idx].path)
         else
             null;
 
         var pick_idx: ?usize = null;
-        if (target_prompt_id) |tid| {
+        if (target_rule_id) |tid| {
             for (resp.operations, 0..) |op, i| {
-                if (op.prompt_id) |pid| {
+                if (op.rule_id) |pid| {
                     if (std.mem.eql(u8, pid, tid)) {
                         pick_idx = i;
                         break;
@@ -1858,10 +1858,10 @@ pub const Dashboard = struct {
     }
 
     fn submitComment(self: *Dashboard) void {
-        const all_p = self.getPrompts();
-        const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
+        const all_p = self.getRules();
+        const si = @min(self.selected_rule, if (all_p.len > 0) all_p.len - 1 else 0);
         if (all_p.len == 0) return;
-        const prs_for = self.getPrsForPrompt(all_p[si].path);
+        const prs_for = self.getPrsForRule(all_p[si].path);
         const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
         if (prs_for.len == 0) return;
 
@@ -1878,10 +1878,10 @@ pub const Dashboard = struct {
     }
 
     pub fn doPrAction(self: *Dashboard, action: []const u8) void {
-        const all_p = self.getPrompts();
-        const si = @min(self.selected_prompt, if (all_p.len > 0) all_p.len - 1 else 0);
+        const all_p = self.getRules();
+        const si = @min(self.selected_rule, if (all_p.len > 0) all_p.len - 1 else 0);
         if (all_p.len == 0) return;
-        const prs_for = self.getPrsForPrompt(all_p[si].path);
+        const prs_for = self.getPrsForRule(all_p[si].path);
         const pri = @min(self.selected_pr_idx, if (prs_for.len > 0) prs_for.len - 1 else 0);
         if (prs_for.len == 0) return;
 
@@ -1918,7 +1918,7 @@ pub const Dashboard = struct {
                 const al: data.AccessLevel = if (std.mem.eql(u8, ws.role, "admin")) .admin else .member;
                 list.append(alloc, .{
                     .name = ws.name,
-                    .prompts = 0,
+                    .rules = 0,
                     .contexts = 0,
                     .local_rev = 0,
                     .remote_rev = 0,
@@ -1940,14 +1940,14 @@ pub const Dashboard = struct {
         return 0;
     }
 
-    fn wsPromptsCount(self: *Dashboard) usize {
+    fn wsRulesCount(self: *Dashboard) usize {
         self.api_state.mutex.lock();
         defer self.api_state.mutex.unlock();
-        if (self.api_state.ws_detail) |ws_d| return ws_d.ws_prompts.len;
+        if (self.api_state.ws_detail) |ws_d| return ws_d.ws_rules.len;
         return 0;
     }
 
-    const AnalysisCounts = struct { prompt_count: usize, member_count: usize, input_count: usize };
+    const AnalysisCounts = struct { rule_count: usize, member_count: usize, input_count: usize };
 
     const AnalysisScopeInfo = struct {
         label: []const u8,
@@ -2117,13 +2117,13 @@ pub const Dashboard = struct {
             break :blk latestInputs(inputs, self.dashboard_input_capacity).len;
         } else 0;
 
-        const prompt_count: usize = if (self.api_state.org_stats) |stats|
-            stats.prompts.len
+        const rule_count: usize = if (self.api_state.org_stats) |stats|
+            stats.rules.len
         else
             0;
 
         return .{
-            .prompt_count = prompt_count,
+            .rule_count = rule_count,
             .member_count = if (self.api_state.org_stats) |stats| stats.users.len else 0,
             .input_count = input_count,
         };
@@ -2134,8 +2134,8 @@ pub const Dashboard = struct {
     }
 
     // Modal overlay showing the full text of the currently-selected user
-    // prompt from the Recent Inputs panel. Wraps at the box width and
-    // truncates if the prompt is longer than the box can display.
+    // rule from the Recent Inputs panel. Wraps at the box width and
+    // truncates if the rule is longer than the box can display.
     fn drawInputDetailOverlay(self: *Dashboard, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         const content_and_ts: struct { content: []const u8, ts: i64 } = blk: {
             const scoped = self.scopedAttestationData() orelse break :blk .{ .content = "", .ts = 0 };
@@ -2208,11 +2208,11 @@ pub const Dashboard = struct {
         const size = ctx.max.size();
 
         // Title: show reply context or "New Comment"
-        const all_prompts = self.getPrompts();
-        const sel_idx = @min(self.selected_prompt, if (all_prompts.len > 0) all_prompts.len - 1 else 0);
-        const title = if (all_prompts.len > 0) blk: {
-            const p = &all_prompts[sel_idx];
-            const prs = self.getPrsForPrompt(p.path);
+        const all_rules = self.getRules();
+        const sel_idx = @min(self.selected_rule, if (all_rules.len > 0) all_rules.len - 1 else 0);
+        const title = if (all_rules.len > 0) blk: {
+            const p = &all_rules[sel_idx];
+            const prs = self.getPrsForRule(p.path);
             break :blk if (prs.len > 0 and self.selected_pr_idx < prs.len)
                 try std.fmt.allocPrint(ctx.arena, "Comment on {s}", .{prs[self.selected_pr_idx].id})
             else
@@ -2255,9 +2255,9 @@ pub const Dashboard = struct {
         if (self.show_help) return "Keyboard reference overlay.";
         return switch (self.selected_module) {
             .dashboard => "Live signal and recent input feed.",
-            .library => "Bundle facet, prompt list, and passive preview.",
+            .library => "Bundle facet, rule list, and passive preview.",
             .workspace => "Workspace list and sync status detail.",
-            .analysis => "Prompt and member aggregates.",
+            .analysis => "Rule and member aggregates.",
         };
     }
 
@@ -2266,7 +2266,7 @@ pub const Dashboard = struct {
     /// edit op (`e`, `D`, `m`). No-op when no workspace is active —
     /// draft features just stay silent rather than surface an error.
     pub fn refreshDraftsCache(self: *Dashboard) void {
-        self.drafts_by_prompt_path = .{};
+        self.drafts_by_rule_path = .{};
         self.drafts_by_context_path = .{};
         // drafts_create_*_paths are handed to the file tree, which
         // stores them in its `expanded` StringHashMap and `dir_paths`
@@ -2279,7 +2279,7 @@ pub const Dashboard = struct {
         // arena. Individual `free` calls are no-ops there, so the
         // old slices leak within the arena until session end — that
         // is acceptable for the few bytes per refresh this costs.
-        self.drafts_create_prompt_paths = &.{};
+        self.drafts_create_rule_paths = &.{};
         self.drafts_create_context_paths = &.{};
         self.drafts_total = 0;
         self.drafts_ready = 0;
@@ -2293,7 +2293,7 @@ pub const Dashboard = struct {
         var index = drafts_mod.loadIndex(arena, ws_dir) catch return;
         defer index.deinit(arena);
 
-        var create_prompts: std.ArrayListUnmanaged([]const u8) = .empty;
+        var create_rules: std.ArrayListUnmanaged([]const u8) = .empty;
         var create_contexts: std.ArrayListUnmanaged([]const u8) = .empty;
 
         for (index.entries.items) |entry| {
@@ -2310,7 +2310,7 @@ pub const Dashboard = struct {
             const key_src = entry.current_path orelse entry.draft_path;
             const key = arena.dupe(u8, key_src) catch continue;
             const target_map = switch (entry.category) {
-                .prompt => &self.drafts_by_prompt_path,
+                .rule => &self.drafts_by_rule_path,
                 .context => &self.drafts_by_context_path,
             };
             target_map.put(arena, key, entry.status) catch {};
@@ -2321,14 +2321,14 @@ pub const Dashboard = struct {
                 // single refresh so drafts_arena is unsafe.
                 const path_copy = api_alloc.dupe(u8, entry.draft_path) catch continue;
                 const dest = switch (entry.category) {
-                    .prompt => &create_prompts,
+                    .rule => &create_rules,
                     .context => &create_contexts,
                 };
                 dest.append(api_alloc, path_copy) catch {};
             }
         }
 
-        self.drafts_create_prompt_paths = create_prompts.toOwnedSlice(api_alloc) catch &.{};
+        self.drafts_create_rule_paths = create_rules.toOwnedSlice(api_alloc) catch &.{};
         self.drafts_create_context_paths = create_contexts.toOwnedSlice(api_alloc) catch &.{};
     }
 
@@ -2338,7 +2338,7 @@ pub const Dashboard = struct {
         path: []const u8,
     ) ?drafts_mod.DraftStatus {
         return switch (category) {
-            .prompt => self.drafts_by_prompt_path.get(path),
+            .rule => self.drafts_by_rule_path.get(path),
             .context => self.drafts_by_context_path.get(path),
         };
     }
@@ -2356,7 +2356,7 @@ pub const Dashboard = struct {
     ) ?[]const u8 {
         const ws_id = self.activeWsId() orelse return null;
         const has_draft = switch (category) {
-            .prompt => self.drafts_by_prompt_path.contains(path),
+            .rule => self.drafts_by_rule_path.contains(path),
             .context => self.drafts_by_context_path.contains(path),
         };
         if (!has_draft) return null;
@@ -2373,26 +2373,26 @@ pub const Dashboard = struct {
         const ws_id = self.activeWsId() orelse return null;
         switch (self.selected_module) {
             .library => {
-                const prompts = self.getPrompts();
-                if (self.selected_prompt < prompts.len) {
-                    const prompt = &prompts[self.selected_prompt];
+                const rules = self.getRules();
+                if (self.selected_rule < rules.len) {
+                    const rule = &rules[self.selected_rule];
                     return .{
                         .ws_id = ws_id,
-                        .category = .prompt,
-                        .path = prompt.path,
-                        .prompt_id = self.lookupPromptId(prompt.path),
+                        .category = .rule,
+                        .path = rule.path,
+                        .rule_id = self.lookupRuleId(rule.path),
                     };
                 }
                 // Virtual row: a local create-op draft that has no
-                // server-side prompt yet. The index is offset by
-                // `prompts.len` so we can recover the create-draft
-                // path from drafts_create_prompt_paths.
-                const k = self.selected_prompt - prompts.len;
-                if (k >= self.drafts_create_prompt_paths.len) return null;
+                // server-side rule yet. The index is offset by
+                // `rules.len` so we can recover the create-draft
+                // path from drafts_create_rule_paths.
+                const k = self.selected_rule - rules.len;
+                if (k >= self.drafts_create_rule_paths.len) return null;
                 return .{
                     .ws_id = ws_id,
-                    .category = .prompt,
-                    .path = self.drafts_create_prompt_paths[k],
+                    .category = .rule,
+                    .path = self.drafts_create_rule_paths[k],
                 };
             },
             .workspace => {
@@ -2420,20 +2420,20 @@ pub const Dashboard = struct {
                             .path = self.drafts_create_context_paths[k],
                         };
                     },
-                    .prompts => {
-                        if (leaf >= live.ws_prompts.len) return null;
-                        const wp = live.ws_prompts[leaf];
+                    .rules => {
+                        if (leaf >= live.ws_rules.len) return null;
+                        const wp = live.ws_rules[leaf];
                         const path = if (wp.path.len > 0) wp.path else blk: {
-                            for (self.getPrompts()) |lp| {
+                            for (self.getRules()) |lp| {
                                 if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break :blk lp.path;
                             }
                             return null;
                         };
                         return .{
                             .ws_id = ws_id,
-                            .category = .prompt,
+                            .category = .rule,
                             .path = path,
-                            .prompt_id = self.lookupPromptId(path),
+                            .rule_id = self.lookupRuleId(path),
                         };
                     },
                 }
@@ -2477,7 +2477,7 @@ pub const Dashboard = struct {
                 .operation = .modify,
                 .draft_path = target.path,
                 .current_path = target.path,
-                .prompt_id = target.prompt_id,
+                .rule_id = target.rule_id,
                 .context_id = target.context_id,
                 .base_hash = seed_hash[0..],
             }, seed) catch |err| switch (err) {
@@ -2520,11 +2520,11 @@ pub const Dashboard = struct {
     }
 
     /// Pull the authoritative bytes for a file so a new modify-draft
-    /// can seed its copy. Prompts pull from the library cache; context
+    /// can seed its copy. Rules pull from the library cache; context
     /// files from the workspace context content cache.
     fn seedContentForTarget(self: *Dashboard, target: DraftTarget) ?[]const u8 {
         return switch (target.category) {
-            .prompt => self.cachedPromptBody(target.path),
+            .rule => self.cachedRuleBody(target.path),
             .context => self.cachedWorkspaceContextBody(target.ws_id, target.path),
         };
     }
@@ -2582,7 +2582,7 @@ pub const Dashboard = struct {
             .ws_id = target.ws_id,
             .category = target.category,
             .path = path_copy,
-            .prompt_id = target.prompt_id,
+            .rule_id = target.rule_id,
             .context_id = target.context_id,
         };
         self.pending_discard_path_owned = path_copy;
@@ -2647,7 +2647,7 @@ pub const Dashboard = struct {
             .ws_id = target.ws_id,
             .category = target.category,
             .path = path_copy,
-            .prompt_id = target.prompt_id,
+            .rule_id = target.rule_id,
             .context_id = target.context_id,
         };
         self.pr_composer_path_owned = path_copy;
@@ -2704,7 +2704,7 @@ pub const Dashboard = struct {
             return;
         };
         switch (target.category) {
-            .prompt => self.submitPromptPr(target),
+            .rule => self.submitRulePr(target),
             .context => self.submitContextPr(target),
         }
     }
@@ -2755,7 +2755,7 @@ pub const Dashboard = struct {
         base_hash: ?[]const u8,
     };
 
-    fn submitPromptPr(self: *Dashboard, target: DraftTarget) void {
+    fn submitRulePr(self: *Dashboard, target: DraftTarget) void {
         const alloc = self.api_state.allocator();
         const read = self.readDraftForSubmit(alloc, target) orelse return;
         defer alloc.free(read.ws_dir);
@@ -2768,7 +2768,7 @@ pub const Dashboard = struct {
             self.status_line = "Draft entry missing; try again.";
             return;
         };
-        // Spec s1-5 §2.2: modify/rename/delete must carry prompt_id +
+        // Spec s1-5 §2.2: modify/rename/delete must carry rule_id +
         // base_hash; create must carry path + content. The hub
         // rejects any operation that is missing a required field.
         const operation_type: []const u8 = switch (entry.operation) {
@@ -2786,20 +2786,20 @@ pub const Dashboard = struct {
             (alloc.dupe(u8, read.content) catch return);
         defer if (content_copy) |c| alloc.free(c);
 
-        // Modify/rename/delete need prompt_id; resolve from the draft
+        // Modify/rename/delete need rule_id; resolve from the draft
         // target first (authoritative) then fall back to a library
         // lookup by path. Create drafts have neither — that's the
-        // expected missing prompt_id, not an error.
-        const prompt_id_copy_opt: ?[]const u8 = if (entry.operation == .create)
+        // expected missing rule_id, not an error.
+        const rule_id_copy_opt: ?[]const u8 = if (entry.operation == .create)
             null
         else blk: {
-            const pid = target.prompt_id orelse self.lookupPromptId(target.path) orelse {
-                self.status_line = "Unknown prompt id for this draft.";
+            const pid = target.rule_id orelse self.lookupRuleId(target.path) orelse {
+                self.status_line = "Unknown rule id for this draft.";
                 return;
             };
             break :blk (alloc.dupe(u8, pid) catch return);
         };
-        defer if (prompt_id_copy_opt) |pid| alloc.free(pid);
+        defer if (rule_id_copy_opt) |pid| alloc.free(pid);
 
         const path_copy_opt: ?[]const u8 = if (entry.operation == .create)
             (alloc.dupe(u8, target.path) catch return)
@@ -2821,15 +2821,15 @@ pub const Dashboard = struct {
         }
 
         api.specs.dispatchFromState(
-            api.specs.CreatePromptPrParams,
-            api.specs.CreatePromptPrResponse,
-            api.specs.create_prompt_pr,
-            &self.api_state.create_prompt_pr_pending,
+            api.specs.CreateRulePrParams,
+            api.specs.CreateRulePrResponse,
+            api.specs.create_rule_pr,
+            &self.api_state.create_rule_pr_pending,
             self.api_state,
             .{
                 .description = desc_copy,
                 .operation_type = operation_type,
-                .prompt_id = prompt_id_copy_opt,
+                .rule_id = rule_id_copy_opt,
                 .path = path_copy_opt,
                 .content = content_copy,
                 .base_hash = base_hash_copy_opt,
@@ -2953,15 +2953,15 @@ pub const Dashboard = struct {
         const box_h: u16 = 9;
         const target = self.pr_composer_target orelse DraftTarget{
             .ws_id = "",
-            .category = .prompt,
+            .category = .rule,
             .path = "",
         };
         const title = switch (target.category) {
-            .prompt => "New Prompt PR",
+            .rule => "New Rule PR",
             .context => "New Context PR",
         };
         const path_label = switch (target.category) {
-            .prompt => "prompt:",
+            .rule => "rule:",
             .context => "file:",
         };
         const modal = Modal{
@@ -3105,11 +3105,11 @@ pub const Dashboard = struct {
         const box_w = @min(size.width -| 4, 54);
         const box_h: u16 = 7;
         const title = switch (self.new_draft_category) {
-            .prompt => "New Prompt Draft",
+            .rule => "New Rule Draft",
             .context => "New Context Draft",
         };
         const hint = switch (self.new_draft_category) {
-            .prompt => "e.g. rule/00_MY_RULE.md",
+            .rule => "e.g. rule/00_MY_RULE.md",
             .context => "e.g. spec/NEW_SPEC.md",
         };
         const modal = Modal{
@@ -3136,8 +3136,8 @@ pub const Dashboard = struct {
         return surface;
     }
 
-    fn consumeCreatePromptPrResult(self: *Dashboard) void {
-        const result = self.api_state.create_prompt_pr_pending.consume() orelse return;
+    fn consumeCreateRulePrResult(self: *Dashboard) void {
+        const result = self.api_state.create_rule_pr_pending.consume() orelse return;
         self.pr_composer_submitting = false;
         switch (result) {
             .ok => |resp| {
@@ -3162,7 +3162,7 @@ pub const Dashboard = struct {
         }
     }
 
-    /// Shared post-submit path for both prompt and context PRs. Marks
+    /// Shared post-submit path for both rule and context PRs. Marks
     /// the draft as submitted against disk, refreshes the in-memory
     /// cache, closes the composer, and posts a user-facing confirmation.
     fn markComposerSubmitted(self: *Dashboard, pr_id: []const u8, status: []const u8) void {
@@ -3172,7 +3172,7 @@ pub const Dashboard = struct {
         defer alloc.free(ws_dir);
         drafts_mod.setDraftStatus(alloc, ws_dir, target.category, target.path, .submitted) catch {};
         self.refreshDraftsCache();
-        // A new PR exists on the hub, but prompt_prs_cache still
+        // A new PR exists on the hub, but rule_prs_cache still
         // holds the pre-submit snapshot — the Pull Requests tab
         // would render stale rows until a manual `r` refresh. Drop
         // the cached details so the next render re-fetches.
@@ -3191,7 +3191,7 @@ pub const Dashboard = struct {
         self.selected_module = tab;
         self.analysis_show_input_detail = false;
         self.analysis_show_member_detail = false;
-        self.analysis_expanded_prompt = null;
+        self.analysis_expanded_rule = null;
         switch (tab) {
             .dashboard => {
                 if (self.analysis_focus != .chart and self.analysis_focus != .inputs) {
@@ -3199,8 +3199,8 @@ pub const Dashboard = struct {
                 }
             },
             .analysis => {
-                if (self.analysis_focus != .prompts and self.analysis_focus != .members) {
-                    self.analysis_focus = .prompts;
+                if (self.analysis_focus != .rules and self.analysis_focus != .members) {
+                    self.analysis_focus = .rules;
                 }
             },
             else => {},

--- a/src/client/tui/app/analysis.zig
+++ b/src/client/tui/app/analysis.zig
@@ -16,16 +16,16 @@ pub fn drawRoot(
     w.fillSurface(&root, theme.CANVAS);
 
     const members_w: u16 = 18;
-    const prompts_w: u16 = size.width -| members_w;
+    const rules_w: u16 = size.width -| members_w;
     const children = try ctx.arena.alloc(vxfw.SubSurface, 2);
 
     const main_surface = if (self.analysis_show_member_detail)
-        try drawMemberDetail(self, ctx, prompts_w, size.height, insights)
+        try drawMemberDetail(self, ctx, rules_w, size.height, insights)
     else
-        try drawPrompts(self, ctx, prompts_w, size.height, insights, available);
+        try drawRules(self, ctx, rules_w, size.height, insights, available);
     children[0] = .{ .origin = .{ .row = 0, .col = 0 }, .surface = main_surface };
     children[1] = .{
-        .origin = .{ .row = 0, .col = prompts_w },
+        .origin = .{ .row = 0, .col = rules_w },
         .surface = try drawMembers(self, ctx, members_w, size.height, insights, available),
     };
 
@@ -33,7 +33,7 @@ pub fn drawRoot(
     return root;
 }
 
-pub fn drawPrompts(
+pub fn drawRules(
     self: anytype,
     ctx: vxfw.DrawContext,
     width: u16,
@@ -41,12 +41,12 @@ pub fn drawPrompts(
     insights: *const data.AnalysisData,
     available: bool,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const border_color = theme.focusBorder(self.analysis_focus == .prompts);
+    const border_color = theme.focusBorder(self.analysis_focus == .rules);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), .{ .width = width, .height = height });
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
 
-    w.writeText(&surface, ctx, 3, 0, "Prompts Rank", theme.boldOn(theme.PANEL, theme.TEXT));
+    w.writeText(&surface, ctx, 3, 0, "Rules Rank", theme.boldOn(theme.PANEL, theme.TEXT));
     const col_reach: u16 = width -| 24;
     const col_trend: u16 = width -| 16;
     const col_last: u16 = width -| 8;
@@ -67,22 +67,22 @@ pub fn drawPrompts(
         return surface;
     }
 
-    if (insights.prompts.len == 0) {
-        w.writeText(&surface, ctx, 2, 2, "No prompt analysis data returned by the hub.", theme.fg(theme.MUTED));
+    if (insights.rules.len == 0) {
+        w.writeText(&surface, ctx, 2, 2, "No rule analysis data returned by the hub.", theme.fg(theme.MUTED));
         return surface;
     }
 
     var max_refer: u32 = 1;
-    for (insights.prompts) |prompt| {
-        if (prompt.refer_count > max_refer) max_refer = prompt.refer_count;
+    for (insights.rules) |rule| {
+        if (rule.refer_count > max_refer) max_refer = rule.refer_count;
     }
 
     const name_col: u16 = 2;
     const min_name_w: u16 = 18;
     const max_name_w: u16 = @max(min_name_w, @min(@as(u16, 40), col_reach -| name_col -| 24));
     var measured_name_w: u16 = min_name_w;
-    for (insights.prompts) |prompt| {
-        const candidate = @as(u16, @intCast(ctx.stringWidth(firstLineTrimmed(prompt.name, max_name_w))));
+    for (insights.rules) |rule| {
+        const candidate = @as(u16, @intCast(ctx.stringWidth(firstLineTrimmed(rule.name, max_name_w))));
         if (candidate > measured_name_w) measured_name_w = candidate;
     }
     const name_w: u16 = @min(max_name_w, measured_name_w);
@@ -90,12 +90,12 @@ pub fn drawPrompts(
     const bar_end: u16 = col_reach -| 2;
     const bar_max_w: u16 = bar_end -| bar_start;
 
-    const focused = self.analysis_focus == .prompts;
+    const focused = self.analysis_focus == .rules;
     var row: u16 = 1;
-    for (insights.prompts, 0..) |prompt, prompt_idx| {
+    for (insights.rules, 0..) |rule, rule_idx| {
         if (row >= height -| 1) break;
-        const is_idle = prompt.refer_count == 0;
-        const is_sel = prompt_idx == self.analysis_prompt_cursor and focused;
+        const is_idle = rule.refer_count == 0;
+        const is_sel = rule_idx == self.analysis_rule_cursor and focused;
 
         if (is_sel) {
             w.writeCursorMarker(&surface, 1, row);
@@ -107,11 +107,11 @@ pub fn drawPrompts(
             theme.boldOn(theme.PANEL, theme.TEXT)
         else
             theme.fg(theme.TEXT_SOFT);
-        w.writeText(&surface, ctx, name_col, row, firstLineTrimmed(prompt.name, name_w), name_style);
+        w.writeText(&surface, ctx, name_col, row, firstLineTrimmed(rule.name, name_w), name_style);
 
         if (!is_idle) {
-            const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * prompt.refer_count / max_refer);
-            const bar_w: u16 = if (prompt.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
+            const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * rule.refer_count / max_refer);
+            const bar_w: u16 = if (rule.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
             for (0..bar_w) |offset| {
                 const bc: u16 = bar_start + @as(u16, @intCast(offset));
                 if (bc >= bar_end) break;
@@ -124,16 +124,16 @@ pub fn drawPrompts(
                     .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
                 });
             }
-            const ref_text = try std.fmt.allocPrint(ctx.arena, " {d}", .{prompt.refer_count});
+            const ref_text = try std.fmt.allocPrint(ctx.arena, " {d}", .{rule.refer_count});
             const ref_col: u16 = bar_start + bar_w;
             if (ref_col + @as(u16, @intCast(ctx.stringWidth(ref_text))) < col_reach) {
                 w.writeText(&surface, ctx, ref_col, row, ref_text, theme.fg(theme.TEXT));
             }
         }
 
-        const reach_txt = try std.fmt.allocPrint(ctx.arena, "{d}", .{prompt.workspace_count});
+        const reach_txt = try std.fmt.allocPrint(ctx.arena, "{d}", .{rule.workspace_count});
         w.writeText(&surface, ctx, col_reach, row, reach_txt, theme.fg(theme.MUTED));
-        const trend_summary = try promptTrendSummary(ctx.arena, prompt.trend);
+        const trend_summary = try ruleTrendSummary(ctx.arena, rule.trend);
         const trend_style: vaxis.Style = switch (trend_summary.kind) {
             .up => theme.fg(theme.OK),
             .down => theme.fg(theme.DANGER),
@@ -141,22 +141,22 @@ pub fn drawPrompts(
             .none => theme.fg(theme.DIM),
         };
         w.writeText(&surface, ctx, col_trend, row, trend_summary.text, trend_style);
-        const last_txt = if (prompt.last_referred_days_ago) |days|
+        const last_txt = if (rule.last_referred_days_ago) |days|
             (try std.fmt.allocPrint(ctx.arena, "{d}d", .{days}))
         else
             "\xe2\x80\x94";
         w.writeText(&surface, ctx, col_last, row, last_txt, theme.fg(theme.MUTED));
         row += 1;
 
-        if (self.analysis_expanded_prompt == prompt_idx) {
+        if (self.analysis_expanded_rule == rule_idx) {
             var constraint_max: u32 = 1;
-            for (prompt.constraints) |constraint| {
+            for (rule.constraints) |constraint| {
                 if (constraint.refer_count > constraint_max) constraint_max = constraint.refer_count;
             }
-            for (prompt.constraints, 0..) |constraint, constraint_idx| {
+            for (rule.constraints, 0..) |constraint, constraint_idx| {
                 if (row >= height -| 1) break;
                 const is_constraint_idle = constraint.refer_count == 0;
-                const is_last = constraint_idx + 1 == prompt.constraints.len;
+                const is_last = constraint_idx + 1 == rule.constraints.len;
                 const show_child_id = !std.mem.eql(u8, constraint.id, constraint.label);
                 const child_label_col: u16 = if (show_child_id) 12 else 9;
                 const child_label = firstLineTrimmed(constraint.label, bar_start -| child_label_col -| 2);
@@ -317,30 +317,30 @@ pub fn drawMemberDetail(
     w.writeText(&surface, ctx, 3, row, summary, theme.fg(theme.TEXT));
     row += 2;
 
-    w.writeText(&surface, ctx, 3, row, "Top Prompts", theme.fgBold(theme.TEXT));
+    w.writeText(&surface, ctx, 3, row, "Top Rules", theme.fgBold(theme.TEXT));
     row += 1;
     var max_ref: u32 = 1;
-    for (member.top_prompts) |top_prompt| {
-        if (top_prompt.refer_count > max_ref) max_ref = top_prompt.refer_count;
+    for (member.top_rules) |top_rule| {
+        if (top_rule.refer_count > max_ref) max_ref = top_rule.refer_count;
     }
     const name_col: u16 = 5;
     const count_col: u16 = width -| 7;
     const min_name_w: u16 = 14;
     const max_name_w: u16 = @max(min_name_w, @min(@as(u16, 32), count_col -| name_col -| 12));
     var measured_name_w: u16 = min_name_w;
-    for (member.top_prompts) |top_prompt| {
-        const candidate = @as(u16, @intCast(ctx.stringWidth(firstLineTrimmed(top_prompt.name, max_name_w))));
+    for (member.top_rules) |top_rule| {
+        const candidate = @as(u16, @intCast(ctx.stringWidth(firstLineTrimmed(top_rule.name, max_name_w))));
         if (candidate > measured_name_w) measured_name_w = candidate;
     }
     const name_w: u16 = @min(max_name_w, measured_name_w);
     const bar_start: u16 = name_col + name_w + 1;
     const bar_end: u16 = count_col -| 1;
     const bar_max_w: u16 = bar_end -| bar_start;
-    for (member.top_prompts) |top_prompt| {
+    for (member.top_rules) |top_rule| {
         if (row >= height -| 5) break;
-        w.writeText(&surface, ctx, name_col, row, firstLineTrimmed(top_prompt.name, name_w), theme.fg(theme.TEXT_SOFT));
-        const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * top_prompt.refer_count / max_ref);
-        const bar_w: u16 = if (top_prompt.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
+        w.writeText(&surface, ctx, name_col, row, firstLineTrimmed(top_rule.name, name_w), theme.fg(theme.TEXT_SOFT));
+        const bar_w_raw: u16 = @intCast(@as(u32, bar_max_w) * top_rule.refer_count / max_ref);
+        const bar_w: u16 = if (top_rule.refer_count > 0 and bar_w_raw == 0 and bar_max_w > 0) 1 else bar_w_raw;
         for (0..bar_w) |offset| {
             const bc: u16 = bar_start + @as(u16, @intCast(offset));
             if (bc >= bar_end) break;
@@ -353,7 +353,7 @@ pub fn drawMemberDetail(
                 .style = .{ .fg = theme.lerpColor(theme.ACCENT_SOFT, theme.ACCENT, t), .bg = theme.PANEL },
             });
         }
-        const ref_txt = try std.fmt.allocPrint(ctx.arena, "{d}", .{top_prompt.refer_count});
+        const ref_txt = try std.fmt.allocPrint(ctx.arena, "{d}", .{top_rule.refer_count});
         w.writeText(&surface, ctx, count_col, row, ref_txt, theme.fg(theme.MUTED));
         row += 1;
     }
@@ -365,24 +365,24 @@ pub fn handleModuleEvent(
     self: anytype,
     ctx: *vxfw.EventContext,
     key: vaxis.Key,
-    prompt_count: usize,
+    rule_count: usize,
     member_count: usize,
 ) anyerror!void {
     if (key.matches(vaxis.Key.tab, .{})) {
         self.analysis_focus = switch (self.analysis_focus) {
-            .prompts => .members,
-            else => .prompts,
+            .rules => .members,
+            else => .rules,
         };
-        self.analysis_expanded_prompt = null;
+        self.analysis_expanded_rule = null;
         self.analysis_show_member_detail = false;
         ctx.consumeAndRedraw();
         return;
     }
     if (key.matches('j', .{}) or key.matches(vaxis.Key.down, .{})) {
         switch (self.analysis_focus) {
-            .prompts => {
-                if (prompt_count > 0 and self.analysis_prompt_cursor < prompt_count - 1)
-                    self.analysis_prompt_cursor += 1;
+            .rules => {
+                if (rule_count > 0 and self.analysis_rule_cursor < rule_count - 1)
+                    self.analysis_rule_cursor += 1;
                 ctx.consumeAndRedraw();
                 return;
             },
@@ -397,8 +397,8 @@ pub fn handleModuleEvent(
     }
     if (key.matches('k', .{}) or key.matches(vaxis.Key.up, .{})) {
         switch (self.analysis_focus) {
-            .prompts => {
-                self.analysis_prompt_cursor -|= 1;
+            .rules => {
+                self.analysis_rule_cursor -|= 1;
                 ctx.consumeAndRedraw();
                 return;
             },
@@ -412,11 +412,11 @@ pub fn handleModuleEvent(
     }
     if (key.matches(vaxis.Key.enter, .{})) {
         switch (self.analysis_focus) {
-            .prompts => {
-                if (self.analysis_expanded_prompt == self.analysis_prompt_cursor) {
-                    self.analysis_expanded_prompt = null;
+            .rules => {
+                if (self.analysis_expanded_rule == self.analysis_rule_cursor) {
+                    self.analysis_expanded_rule = null;
                 } else {
-                    self.analysis_expanded_prompt = self.analysis_prompt_cursor;
+                    self.analysis_expanded_rule = self.analysis_rule_cursor;
                 }
                 ctx.consumeAndRedraw();
                 return;
@@ -430,12 +430,12 @@ pub fn handleModuleEvent(
         }
     }
     if (key.matches(vaxis.Key.escape, .{})) {
-        if (self.analysis_expanded_prompt != null) {
-            self.analysis_expanded_prompt = null;
+        if (self.analysis_expanded_rule != null) {
+            self.analysis_expanded_rule = null;
         } else if (self.analysis_show_member_detail) {
             self.analysis_show_member_detail = false;
         } else {
-            self.analysis_focus = .prompts;
+            self.analysis_focus = .rules;
         }
         ctx.consumeAndRedraw();
     }
@@ -453,7 +453,7 @@ const TrendSummary = struct {
     kind: TrendSummaryKind,
 };
 
-fn promptTrendSummary(
+fn ruleTrendSummary(
     arena: std.mem.Allocator,
     trend: [30]u16,
 ) std.mem.Allocator.Error!TrendSummary {

--- a/src/client/tui/app/dashboard.zig
+++ b/src/client/tui/app/dashboard.zig
@@ -140,7 +140,7 @@ pub fn drawInputs(
     w.writeText(&surface, ctx, 2, 0, title_txt, theme.boldOn(theme.PANEL, theme.TEXT));
 
     if (visible_inputs.len == 0) {
-        w.writeText(&surface, ctx, 2, 2, "No recent user rules captured.", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 2, 2, "No recent user inputs captured.", theme.fg(theme.MUTED));
         return surface;
     }
 

--- a/src/client/tui/app/dashboard.zig
+++ b/src/client/tui/app/dashboard.zig
@@ -140,7 +140,7 @@ pub fn drawInputs(
     w.writeText(&surface, ctx, 2, 0, title_txt, theme.boldOn(theme.PANEL, theme.TEXT));
 
     if (visible_inputs.len == 0) {
-        w.writeText(&surface, ctx, 2, 2, "No recent user prompts captured.", theme.fg(theme.MUTED));
+        w.writeText(&surface, ctx, 2, 2, "No recent user rules captured.", theme.fg(theme.MUTED));
         return surface;
     }
 

--- a/src/client/tui/app/library.zig
+++ b/src/client/tui/app/library.zig
@@ -7,7 +7,7 @@ const api = @import("../api.zig");
 const data = @import("../view_types.zig");
 const TableRow = @import("../table_row.zig").TableRow;
 const Column = @import("../table_row.zig").Column;
-const prompt_detail_panel = @import("prompt_detail.zig");
+const rule_detail_panel = @import("rule_detail.zig");
 
 const MAX_TREE_ROWS = 128;
 
@@ -24,7 +24,7 @@ pub fn drawListPanel(
     self: anytype,
     ctx: vxfw.DrawContext,
     bundle_label: []const u8,
-    prompt_count: usize,
+    rule_count: usize,
 ) std.mem.Allocator.Error!vxfw.Surface {
     const size = ctx.max.size();
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
@@ -46,14 +46,14 @@ pub fn drawListPanel(
     const hint = switch (self.detail_tab) {
         .content => try std.fmt.allocPrint(
             ctx.arena,
-            "{d} prompts  bundle: {s}  / search  b filter",
-            .{ prompt_count, bundle_label },
+            "{d} rules  bundle: {s}  / search  b filter",
+            .{ rule_count, bundle_label },
         ),
         .pull_requests => blk: {
-            const prompts = self.getPrompts();
-            const sel_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-            if (prompts.len == 0) break :blk @as([]const u8, "no prompts");
-            const prs = self.getPrsForPrompt(prompts[sel_idx].path);
+            const rules = self.getRules();
+            const sel_idx = @min(self.selected_rule, if (rules.len > 0) rules.len - 1 else 0);
+            if (rules.len == 0) break :blk @as([]const u8, "no rules");
+            const prs = self.getPrsForRule(rules[sel_idx].path);
             break :blk try std.fmt.allocPrint(
                 ctx.arena,
                 "{d} PRs  filter:{s}  f cycle",
@@ -90,7 +90,7 @@ pub fn drawListPanel(
                 // Write on the outer panel surface: the ScrollBars
                 // composite returns a buffer-less surface whose
                 // writeCell would trip the vxfw assert.
-                w.drawEmptyState(&surface, ctx, body_origin_col, body_origin_row, status, "prompts");
+                w.drawEmptyState(&surface, ctx, body_origin_col, body_origin_row, status, "rules");
             } else {
                 self.library_scroll_bars.scroll_view.draw_cursor = false;
                 defer self.library_scroll_bars.scroll_view.draw_cursor = true;
@@ -102,9 +102,9 @@ pub fn drawListPanel(
             }
         },
         .pull_requests => {
-            prompt_detail_panel.syncPrWidgets(self);
+            rule_detail_panel.syncPrWidgets(self);
             if (self.pr_row_count == 0) {
-                w.writeText(&surface, ctx, body_origin_col, body_origin_row, "No pull requests for this prompt.", theme.fg(theme.MUTED));
+                w.writeText(&surface, ctx, body_origin_col, body_origin_row, "No pull requests for this rule.", theme.fg(theme.MUTED));
             } else {
                 self.pr_scroll_bars.scroll_view.draw_cursor = false;
                 defer self.pr_scroll_bars.scroll_view.draw_cursor = true;
@@ -186,7 +186,7 @@ pub fn handleModuleEvent(
         return;
     }
     if (key.matches('n', .{}) and self.detail_tab == .content and !self.detail_focus_content) {
-        self.openNewDraftForm(.prompt);
+        self.openNewDraftForm(.rule);
         ctx.consumeAndRedraw();
         return;
     }
@@ -197,7 +197,7 @@ pub fn handleModuleEvent(
     }
 
     if (self.detail_focus_content) {
-        try prompt_detail_panel.handleEmbeddedPaneEvent(self, ctx, event, key);
+        try rule_detail_panel.handleEmbeddedPaneEvent(self, ctx, event, key);
         return;
     }
     switch (self.detail_tab) {
@@ -260,9 +260,9 @@ fn handleFileListEvent(
     if (pos >= self.library_tree.rowCount()) pos = self.library_tree.rowCount() - 1;
     self.library_scroll_bars.scroll_view.cursor = @intCast(pos);
 
-    if (self.library_tree.leafIndexAt(pos)) |prompt_idx| {
-        if (self.selected_prompt != prompt_idx) {
-            self.selected_prompt = prompt_idx;
+    if (self.library_tree.leafIndexAt(pos)) |rule_idx| {
+        if (self.selected_rule != rule_idx) {
+            self.selected_rule = rule_idx;
             self.selected_pr_idx = 0;
             self.pr_scroll_bars.scroll_view.cursor = 0;
             self.pr_filter = .open;
@@ -284,12 +284,12 @@ fn handlePrListEvent(
         };
         self.pr_scroll_bars.scroll_view.cursor = 0;
         self.selected_pr_idx = 0;
-        prompt_detail_panel.fetchSelectedPrDetail(self);
+        rule_detail_panel.fetchSelectedPrDetail(self);
         ctx.consumeAndRedraw();
         return;
     }
 
-    prompt_detail_panel.syncPrWidgets(self);
+    rule_detail_panel.syncPrWidgets(self);
     if (self.pr_row_count == 0) {
         ctx.consumeEvent();
         return;
@@ -313,16 +313,16 @@ fn handlePrListEvent(
         if (self.pr_indices[pos]) |pr_idx| {
             if (self.selected_pr_idx != pr_idx) {
                 self.selected_pr_idx = pr_idx;
-                prompt_detail_panel.fetchSelectedPrDetail(self);
+                rule_detail_panel.fetchSelectedPrDetail(self);
             }
         }
     }
 }
 
 pub fn syncLibraryWidgets(self: anytype) void {
-    const prompts = self.getPrompts();
+    const rules = self.getRules();
     const bundles = self.getBundles();
-    const create_paths = self.drafts_create_prompt_paths;
+    const create_paths = self.drafts_create_rule_paths;
     const filter_name: ?[]const u8 = if (self.library_bundle_filter == 0)
         null
     else if (self.library_bundle_filter - 1 < bundles.len)
@@ -333,7 +333,7 @@ pub fn syncLibraryWidgets(self: anytype) void {
     var filtered_paths: [MAX_TREE_ROWS][]const u8 = undefined;
     var filtered_orig: [MAX_TREE_ROWS]usize = undefined;
     var filtered_len: usize = 0;
-    for (prompts, 0..) |p, pidx| {
+    for (rules, 0..) |p, pidx| {
         if (filter_name) |fname| {
             if (std.mem.indexOf(u8, p.bundle_names, fname) == null) continue;
         }
@@ -344,14 +344,14 @@ pub fn syncLibraryWidgets(self: anytype) void {
     }
 
     // Append local create-op drafts as virtual rows. Tree-leaf index
-    // is `prompts.len + k` so selectedDraftTarget can tell virtual
+    // is `rules.len + k` so selectedDraftTarget can tell virtual
     // rows from server-backed rows by the index range. Bundle filter
     // does not constrain create drafts — the user created them
     // locally, they should always be visible.
     for (create_paths, 0..) |path, k| {
         if (filtered_len >= MAX_TREE_ROWS) break;
         filtered_paths[filtered_len] = path;
-        filtered_orig[filtered_len] = prompts.len + k;
+        filtered_orig[filtered_len] = rules.len + k;
         filtered_len += 1;
     }
 
@@ -375,13 +375,13 @@ pub fn syncLibraryWidgets(self: anytype) void {
             self.library_widgets[i] = self.library_text_rows[i].widget();
         } else {
             const orig_pidx = self.library_tree.leafIndexAt(i) orelse continue;
-            const is_virtual = orig_pidx >= prompts.len;
+            const is_virtual = orig_pidx >= rules.len;
             const row_path: []const u8 = if (is_virtual) blk: {
-                const k = orig_pidx - prompts.len;
+                const k = orig_pidx - rules.len;
                 if (k >= create_paths.len) continue;
                 break :blk create_paths[k];
-            } else prompts[orig_pidx].path;
-            const pr_label: []const u8 = if (is_virtual) "" else switch (prompts[orig_pidx].open_pr_count) {
+            } else rules[orig_pidx].path;
+            const pr_label: []const u8 = if (is_virtual) "" else switch (rules[orig_pidx].open_pr_count) {
                 0 => "",
                 1 => "\xe2\x80\xa21",
                 2 => "\xe2\x80\xa22",
@@ -389,7 +389,7 @@ pub fn syncLibraryWidgets(self: anytype) void {
                 else => "\xe2\x80\xa2+",
             };
             const row_sel = i == selected_row;
-            const draft_status_opt = self.draftStatusFor(.prompt, row_path);
+            const draft_status_opt = self.draftStatusFor(.rule, row_path);
             const labeled_text = if (draft_status_opt != null)
                 (std.fmt.allocPrint(self.viewAllocator(), "{s} *", .{row_text}) catch row_text)
             else
@@ -416,7 +416,7 @@ pub fn syncLibraryWidgets(self: anytype) void {
     self.library_scroll_bars.scroll_view.cursor = @intCast(cur);
     if (cur < row_count) {
         if (self.library_tree.leafIndexAt(cur)) |pi| {
-            self.selected_prompt = pi;
+            self.selected_rule = pi;
         }
     }
 }

--- a/src/client/tui/app/rule_detail.zig
+++ b/src/client/tui/app/rule_detail.zig
@@ -7,7 +7,7 @@ const api = @import("../api.zig");
 const data = @import("../view_types.zig");
 const diff_viewer = @import("../widgets/diff_viewer.zig");
 
-const PromptDetailLayout = struct {
+const RuleDetailLayout = struct {
     inner_h_pad: u16,
     inner_w_pad: u16,
     content_origin_col: i17,
@@ -16,7 +16,7 @@ const PromptDetailLayout = struct {
     pr_diff_origin_row: i17,
 };
 
-const embedded_layout: PromptDetailLayout = .{
+const embedded_layout: RuleDetailLayout = .{
     .inner_h_pad = 2,
     .inner_w_pad = 4,
     .content_origin_col = 2,
@@ -44,22 +44,22 @@ pub fn drawEmbeddedEmpty(
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
     w.writeText(&surface, ctx, 2, 0, "Detail", theme.boldOn(theme.PANEL, theme.TEXT));
-    w.writeText(&surface, ctx, 2, 2, "No prompts loaded.", theme.fg(theme.MUTED));
+    w.writeText(&surface, ctx, 2, 2, "No rules loaded.", theme.fg(theme.MUTED));
     return surface;
 }
 
 pub fn drawEmbedded(
     self: anytype,
     ctx: vxfw.DrawContext,
-    prompt: *const data.PromptEntry,
+    rule: *const data.RuleEntry,
 ) std.mem.Allocator.Error!vxfw.Surface {
-    const body = try buildPromptDetailBody(self, ctx, prompt, embedded_layout);
+    const body = try buildRuleDetailBody(self, ctx, rule, embedded_layout);
 
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
     const border_color = theme.focusBorder(self.detail_focus_content);
     w.fillSurface(&surface, theme.PANEL);
     w.drawBorder(&surface, border_color, theme.PANEL);
-    try fillPromptDetailSurface(&surface, ctx, prompt, embedded_layout, body);
+    try fillRuleDetailSurface(&surface, ctx, rule, embedded_layout, body);
     return surface;
 }
 
@@ -102,7 +102,7 @@ pub fn handleEmbeddedPaneEvent(
     }
 }
 
-fn buildPromptContentSurface(
+fn buildRuleContentSurface(
     self: anytype,
     ctx: vxfw.DrawContext,
     width_pad: u16,
@@ -112,20 +112,20 @@ fn buildPromptContentSurface(
     return buildContentSurface(self, ctx, width_pad, child_height);
 }
 
-fn buildPromptDetailBody(
+fn buildRuleDetailBody(
     self: anytype,
     ctx: vxfw.DrawContext,
-    prompt: *const data.PromptEntry,
-    layout: PromptDetailLayout,
+    rule: *const data.RuleEntry,
+    layout: RuleDetailLayout,
 ) std.mem.Allocator.Error!DetailBody {
     switch (self.detail_tab) {
         .content => {
             return .{
-                .content = try buildPromptContentSurface(self, ctx, layout.inner_w_pad, ctx.max.height.? -| 2),
+                .content = try buildRuleContentSurface(self, ctx, layout.inner_w_pad, ctx.max.height.? -| 2),
             };
         },
         .pull_requests => {
-            const prs = self.getPrsForPrompt(prompt.path);
+            const prs = self.getPrsForRule(rule.path);
             if (prs.len == 0) return .pull_request_empty;
 
             const inner_h = ctx.max.height.? -| layout.inner_h_pad;
@@ -134,13 +134,13 @@ fn buildPromptDetailBody(
             const pr_idx = @min(self.selected_pr_idx, prs.len - 1);
             const pr = &prs[pr_idx];
             // Title matches design/04 drill-down layout:
-            // "{pr_id} ─ {prompt_path} ─ {status} ─ {author} ─ {created}"
+            // "{pr_id} ─ {rule_path} ─ {status} ─ {author} ─ {created}"
             // Dropped `refer:N` — it's not in the design.
             const created_short = w.formatShortTimestamp(ctx.arena, pr.created) catch pr.created;
             const title = try std.fmt.allocPrint(
                 ctx.arena,
                 "{s} ─ {s} ─ {s} ─ {s} ─ {s}",
-                .{ pr.id, pr.prompt_name, pr.status, pr.author, created_short },
+                .{ pr.id, pr.rule_name, pr.status, pr.author, created_short },
             );
             const op_line = try buildPrSubtitle(ctx.arena, pr);
 
@@ -210,17 +210,17 @@ fn shortHash(raw: []const u8) []const u8 {
     return slice[0..@min(7, slice.len)];
 }
 
-fn fillPromptDetailSurface(
+fn fillRuleDetailSurface(
     surface: *vxfw.Surface,
     ctx: vxfw.DrawContext,
-    prompt: *const data.PromptEntry,
-    layout: PromptDetailLayout,
+    rule: *const data.RuleEntry,
+    layout: RuleDetailLayout,
     body: DetailBody,
 ) std.mem.Allocator.Error!void {
     switch (body) {
         .content => |content_surface| {
-            w.writeText(surface, ctx, 2, 0, prompt.path, theme.boldOn(theme.PANEL, theme.TEXT));
-            try writePromptMetaOnPanelChrome(surface, ctx, @intCast(2 + ctx.stringWidth(prompt.path) + 2), prompt);
+            w.writeText(surface, ctx, 2, 0, rule.path, theme.boldOn(theme.PANEL, theme.TEXT));
+            try writeRuleMetaOnPanelChrome(surface, ctx, @intCast(2 + ctx.stringWidth(rule.path) + 2), rule);
             const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
             children[0] = .{
                 .origin = .{
@@ -233,7 +233,7 @@ fn fillPromptDetailSurface(
         },
         .pull_request_empty => {
             w.writeText(surface, ctx, 2, 0, "Pull Requests", theme.boldOn(theme.PANEL, theme.TEXT));
-            w.writeText(surface, ctx, 2, 2, "No pull requests for this prompt.", theme.fg(theme.MUTED));
+            w.writeText(surface, ctx, 2, 2, "No pull requests for this rule.", theme.fg(theme.MUTED));
         },
         .pull_request_diff => |diff| {
             w.writeText(surface, ctx, 2, 0, diff.title, theme.boldOn(theme.PANEL, theme.TEXT));
@@ -254,53 +254,53 @@ fn fillPromptDetailSurface(
     }
 }
 
-fn writePromptMetaOnPanelChrome(
+fn writeRuleMetaOnPanelChrome(
     surface: *vxfw.Surface,
     ctx: vxfw.DrawContext,
     min_col: u16,
-    prompt: *const data.PromptEntry,
+    rule: *const data.RuleEntry,
 ) std.mem.Allocator.Error!void {
     // Virtual row (local create-op draft not yet submitted) has
     // zero revision / prs / constraints / updated. Rendering
     // `rev0 pr0 c0` would be technically accurate but misleading
     // beside a file that is genuinely new. Show `(new)` instead,
     // mirroring the workspace context panel convention.
-    if (prompt.revision == 0 and prompt.content_hash.len == 0 and prompt.updated.len == 0) {
+    if (rule.revision == 0 and rule.content_hash.len == 0 and rule.updated.len == 0) {
         _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
         return;
     }
 
-    const full = try formatPromptMeta(ctx.arena, prompt, true);
+    const full = try formatRuleMeta(ctx.arena, rule, true);
     if (w.writeHeaderRightIfFits(surface, ctx, 0, min_col, full, theme.fg(theme.MUTED))) return;
 
-    const compact = try formatPromptMeta(ctx.arena, prompt, false);
+    const compact = try formatRuleMeta(ctx.arena, rule, false);
     _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, compact, theme.fg(theme.MUTED));
 }
 
-fn formatPromptMeta(
+fn formatRuleMeta(
     arena: std.mem.Allocator,
-    prompt: *const data.PromptEntry,
+    rule: *const data.RuleEntry,
     include_updated: bool,
 ) std.mem.Allocator.Error![]const u8 {
     if (!include_updated) {
         return std.fmt.allocPrint(
             arena,
             "rev{d} pr{d} c{d}",
-            .{ prompt.revision, prompt.open_pr_count, prompt.constraint_count },
+            .{ rule.revision, rule.open_pr_count, rule.constraint_count },
         );
     }
-    const updated = try w.formatShortTimestamp(arena, prompt.updated);
+    const updated = try w.formatShortTimestamp(arena, rule.updated);
     if (updated.len == 0) {
         return std.fmt.allocPrint(
             arena,
             "rev{d} pr{d} c{d}",
-            .{ prompt.revision, prompt.open_pr_count, prompt.constraint_count },
+            .{ rule.revision, rule.open_pr_count, rule.constraint_count },
         );
     }
     return std.fmt.allocPrint(
         arena,
         "rev{d} pr{d} c{d} {s}",
-        .{ prompt.revision, prompt.open_pr_count, prompt.constraint_count, updated },
+        .{ rule.revision, rule.open_pr_count, rule.constraint_count, updated },
     );
 }
 
@@ -331,11 +331,11 @@ fn handlePrDiffEvent(
 }
 
 pub fn fetchSelectedPrDetail(self: anytype) void {
-    const prompts = self.getPrompts();
-    const prompt_idx = @min(self.selected_prompt, if (prompts.len > 0) prompts.len - 1 else 0);
-    if (prompts.len == 0) return;
+    const rules = self.getRules();
+    const rule_idx = @min(self.selected_rule, if (rules.len > 0) rules.len - 1 else 0);
+    if (rules.len == 0) return;
 
-    const prs = self.getPrsForPrompt(prompts[prompt_idx].path);
+    const prs = self.getPrsForRule(rules[rule_idx].path);
     const pr_idx = @min(self.selected_pr_idx, if (prs.len > 0) prs.len - 1 else 0);
     if (prs.len == 0) return;
 
@@ -343,7 +343,7 @@ pub fn fetchSelectedPrDetail(self: anytype) void {
     if (self.api_state.pr_detail_cache.shouldDispatch(.{ .value = pr_id })) {
         api.specs.dispatchFromState(
             api.specs.PrIdParams,
-            @import("clumsies_lib").protocol.collab_api.PromptPrDetailResponse,
+            @import("clumsies_lib").protocol.collab_api.RulePrDetailResponse,
             api.specs.pr_detail,
             &self.api_state.pr_detail_pending,
             self.api_state,
@@ -363,27 +363,27 @@ pub fn fetchSelectedPrDetail(self: anytype) void {
 }
 
 pub fn syncContentWidget(self: anytype) void {
-    const prompts = self.getPrompts();
+    const rules = self.getRules();
     // Virtual rows (create-op drafts) land at indices past
-    // prompts.len and have no server-side entry — their path lives
-    // in drafts_create_prompt_paths. Without this branch the
+    // rules.len and have no server-side entry — their path lives
+    // in drafts_create_rule_paths. Without this branch the
     // content panel renders empty for any draft created via `n`.
-    const selected_path: ?[]const u8 = if (self.selected_prompt < prompts.len)
-        prompts[self.selected_prompt].path
+    const selected_path: ?[]const u8 = if (self.selected_rule < rules.len)
+        rules[self.selected_rule].path
     else blk: {
-        const k = self.selected_prompt - prompts.len;
-        if (k >= self.drafts_create_prompt_paths.len) break :blk null;
-        break :blk self.drafts_create_prompt_paths[k];
+        const k = self.selected_rule - rules.len;
+        if (k >= self.drafts_create_rule_paths.len) break :blk null;
+        break :blk self.drafts_create_rule_paths[k];
     };
-    const cache_content: []const u8 = if (selected_path) |path| self.cachedPromptBody(path) orelse "" else "";
-    const draft_content: ?[]const u8 = if (selected_path) |path| self.draftContentForView(.prompt, path) else null;
+    const cache_content: []const u8 = if (selected_path) |path| self.cachedRuleBody(path) orelse "" else "";
+    const draft_content: ?[]const u8 = if (selected_path) |path| self.draftContentForView(.rule, path) else null;
     syncContentWidgetBytes(self, cache_content, draft_content);
-    self.requestSelectedPromptDetail();
+    self.requestSelectedRuleDetail();
 }
 
 /// Render the working-copy view for an arbitrary (cache, draft)
 /// byte pair into Dashboard.content_scroll_bars. Shared by the
-/// Library prompt detail pane and the Workspace context / prompts
+/// Library rule detail pane and the Workspace context / rules
 /// content panes so both surfaces scroll identically and use the
 /// same DiffViewer gutter formatter. When draft_content is null the
 /// cache bytes are rendered flat (no diff symbols); otherwise we
@@ -422,16 +422,16 @@ pub fn syncWsContextContentWidget(
 }
 
 /// Workspace-side entrypoint mirroring syncWsContextContentWidget
-/// for the Prompts tab. Workspace prompt bodies come from the same
-/// org-wide prompt_content cache that Library reads, but the draft
-/// overlay is keyed by prompt path so this helper threads both
+/// for the Rules tab. Workspace rule bodies come from the same
+/// org-wide rule_content cache that Library reads, but the draft
+/// overlay is keyed by rule path so this helper threads both
 /// into the shared renderer.
-pub fn syncWsPromptContentWidget(
+pub fn syncWsRuleContentWidget(
     self: anytype,
     path: []const u8,
 ) void {
-    const cache_content: []const u8 = self.cachedPromptBody(path) orelse "";
-    const draft_content: ?[]const u8 = self.draftContentForView(.prompt, path);
+    const cache_content: []const u8 = self.cachedRuleBody(path) orelse "";
+    const draft_content: ?[]const u8 = self.draftContentForView(.rule, path);
     syncContentWidgetBytes(self, cache_content, draft_content);
 }
 
@@ -439,7 +439,7 @@ pub fn syncWsPromptContentWidget(
 /// Dashboard.content_scroll_bars state. Call syncContentWidgetBytes
 /// before this (or another `sync*` variant) so the scroll view's
 /// children slice is populated. Layout params match
-/// buildPromptContentSurface's contract.
+/// buildRuleContentSurface's contract.
 pub fn buildContentSurface(
     self: anytype,
     ctx: vxfw.DrawContext,
@@ -500,16 +500,16 @@ fn gutterRowStyle(marker: diff_viewer.Marker) vaxis.Style {
 }
 
 pub fn syncPrWidgets(self: anytype) void {
-    const all_prompts = self.getPrompts();
-    if (all_prompts.len == 0) {
+    const all_rules = self.getRules();
+    if (all_rules.len == 0) {
         self.pr_row_count = 0;
         self.pr_scroll_bars.scroll_view.children = .{ .slice = self.pr_widgets[0..0] };
         self.pr_scroll_bars.estimated_content_height = 0;
         return;
     }
-    const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
-    const p = &all_prompts[sel_idx];
-    const prs = self.getPrsForPrompt(p.path);
+    const sel_idx = @min(self.selected_rule, all_rules.len - 1);
+    const p = &all_rules[sel_idx];
+    const prs = self.getPrsForRule(p.path);
     const view_alloc = self.viewAllocator();
     var row_idx: usize = 0;
     for (prs, 0..) |pr, pi| {
@@ -572,14 +572,14 @@ pub fn syncPrWidgets(self: anytype) void {
 }
 
 pub fn syncPrDiffAndComments(self: anytype, allocator: std.mem.Allocator) void {
-    const all_prompts = self.getPrompts();
-    if (all_prompts.len == 0) {
+    const all_rules = self.getRules();
+    if (all_rules.len == 0) {
         self.pr_diff_count = 0;
         return;
     }
-    const sel_idx = @min(self.selected_prompt, all_prompts.len - 1);
-    const p = &all_prompts[sel_idx];
-    const prs = self.getPrsForPrompt(p.path);
+    const sel_idx = @min(self.selected_rule, all_rules.len - 1);
+    const p = &all_rules[sel_idx];
+    const prs = self.getPrsForRule(p.path);
     if (prs.len == 0) {
         self.pr_diff_count = 0;
         return;
@@ -609,7 +609,7 @@ pub fn syncPrDiffAndComments(self: anytype, allocator: std.mem.Allocator) void {
         for (pr.comments) |comment| {
             // Header: "author · created". Timestamp is compacted
             // through the shared formatter so comment rows match PR
-            // list + prompt panel timestamp layout.
+            // list + rule panel timestamp layout.
             if (count < self.pr_diff_rows.len) {
                 const created_short = w.formatShortTimestamp(allocator, comment.created) catch comment.created;
                 const header = std.fmt.allocPrint(allocator, "{s} \xc2\xb7 {s}", .{ comment.author, created_short }) catch "??";

--- a/src/client/tui/app/workspace.zig
+++ b/src/client/tui/app/workspace.zig
@@ -6,7 +6,7 @@ const w = @import("../widgets.zig");
 const data = @import("../view_types.zig");
 const api = @import("../api.zig");
 const drafts_mod = @import("../../drafts.zig");
-const prompt_detail = @import("prompt_detail.zig");
+const rule_detail = @import("rule_detail.zig");
 const Modal = w.Modal;
 
 const MAX_TREE_ROWS = 128;
@@ -57,8 +57,8 @@ pub const DetailArgs = struct {
     /// the primary identity and only uses `context_sel` to pull
     /// hub-side metadata (hash / author / updated_at).
     context_sel_path: ?[]const u8,
-    prompt_sel_idx: ?usize,
-    prompt_sel_path: ?[]const u8,
+    rule_sel_idx: ?usize,
+    rule_sel_path: ?[]const u8,
 };
 
 pub fn drawStatus(
@@ -139,7 +139,7 @@ pub fn drawList(
     ctx: vxfw.DrawContext,
     ws_tree: anytype,
     live_ws: ?api.model.WsDetail,
-    lib_prompts: []const data.PromptEntry,
+    lib_rules: []const data.RuleEntry,
 ) std.mem.Allocator.Error!vxfw.Surface {
     const list_border = theme.focusBorder(self.ws_focus == .list);
     var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
@@ -149,7 +149,7 @@ pub fn drawList(
     const cursor_col: u16 = 1;
 
     var tab_col: u16 = 2;
-    const ws_tabs = [_]@TypeOf(self.ws_tab){ .context, .prompts };
+    const ws_tabs = [_]@TypeOf(self.ws_tab){ .context, .rules };
     for (ws_tabs) |tab| {
         tab_col = w.drawInnerTabBadge(&surface, ctx, 0, tab_col, wsTabLabel(tab), tab == self.ws_tab);
         tab_col +|= 1;
@@ -159,7 +159,7 @@ pub fn drawList(
     if (ws_tree.rowCount() == 0) {
         const empty_msg = switch (self.ws_tab) {
             .context => "No context files.",
-            .prompts => "No workspace prompts.",
+            .rules => "No workspace rules.",
         };
         w.writeText(&surface, ctx, row_col, 1, empty_msg, theme.fg(theme.MUTED));
         return surface;
@@ -203,15 +203,15 @@ pub fn drawList(
                             .path = self.drafts_create_context_paths[k],
                         };
                     },
-                    .prompts => inner: {
-                        if (leaf >= ws_d.ws_prompts.len) break :inner null;
-                        const wp = ws_d.ws_prompts[leaf];
-                        const prompt_path = if (wp.path.len > 0)
+                    .rules => inner: {
+                        if (leaf >= ws_d.ws_rules.len) break :inner null;
+                        const wp = ws_d.ws_rules[leaf];
+                        const rule_path = if (wp.path.len > 0)
                             wp.path
-                        else for (lib_prompts) |lp| {
+                        else for (lib_rules) |lp| {
                             if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
-                        } else wp.prompt_id;
-                        break :inner MarkerInfo{ .category = .prompt, .path = prompt_path };
+                        } else wp.rule_id;
+                        break :inner MarkerInfo{ .category = .rule, .path = rule_path };
                     },
                 };
                 const m = marker_info orelse break :blk null;
@@ -245,7 +245,7 @@ pub fn drawDetail(
 
     const title: []const u8 = switch (self.ws_tab) {
         .context => if (args.dir_sel) |dir| dir else if (args.context_sel_path) |p| p else "no files",
-        .prompts => if (args.dir_sel) |dir| dir else if (args.prompt_sel_path) |path| path else "no prompts",
+        .rules => if (args.dir_sel) |dir| dir else if (args.rule_sel_path) |path| path else "no rules",
     };
     w.writeText(&surface, ctx, 2, 0, title, theme.boldOn(theme.PANEL, theme.TEXT));
     // Reserve min_col past the title (plus one space) so the
@@ -271,13 +271,13 @@ pub fn drawDetail(
                 w.writeText(&surface, ctx, 2, kv_row, "No context files.", theme.fg(theme.MUTED));
             }
         },
-        .prompts => {
+        .rules => {
             if (args.dir_sel != null) {
                 try drawDirSelected(&surface, ctx, kv_row, max_row);
-            } else if (args.prompt_sel_path) |p| {
-                try drawPromptFileDetail(self, &surface, ctx, kv_row, max_row, p);
+            } else if (args.rule_sel_path) |p| {
+                try drawRuleFileDetail(self, &surface, ctx, kv_row, max_row, p);
             } else {
-                w.writeText(&surface, ctx, 2, kv_row, "No workspace prompts.", theme.fg(theme.MUTED));
+                w.writeText(&surface, ctx, 2, kv_row, "No workspace rules.", theme.fg(theme.MUTED));
             }
         },
     }
@@ -288,7 +288,7 @@ pub fn drawDetail(
 /// Render a one-line metadata badge at the top-right of the header,
 /// mirroring Library's `rev{N} pr{N} c{N} {updated}` convention. For
 /// context files we render `hash7 author updated`; for workspace
-/// prompts the hash is all we have from the manifest; for virtual
+/// rules the hash is all we have from the manifest; for virtual
 /// (create-op) drafts we render an accent-colored `(new)` banner so
 /// the user knows the file is unsubmitted.
 fn writeWsMetaOnHeader(
@@ -317,10 +317,10 @@ fn writeWsMetaOnHeader(
                 _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, "(new)", theme.fg(theme.ACCENT));
             }
         },
-        .prompts => {
-            if (args.prompt_sel_idx) |idx| {
-                if (idx >= ws_d.ws_prompts.len) return;
-                const p = &ws_d.ws_prompts[idx];
+        .rules => {
+            if (args.rule_sel_idx) |idx| {
+                if (idx >= ws_d.ws_rules.len) return;
+                const p = &ws_d.ws_rules[idx];
                 const hash7 = hashBadge(p.content_hash);
                 _ = w.writeHeaderRightIfFits(surface, ctx, 0, min_col, hash7, theme.fg(theme.MUTED));
             }
@@ -368,31 +368,31 @@ fn drawContextFileDetail(
     });
 }
 
-fn drawPromptFileDetail(
+fn drawRuleFileDetail(
     self: anytype,
     surface: *vxfw.Surface,
     ctx: vxfw.DrawContext,
     start_row: u16,
     max_row: u16,
-    prompt_path: []const u8,
+    rule_path: []const u8,
 ) !void {
     if (self.ws_show_diff) {
         w.writeText(surface, ctx, 2, start_row, "No diff available", theme.fg(theme.MUTED));
         return;
     }
     try attachContentSurface(self, surface, ctx, start_row, max_row, .{
-        .prompt = .{ .path = prompt_path },
+        .rule = .{ .path = rule_path },
     });
 }
 
 const ContentSource = union(enum) {
     context: struct { ws_id: []const u8, path: []const u8 },
-    prompt: struct { path: []const u8 },
+    rule: struct { path: []const u8 },
 };
 
 /// Seed the shared content_scroll_bars with working-copy bytes for
 /// the source and attach the scroll view as a child surface below
-/// the metadata rows. Library's prompt_detail path uses the same
+/// the metadata rows. Library's rule_detail path uses the same
 /// scroll bars, so switching modules redraws content into the same
 /// widget state — no per-module scroll state today.
 fn attachContentSurface(
@@ -404,8 +404,8 @@ fn attachContentSurface(
     source: ContentSource,
 ) !void {
     switch (source) {
-        .context => |c| prompt_detail.syncWsContextContentWidget(self, c.ws_id, c.path),
-        .prompt => |p| prompt_detail.syncWsPromptContentWidget(self, p.path),
+        .context => |c| rule_detail.syncWsContextContentWidget(self, c.ws_id, c.path),
+        .rule => |p| rule_detail.syncWsRuleContentWidget(self, p.path),
     }
     const content_h: u16 = if (max_row > start_row) max_row - start_row else 0;
     if (content_h == 0) return;
@@ -414,7 +414,7 @@ fn attachContentSurface(
         .{ .width = ctx.max.width.? -| width_pad, .height = content_h },
         .{ .width = ctx.max.width.? -| width_pad, .height = content_h },
     );
-    const body = try prompt_detail.buildContentSurface(self, inner_ctx, width_pad, content_h);
+    const body = try rule_detail.buildContentSurface(self, inner_ctx, width_pad, content_h);
     const prev = surface.children;
     const children = try ctx.arena.alloc(vxfw.SubSurface, prev.len + 1);
     for (prev, 0..) |c, i| children[i] = c;
@@ -461,7 +461,7 @@ pub fn handleModuleEvent(
     // `n` creates a new context-file draft. Bound at module level
     // (like Library's `n`) rather than inside list-focus so users
     // can still reach it from the workspace bar without tabbing
-    // into the list first. Prompts are org-owned — workspace does
+    // into the list first. Rules are org-owned — workspace does
     // not create them, so `n` is gated on the Context tab.
     if (key.matches('n', .{}) and self.ws_tab == .context) {
         self.openNewDraftForm(.context);
@@ -487,7 +487,7 @@ pub fn handleModuleEvent(
 fn wsTabLabel(tab: anytype) []const u8 {
     return switch (tab) {
         .context => "Context",
-        .prompts => "Prompts",
+        .rules => "Rules",
     };
 }
 
@@ -651,7 +651,7 @@ fn handleContentFocusEvent(
     }
     // Forward scroll keys to the shared content_scroll_bars so j/k,
     // arrow keys, PgUp/PgDn, g/G drive the content panel identically
-    // to the Library prompt-detail pane. vxfw's ScrollView consumes
+    // to the Library rule-detail pane. vxfw's ScrollView consumes
     // the ones it knows and ignores the rest, so this is safe as a
     // catch-all.
     try self.content_scroll_bars.scroll_view.handleEvent(ctx, .{ .key_press = key });
@@ -720,21 +720,21 @@ pub fn syncWsRows(self: anytype) void {
                 item_count += 1;
             }
         },
-        .prompts => {
-            const lib_prompts = self.getPrompts();
-            item_count = @min(ws_d.ws_prompts.len, MAX_TREE_ROWS);
+        .rules => {
+            const lib_rules = self.getRules();
+            item_count = @min(ws_d.ws_rules.len, MAX_TREE_ROWS);
             for (0..item_count) |i| {
-                const wp = ws_d.ws_prompts[i];
+                const wp = ws_d.ws_rules[i];
                 paths_buf[i] = if (wp.path.len > 0)
                     wp.path
-                else for (lib_prompts) |lp| {
+                else for (lib_rules) |lp| {
                     if (std.mem.eql(u8, lp.content_hash, wp.content_hash)) break lp.path;
-                } else wp.prompt_id;
+                } else wp.rule_id;
                 orig_idx[i] = i;
             }
-            // Workspace does not own prompt creation, so no virtual
+            // Workspace does not own rule creation, so no virtual
             // rows are appended here. Library is the place to create
-            // a new prompt draft; once submitted and merged it shows
+            // a new rule draft; once submitted and merged it shows
             // up through the workspace manifest.
         },
     }
@@ -929,7 +929,7 @@ fn drawCreateForm(
         ctx,
         c0 + label_w,
         row,
-        "(optional) seeds workspace with a prompt set",
+        "(optional) seeds workspace with a rule set",
         theme.textOn(bg, theme.MUTED),
     );
     row += 1;
@@ -997,8 +997,8 @@ fn drawCreateBundleList(
 
         const text = std.fmt.allocPrint(
             ctx.arena,
-            "{s}{s}  ({d} prompts)",
-            .{ marker, b.name, b.prompt_count },
+            "{s}{s}  ({d} rules)",
+            .{ marker, b.name, b.rule_count },
         ) catch continue;
 
         const render_row: u16 = row + 1 + @as(u16, @intCast(i - scroll_start));

--- a/src/client/tui/attestation_reader.zig
+++ b/src/client/tui/attestation_reader.zig
@@ -1,6 +1,6 @@
 // Read local attestation.jsonl files and compute analysis stats.
 const std = @import("std");
-const workspace_prompt = @import("../prompt.zig");
+const workspace_rule = @import("../rule.zig");
 const data = @import("view_types.zig");
 
 pub const LocalStats = struct {
@@ -10,7 +10,7 @@ pub const LocalStats = struct {
     signal_ratio: u8 = 0,
     refer_trend: [30]u16 = .{0} ** 30,
     refers: []const ReferEvent = &.{},
-    prompts: []const data.AnalysisPrompt = &.{},
+    rules: []const data.AnalysisRule = &.{},
     inputs: []const InputEvent = &.{},
     workspaces: []const WorkspaceLocalStats = &.{},
 
@@ -30,7 +30,7 @@ pub const WorkspaceLocalStats = struct {
     signal_ratio: u8 = 0,
     refer_trend: [30]u16 = .{0} ** 30,
     refers: []const ReferEvent = &.{},
-    prompts: []const data.AnalysisPrompt = &.{},
+    rules: []const data.AnalysisRule = &.{},
     inputs: []const InputEvent = &.{},
 };
 
@@ -51,14 +51,14 @@ const AttestationEvent = struct {
     session_id: []const u8 = "",
     type: []const u8 = "",
     timestamp: i64 = 0,
-    prompt_id: ?[]const u8 = null,
-    prompt_hash: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
+    rule_hash: ?[]const u8 = null,
     constraint_id: ?[]const u8 = null,
     reason: ?[]const u8 = null,
     content: ?[]const u8 = null,
 };
 
-const PromptConstraintTotals = std.StringHashMap(u16);
+const RuleConstraintTotals = std.StringHashMap(u16);
 
 pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     const base = getBaseDir(allocator) orelse return null;
@@ -71,8 +71,8 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
 
     var all_events: std.ArrayList(AttestationEvent) = .empty;
     var workspace_stats: std.ArrayList(WorkspaceLocalStats) = .empty;
-    var all_prompt_totals: PromptConstraintTotals = .init(allocator);
-    defer deinitPromptConstraintTotals(allocator, &all_prompt_totals);
+    var all_rule_totals: RuleConstraintTotals = .init(allocator);
+    defer deinitRuleConstraintTotals(allocator, &all_rule_totals);
     var it = dir.iterate();
     while (it.next() catch null) |entry| {
         if (entry.kind != .directory) continue;
@@ -88,12 +88,12 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
         if (ws_events.items.len == 0) continue;
         keep_ws_id = true;
 
-        var ws_prompt_totals = loadPromptConstraintTotals(allocator, ws_dir) catch PromptConstraintTotals.init(allocator);
-        defer deinitPromptConstraintTotals(allocator, &ws_prompt_totals);
+        var ws_rule_totals = loadRuleConstraintTotals(allocator, ws_dir) catch RuleConstraintTotals.init(allocator);
+        defer deinitRuleConstraintTotals(allocator, &ws_rule_totals);
 
-        mergePromptConstraintTotals(allocator, &all_prompt_totals, &ws_prompt_totals);
+        mergeRuleConstraintTotals(allocator, &all_rule_totals, &ws_rule_totals);
 
-        const ws_stats = computeStats(allocator, ws_events.items, &ws_prompt_totals);
+        const ws_stats = computeStats(allocator, ws_events.items, &ws_rule_totals);
         workspace_stats.append(allocator, .{
             .ws_id = ws_id,
             .total_refer_count = ws_stats.total_refer_count,
@@ -102,7 +102,7 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
             .signal_ratio = ws_stats.signal_ratio,
             .refer_trend = ws_stats.refer_trend,
             .refers = ws_stats.refers,
-            .prompts = ws_stats.prompts,
+            .rules = ws_stats.rules,
             .inputs = ws_stats.inputs,
         }) catch continue;
 
@@ -112,7 +112,7 @@ pub fn readLocalStats(allocator: std.mem.Allocator) ?LocalStats {
     }
 
     if (all_events.items.len == 0) return null;
-    var all_stats = computeStats(allocator, all_events.items, &all_prompt_totals);
+    var all_stats = computeStats(allocator, all_events.items, &all_rule_totals);
     all_stats.workspaces = workspace_stats.items;
     return all_stats;
 }
@@ -174,8 +174,8 @@ fn cloneAttestationEvent(allocator: std.mem.Allocator, ws_id: []const u8, src: A
         .session_id = try allocator.dupe(u8, src.session_id),
         .type = try allocator.dupe(u8, src.type),
         .timestamp = src.timestamp,
-        .prompt_id = null,
-        .prompt_hash = null,
+        .rule_id = null,
+        .rule_hash = null,
         .constraint_id = null,
         .reason = null,
         .content = null,
@@ -183,11 +183,11 @@ fn cloneAttestationEvent(allocator: std.mem.Allocator, ws_id: []const u8, src: A
     errdefer allocator.free(out.session_id);
     errdefer allocator.free(out.type);
 
-    out.prompt_id = try dupeOptional(allocator, src.prompt_id);
-    errdefer if (out.prompt_id) |s| allocator.free(s);
+    out.rule_id = try dupeOptional(allocator, src.rule_id);
+    errdefer if (out.rule_id) |s| allocator.free(s);
 
-    out.prompt_hash = try dupeOptional(allocator, src.prompt_hash);
-    errdefer if (out.prompt_hash) |s| allocator.free(s);
+    out.rule_hash = try dupeOptional(allocator, src.rule_hash);
+    errdefer if (out.rule_hash) |s| allocator.free(s);
 
     out.constraint_id = try dupeOptional(allocator, src.constraint_id);
     errdefer if (out.constraint_id) |s| allocator.free(s);
@@ -208,18 +208,18 @@ fn dupeOptional(allocator: std.mem.Allocator, maybe: ?[]const u8) !?[]const u8 {
 fn freeAttestationEventOwned(allocator: std.mem.Allocator, ev: AttestationEvent) void {
     allocator.free(ev.session_id);
     allocator.free(ev.type);
-    if (ev.prompt_id) |s| allocator.free(s);
-    if (ev.prompt_hash) |s| allocator.free(s);
+    if (ev.rule_id) |s| allocator.free(s);
+    if (ev.rule_hash) |s| allocator.free(s);
     if (ev.constraint_id) |s| allocator.free(s);
     if (ev.reason) |s| allocator.free(s);
     if (ev.content) |s| allocator.free(s);
 }
 
-fn loadPromptConstraintTotals(allocator: std.mem.Allocator, ws_dir: []const u8) !PromptConstraintTotals {
-    var totals: PromptConstraintTotals = .init(allocator);
-    errdefer deinitPromptConstraintTotals(allocator, &totals);
+fn loadRuleConstraintTotals(allocator: std.mem.Allocator, ws_dir: []const u8) !RuleConstraintTotals {
+    var totals: RuleConstraintTotals = .init(allocator);
+    errdefer deinitRuleConstraintTotals(allocator, &totals);
 
-    var manifest = workspace_prompt.loadManifest(allocator, ws_dir) catch |err| switch (err) {
+    var manifest = workspace_rule.loadManifest(allocator, ws_dir) catch |err| switch (err) {
         error.InvalidManifest, error.FileNotFound => return totals,
         else => return err,
     };
@@ -228,59 +228,59 @@ fn loadPromptConstraintTotals(allocator: std.mem.Allocator, ws_dir: []const u8) 
     var ids: std.ArrayList([]const u8) = .empty;
     defer ids.deinit(allocator);
 
-    var it = manifest.prompts.iterator();
+    var it = manifest.rules.iterator();
     while (it.next()) |entry| {
         ids.append(allocator, entry.key_ptr.*) catch continue;
     }
 
     if (ids.items.len == 0) return totals;
 
-    var loaded = workspace_prompt.loadPrompts(allocator, ws_dir, ids.items, &.{}) catch |err| switch (err) {
-        error.UnknownPromptId, error.FileNotFound, error.UnsafeCachePath => return totals,
+    var loaded = workspace_rule.loadRules(allocator, ws_dir, ids.items, &.{}) catch |err| switch (err) {
+        error.UnknownRuleId, error.FileNotFound, error.UnsafeCachePath => return totals,
         else => return err,
     };
     defer loaded.deinit(allocator);
 
-    for (loaded.items.items) |prompt_item| {
-        const content = prompt_item.content orelse continue;
-        var parsed = workspace_prompt.parseConstraints(allocator, content) catch continue;
+    for (loaded.items.items) |rule_item| {
+        const content = rule_item.content orelse continue;
+        var parsed = workspace_rule.parseConstraints(allocator, content) catch continue;
         defer parsed.deinit(allocator);
 
         const constraint_total: u16 = @intCast(@min(parsed.constraints.items.len, std.math.maxInt(u16)));
-        putPromptConstraintTotal(allocator, &totals, prompt_item.id, constraint_total) catch continue;
+        putRuleConstraintTotal(allocator, &totals, rule_item.id, constraint_total) catch continue;
     }
 
     return totals;
 }
 
-fn mergePromptConstraintTotals(
+fn mergeRuleConstraintTotals(
     allocator: std.mem.Allocator,
-    target: *PromptConstraintTotals,
-    source: *const PromptConstraintTotals,
+    target: *RuleConstraintTotals,
+    source: *const RuleConstraintTotals,
 ) void {
     var it = source.iterator();
     while (it.next()) |entry| {
-        putPromptConstraintTotal(allocator, target, entry.key_ptr.*, entry.value_ptr.*) catch continue;
+        putRuleConstraintTotal(allocator, target, entry.key_ptr.*, entry.value_ptr.*) catch continue;
     }
 }
 
-fn putPromptConstraintTotal(
+fn putRuleConstraintTotal(
     allocator: std.mem.Allocator,
-    totals: *PromptConstraintTotals,
-    prompt_id: []const u8,
+    totals: *RuleConstraintTotals,
+    rule_id: []const u8,
     constraint_total: u16,
 ) !void {
-    if (totals.getPtr(prompt_id)) |value_ptr| {
+    if (totals.getPtr(rule_id)) |value_ptr| {
         if (constraint_total > value_ptr.*) value_ptr.* = constraint_total;
         return;
     }
 
-    const key = try allocator.dupe(u8, prompt_id);
+    const key = try allocator.dupe(u8, rule_id);
     errdefer allocator.free(key);
     try totals.put(key, constraint_total);
 }
 
-fn deinitPromptConstraintTotals(allocator: std.mem.Allocator, totals: *PromptConstraintTotals) void {
+fn deinitRuleConstraintTotals(allocator: std.mem.Allocator, totals: *RuleConstraintTotals) void {
     var key_it = totals.keyIterator();
     while (key_it.next()) |key| allocator.free(key.*);
     totals.deinit();
@@ -289,15 +289,15 @@ fn deinitPromptConstraintTotals(allocator: std.mem.Allocator, totals: *PromptCon
 fn computeStats(
     allocator: std.mem.Allocator,
     events: []const AttestationEvent,
-    prompt_totals: *const PromptConstraintTotals,
+    rule_totals: *const RuleConstraintTotals,
 ) LocalStats {
     var stats: LocalStats = .{};
 
-    const PromptAcc = struct {
+    const RuleAcc = struct {
         refer_count: u32 = 0,
         constraints: std.StringHashMap(u32),
     };
-    var prompt_map: std.StringHashMap(PromptAcc) = .init(allocator);
+    var rule_map: std.StringHashMap(RuleAcc) = .init(allocator);
 
     var refers_list: std.ArrayList(ReferEvent) = .empty;
     var inputs_list: std.ArrayList(InputEvent) = .empty;
@@ -330,8 +330,8 @@ fn computeStats(
             stats.refer_trend[bucket] += 1;
         }
 
-        const pid = ev.prompt_id orelse continue;
-        const entry = prompt_map.getOrPut(pid) catch continue;
+        const pid = ev.rule_id orelse continue;
+        const entry = rule_map.getOrPut(pid) catch continue;
         if (!entry.found_existing) {
             entry.value_ptr.* = .{ .refer_count = 0, .constraints = .init(allocator) };
         }
@@ -344,14 +344,14 @@ fn computeStats(
         }
     }
 
-    var prompts_list: std.ArrayList(data.AnalysisPrompt) = .empty;
+    var rules_list: std.ArrayList(data.AnalysisRule) = .empty;
     var total_constraints: u32 = 0;
     var active_constraints: u32 = 0;
 
-    var map_it = prompt_map.iterator();
+    var map_it = rule_map.iterator();
     while (map_it.next()) |kv| {
         const active_count_u32: u32 = @intCast(kv.value_ptr.constraints.count());
-        const total_count_u32: u32 = if (prompt_totals.get(kv.key_ptr.*)) |count|
+        const total_count_u32: u32 = if (rule_totals.get(kv.key_ptr.*)) |count|
             @max(@as(u32, count), active_count_u32)
         else
             active_count_u32;
@@ -387,7 +387,7 @@ fn computeStats(
             }
         }.cmp);
 
-        prompts_list.append(allocator, .{
+        rules_list.append(allocator, .{
             .name = kv.key_ptr.*,
             .constraint_count = total_count,
             .active_constraint_count = active_count,
@@ -403,8 +403,8 @@ fn computeStats(
         }) catch continue;
     }
 
-    std.mem.sort(data.AnalysisPrompt, prompts_list.items, {}, struct {
-        fn cmp(_: void, a: data.AnalysisPrompt, b: data.AnalysisPrompt) bool {
+    std.mem.sort(data.AnalysisRule, rules_list.items, {}, struct {
+        fn cmp(_: void, a: data.AnalysisRule, b: data.AnalysisRule) bool {
             return a.refer_count > b.refer_count;
         }
     }.cmp);
@@ -416,7 +416,7 @@ fn computeStats(
     else
         0;
     stats.refers = refers_list.items;
-    stats.prompts = prompts_list.items;
+    stats.rules = rules_list.items;
 
     std.mem.sort(InputEvent, inputs_list.items, {}, struct {
         fn cmp(_: void, a: InputEvent, b: InputEvent) bool {
@@ -428,7 +428,7 @@ fn computeStats(
     return stats;
 }
 
-test "computeStats uses prompt totals to derive non-100 signal ratios" {
+test "computeStats uses rule totals to derive non-100 signal ratios" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
@@ -439,7 +439,7 @@ test "computeStats uses prompt totals to derive non-100 signal ratios" {
             .session_id = "ses-1",
             .type = "refer",
             .timestamp = std.time.milliTimestamp(),
-            .prompt_id = "p-1",
+            .rule_id = "p-1",
             .constraint_id = "c-1",
         },
         .{
@@ -447,27 +447,27 @@ test "computeStats uses prompt totals to derive non-100 signal ratios" {
             .session_id = "ses-1",
             .type = "refer",
             .timestamp = std.time.milliTimestamp(),
-            .prompt_id = "p-1",
+            .rule_id = "p-1",
             .constraint_id = "c-2",
         },
     };
 
-    var totals: PromptConstraintTotals = .init(alloc);
-    defer deinitPromptConstraintTotals(alloc, &totals);
-    try putPromptConstraintTotal(alloc, &totals, "p-1", 4);
+    var totals: RuleConstraintTotals = .init(alloc);
+    defer deinitRuleConstraintTotals(alloc, &totals);
+    try putRuleConstraintTotal(alloc, &totals, "p-1", 4);
 
     const stats = computeStats(alloc, &events, &totals);
 
     try std.testing.expectEqual(@as(u32, 4), stats.constraint_count);
     try std.testing.expectEqual(@as(u32, 2), stats.active_constraint_count);
     try std.testing.expectEqual(@as(u8, 50), stats.signal_ratio);
-    try std.testing.expectEqual(@as(u8, 4), stats.prompts[0].constraint_count);
-    try std.testing.expectEqual(@as(u8, 2), stats.prompts[0].active_constraint_count);
-    try std.testing.expectEqual(@as(u8, 2), stats.prompts[0].idle_constraint_count);
-    try std.testing.expectEqual(@as(u8, 50), stats.prompts[0].signal_ratio);
+    try std.testing.expectEqual(@as(u8, 4), stats.rules[0].constraint_count);
+    try std.testing.expectEqual(@as(u8, 2), stats.rules[0].active_constraint_count);
+    try std.testing.expectEqual(@as(u8, 2), stats.rules[0].idle_constraint_count);
+    try std.testing.expectEqual(@as(u8, 50), stats.rules[0].signal_ratio);
 }
 
-test "computeStats falls back to active constraint counts when prompt totals are unavailable" {
+test "computeStats falls back to active constraint counts when rule totals are unavailable" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const alloc = arena.allocator();
@@ -478,13 +478,13 @@ test "computeStats falls back to active constraint counts when prompt totals are
             .session_id = "ses-1",
             .type = "refer",
             .timestamp = std.time.milliTimestamp(),
-            .prompt_id = "p-1",
+            .rule_id = "p-1",
             .constraint_id = "c-1",
         },
     };
 
-    var totals: PromptConstraintTotals = .init(alloc);
-    defer deinitPromptConstraintTotals(alloc, &totals);
+    var totals: RuleConstraintTotals = .init(alloc);
+    defer deinitRuleConstraintTotals(alloc, &totals);
 
     const stats = computeStats(alloc, &events, &totals);
 

--- a/src/client/tui/drafts_reader.zig
+++ b/src/client/tui/drafts_reader.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 
 pub const DraftEntry = struct {
     category: []const u8,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     current_path: ?[]const u8 = null,
     draft_path: []const u8,
     operation: []const u8,
@@ -54,7 +54,7 @@ fn readIndexFile(allocator: std.mem.Allocator, path: []const u8, out: *std.Array
         version: u32 = 1,
         drafts: []const struct {
             category: []const u8 = "",
-            prompt_id: ?[]const u8 = null,
+            rule_id: ?[]const u8 = null,
             current_path: ?[]const u8 = null,
             draft_path: []const u8 = "",
             operation: []const u8 = "",
@@ -70,7 +70,7 @@ fn readIndexFile(allocator: std.mem.Allocator, path: []const u8, out: *std.Array
     for (parsed.value.drafts) |d| {
         out.append(allocator, .{
             .category = allocator.dupe(u8, d.category) catch continue,
-            .prompt_id = if (d.prompt_id) |pid| (allocator.dupe(u8, pid) catch continue) else null,
+            .rule_id = if (d.rule_id) |pid| (allocator.dupe(u8, pid) catch continue) else null,
             .current_path = if (d.current_path) |cp| (allocator.dupe(u8, cp) catch continue) else null,
             .draft_path = allocator.dupe(u8, d.draft_path) catch continue,
             .operation = allocator.dupe(u8, d.operation) catch continue,

--- a/src/client/tui/view_types.zig
+++ b/src/client/tui/view_types.zig
@@ -1,7 +1,7 @@
 // View model types for TUI display, transformed from Hub API responses.
 const std = @import("std");
 
-pub const PromptEntry = struct {
+pub const RuleEntry = struct {
     path: []const u8,
     kind: []const u8,
     refer_count: []const u8,
@@ -39,7 +39,7 @@ pub const ActiveSessionView = struct {
 
 pub const PullRequestEntry = struct {
     id: []const u8,
-    prompt_name: []const u8,
+    rule_name: []const u8,
     status: []const u8,
     author: []const u8,
     created: []const u8,
@@ -63,7 +63,7 @@ pub const AccessLevel = enum {
 
 pub const WorkspaceEntry = struct {
     name: []const u8,
-    prompts: u8,
+    rules: u8,
     contexts: u8,
     local_rev: u16,
     remote_rev: u16,
@@ -80,12 +80,12 @@ pub const ConstraintStat = struct {
     idle_days: ?u16,
 };
 
-pub const MemberPromptStat = struct {
+pub const MemberRuleStat = struct {
     name: []const u8,
     refer_count: u32,
 };
 
-pub const AnalysisPrompt = struct {
+pub const AnalysisRule = struct {
     name: []const u8,
     constraint_count: u8,
     active_constraint_count: u8,
@@ -105,7 +105,7 @@ pub const MemberStats = struct {
     refer_count: u32,
     active_days: u8,
     trend: [30]u16,
-    top_prompts: []const MemberPromptStat,
+    top_rules: []const MemberRuleStat,
     models: []const ModelStats,
 };
 
@@ -122,7 +122,7 @@ pub const AlertLevel = enum {
 };
 
 pub const AnalysisAlert = struct {
-    prompt_name: []const u8,
+    rule_name: []const u8,
     level: AlertLevel,
     message: []const u8,
 };
@@ -136,7 +136,7 @@ pub const AnalysisData = struct {
     today_delta_pct: i8 = 0,
     last_event_minutes_ago: u16 = 0,
     refer_trend: [30]u16 = .{0} ** 30,
-    prompts: []const AnalysisPrompt = &.{},
+    rules: []const AnalysisRule = &.{},
     members: []const MemberStats = &.{},
     models: []const ModelStats = &.{},
     alerts: []const AnalysisAlert = &.{},
@@ -157,7 +157,7 @@ pub const ContextFile = struct {
     branch_diff: []const []const u8,
 };
 
-pub const WsPromptEntry = struct {
+pub const WsRuleEntry = struct {
     name: []const u8,
     kind: []const u8,
     hash: []const u8,
@@ -199,7 +199,7 @@ pub const TokenInfo = struct {
 
 // Token scope definitions
 pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
-    .{ .name = "library:read", .description = "Read prompts and bundles" },
+    .{ .name = "library:read", .description = "Read rules and bundles" },
     .{ .name = "library:write", .description = "Create pull requests" },
     .{ .name = "bundle:write", .description = "Bundle CRUD" },
     .{ .name = "workspace:read", .description = "Read workspace manifest/files" },
@@ -215,7 +215,7 @@ pub const ALL_SCOPES = [_]struct { name: []const u8, description: []const u8 }{
 
 // Derives kind short label from path prefix. Rule is the default kind;
 // workflow/ is the only explicit prefix. Reserved top-level paths (META_PROMPT.md,
-// PIN.md) produce an empty label since they are not searchable prompts.
+// PIN.md) produce an empty label since they are not searchable rules.
 pub fn kindFromPath(path: []const u8) []const u8 {
     if (std.mem.eql(u8, path, "META_PROMPT.md")) return "";
     if (std.mem.eql(u8, path, "PIN.md")) return "";

--- a/src/client/workspace_config.zig
+++ b/src/client/workspace_config.zig
@@ -1,6 +1,6 @@
 //! Workspace binding resolution. Reads ~/.clumsies/config.toml to find which workspace owns a
 //! given filesystem path. The MCP server uses this at startup to determine which workspace's
-//! prompts and context to serve.
+//! rules and context to serve.
 const std = @import("std");
 const toml = @import("toml");
 const auth = @import("auth.zig");

--- a/src/hub/attestation.zig
+++ b/src/hub/attestation.zig
@@ -1,5 +1,5 @@
 //! Hub attestation endpoints. Ingests attestation events uploaded by clients (POST /api/attestations), stores them
-//! in PostgreSQL, and serves aggregated statistics: refer counts, signal ratios, per-prompt and
+//! in PostgreSQL, and serves aggregated statistics: refer counts, signal ratios, per-rule and
 //! per-user trends for the TUI dashboard.
 const std = @import("std");
 const httpz = @import("httpz");
@@ -8,13 +8,13 @@ const Server = @import("server.zig");
 const auth = @import("auth.zig");
 const apiError = @import("api_error.zig").send;
 const log = std.log.scoped(.attestation_stats);
-const OrgPromptStats = stats_api.OrgPromptStat;
+const OrgRuleStats = stats_api.OrgRuleStat;
 const OrgStatsResponse = stats_api.OrgStatsResponse;
 const OrgUserStats = stats_api.OrgUserStat;
 const TrendEntry = stats_api.TrendPoint;
 const TrendSeries = stats_api.TrendSeries;
-const UserTopPromptStat = stats_api.OrgUserTopPromptStat;
-const WorkspacePromptStat = stats_api.WorkspacePromptStat;
+const UserTopRuleStat = stats_api.OrgUserTopRuleStat;
+const WorkspaceRuleStat = stats_api.WorkspaceRuleStat;
 const WorkspaceStatsResponse = stats_api.WorkspaceStatsResponse;
 
 const AttestationEventInput = struct {
@@ -23,8 +23,8 @@ const AttestationEventInput = struct {
     ws_id: []const u8,
     type: []const u8,
     timestamp: i64,
-    prompt_id: ?[]const u8 = null,
-    prompt_hash: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
+    rule_hash: ?[]const u8 = null,
     constraint_id: ?[]const u8 = null,
     reason: ?[]const u8 = null,
     content: ?[]const u8 = null,
@@ -107,50 +107,50 @@ fn setTrendBucket(series: []i64, age_days: i64, count: i64) void {
     series[idx] = count;
 }
 
-fn queryPromptTrendSeries(
+fn queryRuleTrendSeries(
     conn: anytype,
     arena: std.mem.Allocator,
     org_id: []const u8,
     max_days: u32,
 ) std.StringHashMap([]i64) {
-    var series_by_prompt = std.StringHashMap([]i64).init(arena);
+    var series_by_rule = std.StringHashMap([]i64).init(arena);
     const cutoff_ms = recentCutoffMs(max_days);
 
     var result = conn.query(
-        \\SELECT te.prompt_id,
+        \\SELECT te.rule_id,
         \\  floor(extract(epoch from (date_trunc('day', now()) - date_trunc('day', to_timestamp(te.timestamp / 1000)))) / 86400)::bigint as age_days,
         \\  count(*) as refer_count
         \\FROM attestation_events te
         \\JOIN workspaces w ON w.ws_id = te.ws_id
         \\WHERE w.org_id = $1::uuid
         \\  AND te.type = 'refer'
-        \\  AND te.prompt_id IS NOT NULL
+        \\  AND te.rule_id IS NOT NULL
         \\  AND te.timestamp >= $2
-        \\GROUP BY te.prompt_id, age_days
-        \\ORDER BY te.prompt_id, age_days
+        \\GROUP BY te.rule_id, age_days
+        \\ORDER BY te.rule_id, age_days
     , .{ org_id, cutoff_ms }) catch |err| {
-        log.err("prompt trend query failed: {}", .{err});
-        return series_by_prompt;
+        log.err("rule trend query failed: {}", .{err});
+        return series_by_rule;
     };
     defer result.deinit();
 
     while (result.next() catch null) |row| {
-        const prompt_id = row.get([]const u8, 0) catch continue;
+        const rule_id = row.get([]const u8, 0) catch continue;
         const age_days = row.get(i64, 1) catch continue;
         const refer_count = row.get(i64, 2) catch continue;
 
-        if (series_by_prompt.getPtr(prompt_id)) |series_ptr| {
+        if (series_by_rule.getPtr(rule_id)) |series_ptr| {
             setTrendBucket(series_ptr.*, age_days, refer_count);
             continue;
         }
 
         const series = zeroTrendSeries(arena, max_days);
-        const key = arena.dupe(u8, prompt_id) catch continue;
-        series_by_prompt.put(key, series) catch continue;
+        const key = arena.dupe(u8, rule_id) catch continue;
+        series_by_rule.put(key, series) catch continue;
         setTrendBucket(series, age_days, refer_count);
     }
 
-    return series_by_prompt;
+    return series_by_rule;
 }
 
 fn queryUserTrendSeries(
@@ -199,39 +199,39 @@ fn queryUserTrendSeries(
     return series_by_user;
 }
 
-fn queryUserTopPrompts(
+fn queryUserTopRules(
     conn: anytype,
     arena: std.mem.Allocator,
     org_id: []const u8,
-) std.StringHashMap([]const UserTopPromptStat) {
-    var lists = std.StringHashMap(std.ArrayList(UserTopPromptStat)).init(arena);
+) std.StringHashMap([]const UserTopRuleStat) {
+    var lists = std.StringHashMap(std.ArrayList(UserTopRuleStat)).init(arena);
 
     var result = conn.query(
-        \\SELECT te.user_id, te.prompt_id, count(*) as refer_count
+        \\SELECT te.user_id, te.rule_id, count(*) as refer_count
         \\FROM attestation_events te
         \\JOIN workspaces w ON w.ws_id = te.ws_id
         \\WHERE w.org_id = $1::uuid
         \\  AND te.type = 'refer'
         \\  AND te.user_id IS NOT NULL
-        \\  AND te.prompt_id IS NOT NULL
-        \\GROUP BY te.user_id, te.prompt_id
-        \\ORDER BY te.user_id, refer_count DESC, te.prompt_id
+        \\  AND te.rule_id IS NOT NULL
+        \\GROUP BY te.user_id, te.rule_id
+        \\ORDER BY te.user_id, refer_count DESC, te.rule_id
     , .{org_id}) catch |err| {
-        log.err("user top prompts query failed: {}", .{err});
-        const empty = std.StringHashMap([]const UserTopPromptStat).init(arena);
+        log.err("user top rules query failed: {}", .{err});
+        const empty = std.StringHashMap([]const UserTopRuleStat).init(arena);
         return empty;
     };
     defer result.deinit();
 
     while (result.next() catch null) |row| {
         const user_id = row.get([]const u8, 0) catch continue;
-        const prompt_id = row.get([]const u8, 1) catch continue;
+        const rule_id = row.get([]const u8, 1) catch continue;
         const refer_count = row.get(i64, 2) catch continue;
 
         if (lists.getPtr(user_id)) |list_ptr| {
             if (list_ptr.items.len >= 3) continue;
             list_ptr.append(arena, .{
-                .prompt_id = arena.dupe(u8, prompt_id) catch continue,
+                .rule_id = arena.dupe(u8, rule_id) catch continue,
                 .refer_count = refer_count,
             }) catch continue;
             continue;
@@ -241,12 +241,12 @@ fn queryUserTopPrompts(
         lists.put(key, .empty) catch continue;
         const list_ptr = lists.getPtr(user_id) orelse continue;
         list_ptr.append(arena, .{
-            .prompt_id = arena.dupe(u8, prompt_id) catch continue,
+            .rule_id = arena.dupe(u8, rule_id) catch continue,
             .refer_count = refer_count,
         }) catch continue;
     }
 
-    var frozen = std.StringHashMap([]const UserTopPromptStat).init(arena);
+    var frozen = std.StringHashMap([]const UserTopRuleStat).init(arena);
     var it = lists.iterator();
     while (it.next()) |entry| {
         frozen.put(entry.key_ptr.*, entry.value_ptr.items) catch continue;
@@ -290,9 +290,9 @@ pub fn handleUpload(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
             continue;
         }
 
-        // Validate prompt_id exists if provided
-        if (event.prompt_id) |pid| {
-            var check = conn.row("SELECT 1 FROM prompts WHERE prompt_id = $1", .{pid}) catch {
+        // Validate rule_id exists if provided
+        if (event.rule_id) |pid| {
+            var check = conn.row("SELECT 1 FROM rules WHERE rule_id = $1", .{pid}) catch {
                 deduplicated += 1;
                 continue;
             };
@@ -305,13 +305,13 @@ pub fn handleUpload(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
         }
         const rows_affected = conn.exec(
             \\INSERT INTO attestation_events (user_id, ws_id, session_id, event_id, type, timestamp,
-            \\  prompt_id, prompt_hash, constraint_id, reason, content, content_hash)
+            \\  rule_id, rule_hash, constraint_id, reason, content, content_hash)
             \\VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             \\ON CONFLICT (ws_id, session_id, event_id) DO NOTHING
         , .{
             user.user_id,             event.ws_id,       event.session_id,
             @as(i64, event.event_id), event.type,        @as(i64, event.timestamp),
-            event.prompt_id,          event.prompt_hash, event.constraint_id,
+            event.rule_id,          event.rule_hash, event.constraint_id,
             event.reason,             event.content,     event.content_hash,
         }) catch {
             deduplicated += 1;
@@ -362,15 +362,15 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         \\SELECT
         \\  (SELECT count(*) FROM attestation_events te JOIN workspaces w ON w.ws_id = te.ws_id WHERE w.org_id = $1::uuid AND te.type = 'refer') as refer_count,
         \\  (SELECT count(*) FROM workspaces WHERE org_id = $1::uuid) as ws_count,
-        \\  (SELECT count(*) FROM prompts WHERE org_id = $1::uuid) as prompt_count
+        \\  (SELECT count(*) FROM rules WHERE org_id = $1::uuid) as rule_count
     , .{user.org_id}) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
         try res.json(OrgStatsResponse{
             .total_refer_count = 0,
             .workspace_count = 0,
-            .prompt_count = 0,
-            .prompts = &.{},
+            .rule_count = 0,
+            .rules = &.{},
             .users = &.{},
             .trend = TrendSeries{ .period = period, .data = &.{} },
         }, .{});
@@ -378,67 +378,67 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     };
     const total_refer_count = try row.get(i64, 0);
     const workspace_count = try row.get(i64, 1);
-    const prompt_count = try row.get(i64, 2);
+    const rule_count = try row.get(i64, 2);
     row.deinit() catch {};
 
-    const prompt_trends = queryPromptTrendSeries(conn, req.arena, user.org_id, max_days);
+    const rule_trends = queryRuleTrendSeries(conn, req.arena, user.org_id, max_days);
     const user_trends = queryUserTrendSeries(conn, req.arena, user.org_id, max_days);
-    const user_top_prompts = queryUserTopPrompts(conn, req.arena, user.org_id);
+    const user_top_rules = queryUserTopRules(conn, req.arena, user.org_id);
 
-    // Per-prompt aggregated stats via LEFT JOINs
-    var prompt_list: std.ArrayList(OrgPromptStats) = .empty;
-    var prompt_result = conn.query(
-        \\SELECT p.prompt_id,
+    // Per-rule aggregated stats via LEFT JOINs
+    var rule_list: std.ArrayList(OrgRuleStats) = .empty;
+    var rule_result = conn.query(
+        \\SELECT p.rule_id,
         \\  COALESCE(te_stats.refer_count, 0),
         \\  COALESCE(te_stats.active_constraints, 0),
         \\  COALESCE(ws_stats.workspace_count, 0),
         \\  COALESCE(bp_stats.bundle_count, 0),
         \\  COALESCE(pr_stats.open_pr_count, 0),
         \\  te_stats.last_referred_at
-        \\FROM prompts p
+        \\FROM rules p
         \\LEFT JOIN (
-        \\  SELECT te.prompt_id, count(*) as refer_count,
+        \\  SELECT te.rule_id, count(*) as refer_count,
         \\    count(DISTINCT te.constraint_id) as active_constraints,
         \\    max(te.timestamp) as last_referred_at
         \\  FROM attestation_events te JOIN workspaces w ON w.ws_id = te.ws_id
-        \\  WHERE w.org_id = $1::uuid AND te.type = 'refer' AND te.prompt_id IS NOT NULL
-        \\  GROUP BY te.prompt_id
-        \\) te_stats ON te_stats.prompt_id = p.prompt_id
+        \\  WHERE w.org_id = $1::uuid AND te.type = 'refer' AND te.rule_id IS NOT NULL
+        \\  GROUP BY te.rule_id
+        \\) te_stats ON te_stats.rule_id = p.rule_id
         \\LEFT JOIN (
-        \\  SELECT wp.prompt_id, count(DISTINCT wp.ws_id) as workspace_count
-        \\  FROM workspace_prompts wp JOIN workspaces w ON w.ws_id = wp.ws_id
+        \\  SELECT wp.rule_id, count(DISTINCT wp.ws_id) as workspace_count
+        \\  FROM workspace_rules wp JOIN workspaces w ON w.ws_id = wp.ws_id
         \\  WHERE w.org_id = $1::uuid
-        \\  GROUP BY wp.prompt_id
-        \\) ws_stats ON ws_stats.prompt_id = p.prompt_id
+        \\  GROUP BY wp.rule_id
+        \\) ws_stats ON ws_stats.rule_id = p.rule_id
         \\LEFT JOIN (
-        \\  SELECT bp.prompt_id, count(*) as bundle_count
-        \\  FROM bundle_prompts bp JOIN bundles b ON b.bundle_id = bp.bundle_id
+        \\  SELECT bp.rule_id, count(*) as bundle_count
+        \\  FROM bundle_rules bp JOIN bundles b ON b.bundle_id = bp.bundle_id
         \\  WHERE b.org_id = $1::uuid
-        \\  GROUP BY bp.prompt_id
-        \\) bp_stats ON bp_stats.prompt_id = p.prompt_id
+        \\  GROUP BY bp.rule_id
+        \\) bp_stats ON bp_stats.rule_id = p.rule_id
         \\LEFT JOIN (
-        \\  SELECT op.prompt_id, count(DISTINCT op.pr_id) as open_pr_count
-        \\  FROM prompt_pr_operations op
-        \\  JOIN prompt_prs pr ON pr.pr_id = op.pr_id
-        \\  WHERE pr.org_id = $1::uuid AND pr.status = 'open' AND op.prompt_id IS NOT NULL
-        \\  GROUP BY op.prompt_id
-        \\) pr_stats ON pr_stats.prompt_id = p.prompt_id
+        \\  SELECT op.rule_id, count(DISTINCT op.pr_id) as open_pr_count
+        \\  FROM rule_pr_operations op
+        \\  JOIN rule_prs pr ON pr.pr_id = op.pr_id
+        \\  WHERE pr.org_id = $1::uuid AND pr.status = 'open' AND op.rule_id IS NOT NULL
+        \\  GROUP BY op.rule_id
+        \\) pr_stats ON pr_stats.rule_id = p.rule_id
         \\WHERE p.org_id = $1::uuid
         \\ORDER BY COALESCE(te_stats.refer_count, 0) DESC
     , .{user.org_id}) catch |err| blk: {
-        log.err("org stats prompt query failed: {}", .{err});
+        log.err("org stats rule query failed: {}", .{err});
         break :blk null;
     };
-    if (prompt_result) |*pr| {
+    if (rule_result) |*pr| {
         defer pr.*.deinit();
         while (true) {
             const prow = pr.*.next() catch |err| {
-                log.err("org stats prompt query next failed: {}", .{err});
+                log.err("org stats rule query next failed: {}", .{err});
                 break;
             } orelse break;
-            prompt_list.append(req.arena, .{
-                .prompt_id = req.arena.dupe(u8, prow.get([]const u8, 0) catch |err| {
-                    log.err("org stats prompt_id get failed: {}", .{err});
+            rule_list.append(req.arena, .{
+                .rule_id = req.arena.dupe(u8, prow.get([]const u8, 0) catch |err| {
+                    log.err("org stats rule_id get failed: {}", .{err});
                     continue;
                 }) catch continue,
                 .refer_count = prow.get(i64, 1) catch |err| {
@@ -465,7 +465,7 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
                     log.err("org stats last_referred_at get failed: {}", .{err});
                     break :blk null;
                 },
-                .trend = if (prompt_trends.get(prow.get([]const u8, 0) catch "")) |trend| trend else zeroTrendSeries(req.arena, max_days),
+                .trend = if (rule_trends.get(prow.get([]const u8, 0) catch "")) |trend| trend else zeroTrendSeries(req.arena, max_days),
             }) catch continue;
         }
     }
@@ -526,7 +526,7 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
                     break :blk null;
                 },
                 .trend = if (user_trends.get(user_id)) |trend| trend else zeroTrendSeries(req.arena, max_days),
-                .top_prompts = if (user_top_prompts.get(user_id)) |tops| tops else &.{},
+                .top_rules = if (user_top_rules.get(user_id)) |tops| tops else &.{},
             }) catch continue;
         }
     }
@@ -542,8 +542,8 @@ pub fn handleOrgStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     try res.json(OrgStatsResponse{
         .total_refer_count = total_refer_count,
         .workspace_count = workspace_count,
-        .prompt_count = prompt_count,
-        .prompts = prompt_list.items,
+        .rule_count = rule_count,
+        .rules = rule_list.items,
         .users = user_list.items,
         .trend = TrendSeries{ .period = period, .data = trend_data },
     }, .{});
@@ -591,7 +591,7 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
             .ws_id = ws_id,
             .total_refer_count = 0,
             .constraint_coverage = 0,
-            .prompts = &.{},
+            .rules = &.{},
             .trend = TrendSeries{ .period = period, .data = &.{} },
         }, .{});
         return;
@@ -599,12 +599,12 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
     const total_refer_count = try row.get(i64, 0);
     row.deinit() catch {};
 
-    // Query constraint coverage: fraction of workspace prompts that have been referred
+    // Query constraint coverage: fraction of workspace rules that have been referred
     var coverage: f64 = 0.0;
     var cov_row = conn.row(
-        \\SELECT count(DISTINCT te.prompt_id)::float / GREATEST(count(DISTINCT wp.prompt_id), 1)
-        \\FROM workspace_prompts wp
-        \\LEFT JOIN attestation_events te ON te.prompt_id = wp.prompt_id AND te.ws_id = wp.ws_id AND te.type = 'refer'
+        \\SELECT count(DISTINCT te.rule_id)::float / GREATEST(count(DISTINCT wp.rule_id), 1)
+        \\FROM workspace_rules wp
+        \\LEFT JOIN attestation_events te ON te.rule_id = wp.rule_id AND te.ws_id = wp.ws_id AND te.type = 'refer'
         \\WHERE wp.ws_id = $1
     , .{ws_id}) catch null;
     if (cov_row != null) {
@@ -612,26 +612,26 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
         cov_row.?.deinit() catch {};
     }
 
-    // Per-prompt refer counts
-    var prompt_list: std.ArrayList(WorkspacePromptStat) = .empty;
+    // Per-rule refer counts
+    var rule_list: std.ArrayList(WorkspaceRuleStat) = .empty;
 
-    var prompt_result = conn.query(
-        "SELECT prompt_id, count(*) FROM attestation_events WHERE ws_id = $1 AND type = 'refer' AND prompt_id IS NOT NULL GROUP BY prompt_id ORDER BY count(*) DESC",
+    var rule_result = conn.query(
+        "SELECT rule_id, count(*) FROM attestation_events WHERE ws_id = $1 AND type = 'refer' AND rule_id IS NOT NULL GROUP BY rule_id ORDER BY count(*) DESC",
         .{ws_id},
     ) catch |err| blk: {
-        log.err("workspace stats prompt query failed: {}", .{err});
+        log.err("workspace stats rule query failed: {}", .{err});
         break :blk null;
     };
-    if (prompt_result) |*pr| {
+    if (rule_result) |*pr| {
         defer pr.*.deinit();
         while (true) {
             const prow = pr.*.next() catch |err| {
-                log.err("workspace stats prompt query next failed: {}", .{err});
+                log.err("workspace stats rule query next failed: {}", .{err});
                 break;
             } orelse break;
-            prompt_list.append(req.arena, .{
-                .prompt_id = req.arena.dupe(u8, prow.get([]const u8, 0) catch |err| {
-                    log.err("workspace stats prompt_id get failed: {}", .{err});
+            rule_list.append(req.arena, .{
+                .rule_id = req.arena.dupe(u8, prow.get([]const u8, 0) catch |err| {
+                    log.err("workspace stats rule_id get failed: {}", .{err});
                     continue;
                 }) catch continue,
                 .refer_count = prow.get(i64, 1) catch |err| {
@@ -647,19 +647,19 @@ pub fn handleWorkspaceStats(ctx: *Server.Context, req: *httpz.Request, res: *htt
         .ws_id = ws_id,
         .total_refer_count = total_refer_count,
         .constraint_coverage = coverage,
-        .prompts = prompt_list.items,
+        .rules = rule_list.items,
         .trend = TrendSeries{ .period = period, .data = trend_data },
     }, .{});
 }
 
-pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleRuleStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
     if (!auth.requireScope(user, "stats:read", res)) return;
 
-    const prompt_id = req.param("prompt_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "prompt_id is required");
+    const rule_id = req.param("rule_id") orelse {
+        return apiError(res, 400, "BAD_REQUEST", "rule_id is required");
     };
 
     const qs = req.query() catch {
@@ -685,12 +685,12 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     defer conn.release();
 
     var row = conn.row(
-        "SELECT count(*) FROM attestation_events WHERE prompt_id = $1 AND type = 'refer'",
-        .{prompt_id},
+        "SELECT count(*) FROM attestation_events WHERE rule_id = $1 AND type = 'refer'",
+        .{rule_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        try res.json(.{ .prompt_id = prompt_id, .total_refer_count = @as(i64, 0), .constraints = @as([]const ConstraintStat, &.{}), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
+        try res.json(.{ .rule_id = rule_id, .total_refer_count = @as(i64, 0), .constraints = @as([]const ConstraintStat, &.{}), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
         return;
     };
     const total_refer_count = try row.get(i64, 0);
@@ -698,10 +698,10 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
 
     // Query per-constraint breakdown
     var constraint_result = conn.query(
-        "SELECT constraint_id, count(*) as cnt FROM attestation_events WHERE prompt_id = $1 AND type = 'refer' AND constraint_id IS NOT NULL GROUP BY constraint_id ORDER BY cnt DESC",
-        .{prompt_id},
+        "SELECT constraint_id, count(*) as cnt FROM attestation_events WHERE rule_id = $1 AND type = 'refer' AND constraint_id IS NOT NULL GROUP BY constraint_id ORDER BY cnt DESC",
+        .{rule_id},
     ) catch {
-        try res.json(.{ .prompt_id = prompt_id, .total_refer_count = total_refer_count, .constraints = @as([]const ConstraintStat, &.{}), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
+        try res.json(.{ .rule_id = rule_id, .total_refer_count = total_refer_count, .constraints = @as([]const ConstraintStat, &.{}), .trend = .{ .period = period, .data = @as([]const TrendEntry, &.{}) } }, .{});
         return;
     };
     defer constraint_result.deinit();
@@ -714,10 +714,10 @@ pub fn handlePromptStats(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         }) catch continue;
     }
 
-    const trend_data = queryTrend(conn, req.arena, sql_trunc, "prompt_id = $1", .{prompt_id}, max_days);
+    const trend_data = queryTrend(conn, req.arena, sql_trunc, "rule_id = $1", .{rule_id}, max_days);
 
     try res.json(.{
-        .prompt_id = prompt_id,
+        .rule_id = rule_id,
         .total_refer_count = total_refer_count,
         .constraints = constraints.items,
         .trend = .{ .period = period, .data = trend_data },

--- a/src/hub/attestation.zig
+++ b/src/hub/attestation.zig
@@ -309,10 +309,10 @@ pub fn handleUpload(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
             \\VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             \\ON CONFLICT (ws_id, session_id, event_id) DO NOTHING
         , .{
-            user.user_id,             event.ws_id,       event.session_id,
-            @as(i64, event.event_id), event.type,        @as(i64, event.timestamp),
-            event.rule_id,          event.rule_hash, event.constraint_id,
-            event.reason,             event.content,     event.content_hash,
+            user.user_id,             event.ws_id,     event.session_id,
+            @as(i64, event.event_id), event.type,      @as(i64, event.timestamp),
+            event.rule_id,            event.rule_hash, event.constraint_id,
+            event.reason,             event.content,   event.content_hash,
         }) catch {
             deduplicated += 1;
             continue;

--- a/src/hub/collab.zig
+++ b/src/hub/collab.zig
@@ -1,6 +1,6 @@
 //! Hub collaboration endpoints. Implements the Pull Request lifecycle: create PR from workspace
 //! local edit, list/get PR details, add review comments, accept/reject, and track PR operations
-//! (add/modify/delete prompts). PRs are the only path for changes to enter the Library.
+//! (add/modify/delete rules). PRs are the only path for changes to enter the Library.
 const std = @import("std");
 const httpz = @import("httpz");
 const collab_api = @import("clumsies_lib").protocol.collab_api;
@@ -9,17 +9,17 @@ const Server = @import("server.zig");
 const auth = @import("auth.zig");
 const db_mod = @import("db.zig");
 const apiError = @import("api_error.zig").send;
-const PromptPrComment = collab_api.PromptPrComment;
-const PromptPrCommentsResponse = collab_api.PromptPrCommentsResponse;
-const PromptPrDetailResponse = collab_api.PromptPrDetailResponse;
-const PromptPrListItem = collab_api.PromptPrListItem;
-const PromptPrListResponse = collab_api.PromptPrListResponse;
-const PromptPrChange = collab_api.PromptPrChange;
-const PromptPrUsageSummary = collab_api.PromptPrUsageSummary;
+const RulePrComment = collab_api.RulePrComment;
+const RulePrCommentsResponse = collab_api.RulePrCommentsResponse;
+const RulePrDetailResponse = collab_api.RulePrDetailResponse;
+const RulePrListItem = collab_api.RulePrListItem;
+const RulePrListResponse = collab_api.RulePrListResponse;
+const RulePrChange = collab_api.RulePrChange;
+const RulePrUsageSummary = collab_api.RulePrUsageSummary;
 
 const Operation = struct {
     type: []const u8,
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     base_hash: ?[]const u8 = null,
     content: ?[]const u8 = null,
     path: ?[]const u8 = null,
@@ -73,10 +73,10 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     const pr_id: []const u8 = &id_buf;
 
     _ = conn.exec(
-        \\INSERT INTO prompt_prs (pr_id, org_id, author_id, description)
+        \\INSERT INTO rule_prs (pr_id, org_id, author_id, description)
         \\VALUES ($1, $2::uuid, $3, $4)
     , .{ pr_id, user.org_id, user.user_id, body.description }) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "failed to create prompt PR");
+        return apiError(res, 500, "INTERNAL_ERROR", "failed to create rule PR");
     };
 
     for (body.operations, 0..) |op, idx| {
@@ -88,10 +88,10 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
             null;
 
         _ = conn.exec(
-            \\INSERT INTO prompt_pr_operations (pr_id, op_index, type, prompt_id, base_hash, content, path)
+            \\INSERT INTO rule_pr_operations (pr_id, op_index, type, rule_id, base_hash, content, path)
             \\VALUES ($1, $2, $3, $4, $5, $6, $7)
-        , .{ pr_id, @as(i32, @intCast(idx)), op.type, op.prompt_id, op.base_hash, op.content, target_path }) catch {
-            _ = conn.exec("DELETE FROM prompt_prs WHERE pr_id = $1", .{pr_id}) catch {};
+        , .{ pr_id, @as(i32, @intCast(idx)), op.type, op.rule_id, op.base_hash, op.content, target_path }) catch {
+            _ = conn.exec("DELETE FROM rule_prs WHERE pr_id = $1", .{pr_id}) catch {};
             return apiError(res, 500, "INTERNAL_ERROR", "failed to store operation");
         };
     }
@@ -112,8 +112,8 @@ fn isValidType(t: []const u8) bool {
 
 fn validateOperation(conn: anytype, org_id: []const u8, op: Operation, res: *httpz.Response) !bool {
     if (std.mem.eql(u8, op.type, "modify")) {
-        const pid = op.prompt_id orelse {
-            try apiError(res, 400, "BAD_REQUEST", "modify requires prompt_id");
+        const pid = op.rule_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "modify requires rule_id");
             return false;
         };
         const base_hash = op.base_hash orelse {
@@ -130,8 +130,8 @@ fn validateOperation(conn: anytype, org_id: []const u8, op: Operation, res: *htt
         };
         return try verifyPromptBaseHash(conn, org_id, pid, base_hash, res);
     } else if (std.mem.eql(u8, op.type, "rename")) {
-        const pid = op.prompt_id orelse {
-            try apiError(res, 400, "BAD_REQUEST", "rename requires prompt_id");
+        const pid = op.rule_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "rename requires rule_id");
             return false;
         };
         const base_hash = op.base_hash orelse {
@@ -165,12 +165,12 @@ fn validateOperation(conn: anytype, org_id: []const u8, op: Operation, res: *htt
         };
         return try verifyPathAvailable(conn, org_id, path, null, res);
     } else if (std.mem.eql(u8, op.type, "delete")) {
-        const pid = op.prompt_id orelse {
-            try apiError(res, 400, "BAD_REQUEST", "delete requires prompt_id");
+        const pid = op.rule_id orelse {
+            try apiError(res, 400, "BAD_REQUEST", "delete requires rule_id");
             return false;
         };
         var row = conn.row(
-            "SELECT 1 FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+            "SELECT 1 FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
             .{ org_id, pid },
         ) catch {
             try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -180,26 +180,26 @@ fn validateOperation(conn: anytype, org_id: []const u8, op: Operation, res: *htt
             r.deinit() catch {};
             return true;
         }
-        try apiError(res, 404, "NOT_FOUND", "prompt not found");
+        try apiError(res, 404, "NOT_FOUND", "rule not found");
         return false;
     }
     return false;
 }
 
-fn verifyPromptBaseHash(conn: anytype, org_id: []const u8, prompt_id: []const u8, base_hash: []const u8, res: *httpz.Response) !bool {
+fn verifyPromptBaseHash(conn: anytype, org_id: []const u8, rule_id: []const u8, base_hash: []const u8, res: *httpz.Response) !bool {
     var row = conn.row(
-        "SELECT content_hash FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
-        .{ org_id, prompt_id },
+        "SELECT content_hash FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
+        .{ org_id, rule_id },
     ) catch {
         try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         return false;
     } orelse {
-        try apiError(res, 404, "NOT_FOUND", "prompt not found");
+        try apiError(res, 404, "NOT_FOUND", "rule not found");
         return false;
     };
     const current_hash_raw = row.get([]const u8, 0) catch {
         row.deinit() catch {};
-        try apiError(res, 500, "INTERNAL_ERROR", "failed to read prompt hash");
+        try apiError(res, 500, "INTERNAL_ERROR", "failed to read rule hash");
         return false;
     };
     var buf: [96]u8 = undefined;
@@ -213,9 +213,9 @@ fn verifyPromptBaseHash(conn: anytype, org_id: []const u8, prompt_id: []const u8
     return true;
 }
 
-fn verifyPathAvailable(conn: anytype, org_id: []const u8, path: []const u8, allow_prompt_id: ?[]const u8, res: *httpz.Response) !bool {
+fn verifyPathAvailable(conn: anytype, org_id: []const u8, path: []const u8, allow_rule_id: ?[]const u8, res: *httpz.Response) !bool {
     var row = conn.row(
-        "SELECT prompt_id FROM prompts WHERE org_id = $1::uuid AND path = $2",
+        "SELECT rule_id FROM rules WHERE org_id = $1::uuid AND path = $2",
         .{ org_id, path },
     ) catch {
         try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -224,7 +224,7 @@ fn verifyPathAvailable(conn: anytype, org_id: []const u8, path: []const u8, allo
     if (row) |*r| {
         defer r.deinit() catch {};
         const existing_pid = r.get([]const u8, 0) catch "";
-        if (allow_prompt_id) |allowed| {
+        if (allow_rule_id) |allowed| {
             if (std.mem.eql(u8, existing_pid, allowed)) return true;
         }
         try apiError(res, 409, "CONFLICT", "target path already exists in Library");
@@ -264,27 +264,27 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
         return apiError(res, 400, "BAD_REQUEST", "invalid query");
     };
     const status_filter = qs.get("status");
-    const prompt_filter = qs.get("prompt_id");
+    const rule_filter = qs.get("rule_id");
 
     const conn = ctx.pool.acquire() catch {
         return apiError(res, 503, "SERVICE_UNAVAILABLE", "database unavailable");
     };
     defer conn.release();
 
-    var list: std.ArrayList(PromptPrListItem) = .empty;
+    var list: std.ArrayList(RulePrListItem) = .empty;
 
     const base_sql =
         \\SELECT pp.pr_id, pp.status, pp.description, pp.created_at::text, u.username,
-        \\  (SELECT count(*) FROM prompt_pr_operations op WHERE op.pr_id = pp.pr_id) as op_count
-        \\FROM prompt_prs pp JOIN users u ON u.user_id = pp.author_id
+        \\  (SELECT count(*) FROM rule_pr_operations op WHERE op.pr_id = pp.pr_id) as op_count
+        \\FROM rule_prs pp JOIN users u ON u.user_id = pp.author_id
     ;
 
-    if (status_filter != null and prompt_filter != null) {
+    if (status_filter != null and rule_filter != null) {
         var result = conn.query(base_sql ++
             \\ WHERE pp.org_id = $1::uuid AND pp.status = $2
-            \\ AND pp.pr_id IN (SELECT pr_id FROM prompt_pr_operations WHERE prompt_id = $3)
+            \\ AND pp.pr_id IN (SELECT pr_id FROM rule_pr_operations WHERE rule_id = $3)
             \\ ORDER BY pp.created_at DESC
-        , .{ user.org_id, status_filter.?, prompt_filter.? }) catch {
+        , .{ user.org_id, status_filter.?, rule_filter.? }) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         };
         defer result.deinit();
@@ -316,10 +316,10 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
                 .operation_count = try row.get(i64, 5),
             });
         }
-    } else if (prompt_filter) |pf| {
+    } else if (rule_filter) |pf| {
         var result = conn.query(base_sql ++
             \\ WHERE pp.org_id = $1::uuid
-            \\ AND pp.pr_id IN (SELECT pr_id FROM prompt_pr_operations WHERE prompt_id = $2)
+            \\ AND pp.pr_id IN (SELECT pr_id FROM rule_pr_operations WHERE rule_id = $2)
             \\ ORDER BY pp.created_at DESC
         , .{ user.org_id, pf }) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -355,7 +355,7 @@ pub fn handleListPrs(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Resp
         }
     }
 
-    try res.json(PromptPrListResponse{ .prs = list.items }, .{});
+    try res.json(RulePrListResponse{ .prs = list.items }, .{});
 }
 
 pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -374,12 +374,12 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     defer conn.release();
 
     var row = conn.row(
-        "SELECT pr_id, status, description, created_at::text FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
+        "SELECT pr_id, status, description, created_at::text FROM rule_prs WHERE pr_id = $1 AND org_id = $2::uuid",
         .{ id, user.org_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt PR not found");
+        return apiError(res, 404, "NOT_FOUND", "rule PR not found");
     };
 
     const pr_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
@@ -388,9 +388,9 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     const created_at = try req.arena.dupe(u8, try row.get([]const u8, 3));
     row.deinit() catch {};
 
-    var ops: std.ArrayList(PromptPrChange) = .empty;
+    var ops: std.ArrayList(RulePrChange) = .empty;
     var op_result = conn.query(
-        "SELECT op_index, type, prompt_id, base_hash, content, path FROM prompt_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        "SELECT op_index, type, rule_id, base_hash, content, path FROM rule_pr_operations WHERE pr_id = $1 ORDER BY op_index",
         .{pr_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -400,7 +400,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
     while (try op_result.next()) |orow| {
         const op_index = try orow.get(i32, 0);
         const op_type = try req.arena.dupe(u8, try orow.get([]const u8, 1));
-        const op_prompt_id: ?[]const u8 = if (orow.get([]const u8, 2)) |v|
+        const op_rule_id: ?[]const u8 = if (orow.get([]const u8, 2)) |v|
             try req.arena.dupe(u8, v)
         else |_|
             null;
@@ -419,9 +419,9 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
 
         var base_content: ?[]const u8 = null;
         var current_path: ?[]const u8 = null;
-        if (op_prompt_id) |pid| {
+        if (op_rule_id) |pid| {
             var pr = conn.row(
-                "SELECT content, path FROM prompts WHERE prompt_id = $1",
+                "SELECT content, path FROM rules WHERE rule_id = $1",
                 .{pid},
             ) catch null;
             if (pr) |*br| {
@@ -432,7 +432,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
             if (base_content == null) {
                 if (op_base_hash) |bh| {
                     var hr = conn.row(
-                        "SELECT content, path FROM prompt_history WHERE prompt_id = $1 AND content_hash = $2",
+                        "SELECT content, path FROM rule_history WHERE rule_id = $1 AND content_hash = $2",
                         .{ pid, bh },
                     ) catch null;
                     if (hr) |*h| {
@@ -447,7 +447,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
         try ops.append(req.arena, .{
             .op_index = op_index,
             .type = op_type,
-            .prompt_id = op_prompt_id,
+            .rule_id = op_rule_id,
             .base_hash = op_base_hash,
             .content = op_content,
             .path = op_path,
@@ -456,12 +456,12 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
         });
     }
 
-    var attestation_summary = PromptPrUsageSummary{};
+    var attestation_summary = RulePrUsageSummary{};
 
     var attestation_row = conn.row(
         \\SELECT count(*), count(DISTINCT session_id), max(to_timestamp(timestamp/1000))::text
         \\FROM attestation_events
-        \\WHERE prompt_id IN (SELECT prompt_id FROM prompt_pr_operations WHERE pr_id = $1 AND prompt_id IS NOT NULL)
+        \\WHERE rule_id IN (SELECT rule_id FROM rule_pr_operations WHERE pr_id = $1 AND rule_id IS NOT NULL)
         \\  AND type = 'refer'
     , .{pr_id}) catch null;
     if (attestation_row) |*tr| {
@@ -473,7 +473,7 @@ pub fn handleGetPr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respon
         tr.deinit() catch {};
     }
 
-    try res.json(PromptPrDetailResponse{
+    try res.json(RulePrDetailResponse{
         .pr_id = pr_id,
         .status = status,
         .description = description,
@@ -495,7 +495,7 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     if (!auth.requireScope(user, "pr:merge", res)) return;
 
     if (!std.mem.eql(u8, user.role, "maintainer")) {
-        return apiError(res, 403, "FORBIDDEN", "only maintainers can accept or reject prompt PRs");
+        return apiError(res, 403, "FORBIDDEN", "only maintainers can accept or reject rule PRs");
     }
 
     const id = req.param("id") orelse {
@@ -518,12 +518,12 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     defer conn.release();
 
     var header = conn.row(
-        "SELECT status FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid",
+        "SELECT status FROM rule_prs WHERE pr_id = $1 AND org_id = $2::uuid",
         .{ id, user.org_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt PR not found");
+        return apiError(res, 404, "NOT_FOUND", "rule PR not found");
     };
     const status_raw = header.get([]const u8, 0) catch "";
     var status_buf: [32]u8 = undefined;
@@ -531,7 +531,7 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     @memcpy(status_buf[0..status_len], status_raw[0..status_len]);
     header.deinit() catch {};
     if (!std.mem.eql(u8, status_buf[0..status_len], "open")) {
-        return apiError(res, 400, "BAD_REQUEST", "prompt PR is not open");
+        return apiError(res, 400, "BAD_REQUEST", "rule PR is not open");
     }
 
     const is_accept = std.mem.eql(u8, body.action, "accept");
@@ -541,10 +541,10 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     }
 
     _ = conn.exec(
-        "UPDATE prompt_prs SET status = $1, updated_at = now() WHERE pr_id = $2",
+        "UPDATE rule_prs SET status = $1, updated_at = now() WHERE pr_id = $2",
         .{ if (is_accept) @as([]const u8, "accepted") else @as([]const u8, "rejected"), id },
     ) catch {
-        return apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt PR");
+        return apiError(res, 500, "INTERNAL_ERROR", "failed to update rule PR");
     };
 
     try res.json(.{
@@ -556,7 +556,7 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
 const LoadedOp = struct {
     op_index: i32,
     type: []const u8,
-    prompt_id: ?[]const u8,
+    rule_id: ?[]const u8,
     base_hash: ?[]const u8,
     content: ?[]const u8,
     path: ?[]const u8,
@@ -565,7 +565,7 @@ const LoadedOp = struct {
 fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: []const u8, res: *httpz.Response) !bool {
     var ops: std.ArrayList(LoadedOp) = .empty;
     var op_result = conn.query(
-        "SELECT op_index, type, prompt_id, base_hash, content, path FROM prompt_pr_operations WHERE pr_id = $1 ORDER BY op_index",
+        "SELECT op_index, type, rule_id, base_hash, content, path FROM rule_pr_operations WHERE pr_id = $1 ORDER BY op_index",
         .{pr_id},
     ) catch {
         try apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -594,7 +594,7 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
         try ops.append(arena, .{
             .op_index = op_index,
             .type = t,
-            .prompt_id = pid,
+            .rule_id = pid,
             .base_hash = bh,
             .content = c,
             .path = p,
@@ -608,7 +608,7 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
 
     for (ops.items) |op| {
         if (std.mem.eql(u8, op.type, "modify")) {
-            const pid = op.prompt_id.?;
+            const pid = op.rule_id.?;
             const bh = op.base_hash.?;
             const new_content = op.content.?;
             db_mod.validateContentFormat(new_content) catch {
@@ -617,7 +617,7 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             };
             var row = conn.row(
-                "SELECT content_hash, path FROM prompts WHERE prompt_id = $1",
+                "SELECT content_hash, path FROM rules WHERE rule_id = $1",
                 .{pid},
             ) catch {
                 conn.rollback() catch {};
@@ -625,13 +625,13 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             } orelse {
                 conn.rollback() catch {};
-                try apiError(res, 404, "NOT_FOUND", "target prompt no longer exists");
+                try apiError(res, 404, "NOT_FOUND", "target rule no longer exists");
                 return false;
             };
             const current_hash = row.get([]const u8, 0) catch {
                 row.deinit() catch {};
                 conn.rollback() catch {};
-                try apiError(res, 500, "INTERNAL_ERROR", "failed to read prompt hash");
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to read rule hash");
                 return false;
             };
             const matches = std.mem.eql(u8, current_hash, bh);
@@ -652,24 +652,24 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             };
             _ = conn.exec(
-                "UPDATE prompts SET content = $1, content_hash = $2, description = $3, updated_at = now() WHERE prompt_id = $4",
+                "UPDATE rules SET content = $1, content_hash = $2, description = $3, updated_at = now() WHERE rule_id = $4",
                 .{ new_content, hash_slice, db_mod.extractDescription(new_content), pid },
             ) catch {
                 conn.rollback() catch {};
-                try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to update rule");
                 return false;
             };
             _ = conn.exec(
-                "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                "INSERT INTO rule_history (rule_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
                 .{ pid, hash_slice, path_buf[0..plen], new_content, pr_id },
             ) catch {};
             bumpWorkspaceRevisions(conn, pid);
         } else if (std.mem.eql(u8, op.type, "rename")) {
-            const pid = op.prompt_id.?;
+            const pid = op.rule_id.?;
             const bh = op.base_hash.?;
             const new_path = op.path.?;
             var row = conn.row(
-                "SELECT content_hash FROM prompts WHERE prompt_id = $1",
+                "SELECT content_hash FROM rules WHERE rule_id = $1",
                 .{pid},
             ) catch {
                 conn.rollback() catch {};
@@ -677,7 +677,7 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             } orelse {
                 conn.rollback() catch {};
-                try apiError(res, 404, "NOT_FOUND", "target prompt no longer exists");
+                try apiError(res, 404, "NOT_FOUND", "target rule no longer exists");
                 return false;
             };
             const current_hash = row.get([]const u8, 0) catch "";
@@ -701,24 +701,24 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                     return false;
                 };
                 _ = conn.exec(
-                    "UPDATE prompts SET path = $1, content = $2, content_hash = $3, description = $4, updated_at = now() WHERE prompt_id = $5",
+                    "UPDATE rules SET path = $1, content = $2, content_hash = $3, description = $4, updated_at = now() WHERE rule_id = $5",
                     .{ new_path, new_content, hash_slice, db_mod.extractDescription(new_content), pid },
                 ) catch {
                     conn.rollback() catch {};
-                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update rule");
                     return false;
                 };
                 _ = conn.exec(
-                    "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                    "INSERT INTO rule_history (rule_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
                     .{ pid, hash_slice, new_path, new_content, pr_id },
                 ) catch {};
             } else {
                 _ = conn.exec(
-                    "UPDATE prompts SET path = $1, updated_at = now() WHERE prompt_id = $2",
+                    "UPDATE rules SET path = $1, updated_at = now() WHERE rule_id = $2",
                     .{ new_path, pid },
                 ) catch {
                     conn.rollback() catch {};
-                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update prompt");
+                    try apiError(res, 500, "INTERNAL_ERROR", "failed to update rule");
                     return false;
                 };
             }
@@ -752,7 +752,7 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             };
             _ = conn.exec(
-                "INSERT INTO prompts (prompt_id, org_id, path, content, content_hash, description) VALUES ($1, $2::uuid, $3, $4, $5, $6)",
+                "INSERT INTO rules (rule_id, org_id, path, content, content_hash, description) VALUES ($1, $2::uuid, $3, $4, $5, $6)",
                 .{ new_pid, org_id, path, new_content, hash_slice, db_mod.extractDescription(new_content) },
             ) catch {
                 conn.rollback() catch {};
@@ -760,16 +760,16 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
                 return false;
             };
             _ = conn.exec(
-                "INSERT INTO prompt_history (prompt_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
+                "INSERT INTO rule_history (rule_id, content_hash, path, content, pr_id) VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING",
                 .{ new_pid, hash_slice, path, new_content, pr_id },
             ) catch {};
         } else if (std.mem.eql(u8, op.type, "delete")) {
-            const pid = op.prompt_id.?;
-            _ = conn.exec("DELETE FROM workspace_prompts WHERE prompt_id = $1", .{pid}) catch {};
-            _ = conn.exec("DELETE FROM bundle_prompts WHERE prompt_id = $1", .{pid}) catch {};
-            _ = conn.exec("DELETE FROM prompts WHERE prompt_id = $1", .{pid}) catch {
+            const pid = op.rule_id.?;
+            _ = conn.exec("DELETE FROM workspace_rules WHERE rule_id = $1", .{pid}) catch {};
+            _ = conn.exec("DELETE FROM bundle_rules WHERE rule_id = $1", .{pid}) catch {};
+            _ = conn.exec("DELETE FROM rules WHERE rule_id = $1", .{pid}) catch {
                 conn.rollback() catch {};
-                try apiError(res, 500, "INTERNAL_ERROR", "failed to delete prompt");
+                try apiError(res, 500, "INTERNAL_ERROR", "failed to delete rule");
                 return false;
             };
         }
@@ -789,10 +789,10 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, org_id: []const u8, pr_id: [
     return true;
 }
 
-fn bumpWorkspaceRevisions(conn: anytype, prompt_id: []const u8) void {
+fn bumpWorkspaceRevisions(conn: anytype, rule_id: []const u8) void {
     _ = conn.exec(
-        "UPDATE workspaces SET revision = revision + 1 WHERE ws_id IN (SELECT ws_id FROM workspace_prompts WHERE prompt_id = $1)",
-        .{prompt_id},
+        "UPDATE workspaces SET revision = revision + 1 WHERE ws_id IN (SELECT ws_id FROM workspace_rules WHERE rule_id = $1)",
+        .{rule_id},
     ) catch {};
 }
 
@@ -821,10 +821,10 @@ pub fn handleAddComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz.R
     };
     defer conn.release();
 
-    var pr_row = conn.row("SELECT pr_id FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
+    var pr_row = conn.row("SELECT pr_id FROM rule_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt PR not found");
+        return apiError(res, 404, "NOT_FOUND", "rule PR not found");
     };
     pr_row.deinit() catch {};
 
@@ -839,7 +839,7 @@ pub fn handleAddComment(ctx: *Server.Context, req: *httpz.Request, res: *httpz.R
     }
 
     _ = conn.exec(
-        "INSERT INTO prompt_pr_comments (comment_id, pr_id, author_id, body) VALUES ($1, $2, $3, $4)",
+        "INSERT INTO rule_pr_comments (comment_id, pr_id, author_id, body) VALUES ($1, $2, $3, $4)",
         .{ &cmt_id_buf, id, user.user_id, comment.body },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "failed to add comment");
@@ -869,16 +869,16 @@ pub fn handleListComments(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     };
     defer conn.release();
 
-    var pr_check = conn.row("SELECT pr_id FROM prompt_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
+    var pr_check = conn.row("SELECT pr_id FROM rule_prs WHERE pr_id = $1 AND org_id = $2::uuid", .{ id, user.org_id }) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt PR not found");
+        return apiError(res, 404, "NOT_FOUND", "rule PR not found");
     };
     pr_check.deinit() catch {};
 
     var result = conn.query(
         \\SELECT c.comment_id, c.author_id, u.username, c.body, c.created_at::text
-        \\FROM prompt_pr_comments c
+        \\FROM rule_pr_comments c
         \\JOIN users u ON u.user_id = c.author_id
         \\WHERE c.pr_id = $1
         \\ORDER BY c.created_at
@@ -889,7 +889,7 @@ pub fn handleListComments(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     };
     defer result.deinit();
 
-    var list: std.ArrayList(PromptPrComment) = .empty;
+    var list: std.ArrayList(RulePrComment) = .empty;
     while (try result.next()) |row| {
         try list.append(req.arena, .{
             .comment_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
@@ -900,5 +900,5 @@ pub fn handleListComments(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         });
     }
 
-    try res.json(PromptPrCommentsResponse{ .comments = list.items }, .{});
+    try res.json(RulePrCommentsResponse{ .comments = list.items }, .{});
 }

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -206,28 +206,6 @@ pub fn bootstrap(pool: *Pool) !void {
 }
 
 const migration_sql =
-    \\-- Rename existing tables from old schema (idempotent for new installs).
-    \\DO $$ BEGIN ALTER TABLE prompts RENAME TO rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE workspace_prompts RENAME TO workspace_rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE bundle_prompts RENAME TO bundle_rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE prompt_prs RENAME TO rule_prs; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE prompt_pr_operations RENAME TO rule_pr_operations; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE prompt_pr_comments RENAME TO rule_pr_comments; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE prompt_history RENAME TO rule_history; EXCEPTION WHEN undefined_table THEN NULL; END $$;
-    \\
-    \\-- Rename existing columns from old schema.
-    \\DO $$ BEGIN ALTER TABLE rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE workspace_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE bundle_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE rule_pr_operations RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_hash TO rule_hash; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE rule_history RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
-    \\
-    \\-- Rename existing indexes.
-    \\DO $$ BEGIN ALTER INDEX IF EXISTS prompt_pr_operations_prompt_id_idx RENAME TO rule_pr_operations_rule_id_idx; EXCEPTION WHEN OTHERS THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER INDEX IF EXISTS attestation_events_prompt_ts_idx RENAME TO attestation_events_rule_ts_idx; EXCEPTION WHEN OTHERS THEN NULL; END $$;
-    \\
     \\CREATE TABLE IF NOT EXISTS orgs (
     \\    org_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     \\    name TEXT NOT NULL UNIQUE,

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -216,13 +216,13 @@ const migration_sql =
     \\DO $$ BEGIN ALTER TABLE prompt_history RENAME TO rule_history; EXCEPTION WHEN undefined_table THEN NULL; END $$;
     \\
     \\-- Rename existing columns from old schema.
-    \\DO $$ BEGIN ALTER TABLE rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE workspace_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE bundle_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE rule_pr_operations RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_hash TO rule_hash; EXCEPTION WHEN undefined_column THEN NULL; END $$;
-    \\DO $$ BEGIN ALTER TABLE rule_history RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE workspace_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE bundle_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE rule_pr_operations RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_hash TO rule_hash; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE rule_history RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_table OR undefined_column THEN NULL; END $$;
     \\
     \\-- Rename existing indexes.
     \\DO $$ BEGIN ALTER INDEX IF EXISTS prompt_pr_operations_prompt_id_idx RENAME TO rule_pr_operations_rule_id_idx; EXCEPTION WHEN OTHERS THEN NULL; END $$;

--- a/src/hub/db.zig
+++ b/src/hub/db.zig
@@ -206,6 +206,28 @@ pub fn bootstrap(pool: *Pool) !void {
 }
 
 const migration_sql =
+    \\-- Rename existing tables from old schema (idempotent for new installs).
+    \\DO $$ BEGIN ALTER TABLE prompts RENAME TO rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE workspace_prompts RENAME TO workspace_rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE bundle_prompts RENAME TO bundle_rules; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE prompt_prs RENAME TO rule_prs; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE prompt_pr_operations RENAME TO rule_pr_operations; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE prompt_pr_comments RENAME TO rule_pr_comments; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE prompt_history RENAME TO rule_history; EXCEPTION WHEN undefined_table THEN NULL; END $$;
+    \\
+    \\-- Rename existing columns from old schema.
+    \\DO $$ BEGIN ALTER TABLE rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE workspace_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE bundle_rules RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE rule_pr_operations RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE attestation_events RENAME COLUMN prompt_hash TO rule_hash; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER TABLE rule_history RENAME COLUMN prompt_id TO rule_id; EXCEPTION WHEN undefined_column THEN NULL; END $$;
+    \\
+    \\-- Rename existing indexes.
+    \\DO $$ BEGIN ALTER INDEX IF EXISTS prompt_pr_operations_prompt_id_idx RENAME TO rule_pr_operations_rule_id_idx; EXCEPTION WHEN OTHERS THEN NULL; END $$;
+    \\DO $$ BEGIN ALTER INDEX IF EXISTS attestation_events_prompt_ts_idx RENAME TO attestation_events_rule_ts_idx; EXCEPTION WHEN OTHERS THEN NULL; END $$;
+    \\
     \\CREATE TABLE IF NOT EXISTS orgs (
     \\    org_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     \\    name TEXT NOT NULL UNIQUE,
@@ -256,8 +278,8 @@ const migration_sql =
     \\CREATE INDEX IF NOT EXISTS workspace_members_user_id_idx
     \\    ON workspace_members(user_id);
     \\
-    \\CREATE TABLE IF NOT EXISTS prompts (
-    \\    prompt_id TEXT PRIMARY KEY,
+    \\CREATE TABLE IF NOT EXISTS rules (
+    \\    rule_id TEXT PRIMARY KEY,
     \\    org_id UUID NOT NULL REFERENCES orgs(org_id),
     \\    path TEXT NOT NULL,
     \\    content TEXT NOT NULL DEFAULT '',
@@ -267,10 +289,10 @@ const migration_sql =
     \\    UNIQUE(org_id, path)
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS workspace_prompts (
+    \\CREATE TABLE IF NOT EXISTS workspace_rules (
     \\    ws_id TEXT NOT NULL REFERENCES workspaces(ws_id),
-    \\    prompt_id TEXT NOT NULL REFERENCES prompts(prompt_id),
-    \\    PRIMARY KEY (ws_id, prompt_id)
+    \\    rule_id TEXT NOT NULL REFERENCES rules(rule_id),
+    \\    PRIMARY KEY (ws_id, rule_id)
     \\);
     \\
     \\CREATE TABLE IF NOT EXISTS context_files (
@@ -328,13 +350,13 @@ const migration_sql =
     \\    UNIQUE(org_id, name)
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS bundle_prompts (
+    \\CREATE TABLE IF NOT EXISTS bundle_rules (
     \\    bundle_id TEXT NOT NULL REFERENCES bundles(bundle_id),
-    \\    prompt_id TEXT NOT NULL REFERENCES prompts(prompt_id),
-    \\    PRIMARY KEY (bundle_id, prompt_id)
+    \\    rule_id TEXT NOT NULL REFERENCES rules(rule_id),
+    \\    PRIMARY KEY (bundle_id, rule_id)
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS prompt_prs (
+    \\CREATE TABLE IF NOT EXISTS rule_prs (
     \\    pr_id TEXT PRIMARY KEY,
     \\    org_id UUID NOT NULL REFERENCES orgs(org_id),
     \\    author_id TEXT NOT NULL REFERENCES users(user_id),
@@ -344,22 +366,22 @@ const migration_sql =
     \\    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS prompt_pr_operations (
-    \\    pr_id TEXT NOT NULL REFERENCES prompt_prs(pr_id) ON DELETE CASCADE,
+    \\CREATE TABLE IF NOT EXISTS rule_pr_operations (
+    \\    pr_id TEXT NOT NULL REFERENCES rule_prs(pr_id) ON DELETE CASCADE,
     \\    op_index INTEGER NOT NULL,
     \\    type TEXT NOT NULL CHECK (type IN ('modify', 'rename', 'create', 'delete')),
-    \\    prompt_id TEXT,
+    \\    rule_id TEXT,
     \\    base_hash TEXT,
     \\    content TEXT,
     \\    path TEXT,
     \\    PRIMARY KEY (pr_id, op_index)
     \\);
-    \\CREATE INDEX IF NOT EXISTS prompt_pr_operations_prompt_id_idx
-    \\    ON prompt_pr_operations(prompt_id);
+    \\CREATE INDEX IF NOT EXISTS rule_pr_operations_rule_id_idx
+    \\    ON rule_pr_operations(rule_id);
     \\
-    \\CREATE TABLE IF NOT EXISTS prompt_pr_comments (
+    \\CREATE TABLE IF NOT EXISTS rule_pr_comments (
     \\    comment_id TEXT PRIMARY KEY,
-    \\    pr_id TEXT NOT NULL REFERENCES prompt_prs(pr_id),
+    \\    pr_id TEXT NOT NULL REFERENCES rule_prs(pr_id),
     \\    author_id TEXT NOT NULL REFERENCES users(user_id),
     \\    body TEXT NOT NULL,
     \\    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
@@ -372,8 +394,8 @@ const migration_sql =
     \\    event_id BIGINT NOT NULL,
     \\    type TEXT NOT NULL,
     \\    timestamp BIGINT NOT NULL,
-    \\    prompt_id TEXT,
-    \\    prompt_hash TEXT,
+    \\    rule_id TEXT,
+    \\    rule_hash TEXT,
     \\    constraint_id TEXT,
     \\    reason TEXT,
     \\    content TEXT,
@@ -388,22 +410,22 @@ const migration_sql =
     \\    ON attestation_events(user_id);
     \\CREATE INDEX IF NOT EXISTS attestation_events_ws_ts_idx
     \\    ON attestation_events(ws_id, timestamp DESC);
-    \\CREATE INDEX IF NOT EXISTS attestation_events_prompt_ts_idx
-    \\    ON attestation_events(prompt_id, timestamp DESC);
+    \\CREATE INDEX IF NOT EXISTS attestation_events_rule_ts_idx
+    \\    ON attestation_events(rule_id, timestamp DESC);
     \\
     \\CREATE TABLE IF NOT EXISTS library_manifest (
     \\    org_id UUID PRIMARY KEY REFERENCES orgs(org_id),
     \\    revision INTEGER NOT NULL DEFAULT 0
     \\);
     \\
-    \\CREATE TABLE IF NOT EXISTS prompt_history (
-    \\    prompt_id TEXT NOT NULL REFERENCES prompts(prompt_id),
+    \\CREATE TABLE IF NOT EXISTS rule_history (
+    \\    rule_id TEXT NOT NULL REFERENCES rules(rule_id),
     \\    content_hash TEXT NOT NULL,
     \\    path TEXT NOT NULL DEFAULT '',
     \\    content TEXT NOT NULL DEFAULT '',
     \\    merged_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     \\    pr_id TEXT,
-    \\    PRIMARY KEY (prompt_id, content_hash)
+    \\    PRIMARY KEY (rule_id, content_hash)
     \\);
 ;
 

--- a/src/hub/library.zig
+++ b/src/hub/library.zig
@@ -1,5 +1,5 @@
-//! Hub Library endpoints. The Library is the org's prompt collection and single source of truth.
-//! Serves the library manifest (content index), prompt metadata, prompt content by hash, and
+//! Hub Library endpoints. The Library is the org's rule collection and single source of truth.
+//! Serves the library manifest (content index), rule metadata, rule content by hash, and
 //! bundle definitions.
 const std = @import("std");
 const httpz = @import("httpz");
@@ -11,12 +11,12 @@ const apiError = @import("api_error.zig").send;
 const BundleListResponse = library_api.BundleListResponse;
 const BundleMeta = library_api.BundleMeta;
 const LibraryManifestResponse = library_api.LibraryManifestResponse;
-const PromptListResponse = library_api.PromptListResponse;
-const PromptMeta = library_api.PromptMeta;
-const PromptContentResponse = library_api.PromptContentResponse;
-const BatchPromptContentRequest = library_api.BatchPromptContentRequest;
-const BatchPromptContentResponse = library_api.BatchPromptContentResponse;
-const BatchPromptItem = library_api.BatchPromptItem;
+const RuleListResponse = library_api.RuleListResponse;
+const RuleMeta = library_api.RuleMeta;
+const RuleContentResponse = library_api.RuleContentResponse;
+const BatchRuleContentRequest = library_api.BatchRuleContentRequest;
+const BatchRuleContentResponse = library_api.BatchRuleContentResponse;
+const BatchRuleItem = library_api.BatchRuleItem;
 const ManifestMap = manifest.ManifestMap;
 const ManifestItem = manifest.ManifestItem;
 
@@ -41,7 +41,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     } orelse {
         try res.json(LibraryManifestResponse{
             .revision = @as(i32, 0),
-            .prompts = ManifestMap{ .items = &.{} },
+            .rules = ManifestMap{ .items = &.{} },
         }, .{});
         return;
     };
@@ -59,7 +59,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     }
 
     var result = conn.query(
-        "SELECT prompt_id, path, content_hash FROM prompts WHERE org_id = $1::uuid",
+        "SELECT rule_id, path, content_hash FROM rules WHERE org_id = $1::uuid",
         .{user.org_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -83,11 +83,11 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
 
     try res.json(LibraryManifestResponse{
         .revision = revision,
-        .prompts = ManifestMap{ .items = items.items },
+        .rules = ManifestMap{ .items = items.items },
     }, .{});
 }
 
-pub fn handleListPrompts(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleListRules(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
@@ -106,23 +106,23 @@ pub fn handleListPrompts(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     var result = if (path_prefix) |prefix| blk: {
         const like_arg = try std.fmt.allocPrint(req.arena, "{s}%", .{prefix});
         break :blk conn.query(
-            "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path LIKE $2 ORDER BY p.path",
+            "SELECT p.rule_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM rules p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path LIKE $2 ORDER BY p.path",
             .{ user.org_id, like_arg },
         ) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
         };
     } else conn.query(
-        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid ORDER BY p.path",
+        "SELECT p.rule_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM rules p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid ORDER BY p.path",
         .{user.org_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
     defer result.deinit();
 
-    var list: std.ArrayList(PromptMeta) = .empty;
+    var list: std.ArrayList(RuleMeta) = .empty;
     while (try result.next()) |row| {
         try list.append(req.arena, .{
-            .prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
+            .rule_id = try req.arena.dupe(u8, try row.get([]const u8, 0)),
             .path = try req.arena.dupe(u8, try row.get([]const u8, 1)),
             .content_hash = try req.arena.dupe(u8, try row.get([]const u8, 2)),
             .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 3)),
@@ -130,7 +130,7 @@ pub fn handleListPrompts(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         });
     }
 
-    try res.json(PromptListResponse{ .prompts = list.items }, .{});
+    try res.json(RuleListResponse{ .rules = list.items }, .{});
 }
 
 const HistoryEntry = struct {
@@ -140,7 +140,7 @@ const HistoryEntry = struct {
     pr_id: ?[]const u8,
 };
 
-pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleGetRule(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
@@ -149,10 +149,10 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const prompt_id_q = qs.get("prompt_id");
+    const rule_id_q = qs.get("rule_id");
     const path_q = qs.get("path");
-    if (prompt_id_q == null and path_q == null) {
-        return apiError(res, 400, "BAD_REQUEST", "prompt_id or path query parameter is required");
+    if (rule_id_q == null and path_q == null) {
+        return apiError(res, 400, "BAD_REQUEST", "rule_id or path query parameter is required");
     }
 
     const conn = ctx.pool.acquire() catch {
@@ -160,19 +160,19 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     };
     defer conn.release();
 
-    var row = (if (prompt_id_q) |pid| conn.row(
-        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.prompt_id = $2",
+    var row = (if (rule_id_q) |pid| conn.row(
+        "SELECT p.rule_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM rules p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.rule_id = $2",
         .{ user.org_id, pid },
     ) else conn.row(
-        "SELECT p.prompt_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM prompts p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path = $2",
+        "SELECT p.rule_id, p.path, p.content_hash, p.updated_at::text, o.name as source FROM rules p JOIN orgs o ON o.org_id = p.org_id WHERE p.org_id = $1::uuid AND p.path = $2",
         .{ user.org_id, path_q.? },
     )) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt not found");
+        return apiError(res, 404, "NOT_FOUND", "rule not found");
     };
 
-    const prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
+    const rule_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
     const path = try req.arena.dupe(u8, try row.get([]const u8, 1));
     const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 2));
     const updated_at = try req.arena.dupe(u8, try row.get([]const u8, 3));
@@ -180,8 +180,8 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     row.deinit() catch {};
 
     var history_result = conn.query(
-        "SELECT content_hash, path, merged_at::text, pr_id FROM prompt_history WHERE prompt_id = $1 ORDER BY merged_at DESC",
-        .{prompt_id},
+        "SELECT content_hash, path, merged_at::text, pr_id FROM rule_history WHERE rule_id = $1 ORDER BY merged_at DESC",
+        .{rule_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
@@ -205,7 +205,7 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     }
 
     try res.json(.{
-        .prompt_id = prompt_id,
+        .rule_id = rule_id,
         .path = path,
         .content_hash = content_hash,
         .updated_at = updated_at,
@@ -214,7 +214,7 @@ pub fn handleGetPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     }, .{});
 }
 
-pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleGetRuleContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
@@ -223,10 +223,10 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
     const qs = req.query() catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid query string");
     };
-    const prompt_id_q = qs.get("prompt_id");
+    const rule_id_q = qs.get("rule_id");
     const path_q = qs.get("path");
-    if (prompt_id_q == null and path_q == null) {
-        return apiError(res, 400, "BAD_REQUEST", "prompt_id or path query parameter is required");
+    if (rule_id_q == null and path_q == null) {
+        return apiError(res, 400, "BAD_REQUEST", "rule_id or path query parameter is required");
     }
 
     const conn = ctx.pool.acquire() catch {
@@ -234,16 +234,16 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
     };
     defer conn.release();
 
-    var row = (if (prompt_id_q) |pid| conn.row(
-        "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+    var row = (if (rule_id_q) |pid| conn.row(
+        "SELECT rule_id, content_hash, content, path FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
         .{ user.org_id, pid },
     ) else conn.row(
-        "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND path = $2",
+        "SELECT rule_id, content_hash, content, path FROM rules WHERE org_id = $1::uuid AND path = $2",
         .{ user.org_id, path_q.? },
     )) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt not found");
+        return apiError(res, 404, "NOT_FOUND", "rule not found");
     };
 
     const content_hash = try req.arena.dupe(u8, try row.get([]const u8, 1));
@@ -256,39 +256,39 @@ pub fn handleGetPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *h
         }
     }
 
-    const prompt_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
+    const rule_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
     const body = try req.arena.dupe(u8, try row.get([]const u8, 2));
     const path = try req.arena.dupe(u8, try row.get([]const u8, 3));
     row.deinit() catch {};
 
     res.header("ETag", content_hash);
-    try res.json(PromptContentResponse{
-        .prompt_id = prompt_id,
+    try res.json(RuleContentResponse{
+        .rule_id = rule_id,
         .path = path,
         .content_hash = content_hash,
         .body = body,
     }, .{});
 }
 
-/// Batch prompt content fetch. Clients (notably `clumsies sync`)
-/// send a list of prompt_ids in one POST; the response carries a
+/// Batch rule content fetch. Clients (notably `clumsies sync`)
+/// send a list of rule_ids in one POST; the response carries a
 /// per-id item, each either populated or tagged with a per-item
 /// error. A single fetch replaces what used to be N sequential GETs
 /// and dominates sync wall time over tunneled links.
-pub fn handleBatchPromptContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleBatchRuleContent(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
     if (!auth.requireScope(user, "library:read", res)) return;
 
-    const body = req.json(BatchPromptContentRequest) catch {
+    const body = req.json(BatchRuleContentRequest) catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
     } orelse {
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
     };
 
-    if (body.prompt_ids.len > BATCH_MAX_IDS) {
-        return apiError(res, 400, "BAD_REQUEST", "too many prompt_ids");
+    if (body.rule_ids.len > BATCH_MAX_IDS) {
+        return apiError(res, 400, "BAD_REQUEST", "too many rule_ids");
     }
 
     const conn = ctx.pool.acquire() catch {
@@ -296,26 +296,26 @@ pub fn handleBatchPromptContent(ctx: *Server.Context, req: *httpz.Request, res: 
     };
     defer conn.release();
 
-    var items: std.ArrayList(BatchPromptItem) = .empty;
-    for (body.prompt_ids) |prompt_id| {
+    var items: std.ArrayList(BatchRuleItem) = .empty;
+    for (body.rule_ids) |rule_id| {
         // Distinguish query failure (INTERNAL_ERROR) from a missing
         // row (NOT_FOUND). Previously both collapsed into NOT_FOUND,
         // so a transient database outage presented to the client as
-        // "every prompt is missing" — misleading and impossible to
+        // "every rule is missing" — misleading and impossible to
         // debug without server logs.
         const row_result = conn.row(
-            "SELECT prompt_id, content_hash, content, path FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
-            .{ user.org_id, prompt_id },
+            "SELECT rule_id, content_hash, content, path FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
+            .{ user.org_id, rule_id },
         ) catch {
             try items.append(req.arena, .{
-                .prompt_id = try req.arena.dupe(u8, prompt_id),
+                .rule_id = try req.arena.dupe(u8, rule_id),
                 .@"error" = "INTERNAL_ERROR",
             });
             continue;
         };
         var row = row_result orelse {
             try items.append(req.arena, .{
-                .prompt_id = try req.arena.dupe(u8, prompt_id),
+                .rule_id = try req.arena.dupe(u8, rule_id),
                 .@"error" = "NOT_FOUND",
             });
             continue;
@@ -329,14 +329,14 @@ pub fn handleBatchPromptContent(ctx: *Server.Context, req: *httpz.Request, res: 
         const content = try req.arena.dupe(u8, try row.get([]const u8, 2));
         const path = try req.arena.dupe(u8, try row.get([]const u8, 3));
         try items.append(req.arena, .{
-            .prompt_id = pid,
+            .rule_id = pid,
             .path = path,
             .content_hash = content_hash,
             .body = content,
         });
     }
 
-    try res.json(BatchPromptContentResponse{ .items = items.items }, .{});
+    try res.json(BatchRuleContentResponse{ .items = items.items }, .{});
 }
 
 pub fn handleListBundles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -351,9 +351,9 @@ pub fn handleListBundles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
     defer conn.release();
 
     var result = conn.query(
-        \\SELECT b.name, b.description, b.updated_at::text, count(bp.prompt_id)::bigint
+        \\SELECT b.name, b.description, b.updated_at::text, count(bp.rule_id)::bigint
         \\FROM bundles b
-        \\LEFT JOIN bundle_prompts bp ON bp.bundle_id = b.bundle_id
+        \\LEFT JOIN bundle_rules bp ON bp.bundle_id = b.bundle_id
         \\WHERE b.org_id = $1::uuid
         \\GROUP BY b.bundle_id, b.name, b.description, b.updated_at
         \\ORDER BY b.name
@@ -370,7 +370,7 @@ pub fn handleListBundles(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
             .name = try req.arena.dupe(u8, try row.get([]const u8, 0)),
             .description = try req.arena.dupe(u8, try row.get([]const u8, 1)),
             .updated_at = try req.arena.dupe(u8, try row.get([]const u8, 2)),
-            .prompt_count = try row.get(i64, 3),
+            .rule_count = try row.get(i64, 3),
         });
     }
 
@@ -408,23 +408,23 @@ pub fn handleGetBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     const updated_at = try req.arena.dupe(u8, try row.get([]const u8, 4));
     row.deinit() catch {};
 
-    var prompt_result = conn.query(
-        "SELECT prompt_id FROM bundle_prompts WHERE bundle_id = $1",
+    var rule_result = conn.query(
+        "SELECT rule_id FROM bundle_rules WHERE bundle_id = $1",
         .{bundle_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
-    defer prompt_result.deinit();
+    defer rule_result.deinit();
 
     var ids: std.ArrayList([]const u8) = .empty;
-    while (try prompt_result.next()) |prow| {
+    while (try rule_result.next()) |prow| {
         try ids.append(req.arena, try req.arena.dupe(u8, try prow.get([]const u8, 0)));
     }
 
     try res.json(.{
         .name = bundle_name,
         .description = description,
-        .prompt_ids = ids.items,
+        .rule_ids = ids.items,
         .created_at = created_at,
         .updated_at = updated_at,
     }, .{});
@@ -433,7 +433,7 @@ pub fn handleGetBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
 const CreateBundleRequest = struct {
     name: []const u8,
     description: ?[]const u8 = null,
-    prompt_ids: []const []const u8,
+    rule_ids: []const []const u8,
 };
 
 pub fn handleCreateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -456,10 +456,10 @@ pub fn handleCreateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     };
     defer conn.release();
 
-    // Validate all prompt_ids exist
-    for (body.prompt_ids) |pid| {
+    // Validate all rule_ids exist
+    for (body.rule_ids) |pid| {
         var exists = conn.row(
-            "SELECT 1 FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+            "SELECT 1 FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
             .{ user.org_id, pid },
         ) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -467,7 +467,7 @@ pub fn handleCreateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         if (exists) |*r| {
             r.deinit() catch {};
         } else {
-            return apiError(res, 400, "BAD_REQUEST", "prompt_id not found in Library");
+            return apiError(res, 400, "BAD_REQUEST", "rule_id not found in Library");
         }
     }
 
@@ -498,9 +498,9 @@ pub fn handleCreateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         return apiError(res, 500, "INTERNAL_ERROR", "database insert failed");
     };
 
-    for (body.prompt_ids) |pid| {
+    for (body.rule_ids) |pid| {
         _ = conn.exec(
-            "INSERT INTO bundle_prompts (bundle_id, prompt_id) VALUES ($1, $2)",
+            "INSERT INTO bundle_rules (bundle_id, rule_id) VALUES ($1, $2)",
             .{ bundle_id, pid },
         ) catch {};
     }
@@ -509,13 +509,13 @@ pub fn handleCreateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     try res.json(.{
         .name = body.name,
         .description = desc,
-        .prompt_ids = body.prompt_ids,
+        .rule_ids = body.rule_ids,
     }, .{});
 }
 
 const UpdateBundleRequest = struct {
     description: ?[]const u8 = null,
-    prompt_ids: ?[]const []const u8 = null,
+    rule_ids: ?[]const []const u8 = null,
 };
 
 pub fn handleUpdateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
@@ -564,11 +564,11 @@ pub fn handleUpdateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
         };
     }
 
-    // Replace prompt_ids if provided
-    if (body.prompt_ids) |pids| {
+    // Replace rule_ids if provided
+    if (body.rule_ids) |pids| {
         for (pids) |pid| {
             var exists2 = conn.row(
-                "SELECT 1 FROM prompts WHERE org_id = $1::uuid AND prompt_id = $2",
+                "SELECT 1 FROM rules WHERE org_id = $1::uuid AND rule_id = $2",
                 .{ user.org_id, pid },
             ) catch {
                 return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
@@ -576,14 +576,14 @@ pub fn handleUpdateBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
             if (exists2) |*r| {
                 r.deinit() catch {};
             } else {
-                return apiError(res, 400, "BAD_REQUEST", "prompt_id not found in Library");
+                return apiError(res, 400, "BAD_REQUEST", "rule_id not found in Library");
             }
         }
 
-        _ = conn.exec("DELETE FROM bundle_prompts WHERE bundle_id = $1", .{bundle_id}) catch {};
+        _ = conn.exec("DELETE FROM bundle_rules WHERE bundle_id = $1", .{bundle_id}) catch {};
         for (pids) |pid| {
             _ = conn.exec(
-                "INSERT INTO bundle_prompts (bundle_id, prompt_id) VALUES ($1, $2)",
+                "INSERT INTO bundle_rules (bundle_id, rule_id) VALUES ($1, $2)",
                 .{ bundle_id, pid },
             ) catch {};
         }
@@ -625,7 +625,7 @@ pub fn handleDeleteBundle(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     const bundle_id = try req.arena.dupe(u8, try row.get([]const u8, 0));
     row.deinit() catch {};
 
-    _ = conn.exec("DELETE FROM bundle_prompts WHERE bundle_id = $1", .{bundle_id}) catch {};
+    _ = conn.exec("DELETE FROM bundle_rules WHERE bundle_id = $1", .{bundle_id}) catch {};
     _ = conn.exec("DELETE FROM bundles WHERE bundle_id = $1", .{bundle_id}) catch {};
 
     res.status = 204;

--- a/src/hub/server.zig
+++ b/src/hub/server.zig
@@ -68,8 +68,8 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.patch("/api/workspaces/:ws_id", workspace_handler.handleUpdate, .{});
     router.delete("/api/workspaces/:ws_id", workspace_handler.handleDelete, .{});
     router.get("/api/workspaces/:ws_id/manifest", workspace_handler.handleGetManifest, .{});
-    router.post("/api/workspaces/:ws_id/prompts", workspace_handler.handleAddPrompt, .{});
-    router.delete("/api/workspaces/:ws_id/prompts/:prompt_id", workspace_handler.handleRemovePrompt, .{});
+    router.post("/api/workspaces/:ws_id/rules", workspace_handler.handleAddRule, .{});
+    router.delete("/api/workspaces/:ws_id/rules/:rule_id", workspace_handler.handleRemoveRule, .{});
     // Context
     router.get("/api/workspaces/:ws_id/context/files", context_handler.handleListFiles, .{});
     router.get("/api/workspaces/:ws_id/context/file/content", context_handler.handleGetFileContent, .{});
@@ -88,10 +88,10 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
 
     // Library
     router.get("/api/org/library/manifest", library_handler.handleGetManifest, .{});
-    router.get("/api/org/library/prompts", library_handler.handleListPrompts, .{});
-    router.get("/api/org/library/prompt", library_handler.handleGetPrompt, .{});
-    router.get("/api/org/library/prompt/content", library_handler.handleGetPromptContent, .{});
-    router.post("/api/org/library/prompts/content", library_handler.handleBatchPromptContent, .{});
+    router.get("/api/org/library/rules", library_handler.handleListRules, .{});
+    router.get("/api/org/library/rule", library_handler.handleGetRule, .{});
+    router.get("/api/org/library/rule/content", library_handler.handleGetRuleContent, .{});
+    router.post("/api/org/library/rules/content", library_handler.handleBatchRuleContent, .{});
     router.get("/api/org/bundles", library_handler.handleListBundles, .{});
     router.get("/api/org/bundles/:name", library_handler.handleGetBundle, .{});
     router.post("/api/org/bundles", library_handler.handleCreateBundle, .{});
@@ -102,15 +102,15 @@ pub fn init(allocator: std.mem.Allocator, config: Config, pool: *pg.Pool) !Serve
     router.post("/api/attestations", attestation_handler.handleUpload, .{});
     router.get("/api/stats", attestation_handler.handleOrgStats, .{});
     router.get("/api/stats/workspace/:ws_id", attestation_handler.handleWorkspaceStats, .{});
-    router.get("/api/stats/prompt/:prompt_id", attestation_handler.handlePromptStats, .{});
+    router.get("/api/stats/rule/:rule_id", attestation_handler.handleRuleStats, .{});
 
-    // Prompt PRs
-    router.post("/api/org/prompt-prs", collab_handler.handleCreatePr, .{});
-    router.get("/api/org/prompt-prs", collab_handler.handleListPrs, .{});
-    router.get("/api/org/prompt-prs/:id", collab_handler.handleGetPr, .{});
-    router.put("/api/org/prompt-prs/:id", collab_handler.handleUpdatePr, .{});
-    router.post("/api/org/prompt-prs/:id/comments", collab_handler.handleAddComment, .{});
-    router.get("/api/org/prompt-prs/:id/comments", collab_handler.handleListComments, .{});
+    // Rule PRs
+    router.post("/api/org/rule-prs", collab_handler.handleCreatePr, .{});
+    router.get("/api/org/rule-prs", collab_handler.handleListPrs, .{});
+    router.get("/api/org/rule-prs/:id", collab_handler.handleGetPr, .{});
+    router.put("/api/org/rule-prs/:id", collab_handler.handleUpdatePr, .{});
+    router.post("/api/org/rule-prs/:id/comments", collab_handler.handleAddComment, .{});
+    router.get("/api/org/rule-prs/:id/comments", collab_handler.handleListComments, .{});
 
     return .{ .http = server };
 }

--- a/src/hub/workspace.zig
+++ b/src/hub/workspace.zig
@@ -1,5 +1,5 @@
 //! Hub workspace endpoints. A workspace is a project's working environment: a subset of Library
-//! prompts plus its own context. These endpoints handle workspace CRUD and serve the manifest
+//! rules plus its own context. These endpoints handle workspace CRUD and serve the manifest
 //! that drives the client sync protocol.
 const std = @import("std");
 const httpz = @import("httpz");
@@ -206,7 +206,7 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         }
     }
 
-    const prompts = try collectManifestMap(req.arena, conn, "SELECT wp.prompt_id, p.path, p.content_hash, p.description FROM workspace_prompts wp JOIN prompts p ON p.prompt_id = wp.prompt_id WHERE wp.ws_id = $1", .{ws_id});
+    const rules = try collectManifestMap(req.arena, conn, "SELECT wp.rule_id, p.path, p.content_hash, p.description FROM workspace_rules wp JOIN rules p ON p.rule_id = wp.rule_id WHERE wp.ws_id = $1", .{ws_id});
 
     const context = try collectManifestMap(req.arena, conn, "SELECT context_id, path, content_hash, description FROM context_files WHERE ws_id = $1", .{ws_id});
 
@@ -218,16 +218,16 @@ pub fn handleGetManifest(ctx: *Server.Context, req: *httpz.Request, res: *httpz.
         .ws_id = ws_id_val,
         .name = ws_name,
         .revision = revision,
-        .prompts = prompts,
+        .rules = rules,
         .context = context,
     }, .{});
 }
 
-const AddPromptRequest = struct {
-    prompt_id: []const u8,
+const AddRuleRequest = struct {
+    rule_id: []const u8,
 };
 
-pub fn handleAddPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleAddRule(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
@@ -237,7 +237,7 @@ pub fn handleAddPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
         return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
     };
 
-    const body = req.json(AddPromptRequest) catch {
+    const body = req.json(AddRuleRequest) catch {
         return apiError(res, 400, "BAD_REQUEST", "invalid JSON body");
     } orelse {
         return apiError(res, 400, "BAD_REQUEST", "missing request body");
@@ -254,26 +254,26 @@ pub fn handleAddPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
 
     if (!try checkIfMatch(conn, req, res, ws_id)) return;
 
-    var prompt_row = conn.row(
-        "SELECT prompt_id FROM prompts WHERE prompt_id = $1",
-        .{body.prompt_id},
+    var rule_row = conn.row(
+        "SELECT rule_id FROM rules WHERE rule_id = $1",
+        .{body.rule_id},
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     } orelse {
-        return apiError(res, 404, "NOT_FOUND", "prompt not found");
+        return apiError(res, 404, "NOT_FOUND", "rule not found");
     };
-    prompt_row.deinit() catch {};
+    rule_row.deinit() catch {};
 
     _ = conn.exec(
-        "INSERT INTO workspace_prompts (ws_id, prompt_id) VALUES ($1, $2)",
-        .{ ws_id, body.prompt_id },
+        "INSERT INTO workspace_rules (ws_id, rule_id) VALUES ($1, $2)",
+        .{ ws_id, body.rule_id },
     ) catch {
         if (conn.err) |pg_err| {
             if (std.mem.indexOf(u8, pg_err.message, "duplicate") != null) {
-                return apiError(res, 409, "CONFLICT", "prompt already in workspace");
+                return apiError(res, 409, "CONFLICT", "rule already in workspace");
             }
         }
-        return apiError(res, 500, "INTERNAL_ERROR", "failed to add prompt");
+        return apiError(res, 500, "INTERNAL_ERROR", "failed to add rule");
     };
 
     var rev_row = conn.row(
@@ -290,7 +290,7 @@ pub fn handleAddPrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Re
     try res.json(.{ .revision = new_rev }, .{});
 }
 
-pub fn handleRemovePrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
+pub fn handleRemoveRule(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Response) !void {
     const user = auth.authenticate(ctx, req) catch {
         return apiError(res, 401, "UNAUTHORIZED", "invalid or missing token");
     };
@@ -299,8 +299,8 @@ pub fn handleRemovePrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     const ws_id = req.param("ws_id") orelse {
         return apiError(res, 400, "BAD_REQUEST", "ws_id is required");
     };
-    const prompt_id = req.param("prompt_id") orelse {
-        return apiError(res, 400, "BAD_REQUEST", "prompt_id is required");
+    const rule_id = req.param("rule_id") orelse {
+        return apiError(res, 400, "BAD_REQUEST", "rule_id is required");
     };
 
     const conn = ctx.pool.acquire() catch {
@@ -315,14 +315,14 @@ pub fn handleRemovePrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz
     if (!try checkIfMatch(conn, req, res, ws_id)) return;
 
     const deleted = conn.exec(
-        "DELETE FROM workspace_prompts WHERE ws_id = $1 AND prompt_id = $2",
-        .{ ws_id, prompt_id },
+        "DELETE FROM workspace_rules WHERE ws_id = $1 AND rule_id = $2",
+        .{ ws_id, rule_id },
     ) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database query failed");
     };
 
     if (deleted == null or deleted.? == 0) {
-        return apiError(res, 404, "NOT_FOUND", "prompt not in workspace");
+        return apiError(res, 404, "NOT_FOUND", "rule not in workspace");
     }
 
     var rev_row = conn.row(
@@ -341,7 +341,7 @@ pub fn handleRemovePrompt(ctx: *Server.Context, req: *httpz.Request, res: *httpz
 
 fn initFromBundle(conn: anytype, ws_id: []const u8, bundle_id: []const u8) void {
     var result = conn.query(
-        "SELECT prompt_id FROM bundle_prompts WHERE bundle_id = $1",
+        "SELECT rule_id FROM bundle_rules WHERE bundle_id = $1",
         .{bundle_id},
     ) catch return;
     defer result.deinit();
@@ -349,7 +349,7 @@ fn initFromBundle(conn: anytype, ws_id: []const u8, bundle_id: []const u8) void 
     while (result.next() catch null) |brow| {
         const pid = brow.get([]const u8, 0) catch continue;
         _ = conn.exec(
-            "INSERT INTO workspace_prompts (ws_id, prompt_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+            "INSERT INTO workspace_rules (ws_id, rule_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
             .{ ws_id, pid },
         ) catch {};
     }
@@ -418,14 +418,14 @@ pub fn handleDelete(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Respo
         return apiError(res, 404, "NOT_FOUND", "workspace not found");
     }
 
-    // Cascade delete: comments, pr_files, prs, files, branches, members, prompt refs, then workspace
+    // Cascade delete: comments, pr_files, prs, files, branches, members, rule refs, then workspace
     _ = conn.exec("DELETE FROM context_pr_comments WHERE pr_id IN (SELECT pr_id FROM context_prs WHERE ws_id = $1)", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM context_pr_files WHERE pr_id IN (SELECT pr_id FROM context_prs WHERE ws_id = $1)", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM context_prs WHERE ws_id = $1", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM context_files WHERE ws_id = $1", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM context_branches WHERE ws_id = $1", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM workspace_members WHERE ws_id = $1", .{ws_id}) catch {};
-    _ = conn.exec("DELETE FROM workspace_prompts WHERE ws_id = $1", .{ws_id}) catch {};
+    _ = conn.exec("DELETE FROM workspace_rules WHERE ws_id = $1", .{ws_id}) catch {};
     _ = conn.exec("DELETE FROM workspaces WHERE ws_id = $1", .{ws_id}) catch {
         return apiError(res, 500, "INTERNAL_ERROR", "database delete failed");
     };

--- a/src/protocol/collab_api.zig
+++ b/src/protocol/collab_api.zig
@@ -1,7 +1,7 @@
 //! Collaboration API response shapes. Pull requests carry workspace local edits back to the
-//! Library for review. Each PR contains PromptPrChanges (add/modify/delete) and a
-//! PromptPrUsageSummary showing how much the changed prompt has been referred.
-pub const PromptPrListItem = struct {
+//! Library for review. Each PR contains RulePrChanges (add/modify/delete) and a
+//! RulePrUsageSummary showing how much the changed rule has been referred.
+pub const RulePrListItem = struct {
     pr_id: []const u8,
     status: []const u8,
     description: []const u8,
@@ -10,14 +10,14 @@ pub const PromptPrListItem = struct {
     operation_count: i64 = 0,
 };
 
-pub const PromptPrListResponse = struct {
-    prs: []const PromptPrListItem = &.{},
+pub const RulePrListResponse = struct {
+    prs: []const RulePrListItem = &.{},
 };
 
-pub const PromptPrChange = struct {
+pub const RulePrChange = struct {
     op_index: i32 = 0,
     type: []const u8 = "",
-    prompt_id: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
     base_hash: ?[]const u8 = null,
     content: ?[]const u8 = null,
     path: ?[]const u8 = null,
@@ -25,22 +25,22 @@ pub const PromptPrChange = struct {
     current_path: ?[]const u8 = null,
 };
 
-pub const PromptPrUsageSummary = struct {
+pub const RulePrUsageSummary = struct {
     refer_count: i64 = 0,
     sessions_used: i64 = 0,
     last_referred: ?[]const u8 = null,
 };
 
-pub const PromptPrDetailResponse = struct {
+pub const RulePrDetailResponse = struct {
     pr_id: []const u8,
     status: []const u8,
     description: []const u8,
     created_at: []const u8,
-    operations: []const PromptPrChange = &.{},
-    attestation_summary: PromptPrUsageSummary = .{},
+    operations: []const RulePrChange = &.{},
+    attestation_summary: RulePrUsageSummary = .{},
 };
 
-pub const PromptPrComment = struct {
+pub const RulePrComment = struct {
     comment_id: []const u8 = "",
     author_id: []const u8 = "",
     author: []const u8 = "",
@@ -48,6 +48,6 @@ pub const PromptPrComment = struct {
     created_at: []const u8 = "",
 };
 
-pub const PromptPrCommentsResponse = struct {
-    comments: []const PromptPrComment = &.{},
+pub const RulePrCommentsResponse = struct {
+    comments: []const RulePrComment = &.{},
 };

--- a/src/protocol/library_api.zig
+++ b/src/protocol/library_api.zig
@@ -1,62 +1,62 @@
-//! Library API response shapes. The Library is the org's prompt collection (single source of
-//! truth). These types describe prompt metadata, content, and bundle membership used by CLI
+//! Library API response shapes. The Library is the org's rule collection (single source of
+//! truth). These types describe rule metadata, content, and bundle membership used by CLI
 //! sync and TUI display.
 const manifest = @import("manifest.zig");
 
 pub const LibraryManifestResponse = struct {
     revision: i32,
-    prompts: manifest.ManifestMap,
+    rules: manifest.ManifestMap,
 };
 
-pub const PromptMeta = struct {
-    prompt_id: []const u8,
+pub const RuleMeta = struct {
+    rule_id: []const u8,
     path: []const u8,
     content_hash: []const u8,
     updated_at: []const u8,
     source: []const u8 = "",
 };
 
-pub const PromptListResponse = struct {
-    prompts: []const PromptMeta = &.{},
+pub const RuleListResponse = struct {
+    rules: []const RuleMeta = &.{},
 };
 
-pub const PromptContentResponse = struct {
-    prompt_id: []const u8,
+pub const RuleContentResponse = struct {
+    rule_id: []const u8,
     path: []const u8,
     content_hash: []const u8,
     body: []const u8,
 };
 
-/// Batch prompt content fetch. Used by `clumsies sync` to pull many
-/// prompts in one request instead of one GET per prompt. The single
-/// PromptContentResponse endpoint (used by TUI on-demand loads)
+/// Batch rule content fetch. Used by `clumsies sync` to pull many
+/// rules in one request instead of one GET per rule. The single
+/// RuleContentResponse endpoint (used by TUI on-demand loads)
 /// remains; this is an additive sync-oriented path.
-pub const BatchPromptContentRequest = struct {
-    prompt_ids: []const []const u8,
+pub const BatchRuleContentRequest = struct {
+    rule_ids: []const []const u8,
 };
 
-pub const BatchPromptItem = struct {
-    prompt_id: []const u8,
+pub const BatchRuleItem = struct {
+    rule_id: []const u8,
     path: []const u8 = "",
     content_hash: []const u8 = "",
     body: []const u8 = "",
-    /// Per-item error code when a specific prompt could not be
+    /// Per-item error code when a specific rule could not be
     /// served (e.g. `NOT_FOUND`, `FORBIDDEN`). Empty string means the
     /// item was served successfully; callers should check this
     /// before treating body as authoritative.
     @"error": []const u8 = "",
 };
 
-pub const BatchPromptContentResponse = struct {
-    items: []const BatchPromptItem = &.{},
+pub const BatchRuleContentResponse = struct {
+    items: []const BatchRuleItem = &.{},
 };
 
 pub const BundleMeta = struct {
     name: []const u8,
     description: []const u8 = "",
     updated_at: []const u8 = "",
-    prompt_count: i64 = 0,
-    prompt_ids: []const []const u8 = &.{},
+    rule_count: i64 = 0,
+    rule_ids: []const []const u8 = &.{},
 };
 
 pub const BundleListResponse = struct {

--- a/src/protocol/manifest.zig
+++ b/src/protocol/manifest.zig
@@ -1,6 +1,6 @@
-//! Manifest format: the content index at the heart of the sync protocol. A manifest maps prompt
+//! Manifest format: the content index at the heart of the sync protocol. A manifest maps rule
 //! paths to content hashes. During sync, the client diffs its local manifest against the
-//! server's — only prompts with changed hashes get downloaded.
+//! server's — only rules with changed hashes get downloaded.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -71,7 +71,7 @@ pub const ManifestMap = struct {
 test "ManifestMap parses object entries" {
     const testing = std.testing;
     const body =
-        \\{"prompt-a":{"path":"rule/coding/00_COMPATIBILITY.md","hash":"sha256:abc"}}
+        \\{"rule-a":{"path":"rule/coding/00_COMPATIBILITY.md","hash":"sha256:abc"}}
     ;
 
     const parsed = try std.json.parseFromSlice(ManifestMap, testing.allocator, body, .{
@@ -80,7 +80,7 @@ test "ManifestMap parses object entries" {
     defer parsed.deinit();
 
     try testing.expectEqual(@as(usize, 1), parsed.value.items.len);
-    try testing.expectEqualStrings("prompt-a", parsed.value.items[0].key);
+    try testing.expectEqualStrings("rule-a", parsed.value.items[0].key);
     try testing.expectEqualStrings("rule/coding/00_COMPATIBILITY.md", parsed.value.items[0].value.path);
     try testing.expectEqualStrings("sha256:abc", parsed.value.items[0].value.hash);
 }

--- a/src/protocol/stats_api.zig
+++ b/src/protocol/stats_api.zig
@@ -1,5 +1,5 @@
 //! Statistics API response shapes. Stats aggregate attestation events into constraint-level usage
-//! metrics: refer counts, signal ratios, per-prompt trends, and per-user activity. These feed
+//! metrics: refer counts, signal ratios, per-rule trends, and per-user activity. These feed
 //! the TUI Analysis and Dashboard panels.
 pub const TrendPoint = struct {
     date: []const u8,
@@ -11,8 +11,8 @@ pub const TrendSeries = struct {
     data: []const TrendPoint = &.{},
 };
 
-pub const OrgPromptStat = struct {
-    prompt_id: []const u8,
+pub const OrgRuleStat = struct {
+    rule_id: []const u8,
     refer_count: i64 = 0,
     active_constraint_count: i64 = 0,
     workspace_count: i64 = 0,
@@ -22,8 +22,8 @@ pub const OrgPromptStat = struct {
     trend: []const i64 = &.{},
 };
 
-pub const OrgUserTopPromptStat = struct {
-    prompt_id: []const u8 = "",
+pub const OrgUserTopRuleStat = struct {
+    rule_id: []const u8 = "",
     refer_count: i64 = 0,
 };
 
@@ -34,20 +34,20 @@ pub const OrgUserStat = struct {
     active_days: i64 = 0,
     last_referred_at: ?i64 = null,
     trend: []const i64 = &.{},
-    top_prompts: []const OrgUserTopPromptStat = &.{},
+    top_rules: []const OrgUserTopRuleStat = &.{},
 };
 
 pub const OrgStatsResponse = struct {
     total_refer_count: i64 = 0,
     workspace_count: i64 = 0,
-    prompt_count: i64 = 0,
-    prompts: []const OrgPromptStat = &.{},
+    rule_count: i64 = 0,
+    rules: []const OrgRuleStat = &.{},
     users: []const OrgUserStat = &.{},
     trend: TrendSeries = .{},
 };
 
-pub const WorkspacePromptStat = struct {
-    prompt_id: []const u8,
+pub const WorkspaceRuleStat = struct {
+    rule_id: []const u8,
     refer_count: i64 = 0,
 };
 
@@ -55,6 +55,6 @@ pub const WorkspaceStatsResponse = struct {
     ws_id: []const u8,
     total_refer_count: i64 = 0,
     constraint_coverage: f64 = 0,
-    prompts: []const WorkspacePromptStat = &.{},
+    rules: []const WorkspaceRuleStat = &.{},
     trend: TrendSeries = .{},
 };

--- a/src/protocol/workspace_api.zig
+++ b/src/protocol/workspace_api.zig
@@ -1,6 +1,6 @@
 //! Workspace API request and response shapes. ContextFile describes a file in the workspace's
 //! context tree (project knowledge). WorkspaceManifestResponse carries the manifest that drives
-//! the sync protocol — each entry maps a prompt path to its content hash.
+//! the sync protocol — each entry maps a rule path to its content hash.
 //! CreateWorkspaceRequest / CreateWorkspaceResponse are the wire contract for POST
 //! /api/workspaces, shared between hub, cli and tui.
 const manifest = @import("manifest.zig");
@@ -40,7 +40,7 @@ pub const WorkspaceManifestResponse = struct {
     ws_id: []const u8,
     name: []const u8,
     revision: i32,
-    prompts: manifest.ManifestMap,
+    rules: manifest.ManifestMap,
     context: manifest.ManifestMap,
 };
 

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -229,7 +229,7 @@ pub const USERS = [_]UserFixture{
     .{ .id = "usr-seed-amimibear", .username = "amimibear", .role = "member" },
 };
 
-pub const PROMPTS = [_]RuleFixture{
+pub const RULES = [_]RuleFixture{
     .{ .id = "p-seed-meta", .path = "META_PROMPT.md", .content = META_PROMPT_CONTENT },
     .{ .id = "p-seed-coding", .path = "workflow/00_CODING.md", .content = CODING_WORKFLOW_CONTENT },
     .{ .id = "p-seed-trace", .path = "rule/trace/TRACE_DISCIPLINE.md", .content = TRACE_DISCIPLINE_CONTENT },
@@ -257,7 +257,7 @@ pub const WORKSPACE_MEMBERS = [_]WorkspaceMemberFixture{
     .{ .ws_id = "ws-seed-plugin", .user_id = "usr-seed-amimibear", .role = "member" },
 };
 
-pub const WORKSPACE_PROMPTS = [_]WorkspaceRuleFixture{
+pub const WORKSPACE_RULES = [_]WorkspaceRuleFixture{
     .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-meta" },
     .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-coding" },
     .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-trace" },
@@ -359,7 +359,7 @@ pub const PUMP_SCENARIOS = [_]PumpScenario{
 };
 
 pub fn ruleById(rule_id: []const u8) ?*const RuleFixture {
-    for (&PROMPTS) |*rule| {
+    for (&RULES) |*rule| {
         if (std.mem.eql(u8, rule.id, rule_id)) return rule;
     }
     return null;

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -1,4 +1,4 @@
-//! Seed fixture data: users, workspaces, prompts, bundles, and constraints for development.
+//! Seed fixture data: users, workspaces, rules, bundles, and constraints for development.
 //! These fixtures populate the database with realistic data so the TUI and CLI can be developed
 //! against a working Hub instance.
 const std = @import("std");
@@ -19,7 +19,7 @@ pub const UserFixture = struct {
     status: []const u8 = "active",
 };
 
-pub const PromptFixture = struct {
+pub const RuleFixture = struct {
     id: []const u8,
     path: []const u8,
     content: []const u8,
@@ -36,9 +36,9 @@ pub const WorkspaceMemberFixture = struct {
     role: []const u8,
 };
 
-pub const WorkspacePromptFixture = struct {
+pub const WorkspaceRuleFixture = struct {
     ws_id: []const u8,
-    prompt_id: []const u8,
+    rule_id: []const u8,
 };
 
 pub const ContextFixture = struct {
@@ -49,8 +49,8 @@ pub const ContextFixture = struct {
     content: []const u8,
 };
 
-pub const PumpRefer = struct {
-    prompt_id: []const u8,
+pub const RuleRefer = struct {
+    rule_id: []const u8,
     constraint_id: []const u8,
     reason: []const u8,
 };
@@ -59,7 +59,7 @@ pub const PumpScenario = struct {
     user_id: []const u8,
     ws_id: []const u8,
     input: []const u8,
-    refers: []const PumpRefer,
+    refers: []const RuleRefer,
 };
 
 pub const PumpProfile = struct {
@@ -88,8 +88,8 @@ pub const META_PROMPT_CONTENT =
     \\5. **Refine.** When the user asks you to create, update, or delete rules or
     \\   context, use `context.propose_create()`, `context.propose_update()`,
     \\   `context.propose_rename()`, `context.propose_delete()` for workspace context,
-    \\   and `prompt.propose_create()`, `prompt.propose_update()`,
-    \\   `prompt.propose_rename()`, `prompt.propose_delete()` for library rules.
+    \\   and `rule.propose_create()`, `rule.propose_update()`,
+    \\   `rule.propose_rename()`, `rule.propose_delete()` for library rules.
     \\6. **Submit.** Call `memory.submit()` with a short summary of your work before
     \\   finishing every response. The stop hook will block if you forget.
     \\
@@ -113,7 +113,7 @@ pub const META_PROMPT_CONTENT =
     \\
     \\## Priority
     \\
-    \\Loaded rules > this meta-prompt > your defaults.
+    \\Loaded rules > this meta-rule > your defaults.
     \\
     \\When a rule conflicts with your training, follow the rule.
 ;
@@ -149,7 +149,7 @@ pub const TRACE_DISCIPLINE_CONTENT =
     \\
     \\Keep attestation behavior strict and observable:
     \\
-    \\1. Treat the hub-issued `prompt_id` as the only prompt identity in attestation events.
+    \\1. Treat the hub-issued `rule_id` as the only rule identity in attestation events.
     \\2. Write local `attestation.jsonl` lines in the same JSON shape accepted by `POST /api/attestations`.
     \\3. Emit `user_prompt` before `refer` so Recent Inputs and Insights stay meaningful.
     \\4. Keep the seed pump focused on observability traffic. Do not mutate workspace structure during activity generation.
@@ -160,7 +160,7 @@ pub const HUB_SINGLE_SOURCE_CONTENT =
     \\
     \\- The hub server owns business logic for auth, library, workspace, context, collaboration, and attestation stats.
     \\- CLI, MCP, and TUI are clients. They should talk to the hub over REST instead of duplicating policy.
-    \\- Library prompts are organization-wide. Workspace context stays local to a workspace.
+    \\- Library rules are organization-wide. Workspace context stays local to a workspace.
     \\- Attestation data is a signal for refinement. It should not trigger automatic edits on its own.
 ;
 
@@ -175,7 +175,7 @@ pub const ZIG_TOOLCHAIN_CONTENT =
 pub const BUILD_ENV_CONTEXT =
     \\# Build Environment Snapshot
     \\
-    \\This seed context is derived from `.prompts/context/00_BUILD_ENV.md`.
+    \\This seed context is derived from `.rules/context/00_BUILD_ENV.md`.
     \\
     \\- The repository is built against Zig 0.15.x.
     \\- Developers should verify the active Zig toolchain before building.
@@ -186,30 +186,30 @@ pub const BUILD_ENV_CONTEXT =
 pub const ARCHITECTURE_CONTEXT =
     \\# Architecture Snapshot
     \\
-    \\This seed context is derived from `.prompts/context/01_ARCHITECTURE.md`.
+    \\This seed context is derived from `.rules/context/01_ARCHITECTURE.md`.
     \\
     \\- The hub server is the only layer that owns business logic.
     \\- CLI, MCP, and TUI are clients that integrate over HTTP APIs.
-    \\- Library prompts are shared at the organization level, while context is workspace-scoped.
-    \\- Attestation data exists to support observability and prompt refinement decisions.
+    \\- Library rules are shared at the organization level, while context is workspace-scoped.
+    \\- Attestation data exists to support observability and rule refinement decisions.
 ;
 
 pub const TRACE_ALIGNMENT_CONTEXT =
     \\# MCP Attestation Alignment Snapshot
     \\
-    \\This seed context is derived from `.prompts/plan/MCP_TRACE_ALIGNMENT.md`.
+    \\This seed context is derived from `.rules/plan/MCP_TRACE_ALIGNMENT.md`.
     \\
     \\- Local `attestation.jsonl` should match the server `POST /api/attestations` payload shape.
     \\- `ws_id` must be the hub workspace id, not a local hash.
     \\- `user_prompt` events are required if the TUI should render a Recent Inputs feed.
-    \\- `prompt_id` must always be the hub-issued identifier.
+    \\- `rule_id` must always be the hub-issued identifier.
 ;
 
 pub const RECENT_INPUTS_CONTEXT =
     \\# Recent Inputs Snapshot
     \\
     \\- The TUI Recent Inputs panel reads local attestation files from `~/.clumsies/workspaces/{ws_id}/attestation.jsonl`.
-    \\- `user_prompt` drives the feed; `refer` enriches the prompt-level stats.
+    \\- `user_prompt` drives the feed; `refer` enriches the rule-level stats.
     \\- If the pump only mutates server tables and skips local attestation writes, Recent Inputs will look empty.
 ;
 
@@ -229,7 +229,7 @@ pub const USERS = [_]UserFixture{
     .{ .id = "usr-seed-amimibear", .username = "amimibear", .role = "member" },
 };
 
-pub const PROMPTS = [_]PromptFixture{
+pub const PROMPTS = [_]RuleFixture{
     .{ .id = "p-seed-meta", .path = "META_PROMPT.md", .content = META_PROMPT_CONTENT },
     .{ .id = "p-seed-coding", .path = "workflow/00_CODING.md", .content = CODING_WORKFLOW_CONTENT },
     .{ .id = "p-seed-trace", .path = "rule/trace/TRACE_DISCIPLINE.md", .content = TRACE_DISCIPLINE_CONTENT },
@@ -257,22 +257,22 @@ pub const WORKSPACE_MEMBERS = [_]WorkspaceMemberFixture{
     .{ .ws_id = "ws-seed-plugin", .user_id = "usr-seed-amimibear", .role = "member" },
 };
 
-pub const WORKSPACE_PROMPTS = [_]WorkspacePromptFixture{
-    .{ .ws_id = "ws-seed-sandbox", .prompt_id = "p-seed-meta" },
-    .{ .ws_id = "ws-seed-sandbox", .prompt_id = "p-seed-coding" },
-    .{ .ws_id = "ws-seed-sandbox", .prompt_id = "p-seed-trace" },
-    .{ .ws_id = "ws-seed-sandbox", .prompt_id = "p-seed-build" },
-    .{ .ws_id = "ws-seed-hub", .prompt_id = "p-seed-meta" },
-    .{ .ws_id = "ws-seed-hub", .prompt_id = "p-seed-coding" },
-    .{ .ws_id = "ws-seed-hub", .prompt_id = "p-seed-trace" },
-    .{ .ws_id = "ws-seed-hub", .prompt_id = "p-seed-hub" },
-    .{ .ws_id = "ws-seed-tui", .prompt_id = "p-seed-meta" },
-    .{ .ws_id = "ws-seed-tui", .prompt_id = "p-seed-coding" },
-    .{ .ws_id = "ws-seed-tui", .prompt_id = "p-seed-trace" },
-    .{ .ws_id = "ws-seed-tui", .prompt_id = "p-seed-hub" },
-    .{ .ws_id = "ws-seed-plugin", .prompt_id = "p-seed-meta" },
-    .{ .ws_id = "ws-seed-plugin", .prompt_id = "p-seed-coding" },
-    .{ .ws_id = "ws-seed-plugin", .prompt_id = "p-seed-trace" },
+pub const WORKSPACE_PROMPTS = [_]WorkspaceRuleFixture{
+    .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-meta" },
+    .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-coding" },
+    .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-trace" },
+    .{ .ws_id = "ws-seed-sandbox", .rule_id = "p-seed-build" },
+    .{ .ws_id = "ws-seed-hub", .rule_id = "p-seed-meta" },
+    .{ .ws_id = "ws-seed-hub", .rule_id = "p-seed-coding" },
+    .{ .ws_id = "ws-seed-hub", .rule_id = "p-seed-trace" },
+    .{ .ws_id = "ws-seed-hub", .rule_id = "p-seed-hub" },
+    .{ .ws_id = "ws-seed-tui", .rule_id = "p-seed-meta" },
+    .{ .ws_id = "ws-seed-tui", .rule_id = "p-seed-coding" },
+    .{ .ws_id = "ws-seed-tui", .rule_id = "p-seed-trace" },
+    .{ .ws_id = "ws-seed-tui", .rule_id = "p-seed-hub" },
+    .{ .ws_id = "ws-seed-plugin", .rule_id = "p-seed-meta" },
+    .{ .ws_id = "ws-seed-plugin", .rule_id = "p-seed-coding" },
+    .{ .ws_id = "ws-seed-plugin", .rule_id = "p-seed-trace" },
 };
 
 pub const CONTEXTS = [_]ContextFixture{
@@ -286,29 +286,29 @@ pub const CONTEXTS = [_]ContextFixture{
     .{ .id = "ctx-seed-plugin-adapter", .ws_id = "ws-seed-plugin", .path = "notes/PLUGIN_SETUP.md", .author = "Joji", .content = PLUGIN_SETUP_CONTEXT },
 };
 
-const SANDBOX_REFERS = [_]PumpRefer{
-    .{ .prompt_id = "p-seed-coding", .constraint_id = "coding.load-rules-first", .reason = "loaded coding workflow before making changes" },
-    .{ .prompt_id = "p-seed-trace", .constraint_id = "trace.session-input-before-refer", .reason = "kept recent inputs visible in local trace" },
+const SANDBOX_REFERS = [_]RuleRefer{
+    .{ .rule_id = "p-seed-coding", .constraint_id = "coding.load-rules-first", .reason = "loaded coding workflow before making changes" },
+    .{ .rule_id = "p-seed-trace", .constraint_id = "trace.session-input-before-refer", .reason = "kept recent inputs visible in local trace" },
 };
 
-const HUB_REFERS = [_]PumpRefer{
-    .{ .prompt_id = "p-seed-meta", .constraint_id = "meta.search-load-refer", .reason = "used the setup-search-load-refer loop explicitly" },
-    .{ .prompt_id = "p-seed-hub", .constraint_id = "architecture.hub-owns-business-logic", .reason = "kept bootstrap policy inside the hub layer" },
+const HUB_REFERS = [_]RuleRefer{
+    .{ .rule_id = "p-seed-meta", .constraint_id = "meta.search-load-refer", .reason = "used the setup-search-load-refer loop explicitly" },
+    .{ .rule_id = "p-seed-hub", .constraint_id = "architecture.hub-owns-business-logic", .reason = "kept bootstrap policy inside the hub layer" },
 };
 
-const TUI_REFERS = [_]PumpRefer{
-    .{ .prompt_id = "p-seed-trace", .constraint_id = "trace.local-and-server-shape-match", .reason = "matched local trace shape to the server payload" },
-    .{ .prompt_id = "p-seed-coding", .constraint_id = "coding.run-build-and-test", .reason = "verified behavior after changing the pump path" },
+const TUI_REFERS = [_]RuleRefer{
+    .{ .rule_id = "p-seed-trace", .constraint_id = "trace.local-and-server-shape-match", .reason = "matched local trace shape to the server payload" },
+    .{ .rule_id = "p-seed-coding", .constraint_id = "coding.run-build-and-test", .reason = "verified behavior after changing the pump path" },
 };
 
-const PLUGIN_REFERS = [_]PumpRefer{
-    .{ .prompt_id = "p-seed-meta", .constraint_id = "meta.protocol-responsibility", .reason = "kept the adapter focused on protocol execution" },
-    .{ .prompt_id = "p-seed-trace", .constraint_id = "trace.prompt-id-must-be-hub-issued", .reason = "avoided file-derived ids in refer events" },
+const PLUGIN_REFERS = [_]RuleRefer{
+    .{ .rule_id = "p-seed-meta", .constraint_id = "meta.protocol-responsibility", .reason = "kept the adapter focused on protocol execution" },
+    .{ .rule_id = "p-seed-trace", .constraint_id = "trace.rule-id-must-be-hub-issued", .reason = "avoided file-derived ids in refer events" },
 };
 
-const RESET_REFERS = [_]PumpRefer{
-    .{ .prompt_id = "p-seed-hub", .constraint_id = "architecture.rebuild-only-seed-owned-state", .reason = "reset logic should only target seed-owned fixtures" },
-    .{ .prompt_id = "p-seed-trace", .constraint_id = "trace.keep-pump-structurally-pure", .reason = "pump stayed focused on activity data instead of schema churn" },
+const RESET_REFERS = [_]RuleRefer{
+    .{ .rule_id = "p-seed-hub", .constraint_id = "architecture.rebuild-only-seed-owned-state", .reason = "reset logic should only target seed-owned fixtures" },
+    .{ .rule_id = "p-seed-trace", .constraint_id = "trace.keep-pump-structurally-pure", .reason = "pump stayed focused on activity data instead of schema churn" },
 };
 
 const PROFILE_RAMP_UP = [_]u8{ 1, 1, 2, 2, 3, 3, 4, 4, 5, 6, 7, 8 };
@@ -358,9 +358,9 @@ pub const PUMP_SCENARIOS = [_]PumpScenario{
     },
 };
 
-pub fn promptById(prompt_id: []const u8) ?*const PromptFixture {
-    for (&PROMPTS) |*prompt| {
-        if (std.mem.eql(u8, prompt.id, prompt_id)) return prompt;
+pub fn ruleById(rule_id: []const u8) ?*const RuleFixture {
+    for (&PROMPTS) |*rule| {
+        if (std.mem.eql(u8, rule.id, rule_id)) return rule;
     }
     return null;
 }
@@ -383,9 +383,9 @@ pub fn isSeedWorkspaceId(ws_id: []const u8) bool {
     return std.mem.startsWith(u8, ws_id, SEED_WORKSPACE_PREFIX);
 }
 
-test "promptById returns known prompt fixtures" {
-    try std.testing.expect(promptById("p-seed-meta") != null);
-    try std.testing.expect(promptById("missing") == null);
+test "ruleById returns known rule fixtures" {
+    try std.testing.expect(ruleById("p-seed-meta") != null);
+    try std.testing.expect(ruleById("missing") == null);
 }
 
 test "seed lookup helpers resolve user and workspace fixtures" {

--- a/src/seed/ensure.zig
+++ b/src/seed/ensure.zig
@@ -44,12 +44,12 @@ fn fixturesHealthy(conn: *pg.Conn) !bool {
         if (!try userHealthy(conn, user)) return false;
     }
 
-    for (data.PROMPTS) |prompt| {
+    for (data.PROMPTS) |rule| {
         if (!try stringColumnMatches(
             conn,
-            "SELECT path FROM prompts WHERE prompt_id = $1",
-            .{prompt.id},
-            prompt.path,
+            "SELECT path FROM rules WHERE rule_id = $1",
+            .{rule.id},
+            rule.path,
         )) return false;
     }
 
@@ -73,8 +73,8 @@ fn fixturesHealthy(conn: *pg.Conn) !bool {
     for (data.WORKSPACE_PROMPTS) |binding| {
         if (!try exists(
             conn,
-            "SELECT 1 FROM workspace_prompts WHERE ws_id = $1 AND prompt_id = $2",
-            .{ binding.ws_id, binding.prompt_id },
+            "SELECT 1 FROM workspace_rules WHERE ws_id = $1 AND rule_id = $2",
+            .{ binding.ws_id, binding.rule_id },
         )) return false;
     }
 

--- a/src/seed/ensure.zig
+++ b/src/seed/ensure.zig
@@ -44,7 +44,7 @@ fn fixturesHealthy(conn: *pg.Conn) !bool {
         if (!try userHealthy(conn, user)) return false;
     }
 
-    for (data.PROMPTS) |rule| {
+    for (data.RULES) |rule| {
         if (!try stringColumnMatches(
             conn,
             "SELECT path FROM rules WHERE rule_id = $1",
@@ -70,7 +70,7 @@ fn fixturesHealthy(conn: *pg.Conn) !bool {
         )) return false;
     }
 
-    for (data.WORKSPACE_PROMPTS) |binding| {
+    for (data.WORKSPACE_RULES) |binding| {
         if (!try exists(
             conn,
             "SELECT 1 FROM workspace_rules WHERE ws_id = $1 AND rule_id = $2",

--- a/src/seed/pump.zig
+++ b/src/seed/pump.zig
@@ -204,8 +204,8 @@ fn emitScenario(
     });
 
     for (scenario.refers, 0..) |refer, idx| {
-        const prompt = data.promptById(refer.prompt_id) orelse continue;
-        const prompt_hash = util_hash.contentHash(prompt.content);
+        const rule = data.ruleById(refer.rule_id) orelse continue;
+        const rule_hash = util_hash.contentHash(rule.content);
         insertAttestationEvent(conn, scenario.user_id, .{
             .ws_id = scenario.ws_id,
             .session_id = session_id,
@@ -213,8 +213,8 @@ fn emitScenario(
             .ts = timestamp_base + 2 + @as(i64, @intCast(idx)),
             .payload = .{
                 .refer = .{
-                    .prompt_id = prompt.id,
-                    .prompt_hash = prompt_hash[0..],
+                    .rule_id = rule.id,
+                    .rule_hash = rule_hash[0..],
                     .constraint_id = refer.constraint_id,
                     .reason = refer.reason,
                 },
@@ -225,14 +225,14 @@ fn emitScenario(
 
 fn insertAttestationEvent(conn: *pg.Conn, user_id: ?[]const u8, event: local_attestation.AttestationEvent) void {
     const type_tag = local_attestation.payloadTypeTag(event.payload);
-    const prompt_id: ?[]const u8 = switch (event.payload) {
-        .load => |p| p.prompt_id,
-        .refer => |p| p.prompt_id,
+    const rule_id: ?[]const u8 = switch (event.payload) {
+        .load => |p| p.rule_id,
+        .refer => |p| p.rule_id,
         else => null,
     };
-    const prompt_hash: ?[]const u8 = switch (event.payload) {
-        .load => |p| p.prompt_hash,
-        .refer => |p| p.prompt_hash,
+    const rule_hash: ?[]const u8 = switch (event.payload) {
+        .load => |p| p.rule_hash,
+        .refer => |p| p.rule_hash,
         else => null,
     };
     const constraint_id: ?[]const u8 = switch (event.payload) {
@@ -254,7 +254,7 @@ fn insertAttestationEvent(conn: *pg.Conn, user_id: ?[]const u8, event: local_att
 
     _ = conn.exec(
         \\INSERT INTO attestation_events (user_id, ws_id, session_id, event_id, type, timestamp,
-        \\  prompt_id, prompt_hash, constraint_id, reason, content, content_hash)
+        \\  rule_id, rule_hash, constraint_id, reason, content, content_hash)
         \\VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         \\ON CONFLICT (ws_id, session_id, event_id) DO NOTHING
     , .{
@@ -264,8 +264,8 @@ fn insertAttestationEvent(conn: *pg.Conn, user_id: ?[]const u8, event: local_att
         event.event_id,
         type_tag,
         event.ts,
-        prompt_id,
-        prompt_hash,
+        rule_id,
+        rule_hash,
         constraint_id,
         reason,
         content,

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -21,10 +21,10 @@ pub fn rebuild(conn: *pg.Conn) !void {
     clearSeedLocalState();
 
     _ = conn.exec(
-        \\TRUNCATE orgs, users, tokens, workspaces, workspace_members, prompts, workspace_prompts,
+        \\TRUNCATE orgs, users, tokens, workspaces, workspace_members, rules, workspace_rules,
         \\  context_files, context_prs, context_pr_operations, context_pr_comments,
-        \\  bundles, bundle_prompts, prompt_prs, prompt_pr_operations, prompt_pr_comments,
-        \\  attestation_events, library_manifest, prompt_history
+        \\  bundles, bundle_rules, rule_prs, rule_pr_operations, rule_pr_comments,
+        \\  attestation_events, library_manifest, rule_history
         \\CASCADE
     , .{}) catch |err| {
         log.err("truncate failed: {}", .{err});
@@ -33,10 +33,10 @@ pub fn rebuild(conn: *pg.Conn) !void {
 
     try seedOrg(conn);
     try seedUsers(conn);
-    try seedPrompts(conn);
+    try seedRules(conn);
     try seedWorkspaces(conn);
     try seedWorkspaceMembers(conn);
-    try seedWorkspacePrompts(conn);
+    try seedWorkspaceRules(conn);
     try seedContexts(conn);
     try seedHistoricalAttestation(conn);
     try ensureLocalWorkspaceState();
@@ -80,13 +80,13 @@ fn seedUsers(conn: *pg.Conn) !void {
     }
 }
 
-fn seedPrompts(conn: *pg.Conn) !void {
-    for (data.PROMPTS) |prompt| {
-        const content_hash = util_hash.contentHash(prompt.content);
+fn seedRules(conn: *pg.Conn) !void {
+    for (data.PROMPTS) |rule| {
+        const content_hash = util_hash.contentHash(rule.content);
         _ = try conn.exec(
-            \\INSERT INTO prompts (prompt_id, org_id, path, content, content_hash)
+            \\INSERT INTO rules (rule_id, org_id, path, content, content_hash)
             \\VALUES ($1, $2::uuid, $3, $4, $5)
-        , .{ prompt.id, data.ORG_ID, prompt.path, prompt.content, content_hash[0..] });
+        , .{ rule.id, data.ORG_ID, rule.path, rule.content, content_hash[0..] });
     }
 }
 
@@ -108,12 +108,12 @@ fn seedWorkspaceMembers(conn: *pg.Conn) !void {
     }
 }
 
-fn seedWorkspacePrompts(conn: *pg.Conn) !void {
+fn seedWorkspaceRules(conn: *pg.Conn) !void {
     for (data.WORKSPACE_PROMPTS) |binding| {
         _ = try conn.exec(
-            \\INSERT INTO workspace_prompts (ws_id, prompt_id)
+            \\INSERT INTO workspace_rules (ws_id, rule_id)
             \\VALUES ($1, $2)
-        , .{ binding.ws_id, binding.prompt_id });
+        , .{ binding.ws_id, binding.rule_id });
     }
 }
 
@@ -147,16 +147,16 @@ fn seedHistoricalAttestation(conn: *pg.Conn) !void {
                 ) catch continue;
 
                 for (scenario.refers, 0..) |refer, refer_idx| {
-                    const prompt = data.promptById(refer.prompt_id) orelse continue;
-                    const prompt_hash = util_hash.contentHash(prompt.content);
+                    const rule = data.ruleById(refer.rule_id) orelse continue;
+                    const rule_hash = util_hash.contentHash(rule.content);
                     try insertHistoricalAttestationEvent(conn, scenario.user_id, .{
                         .ws_id = scenario.ws_id,
                         .session_id = session_id,
                         .event_id = @as(i64, @intCast(refer_idx)),
                         .type = "refer",
                         .timestamp = base_ts + @as(i64, @intCast(refer_idx)),
-                        .prompt_id = prompt.id,
-                        .prompt_hash = prompt_hash[0..],
+                        .rule_id = rule.id,
+                        .rule_hash = rule_hash[0..],
                         .constraint_id = refer.constraint_id,
                         .reason = refer.reason,
                     });
@@ -183,8 +183,8 @@ const HistoricalAttestationEvent = struct {
     event_id: i64,
     type: []const u8,
     timestamp: i64,
-    prompt_id: ?[]const u8 = null,
-    prompt_hash: ?[]const u8 = null,
+    rule_id: ?[]const u8 = null,
+    rule_hash: ?[]const u8 = null,
     constraint_id: ?[]const u8 = null,
     reason: ?[]const u8 = null,
 };
@@ -192,7 +192,7 @@ const HistoricalAttestationEvent = struct {
 fn insertHistoricalAttestationEvent(conn: *pg.Conn, user_id: []const u8, event: HistoricalAttestationEvent) !void {
     _ = try conn.exec(
         \\INSERT INTO attestation_events (user_id, ws_id, session_id, event_id, type, timestamp,
-        \\  prompt_id, prompt_hash, constraint_id, reason, content, content_hash)
+        \\  rule_id, rule_hash, constraint_id, reason, content, content_hash)
         \\VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULL, NULL)
         \\ON CONFLICT (ws_id, session_id, event_id) DO NOTHING
     , .{
@@ -202,8 +202,8 @@ fn insertHistoricalAttestationEvent(conn: *pg.Conn, user_id: []const u8, event: 
         event.event_id,
         event.type,
         event.timestamp,
-        event.prompt_id,
-        event.prompt_hash,
+        event.rule_id,
+        event.rule_hash,
         event.constraint_id,
         event.reason,
     });

--- a/src/seed/reset.zig
+++ b/src/seed/reset.zig
@@ -81,7 +81,7 @@ fn seedUsers(conn: *pg.Conn) !void {
 }
 
 fn seedRules(conn: *pg.Conn) !void {
-    for (data.PROMPTS) |rule| {
+    for (data.RULES) |rule| {
         const content_hash = util_hash.contentHash(rule.content);
         _ = try conn.exec(
             \\INSERT INTO rules (rule_id, org_id, path, content, content_hash)
@@ -109,7 +109,7 @@ fn seedWorkspaceMembers(conn: *pg.Conn) !void {
 }
 
 fn seedWorkspaceRules(conn: *pg.Conn) !void {
-    for (data.WORKSPACE_PROMPTS) |binding| {
+    for (data.WORKSPACE_RULES) |binding| {
         _ = try conn.exec(
             \\INSERT INTO workspace_rules (ws_id, rule_id)
             \\VALUES ($1, $2)

--- a/src/util/hash.zig
+++ b/src/util/hash.zig
@@ -1,4 +1,4 @@
-//! Content hashing with SHA-256. Content hashes are the version identity of prompts and context
+//! Content hashing with SHA-256. Content hashes are the version identity of rules and context
 //! files — same hash means same content, no ambiguity. Output format: "sha256:{hex}".
 const std = @import("std");
 const encoding = @import("encoding.zig");

--- a/src/util/path_util.zig
+++ b/src/util/path_util.zig
@@ -1,5 +1,5 @@
 //! Path safety: rejects relative paths that escape their base directory via ".." or absolute
-//! paths. Used to validate prompt paths and context file paths from untrusted input.
+//! paths. Used to validate rule paths and context file paths from untrusted input.
 const std = @import("std");
 const testing = std.testing;
 

--- a/test/hub-e2e.sh
+++ b/test/hub-e2e.sh
@@ -62,13 +62,13 @@ INSERT INTO users (user_id, org_id, username, password_hash, role, status) VALUE
   ON CONFLICT DO NOTHING;
 INSERT INTO library_manifest (org_id, revision) VALUES ('a0000000-0000-0000-0000-000000000001', 0)
   ON CONFLICT DO NOTHING;
-INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+INSERT INTO rules (rule_id, org_id, path, content, content_hash) VALUES
   ('p-test-001', 'a0000000-0000-0000-0000-000000000001', 'rule/coding/STYLE.md', '# STYLE', 'sha256:abc123')
   ON CONFLICT DO NOTHING;
-INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+INSERT INTO rules (rule_id, org_id, path, content, content_hash) VALUES
   ('p-test-002', 'a0000000-0000-0000-0000-000000000001', 'workflow/cmd/COMMIT.md', '# COMMIT', 'sha256:def456')
   ON CONFLICT DO NOTHING;
-INSERT INTO prompts (prompt_id, org_id, path, content, content_hash) VALUES
+INSERT INTO rules (rule_id, org_id, path, content, content_hash) VALUES
   ('p-test-mpf', 'a0000000-0000-0000-0000-000000000001', 'META_PROMPT.md', '# clumsies Protocol Bootstrap', 'sha256:mpf001')
   ON CONFLICT DO NOTHING;
 SQL
@@ -208,27 +208,27 @@ parse_response "$RAW"
 assert_status "remove member" "204" "$STATUS"
 
 # Library
-step "Library: list prompts"
-RAW=$(call GET "/api/org/library/prompts")
+step "Library: list rules"
+RAW=$(call GET "/api/org/library/rules")
 parse_response "$RAW"
-assert_status "list prompts" "200" "$STATUS"
+assert_status "list rules" "200" "$STATUS"
 assert_json "contains STYLE path" "rule/coding/STYLE.md" "$BODY"
 assert_json "returns path field" '"path":' "$BODY"
 
-step "Library: get prompt by prompt_id"
-RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-001")
+step "Library: get rule by rule_id"
+RAW=$(call GET "/api/org/library/rule?rule_id=p-test-001")
 parse_response "$RAW"
-assert_status "get by prompt_id" "200" "$STATUS"
+assert_status "get by rule_id" "200" "$STATUS"
 assert_json "contains path" "rule/coding/STYLE.md" "$BODY"
 
-step "Library: get prompt by path"
-RAW=$(call GET "/api/org/library/prompt?path=rule/coding/STYLE.md")
+step "Library: get rule by path"
+RAW=$(call GET "/api/org/library/rule?path=rule/coding/STYLE.md")
 parse_response "$RAW"
 assert_status "get by path" "200" "$STATUS"
-assert_json "contains prompt_id" "p-test-001" "$BODY"
+assert_json "contains rule_id" "p-test-001" "$BODY"
 
-step "Library: get prompt content by prompt_id"
-RAW=$(call GET "/api/org/library/prompt/content?prompt_id=p-test-001")
+step "Library: get rule content by rule_id"
+RAW=$(call GET "/api/org/library/rule/content?rule_id=p-test-001")
 parse_response "$RAW"
 assert_status "get content" "200" "$STATUS"
 assert_json "contains body" "STYLE" "$BODY"
@@ -238,78 +238,78 @@ RAW=$(call GET "/api/org/library/manifest")
 parse_response "$RAW"
 assert_status "get manifest" "200" "$STATUS"
 assert_json "contains revision" "revision" "$BODY"
-assert_json "prompt entries carry path" '"path":"rule/coding/STYLE.md"' "$BODY"
-assert_json "prompt entries carry hash" '"hash":"sha256:abc123"' "$BODY"
+assert_json "rule entries carry path" '"path":"rule/coding/STYLE.md"' "$BODY"
+assert_json "rule entries carry hash" '"hash":"sha256:abc123"' "$BODY"
 assert_json "includes reserved MPF path" '"path":"META_PROMPT.md"' "$BODY"
 
-# Prompt PRs (multi-operation model)
-step "Prompt PR: create with modify operation"
-RAW=$(call POST "/api/org/prompt-prs" '{"description":"Tighten STYLE rules","operations":[{"type":"modify","prompt_id":"p-test-001","base_hash":"sha256:abc123","content":"# STYLE\n\nTightened.\n\n## Rules\n\n- Rule one"}]}')
+# Rule PRs (multi-operation model)
+step "Rule PR: create with modify operation"
+RAW=$(call POST "/api/org/rule-prs" '{"description":"Tighten STYLE rules","operations":[{"type":"modify","rule_id":"p-test-001","base_hash":"sha256:abc123","content":"# STYLE\n\nTightened.\n\n## Rules\n\n- Rule one"}]}')
 parse_response "$RAW"
-assert_status "create prompt PR" "201" "$STATUS"
+assert_status "create rule PR" "201" "$STATUS"
 assert_json "returns pr_id" "pr_id" "$BODY"
 assert_json "status open" "open" "$BODY"
 PPR_ID=$(echo "$BODY" | grep -o '"pr_id":"[^"]*"' | cut -d'"' -f4)
 
-step "Prompt PR: reject empty operations"
-RAW=$(call POST "/api/org/prompt-prs" '{"description":"empty","operations":[]}')
+step "Rule PR: reject empty operations"
+RAW=$(call POST "/api/org/rule-prs" '{"description":"empty","operations":[]}')
 parse_response "$RAW"
 assert_status "empty ops rejected" "400" "$STATUS"
 
-step "Prompt PR: reject stale base_hash"
-RAW=$(call POST "/api/org/prompt-prs" '{"description":"stale","operations":[{"type":"modify","prompt_id":"p-test-001","base_hash":"sha256:wrong","content":"# X\n\nD\n\n## S\n\n- R"}]}')
+step "Rule PR: reject stale base_hash"
+RAW=$(call POST "/api/org/rule-prs" '{"description":"stale","operations":[{"type":"modify","rule_id":"p-test-001","base_hash":"sha256:wrong","content":"# X\n\nD\n\n## S\n\n- R"}]}')
 parse_response "$RAW"
 assert_status "stale base_hash 409" "409" "$STATUS"
 
-step "Prompt PR: list"
-RAW=$(call GET "/api/org/prompt-prs")
+step "Rule PR: list"
+RAW=$(call GET "/api/org/rule-prs")
 parse_response "$RAW"
-assert_status "list prompt PRs" "200" "$STATUS"
+assert_status "list rule PRs" "200" "$STATUS"
 assert_json "contains PR" "$PPR_ID" "$BODY"
 
-step "Prompt PR: get detail"
-RAW=$(call GET "/api/org/prompt-prs/$PPR_ID")
+step "Rule PR: get detail"
+RAW=$(call GET "/api/org/rule-prs/$PPR_ID")
 parse_response "$RAW"
-assert_status "get prompt PR" "200" "$STATUS"
+assert_status "get rule PR" "200" "$STATUS"
 assert_json "has operations" "operations" "$BODY"
 assert_json "operation type modify" '"type":"modify"' "$BODY"
 
-step "Prompt PR: accept as maintainer"
-RAW=$(call PUT "/api/org/prompt-prs/$PPR_ID" '{"action":"accept"}')
+step "Rule PR: accept as maintainer"
+RAW=$(call PUT "/api/org/rule-prs/$PPR_ID" '{"action":"accept"}')
 parse_response "$RAW"
-assert_status "accept prompt PR" "200" "$STATUS"
+assert_status "accept rule PR" "200" "$STATUS"
 assert_json "status accepted" "accepted" "$BODY"
 
-step "Prompt PR: library now reflects merged content"
-RAW=$(call GET "/api/org/library/prompt/content?prompt_id=p-test-001")
+step "Rule PR: library now reflects merged content"
+RAW=$(call GET "/api/org/library/rule/content?rule_id=p-test-001")
 parse_response "$RAW"
 assert_status "get updated content" "200" "$STATUS"
 assert_json "contains Tightened" "Tightened" "$BODY"
 
-step "Prompt PR: create with rename operation"
+step "Rule PR: create with rename operation"
 # First get current hash of p-test-002
-RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-002")
+RAW=$(call GET "/api/org/library/rule?rule_id=p-test-002")
 parse_response "$RAW"
 P002_HASH=$(echo "$BODY" | grep -o '"content_hash":"[^"]*"' | cut -d'"' -f4)
-RAW=$(call POST "/api/org/prompt-prs" "{\"description\":\"Relocate COMMIT\",\"operations\":[{\"type\":\"rename\",\"prompt_id\":\"p-test-002\",\"base_hash\":\"$P002_HASH\",\"new_path\":\"workflow/git/COMMIT.md\"}]}")
+RAW=$(call POST "/api/org/rule-prs" "{\"description\":\"Relocate COMMIT\",\"operations\":[{\"type\":\"rename\",\"rule_id\":\"p-test-002\",\"base_hash\":\"$P002_HASH\",\"new_path\":\"workflow/git/COMMIT.md\"}]}")
 parse_response "$RAW"
 assert_status "create rename PR" "201" "$STATUS"
 RENAME_PR_ID=$(echo "$BODY" | grep -o '"pr_id":"[^"]*"' | cut -d'"' -f4)
 
-step "Prompt PR: accept rename"
-RAW=$(call PUT "/api/org/prompt-prs/$RENAME_PR_ID" '{"action":"accept"}')
+step "Rule PR: accept rename"
+RAW=$(call PUT "/api/org/rule-prs/$RENAME_PR_ID" '{"action":"accept"}')
 parse_response "$RAW"
 assert_status "accept rename" "200" "$STATUS"
 
-step "Prompt PR: path updated, prompt_id preserved"
-RAW=$(call GET "/api/org/library/prompt?prompt_id=p-test-002")
+step "Rule PR: path updated, rule_id preserved"
+RAW=$(call GET "/api/org/library/rule?rule_id=p-test-002")
 parse_response "$RAW"
 assert_status "get by id after rename" "200" "$STATUS"
 assert_json "path is new" "workflow/git/COMMIT.md" "$BODY"
 
 # Bundles
 step "Bundle: create"
-RAW=$(call POST "/api/org/bundles" '{"name":"test-bundle","description":"test","prompt_ids":["p-test-001","p-test-002"]}')
+RAW=$(call POST "/api/org/bundles" '{"name":"test-bundle","description":"test","rule_ids":["p-test-001","p-test-002"]}')
 parse_response "$RAW"
 assert_status "create bundle" "201" "$STATUS"
 assert_json "returns name" "test-bundle" "$BODY"
@@ -324,10 +324,10 @@ step "Bundle: get"
 RAW=$(call GET "/api/org/bundles/test-bundle")
 parse_response "$RAW"
 assert_status "get bundle" "200" "$STATUS"
-assert_json "contains prompt_ids" "p-test-001" "$BODY"
+assert_json "contains rule_ids" "p-test-001" "$BODY"
 
 step "Bundle: update"
-RAW=$(call PUT "/api/org/bundles/test-bundle" '{"description":"updated desc","prompt_ids":["p-test-001"]}')
+RAW=$(call PUT "/api/org/bundles/test-bundle" '{"description":"updated desc","rule_ids":["p-test-001"]}')
 parse_response "$RAW"
 assert_status "update bundle" "200" "$STATUS"
 
@@ -384,7 +384,7 @@ assert_status "remove member" "204" "$STATUS"
 # The CLI upload_worker is unit-tested separately; this section exercises
 # the hub ingest endpoint that the worker posts to.
 step "Trace: upload setup + refer batch"
-TRACE_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":0,"type":"setup","timestamp":1000},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":1,"type":"refer","timestamp":1001,"prompt_id":"p-test-001","constraint_id":"c-1"},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":2,"type":"refer","timestamp":1002,"prompt_id":"p-test-001","constraint_id":"c-2"}]}'
+TRACE_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":0,"type":"setup","timestamp":1000},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":1,"type":"refer","timestamp":1001,"rule_id":"p-test-001","constraint_id":"c-1"},{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":2,"type":"refer","timestamp":1002,"rule_id":"p-test-001","constraint_id":"c-2"}]}'
 RAW=$(call POST "/api/attestations" "$TRACE_BATCH")
 parse_response "$RAW"
 assert_status "upload batch" "200" "$STATUS"
@@ -407,7 +407,7 @@ parse_response "$RAW"
 assert_json "replay did not double count" '"total_refer_count":2' "$BODY"
 
 step "Trace: append new event advances stats"
-APPEND_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":3,"type":"refer","timestamp":1003,"prompt_id":"p-test-001","constraint_id":"c-3"}]}'
+APPEND_BATCH='{"events":[{"ws_id":"'"$WS_ID"'","session_id":"sess-e2e-1","event_id":3,"type":"refer","timestamp":1003,"rule_id":"p-test-001","constraint_id":"c-3"}]}'
 RAW=$(call POST "/api/attestations" "$APPEND_BATCH")
 parse_response "$RAW"
 assert_status "append batch" "200" "$STATUS"
@@ -458,7 +458,7 @@ assert_status "me with scopes" "200" "$STATUS"
 assert_json "scopes field present" "library:read" "$BODY"
 
 step "Scope: limited token cannot create bundle"
-RAW=$(call POST "/api/org/bundles" '{"name":"scope-test","description":"test","prompt_ids":[]}')
+RAW=$(call POST "/api/org/bundles" '{"name":"scope-test","description":"test","rule_ids":[]}')
 parse_response "$RAW"
 assert_status "limited scope blocked" "403" "$STATUS"
 


### PR DESCRIPTION
## Summary

The domain concept "prompt" (a library rule entry) shares its name with the
general AI term "prompt" (user input to an LLM). This rename to "rule"
eliminates the ambiguity, making the context/rule system self-documenting.

One symmetric batch migration across all layers: protocol types, database
schema, hub API endpoints, seed data, client protocol, MCP tools, TUI,
drafts, CLI commands, and documentation. The database migration uses
idempotent `DO $$ BEGIN ... EXCEPTION WHEN ... END $$` blocks so existing
installations rename tables and columns transparently on next hub start.

## Test plan

- [x] `zig build` compiles cleanly
- [x] `zig build test` — 205/205 tests pass
- [ ] Hub starts and serves on new endpoints (`/api/org/library/rules`, etc.)
- [ ] TUI shows "Rules" tab label and "rules" in empty states
- [ ] MCP tools respond to `rule.propose_create` etc.