### PR TITLE
fix: resolve prompt→rule leftovers breaking search/load for context

### DIFF
--- a/assets/adapters/claude-code/runtime/skills/setup/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/setup/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: setup
+description: Bootstrap the clumsies protocol and re-import META_PROMPT
+user-invocable: true
+---
+Call the `memory.setup` MCP tool to bootstrap the protocol. Read the returned `mpf.content` field carefully — it is the META_PROMPT that governs how you interact with the clumsies constraint system.
+
+After loading, briefly summarize the key protocol rules (search → load → refer → submit cycle and the priority model) to confirm the bootstrap succeeded.

--- a/assets/adapters/codex/runtime/skills/setup/SKILL.md
+++ b/assets/adapters/codex/runtime/skills/setup/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: setup
+description: Load and follow the clumsies setup protocol to re-import META_PROMPT
+metadata:
+  short-description: Re-import META_PROMPT
+---
+Call the `memory.setup` MCP tool to bootstrap the protocol. Read the returned `mpf.content` field carefully — it is the META_PROMPT that governs how you interact with the clumsies constraint system.
+
+After loading, briefly summarize the key protocol rules (search → load → refer → submit cycle and the priority model) to confirm the bootstrap succeeded.

--- a/build.zig
+++ b/build.zig
@@ -288,6 +288,10 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/claude-code/runtime/skills/ntmd/SKILL.md",
     ));
+    options.addOption([]const u8, "adapter_claude_code_runtime_skill_setup", readSourceAsset(
+        b,
+        "assets/adapters/claude-code/runtime/skills/setup/SKILL.md",
+    ));
     options.addOption([]const u8, "adapter_codex_runtime_skill_search", readSourceAsset(
         b,
         "assets/adapters/codex/runtime/skills/search/SKILL.md",
@@ -295,6 +299,10 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
     options.addOption([]const u8, "adapter_codex_runtime_skill_ntmd", readSourceAsset(
         b,
         "assets/adapters/codex/runtime/skills/ntmd/SKILL.md",
+    ));
+    options.addOption([]const u8, "adapter_codex_runtime_skill_setup", readSourceAsset(
+        b,
+        "assets/adapters/codex/runtime/skills/setup/SKILL.md",
     ));
 }
 

--- a/src/client/adapter/packages/claude_code.zig
+++ b/src/client/adapter/packages/claude_code.zig
@@ -98,6 +98,15 @@ pub fn renderRuntimeAssets(
         .file_mode = 0o644,
         .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_ntmd),
     });
+    try assets.append(allocator, .{
+        .resource_id = "claude-code.skills.setup",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, scope, "skills/setup/SKILL.md"),
+        .ownership = "exclusive",
+        .label = "Claude Code setup skill",
+        .file_mode = 0o644,
+        .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_setup),
+    });
 
     if (scope == .workspace) {
         const skills_root_absolute = try std.fs.path.join(allocator, &.{ target_root, ".claude", "skills" });

--- a/src/client/adapter/packages/codex.zig
+++ b/src/client/adapter/packages/codex.zig
@@ -98,6 +98,15 @@ pub fn renderRuntimeAssets(
         .file_mode = 0o644,
         .content = try allocator.dupe(u8, build_options.adapter_codex_runtime_skill_ntmd),
     });
