### PR TITLE
mcp: raise stdin read buffer to 1 MB

### DIFF
--- a/src/client/mcp/server.zig
+++ b/src/client/mcp/server.zig
@@ -33,13 +33,21 @@ pub fn runWithRoot(
     };
     defer flushOnExit(allocator, &state);
 
-    var stdin_buffer: [1 << 20]u8 = undefined;
-    var stdin_reader = std.fs.File.Reader.init(std.fs.File.stdin(), &stdin_buffer);
+    const stdin_buffer = try allocator.alloc(u8, protocol.MAX_MESSAGE_SIZE);
+    defer allocator.free(stdin_buffer);
+    var stdin_reader = std.fs.File.Reader.init(std.fs.File.stdin(), stdin_buffer);
     const reader = &stdin_reader.interface;
 
     while (true) {
         const raw_line = reader.takeDelimiterExclusive('\n') catch |err| switch (err) {
             error.EndOfStream => break,
+            error.StreamTooLong => {
+                const resp = try protocol.buildErrorAlloc(allocator, null, .parse_error, "message exceeds MAX_MESSAGE_SIZE");
+                try stdout.writeAll(resp);
+                try stdout.flush();
+                allocator.free(resp);
+                continue;
+            },
             else => return err,
         };
         const line = std.mem.trim(u8, raw_line, " \t\r");

--- a/src/client/mcp/server.zig
+++ b/src/client/mcp/server.zig
@@ -33,7 +33,7 @@ pub fn runWithRoot(
     };
     defer flushOnExit(allocator, &state);
 
-    var stdin_buffer: [4096]u8 = undefined;
+    var stdin_buffer: [1 << 20]u8 = undefined;
     var stdin_reader = std.fs.File.Reader.init(std.fs.File.stdin(), &stdin_buffer);
     const reader = &stdin_reader.interface;
 


### PR DESCRIPTION
## Summary

- The MCP server's stdin read buffer was only 4 KB, causing `takeDelimiterExclusive` to fail on any JSON-RPC line exceeding that size
- This silently killed the server process when `propose_update` or `propose_create` carried full document bodies (architecture rules, research contexts) — the agent only saw an opaque "Connection closed"
- Increase the buffer to 1 MB (`1 << 20`), which covers all practical MCP message sizes

## Test plan

- [ ] `zig build && zig build test` — existing tests pass
- [ ] Run `clumsies mcp` and send a `rule_propose_update` with a body > 4 KB — should succeed without connection drop
- [ ] Verify normal MCP operations (setup, search, load, refer, submit) still work correctly