### PR TITLE
rule: make loadMpf draft-aware so setup returns local edits

### DIFF
--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -9,11 +9,13 @@ const util_hash = @import("clumsies_lib").util.hash;
 pub const DraftCategory = enum {
     rule,
     context,
+    meta_prompt,
 
     fn toString(self: DraftCategory) []const u8 {
         return switch (self) {
             .rule => "rule",
             .context => "context",
+            .meta_prompt => "meta_prompt",
         };
     }
 };
@@ -119,6 +121,8 @@ fn parseEntry(obj: std.json.ObjectMap) ?DraftEntry {
         .rule
     else if (std.mem.eql(u8, category_str, "context"))
         .context
+    else if (std.mem.eql(u8, category_str, "meta_prompt"))
+        .meta_prompt
     else
         return null;
 
@@ -337,11 +341,16 @@ pub fn reconcileDrafts(
         const base_hash = entry.base_hash orelse continue;
         const cur = entry.current_path orelse continue;
 
-        const rel_dir: []const u8 = switch (entry.category) {
-            .rule => "rule",
-            .context => "context",
+        const cache_path = if (entry.category == .meta_prompt)
+            try std.fs.path.join(allocator, &.{ cache_dir, cur })
+        else blk: {
+            const rel_dir: []const u8 = switch (entry.category) {
+                .rule => "rule",
+                .context => "context",
+                else => unreachable,
+            };
+            break :blk try std.fs.path.join(allocator, &.{ cache_dir, rel_dir, cur });
         };
-        const cache_path = try std.fs.path.join(allocator, &.{ cache_dir, rel_dir, cur });
         defer allocator.free(cache_path);
 
         const file = std.fs.openFileAbsolute(cache_path, .{}) catch continue;

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -501,6 +501,7 @@ fn handleProposeCreate(
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_create = .{ .path = path } },
         .rule => .{ .rule_propose_create = .{ .path = path } },
+        .meta_prompt => return error.InvalidParams,
     };
     session.recordEvent(allocator, payload);
 
@@ -517,6 +518,7 @@ fn handleProposeUpdate(
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
         .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
+        .meta_prompt => return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const body = requiredString(args, "body") orelse return error.InvalidParams;
@@ -529,11 +531,13 @@ fn handleProposeUpdate(
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
         .rule => manifest.rules.get(id) orelse return error.FileNotFound,
+        .meta_prompt => return error.InvalidParams,
     };
 
     const cache_content = switch (category) {
         .context => try workspace_rule.readContextCacheFile(allocator, workspace_root, m_entry.path),
         .rule => try readRuleCacheFile(allocator, workspace_root, m_entry.path),
+        .meta_prompt => return error.InvalidParams,
     };
     defer allocator.free(cache_content);
 
@@ -553,6 +557,7 @@ fn handleProposeUpdate(
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_update = .{ .id = id } },
         .rule => .{ .rule_propose_update = .{ .id = id } },
+        .meta_prompt => return error.InvalidParams,
     };
     session.recordEvent(allocator, payload);
 
@@ -569,6 +574,7 @@ fn handleProposeRename(
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
         .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
+        .meta_prompt => return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const new_path = requiredString(args, "new_path") orelse return error.InvalidParams;
@@ -581,11 +587,13 @@ fn handleProposeRename(
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
         .rule => manifest.rules.get(id) orelse return error.FileNotFound,
+        .meta_prompt => return error.InvalidParams,
     };
 
     const cache_content = switch (category) {
         .context => try workspace_rule.readContextCacheFile(allocator, workspace_root, m_entry.path),
         .rule => try readRuleCacheFile(allocator, workspace_root, m_entry.path),
+        .meta_prompt => return error.InvalidParams,
     };
     defer allocator.free(cache_content);
 
@@ -605,6 +613,7 @@ fn handleProposeRename(
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_rename = .{ .id = id, .new_path = new_path } },
         .rule => .{ .rule_propose_rename = .{ .id = id, .new_path = new_path } },
+        .meta_prompt => return error.InvalidParams,
     };
     session.recordEvent(allocator, payload);
 
@@ -621,6 +630,7 @@ fn handleProposeDelete(
     const id = switch (category) {
         .context => requiredString(args, "context_id") orelse return error.InvalidParams,
         .rule => requiredString(args, "rule_id") orelse return error.InvalidParams,
+        .meta_prompt => return error.InvalidParams,
     };
     if (id.len == 0) return error.InvalidParams;
     const description = optionalString(args, "description");
@@ -631,6 +641,7 @@ fn handleProposeDelete(
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse return error.FileNotFound,
         .rule => manifest.rules.get(id) orelse return error.FileNotFound,
+        .meta_prompt => return error.InvalidParams,
     };
 
     try drafts_mod.createDraft(allocator, workspace_root, .{
@@ -646,6 +657,7 @@ fn handleProposeDelete(
     const payload: attestation.AttestationEvent.Payload = switch (category) {
         .context => .{ .context_propose_delete = .{ .id = id } },
         .rule => .{ .rule_propose_delete = .{ .id = id } },
+        .meta_prompt => return error.InvalidParams,
     };
     session.recordEvent(allocator, payload);
 

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -102,16 +102,30 @@ pub const MetaPromptResult = struct {
 /// MPF lives at `{ws_dir}/cache/META_PROMPT.md` — reserved paths
 /// sit at the cache root rather than under the `rule/` namespace
 /// so a future MPF rename does not reshuffle the rule tree.
+/// If a draft exists for META_PROMPT, the draft content is returned
+/// instead of the cached version — mirroring the draft resolution
+/// that `loadRules` applies to rules and contexts.
 pub fn loadMpf(allocator: std.mem.Allocator, ws_dir: []const u8, known_hash: ?[]const u8) !MetaPromptResult {
-    const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
-    defer allocator.free(mpf_path);
+    var draft_index = try drafts.loadIndex(allocator, ws_dir);
+    defer draft_index.deinit(allocator);
 
-    const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return .{ .content = null, .hash = null };
-    defer file.close();
+    const draft_entry = draft_index.findByCurrentPath(.meta_prompt, "META_PROMPT.md");
 
-    var read_buf: [4096]u8 = undefined;
-    var fr = std.fs.File.Reader.init(file, &read_buf);
-    const content = fr.interface.allocRemaining(allocator, std.io.Limit.limited(10 * 1024 * 1024)) catch return .{ .content = null, .hash = null };
+    if (draft_entry) |entry| {
+        if (entry.operation == .delete) return .{ .content = null, .hash = null };
+    }
+
+    const content: []const u8 = if (draft_entry) |entry|
+        try drafts.readDraftFile(allocator, ws_dir, .meta_prompt, entry.draft_path)
+    else blk: {
+        const mpf_path = try std.fs.path.join(allocator, &.{ ws_dir, "cache", "META_PROMPT.md" });
+        defer allocator.free(mpf_path);
+        const file = std.fs.openFileAbsolute(mpf_path, .{}) catch return .{ .content = null, .hash = null };
+        defer file.close();
+        var read_buf: [4096]u8 = undefined;
+        var fr = std.fs.File.Reader.init(file, &read_buf);
+        break :blk fr.interface.allocRemaining(allocator, std.io.Limit.limited(10 * 1024 * 1024)) catch return .{ .content = null, .hash = null };
+    };
     errdefer allocator.free(content);
 
     const hash = try util_hash.sha256HexAlloc(allocator, content);
@@ -1180,6 +1194,113 @@ test "loadMpf: returns null when file missing" {
 
     try testing.expect(result.content == null);
     try testing.expect(result.hash == null);
+}
+
+test "loadMpf: draft content overrides cache" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "cached mpf");
+
+    try tmp.dir.makePath("drafts/meta_prompt");
+    try writeFile(tmp.dir, "drafts/meta_prompt/META_PROMPT.md", "draft mpf");
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "meta_prompt",
+        \\      "current_path": "META_PROMPT.md",
+        \\      "draft_path": "META_PROMPT.md",
+        \\      "operation": "modify",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadMpf(testing.allocator, root, null);
+    defer result.deinit(testing.allocator);
+
+    try testing.expect(result.content != null);
+    try testing.expectEqualStrings("draft mpf", result.content.?);
+    try testing.expect(result.hash != null);
+}
+
+test "loadMpf: delete draft makes mpf appear absent" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "cached mpf");
+
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "meta_prompt",
+        \\      "current_path": "META_PROMPT.md",
+        \\      "draft_path": "META_PROMPT.md",
+        \\      "operation": "delete",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var result = try loadMpf(testing.allocator, root, null);
+    defer result.deinit(testing.allocator);
+
+    try testing.expect(result.content == null);
+    try testing.expect(result.hash == null);
+}
+
+test "loadMpf: delta works with draft content" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache");
+    try writeFile(tmp.dir, "cache/META_PROMPT.md", "cached mpf");
+
+    try tmp.dir.makePath("drafts/meta_prompt");
+    try writeFile(tmp.dir, "drafts/meta_prompt/META_PROMPT.md", "draft mpf");
+    try tmp.dir.makePath("drafts");
+    try writeFile(tmp.dir, "drafts/index.json",
+        \\{
+        \\  "drafts": [
+        \\    {
+        \\      "category": "meta_prompt",
+        \\      "current_path": "META_PROMPT.md",
+        \\      "draft_path": "META_PROMPT.md",
+        \\      "operation": "modify",
+        \\      "status": "editing"
+        \\    }
+        \\  ]
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var first = try loadMpf(testing.allocator, root, null);
+    const hash = try testing.allocator.dupe(u8, first.hash.?);
+    defer testing.allocator.free(hash);
+    first.deinit(testing.allocator);
+
+    var second = try loadMpf(testing.allocator, root, hash);
+    defer second.deinit(testing.allocator);
+
+    try testing.expect(second.content == null);
+    try testing.expect(second.hash != null);
+    try testing.expectEqualStrings(hash, second.hash.?);
 }
 
 test "parseConstraints: list items become individual constraints" {

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -2318,7 +2318,7 @@ pub const Dashboard = struct {
             };
             target_map.put(arena, key, entry.status) catch {};
 
-            if (entry.operation == .create) {
+            if (entry.operation == .create and entry.category != .meta_prompt) {
                 // Long-lived dup — see the note at the top of this
                 // function. The tree borrows these slices beyond a
                 // single refresh so drafts_arena is unsafe.
@@ -2326,7 +2326,7 @@ pub const Dashboard = struct {
                 const dest = switch (entry.category) {
                     .rule => &create_rules,
                     .context => &create_contexts,
-                    .meta_prompt => continue,
+                    .meta_prompt => unreachable,
                 };
                 dest.append(api_alloc, path_copy) catch {};
             }

--- a/src/client/tui/app.zig
+++ b/src/client/tui/app.zig
@@ -237,6 +237,7 @@ pub const Dashboard = struct {
     drafts_arena: std.heap.ArenaAllocator,
     drafts_by_rule_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
     drafts_by_context_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
+    drafts_by_meta_prompt_path: std.StringHashMapUnmanaged(drafts_mod.DraftStatus) = .{},
     /// Paths of local `operation=create` drafts per category. These do
     /// not exist on the hub yet, so the server-side rules /
     /// context_files lists never carry them — the list renderers
@@ -2268,6 +2269,7 @@ pub const Dashboard = struct {
     pub fn refreshDraftsCache(self: *Dashboard) void {
         self.drafts_by_rule_path = .{};
         self.drafts_by_context_path = .{};
+        self.drafts_by_meta_prompt_path = .{};
         // drafts_create_*_paths are handed to the file tree, which
         // stores them in its `expanded` StringHashMap and `dir_paths`
         // array without duping. Both the hashmap key and the dir
@@ -2312,6 +2314,7 @@ pub const Dashboard = struct {
             const target_map = switch (entry.category) {
                 .rule => &self.drafts_by_rule_path,
                 .context => &self.drafts_by_context_path,
+                .meta_prompt => &self.drafts_by_meta_prompt_path,
             };
             target_map.put(arena, key, entry.status) catch {};
 
@@ -2323,6 +2326,7 @@ pub const Dashboard = struct {
                 const dest = switch (entry.category) {
                     .rule => &create_rules,
                     .context => &create_contexts,
+                    .meta_prompt => continue,
                 };
                 dest.append(api_alloc, path_copy) catch {};
             }
@@ -2340,6 +2344,7 @@ pub const Dashboard = struct {
         return switch (category) {
             .rule => self.drafts_by_rule_path.get(path),
             .context => self.drafts_by_context_path.get(path),
+            .meta_prompt => self.drafts_by_meta_prompt_path.get(path),
         };
     }
 
@@ -2358,6 +2363,7 @@ pub const Dashboard = struct {
         const has_draft = switch (category) {
             .rule => self.drafts_by_rule_path.contains(path),
             .context => self.drafts_by_context_path.contains(path),
+            .meta_prompt => self.drafts_by_meta_prompt_path.contains(path),
         };
         if (!has_draft) return null;
         const arena = self.viewAllocator();
@@ -2526,6 +2532,7 @@ pub const Dashboard = struct {
         return switch (target.category) {
             .rule => self.cachedRuleBody(target.path),
             .context => self.cachedWorkspaceContextBody(target.ws_id, target.path),
+            .meta_prompt => null,
         };
     }
 
@@ -2706,6 +2713,7 @@ pub const Dashboard = struct {
         switch (target.category) {
             .rule => self.submitRulePr(target),
             .context => self.submitContextPr(target),
+            .meta_prompt => {},
         }
     }
 
@@ -2959,10 +2967,12 @@ pub const Dashboard = struct {
         const title = switch (target.category) {
             .rule => "New Rule PR",
             .context => "New Context PR",
+            .meta_prompt => "New Meta-Prompt PR",
         };
         const path_label = switch (target.category) {
             .rule => "rule:",
             .context => "file:",
+            .meta_prompt => "file:",
         };
         const modal = Modal{
             .title = title,
@@ -3107,10 +3117,12 @@ pub const Dashboard = struct {
         const title = switch (self.new_draft_category) {
             .rule => "New Rule Draft",
             .context => "New Context Draft",
+            .meta_prompt => "New Meta-Prompt Draft",
         };
         const hint = switch (self.new_draft_category) {
             .rule => "e.g. rule/00_MY_RULE.md",
             .context => "e.g. spec/NEW_SPEC.md",
+            .meta_prompt => "META_PROMPT.md",
         };
         const modal = Modal{
             .title = title,


### PR DESCRIPTION
## Summary

loadMpf read META_PROMPT exclusively from the workspace cache,
bypassing the draft system entirely. When a local draft of
META_PROMPT existed (e.g. from a user edit through the TUI or a
future propose tool), agents calling memory.setup would receive
stale cached content instead of the working copy.

Add meta_prompt to the DraftCategory enum so loadMpf can consult
the draft index the same way loadRules already does for rules and
contexts. Draft content takes priority over cache when present; a
delete-draft causes META_PROMPT to appear absent. The knownHash
delta comparison is applied to whichever source wins.

Wire the new enum variant through 22 exhaustive switches across the
MCP propose handlers (returning InvalidParams) and the TUI dashboard
(a new drafts_by_meta_prompt_path map).

## Test plan

- [x] `zig build test` — 3 new tests: draft overrides cache, delete
      draft makes MPF absent, knownHash delta works with draft content
- [x] `zig build` — no compile errors (Zig exhaustive switch catches
      every missed case)
- [x] Manual: `memory.setup` with old knownHash returns new MPF content
      after sync