+    try assets.append(allocator, .{
+        .resource_id = "codex.skills.setup",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "skills/setup/SKILL.md"),
+        .ownership = "exclusive",
+        .label = "Codex setup skill",
+        .file_mode = 0o644,
+        .content = try allocator.dupe(u8, build_options.adapter_codex_runtime_skill_setup),
+    });
 
     if (scope == .workspace) {
         const workspace_root = workspaceRootFromAdapterRoot(target_root);

--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -24,7 +24,7 @@ pub fn renderImportedWorkflowSkills(
     const cache_dir = workspace_config.getCachePath(allocator, binding.ws_id) catch return allocator.alloc(model.RenderedAsset, 0);
     defer allocator.free(cache_dir);
 
-    const workflow_root = try std.fs.path.join(allocator, &.{ cache_dir, "prompt", "workflow" });
+    const workflow_root = try std.fs.path.join(allocator, &.{ cache_dir, "rule", "workflow" });
     defer allocator.free(workflow_root);
 
     var workflow_dir = std.fs.openDirAbsolute(workflow_root, .{ .iterate = true }) catch |err| switch (err) {

--- a/src/client/commands/help.zig
+++ b/src/client/commands/help.zig
@@ -5,7 +5,7 @@ const Color = styles.Color;
 const P = styles.P;
 
 pub fn run(stdout: *std.Io.Writer) !void {
-    try stdout.print("{s}{s}{s}clumsies{s} - Prompt + context management for AI agents\n\n", .{ P, Color.bold, Color.orange, Color.reset });
+    try stdout.print("{s}{s}{s}clumsies{s} - Rule + context management for AI agents\n\n", .{ P, Color.bold, Color.orange, Color.reset });
     try stdout.print("{s}{s}{s}Usage:{s}\n", .{ P, Color.bold, Color.orange, Color.reset });
     try stdout.print("{s}    {s}clumsies{s}            Launch TUI Dashboard\n", .{ P, Color.cyan, Color.reset });
     try stdout.print("{s}    {s}clumsies login{s}      Authenticate with Hub\n", .{ P, Color.cyan, Color.reset });

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -114,32 +114,32 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     // cache so we only ship the IDs/paths that genuinely need
     // refetching. On a warm cache this trims the batch request down
     // to zero items and sync finishes on the manifest call alone.
-    var prompts_to_fetch: std.ArrayList([]const u8) = .empty;
-    defer prompts_to_fetch.deinit(allocator);
-    var prompts_path_for_id: std.StringHashMapUnmanaged([]const u8) = .empty;
-    defer prompts_path_for_id.deinit(allocator);
-    var prompt_skipped: usize = 0;
-    var regular_prompts_to_fetch: usize = 0;
+    var rule_to_fetch: std.ArrayList([]const u8) = .empty;
+    defer rule_to_fetch.deinit(allocator);
+    var rule_path_for_id: std.StringHashMapUnmanaged([]const u8) = .empty;
+    defer rule_path_for_id.deinit(allocator);
+    var rule_skipped: usize = 0;
+    var regular_rule_to_fetch: usize = 0;
     // Reserved paths (MPF) are reported on their own line so the
-    // "Prompts: N unchanged, M to fetch" summary refers only to
+    // "Rules: N unchanged, M to fetch" summary refers only to
     // regular rules + workflows. The reserved file still shares the
     // batch fetch below — it is just accounted for separately in
     // the human-readable output.
     var mpf_status: enum { absent, unchanged, to_fetch } = .absent;
     for (manifest.rules.items) |entry| {
         const rule_id = entry.key;
-        const prompt_path = entry.value.path;
+        const rule_path = entry.value.path;
         const remote_hash = stripHashPrefix(entry.value.hash);
-        const matches = try localFileMatchesHash(allocator, cache_dir, cacheSubDirForPromptPath(prompt_path), prompt_path, remote_hash);
-        const is_mpf = std.mem.eql(u8, prompt_path, "META_PROMPT.md");
+        const matches = try localFileMatchesHash(allocator, cache_dir, cacheSubDirForRulePath(rule_path), rule_path, remote_hash);
+        const is_mpf = std.mem.eql(u8, rule_path, "META_PROMPT.md");
         if (is_mpf) mpf_status = if (matches) .unchanged else .to_fetch;
         if (matches) {
-            if (!is_mpf) prompt_skipped += 1;
+            if (!is_mpf) rule_skipped += 1;
             continue;
         }
-        try prompts_to_fetch.append(allocator, rule_id);
-        try prompts_path_for_id.put(allocator, rule_id, prompt_path);
-        if (!is_mpf) regular_prompts_to_fetch += 1;
+        try rule_to_fetch.append(allocator, rule_id);
+        try rule_path_for_id.put(allocator, rule_id, rule_path);
+        if (!is_mpf) regular_rule_to_fetch += 1;
     }
 
     var contexts_to_fetch: std.ArrayList([]const u8) = .empty;
@@ -160,16 +160,16 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         .unchanged => try stdout.print("{s}\xe2\x86\x92 META_PROMPT.md: unchanged\n", .{P}),
         .to_fetch => try stdout.print("{s}\xe2\x86\x92 META_PROMPT.md: to fetch\n", .{P}),
     }
-    try stdout.print("{s}\xe2\x86\x92 Prompts: {d} unchanged, {d} to fetch\n", .{ P, prompt_skipped, regular_prompts_to_fetch });
+    try stdout.print("{s}\xe2\x86\x92 Rules: {d} unchanged, {d} to fetch\n", .{ P, rule_skipped, regular_rule_to_fetch });
     try stdout.flush();
 
-    var prompt_fetched: usize = 0;
+    var rule_fetched: usize = 0;
     {
         var start: usize = 0;
-        while (start < prompts_to_fetch.items.len) {
-            const end = @min(start + BATCH_CHUNK_SIZE, prompts_to_fetch.items.len);
-            prompt_fetched += fetchPromptsBatch(allocator, &hub, stderr, cache_dir, prompts_to_fetch.items[start..end], &prompts_path_for_id) catch |err| {
-                try stderr.print("{s}{s}{s}Error:{s} Prompt batch fetch failed for items {d}-{d}: {s}\n", .{ P, Color.bold, Color.red, Color.reset, start + 1, end, @errorName(err) });
+        while (start < rule_to_fetch.items.len) {
+            const end = @min(start + BATCH_CHUNK_SIZE, rule_to_fetch.items.len);
+            rule_fetched += fetchRuleBatch(allocator, &hub, stderr, cache_dir, rule_to_fetch.items[start..end], &rule_path_for_id) catch |err| {
+                try stderr.print("{s}{s}{s}Error:{s} Rule batch fetch failed for items {d}-{d}: {s}\n", .{ P, Color.bold, Color.red, Color.reset, start + 1, end, @errorName(err) });
                 return;
             };
             start = end;
@@ -192,12 +192,12 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         }
     }
 
-    // MPF is intentionally excluded from `prompt_skipped` so the
-    // "Prompts" line only reports regular rules + workflows. Re-add
+    // MPF is intentionally excluded from `rule_skipped` so the
+    // "Rules" line only reports regular rules + workflows. Re-add
     // it to the final rule_count when MPF was unchanged this sync
     // so the totals still reflect every manifest entry.
     const mpf_in_unchanged: usize = if (mpf_status == .unchanged) 1 else 0;
-    const rule_count = prompt_fetched + prompt_skipped + mpf_in_unchanged;
+    const rule_count = rule_fetched + rule_skipped + mpf_in_unchanged;
     const context_count = context_fetched + context_skipped;
 
     // Write manifest.json to cache
@@ -215,9 +215,9 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     }
 
     const reconcile = drafts_mod.reconcileDrafts(allocator, ws_dir, cache_dir) catch drafts_mod.ReconcileSummary{};
-    const skipped_suffix = try std.fmt.allocPrint(allocator, " ({d} rules + {d} context unchanged)", .{ prompt_skipped, context_skipped });
+    const skipped_suffix = try std.fmt.allocPrint(allocator, " ({d} rules + {d} context unchanged)", .{ rule_skipped, context_skipped });
     defer allocator.free(skipped_suffix);
-    const skipped_note: []const u8 = if (prompt_skipped + context_skipped > 0) skipped_suffix else "";
+    const skipped_note: []const u8 = if (rule_skipped + context_skipped > 0) skipped_suffix else "";
     if (reconcile.conflicted > 0) {
         try stdout.print("{s}{s}{s}Synced:{s} {d} rules, {d} context files{s}, {d} drafts flagged conflicted\n", .{ P, Color.bold, Color.green, Color.reset, rule_count, context_count, skipped_note, reconcile.conflicted });
     } else {
@@ -230,7 +230,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
 /// so the user can tell why a "46 of 46" manifest only produced
 /// "44 written"; the overall return value is the count of rules
 /// successfully written to cache.
-fn fetchPromptsBatch(
+fn fetchRuleBatch(
     allocator: std.mem.Allocator,
     hub: *HubClient,
     stderr: *std.Io.Writer,
@@ -272,7 +272,7 @@ fn fetchPromptsBatch(
                 try stderr.print("  ! rule {s}: missing path in response\n", .{item.rule_id});
                 continue;
             };
-        writeToCache(allocator, cache_dir, cacheSubDirForPromptPath(target_path), target_path, item.body) catch |err| {
+        writeToCache(allocator, cache_dir, cacheSubDirForRulePath(target_path), target_path, item.body) catch |err| {
             try stderr.print("  ! rule {s}: write failed ({s})\n", .{ target_path, @errorName(err) });
             continue;
         };
@@ -286,12 +286,12 @@ fn fetchPromptsBatch(
 /// root so loaders can read them without knowing the rule
 /// namespace layout. Everything else lives under `cache/rule/` so
 /// the rule namespace cannot collide with context.
-fn cacheSubDirForPromptPath(prompt_path: []const u8) []const u8 {
-    if (std.mem.eql(u8, prompt_path, "META_PROMPT.md")) return "";
+fn cacheSubDirForRulePath(rule_path: []const u8) []const u8 {
+    if (std.mem.eql(u8, rule_path, "META_PROMPT.md")) return "";
     return "rule";
 }
 
-/// Batch-fetch context file bodies. Mirrors `fetchPromptsBatch` but
+/// Batch-fetch context file bodies. Mirrors `fetchRuleBatch` but
 /// keyed by path inside a single workspace.
 fn fetchContextBatch(
     allocator: std.mem.Allocator,
@@ -471,13 +471,13 @@ test "stripHashPrefix handles empty input" {
     try testing.expectEqualStrings("", stripHashPrefix(""));
 }
 
-test "cacheSubDirForPromptPath routes META_PROMPT to cache root" {
-    try testing.expectEqualStrings("", cacheSubDirForPromptPath("META_PROMPT.md"));
+test "cacheSubDirForRulePath routes META_PROMPT to cache root" {
+    try testing.expectEqualStrings("", cacheSubDirForRulePath("META_PROMPT.md"));
 }
 
-test "cacheSubDirForPromptPath routes regular paths under rule/" {
-    try testing.expectEqualStrings("rule", cacheSubDirForPromptPath("coding/STYLE.md"));
-    try testing.expectEqualStrings("rule", cacheSubDirForPromptPath("workflow/CODING.md"));
+test "cacheSubDirForRulePath routes regular paths under rule/" {
+    try testing.expectEqualStrings("rule", cacheSubDirForRulePath("coding/STYLE.md"));
+    try testing.expectEqualStrings("rule", cacheSubDirForRulePath("workflow/CODING.md"));
 }
 
 test "localFileMatchesHash returns true on hash match" {

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -256,10 +256,14 @@ fn matchesGroup(item_group: []const u8, filter: []const u8) bool {
 }
 
 fn matchesQuery(haystack: []const u8, query: []const u8) bool {
-    if (query.len > haystack.len) return false;
-    var i: usize = 0;
-    while (i + query.len <= haystack.len) : (i += 1) {
-        if (std.ascii.eqlIgnoreCase(haystack[i .. i + query.len], query)) return true;
+    var tokens = std.mem.splitAny(u8, query, " \t");
+    while (tokens.next()) |token| {
+        if (token.len == 0) continue;
+        if (token.len > haystack.len) continue;
+        var i: usize = 0;
+        while (i + token.len <= haystack.len) : (i += 1) {
+            if (std.ascii.eqlIgnoreCase(haystack[i .. i + token.len], token)) return true;
+        }
     }
     return false;
 }
@@ -421,47 +425,89 @@ pub fn loadRules(
             return err;
         };
 
-        const m_entry = manifest.rules.get(id) orelse return error.UnknownRuleId;
-        const kind = kindFromPath(m_entry.path) orelse return error.UnknownRuleId;
+        if (manifest.rules.get(id)) |m_entry| {
+            const kind = kindFromPath(m_entry.path) orelse return error.UnknownRuleId;
 
-        const known_hash = knownHashFor(id, known);
-        const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
+            const known_hash = knownHashFor(id, known);
+            const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
 
-        const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
-        if (draft_entry) |entry| {
-            if (entry.operation == .delete) return error.UnknownRuleId;
-        }
-
-        const content = if (changed) blk: {
+            const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
             if (draft_entry) |entry| {
-                break :blk try drafts.readDraftFile(allocator, ws_dir, .rule, entry.draft_path);
+                if (entry.operation == .delete) return error.UnknownRuleId;
             }
-            break :blk try readCacheFileAlloc(allocator, ws_dir, m_entry.path);
-        } else null;
-        errdefer if (content) |owned| allocator.free(owned);
 
-        const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
-        const group_slice = groupFromPath(m_entry.path);
+            const content = if (changed) blk: {
+                if (draft_entry) |entry| {
+                    break :blk try drafts.readDraftFile(allocator, ws_dir, .rule, entry.draft_path);
+                }
+                break :blk try readCacheFileAlloc(allocator, ws_dir, m_entry.path);
+            } else null;
+            errdefer if (content) |owned| allocator.free(owned);
 
-        const has_draft = draft_entry != null;
-        const draft_base = if (draft_entry) |entry|
-            if (entry.base_hash) |bh| try allocator.dupe(u8, bh) else null
-        else
-            null;
-        errdefer if (draft_base) |bh| allocator.free(bh);
+            const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
+            const group_slice = groupFromPath(m_entry.path);
 
-        try result.items.append(allocator, .{
-            .id = try allocator.dupe(u8, id),
-            .kind = kind,
-            .path = try allocator.dupe(u8, m_entry.path),
-            .name = try allocator.dupe(u8, display_name),
-            .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
-            .hash = try allocator.dupe(u8, m_entry.hash),
-            .changed = changed,
-            .content = content,
-            .has_draft = has_draft,
-            .draft_base_hash = draft_base,
-        });
+            const has_draft = draft_entry != null;
+            const draft_base = if (draft_entry) |entry|
+                if (entry.base_hash) |bh| try allocator.dupe(u8, bh) else null
+            else
+                null;
+            errdefer if (draft_base) |bh| allocator.free(bh);
+
+            try result.items.append(allocator, .{
+                .id = try allocator.dupe(u8, id),
+                .kind = kind,
+                .path = try allocator.dupe(u8, m_entry.path),
+                .name = try allocator.dupe(u8, display_name),
+                .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
+                .hash = try allocator.dupe(u8, m_entry.hash),
+                .changed = changed,
+                .content = content,
+                .has_draft = has_draft,
+                .draft_base_hash = draft_base,
+            });
+        } else if (manifest.context.get(id)) |m_entry| {
+            const known_hash = knownHashFor(id, known);
+            const changed = known_hash == null or !std.mem.eql(u8, known_hash.?, m_entry.hash);
+
+            const draft_entry = draft_index.findByCurrentPath(.context, m_entry.path);
+            if (draft_entry) |entry| {
+                if (entry.operation == .delete) return error.UnknownRuleId;
+            }
+
+            const content = if (changed) blk: {
+                if (draft_entry) |entry| {
+                    break :blk try drafts.readDraftFile(allocator, ws_dir, .context, entry.draft_path);
+                }
+                break :blk try readContextCacheFile(allocator, ws_dir, m_entry.path);
+            } else null;
+            errdefer if (content) |owned| allocator.free(owned);
+
+            const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
+            const group_slice = groupFromPath(m_entry.path);
+
+            const has_draft = draft_entry != null;
+            const draft_base = if (draft_entry) |entry|
+                if (entry.base_hash) |bh| try allocator.dupe(u8, bh) else null
+            else
+                null;
+            errdefer if (draft_base) |bh| allocator.free(bh);
+
+            try result.items.append(allocator, .{
+                .id = try allocator.dupe(u8, id),
+                .kind = .context,
+                .path = try allocator.dupe(u8, m_entry.path),
+                .name = try allocator.dupe(u8, display_name),
+                .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
+                .hash = try allocator.dupe(u8, m_entry.hash),
+                .changed = changed,
+                .content = content,
+                .has_draft = has_draft,
+                .draft_base_hash = draft_base,
+            });
+        } else {
+            return error.UnknownRuleId;
+        }
     }
 
     return result;

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -304,9 +304,14 @@ pub fn discoverSearchable(
         }
 
         if (query_filter) |q| {
-            const in_path = matchesQuery(m_entry.path, q);
-            const in_desc = m_entry.description.len > 0 and matchesQuery(m_entry.description, q);
-            if (!in_path and !in_desc) continue;
+            const trimmed = std.mem.trim(u8, q, " \t");
+            if (trimmed.len == 0) {
+                // empty/whitespace-only query is treated as no filter
+            } else {
+                const in_path = matchesQuery(m_entry.path, trimmed);
+                const in_desc = m_entry.description.len > 0 and matchesQuery(m_entry.description, trimmed);
+                if (!in_path and !in_desc) continue;
+            }
         }
 
         const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
@@ -977,6 +982,68 @@ test "loadRules: unknown id returns UnknownRuleId" {
     try testing.expectError(error.UnknownRuleId, loadRules(testing.allocator, root, &.{"p-missing"}, &.{}));
 }
 
+test "loadRules: context id reads from cache/context" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/context/spec");
+    try writeFile(tmp.dir, "cache/context/spec/API.md", "api spec content");
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "rules": {},
+        \\  "context": {
+        \\    "c-api": {"path": "spec/API.md", "hash": "sha256:abc"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadRules(testing.allocator, root, &.{"c-api"}, &.{});
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), result.items.items.len);
+    try testing.expectEqualStrings("c-api", result.items.items[0].id);
+    try testing.expectEqual(RuleKind.context, result.items.items[0].kind);
+    try testing.expect(result.items.items[0].changed);
+    try testing.expectEqualStrings("api spec content", result.items.items[0].content.?);
+}
+
+test "loadRules: mixed rule and context ids" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/rule/coding");
+    try writeFile(tmp.dir, "cache/rule/coding/STYLE.md", "style");
+    try tmp.dir.makePath("cache/context/spec");
+    try writeFile(tmp.dir, "cache/context/spec/API.md", "api");
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "rules": {
+        \\    "p-style": {"path": "coding/STYLE.md", "hash": "sha256:aaa"}
+        \\  },
+        \\  "context": {
+        \\    "c-api": {"path": "spec/API.md", "hash": "sha256:bbb"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadRules(testing.allocator, root, &.{ "p-style", "c-api" }, &.{});
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 2), result.items.items.len);
+    try testing.expectEqualStrings("p-style", result.items.items[0].id);
+    try testing.expectEqual(RuleKind.rule, result.items.items[0].kind);
+    try testing.expectEqualStrings("c-api", result.items.items[1].id);
+    try testing.expectEqual(RuleKind.context, result.items.items[1].kind);
+}
+
 test "loadRules: draft content overrides cache when indexed" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1171,4 +1238,21 @@ test "parseConstraints: empty content" {
     try testing.expect(!result.valid);
     try testing.expectEqual(@as(usize, 0), result.constraints.items.len);
     try testing.expectEqual(@as(usize, 1), result.issues.items.len);
+}
+
+test "matchesQuery: single token matches substring" {
+    try testing.expect(matchesQuery("zig/ZIG_STYLE.md", "style"));
+    try testing.expect(matchesQuery("zig/ZIG_STYLE.md", "ZIG"));
+    try testing.expect(!matchesQuery("zig/ZIG_STYLE.md", "python"));
+}
+
+test "matchesQuery: multi-token query matches any token" {
+    try testing.expect(matchesQuery("zig/ZIG_STYLE.md", "zig style"));
+    try testing.expect(matchesQuery("coding/STYLE.md", "zig style"));
+    try testing.expect(!matchesQuery("coding/STYLE.md", "zig python"));
+}
+
+test "matchesQuery: empty or whitespace query matches nothing" {
+    try testing.expect(!matchesQuery("any/path.md", ""));
+    try testing.expect(!matchesQuery("any/path.md", "   "));
 }


### PR DESCRIPTION
## Summary

Three protocol bugs remained after the prompt→rule rename: sync_cmd still
used prompt_* variable names and wrote to cache/prompt/, loadRules only
checked manifest.rules so context IDs always returned UnknownRuleId (#96),
and matchesQuery treated multi-word queries as a single substring so
memory.search never matched.

Clean up the leftover naming, fix loadRules to also resolve context entries
from manifest.context via cache/context/, split search queries into tokens
for OR matching, and update the CLI slogan. Also adds a native /setup skill
for both claude-code and codex adapters so users can manually re-bootstrap
the META_PROMPT.

## Test plan

- [x] `zig build test` passes
- [x] `clumsies sync` writes to `cache/rule/` with `"rules"` manifest key
- [x] `memory.search` returns results for both rules and context
- [x] `memory.load` with context ID returns content instead of "Unknown rule id" (fixes #96)