### PR TITLE
mcp: rename search to discover and include drafts in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You own the rules. The agent loads them on demand. Every interaction is traced a
 
 - **Persistent context at scale.** Agents load rules on demand instead of stuffing everything into one context window. Large projects with dozens of rule files do not silently lose instructions under context pressure.
 - **Organization-owned library.** Update a rule once, sync everywhere. No more copying `.cursorrules` between repos or hoping everyone has the latest version.
-- **Built-in observability.** Every agent interaction is recorded as an attestation event — which constraints were loaded, which were applied, and the agent's self-assessment. The event lifecycle (`user_prompt` → `search`/`load`/`refer` → `agent_report`) gives you data-driven insight into which rules work and which get ignored. Agent adapters enforce turn closure: the stop hook ensures the agent submits a summary before finishing.
+- **Built-in observability.** Every agent interaction is recorded as an attestation event — which constraints were loaded, which were applied, and the agent's self-assessment. The event lifecycle (`user_prompt` → `discover`/`load`/`refer` → `agent_report`) gives you data-driven insight into which rules work and which get ignored. Agent adapters enforce turn closure: the stop hook ensures the agent submits a summary before finishing.
 - **Agent-agnostic adapters.** An adapter layer sits between your rules and the agent runtime. Claude Code, Codex, Cursor — same rules, same attestations, no vendor lock-in.
 - **Self-hosted, zero vendor lock-in.** Runs entirely in your infrastructure with PostgreSQL and Zig.
 

--- a/assets/adapters/claude-code/runtime/skills/discover/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/discover/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: search
+name: discover
 description: Discover available rules in the Library
 argument-hint: "[-k rule|workflow|context] [-g group]"
 user-invocable: true
 ---
-Call the `memory.search` MCP tool to discover available rules.
+Call the `memory.discover` MCP tool to discover available rules.
 
 $ARGUMENTS

--- a/assets/adapters/codex/runtime/skills/discover/SKILL.md
+++ b/assets/adapters/codex/runtime/skills/discover/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: search
+name: discover
 description: Discover available rules in the Library
 argument-hint: "[-k rule|workflow|context] [-g group]"
 user-invocable: true
 ---
-Call the `memory.search` MCP tool to discover available rules.
+Call the `memory.discover` MCP tool to discover available rules.
 
 $ARGUMENTS

--- a/build.zig
+++ b/build.zig
@@ -280,9 +280,9 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/claude-code/runtime/hooks/stop-refer-check.sh.tpl",
     ));
-    options.addOption([]const u8, "adapter_claude_code_runtime_skill_search", readSourceAsset(
+    options.addOption([]const u8, "adapter_claude_code_runtime_skill_discover", readSourceAsset(
         b,
-        "assets/adapters/claude-code/runtime/skills/search/SKILL.md",
+        "assets/adapters/claude-code/runtime/skills/discover/SKILL.md",
     ));
     options.addOption([]const u8, "adapter_claude_code_runtime_skill_ntmd", readSourceAsset(
         b,
@@ -292,9 +292,9 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/claude-code/runtime/skills/setup/SKILL.md",
     ));
-    options.addOption([]const u8, "adapter_codex_runtime_skill_search", readSourceAsset(
+    options.addOption([]const u8, "adapter_codex_runtime_skill_discover", readSourceAsset(
         b,
-        "assets/adapters/codex/runtime/skills/search/SKILL.md",
+        "assets/adapters/codex/runtime/skills/discover/SKILL.md",
     ));
     options.addOption([]const u8, "adapter_codex_runtime_skill_ntmd", readSourceAsset(
         b,

--- a/docs/guides/agent-runtime.md
+++ b/docs/guides/agent-runtime.md
@@ -28,7 +28,7 @@ So the practical order is:
 In the current implementation, the MCP tool surface is:
 
 - `memory.setup`
-- `memory.search`
+- `memory.discover`
 - `memory.load`
 - `memory.refer`
 - `memory.submit`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -12,7 +12,7 @@ The current implementation exposes these MCP tools:
 
 | Tool family | Tools |
 | --- | --- |
-| session and attestation | `memory.setup`, `memory.search`, `memory.load`, `memory.refer`, `memory.submit`, `memory.reject` |
+| session and attestation | `memory.setup`, `memory.discover`, `memory.load`, `memory.refer`, `memory.submit`, `memory.reject` |
 | workspace context proposals | `context.propose_create`, `context.propose_update`, `context.propose_rename`, `context.propose_delete` |
 | Library rule proposals | `rule.propose_create`, `rule.propose_update`, `rule.propose_rename`, `rule.propose_delete` |
 
@@ -23,7 +23,7 @@ This is the real protocol surface in the running code. The server test suite exp
 The stable mental model now matches the current `META_PROMPT` very closely:
 
 1. bootstrap the session with `memory.setup`
-2. discover relevant material with `memory.search`
+2. discover relevant material with `memory.discover`
 3. load only the content the task actually needs with `memory.load`
 4. apply the loaded rules in the work
 5. declare applied constraints with `memory.refer`
@@ -97,9 +97,9 @@ In the current runtime, that meta-prompt frame comes from the workspace-scoped [
 
 The current bootstrap content is intentionally simpler than earlier revisions. It now frames the protocol as `discover -> load -> apply -> refer -> refine -> submit`, and its priority model is `loaded rules > this meta-prompt > your defaults`.
 
-## `memory.search`
+## `memory.discover`
 
-`memory.search` discovers available rules, workflows, and context files without loading their full content.
+`memory.discover` discovers available rules, workflows, and context files without loading their full content.
 
 ### Input
 
@@ -387,6 +387,6 @@ For `memory.submit`, validation is slightly stricter than the schema summary alo
 
 The protocol is tightly coupled to attestation, but not in a noisy way.
 
-Each meaningful runtime action records structured local evidence. `memory.search`, `memory.load`, `memory.refer`, `memory.submit`, `memory.reject`, and all proposal tools generate attestation events that later feed Hub-side aggregation.
+Each meaningful runtime action records structured local evidence. `memory.discover`, `memory.load`, `memory.refer`, `memory.submit`, `memory.reject`, and all proposal tools generate attestation events that later feed Hub-side aggregation.
 
 This is one reason clumsies is different from plain prompt storage. The protocol is not there only to serve content. It is there to make rule use and content-change proposals legible.

--- a/docs/meta-prompt.md
+++ b/docs/meta-prompt.md
@@ -18,7 +18,7 @@ That path matters because the file is part of the workspace cache, not a random 
 
 The current file establishes four ideas.
 
-First, rules and workflows are not supposed to be discovered by crawling local files. The agent is supposed to use `memory.search` and `memory.load`.
+First, rules and workflows are not supposed to be discovered by crawling local files. The agent is supposed to use `memory.discover` and `memory.load`.
 
 Second, applying a constraint is not silent. The agent is supposed to call `memory.refer` when a loaded constraint actually shaped the turn.
 
@@ -41,7 +41,7 @@ but take priority when they conflict.
 
 Follow this loop every turn:
 
-1. **Discover.** Call `memory.search()` to list all available rules,
+1. **Discover.** Call `memory.discover()` to list all available rules,
    workflows, and context. Read their descriptions to decide what is relevant.
 2. **Load.** Call `memory.load()` with the ids you need. Loaded content includes
    parsed rule ids.
@@ -66,7 +66,7 @@ Follow this loop every turn:
 
 Categories are organizational only (e.g. `coding/`, `zig/`, `writing/`).
 
-Filter with `memory.search({kind: "rule"})` or `memory.search({group: "zig"})`.
+Filter with `memory.discover({kind: "rule"})` or `memory.discover({group: "zig"})`.
 
 ## Priority
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -197,7 +197,7 @@ This explains several behaviors that would otherwise look arbitrary.
 
 `clumsies sync` can skip unchanged content because it compares manifest entries to the files already present in cache. MCP can serve quickly because it reads local files from cache rather than re-fetching from Hub for every tool call. Agent bootstrap can be deterministic because `META_PROMPT.md` comes from the workspace cache path, not from a random repo file somebody happened to create.
 
-`META_PROMPT.md` also deserves to be read as a first-class runtime artifact. It is the bootstrap frame that tells the agent to discover constraints through `memory.search`, load them through `memory.load`, and declare actual usage through `memory.refer`. The full current workspace copy is documented on the dedicated [META_PROMPT](/meta-prompt) page because it is stable enough to matter, but specific enough that it should not be duplicated across every runtime section.
+`META_PROMPT.md` also deserves to be read as a first-class runtime artifact. It is the bootstrap frame that tells the agent to discover constraints through `memory.discover`, load them through `memory.load`, and declare actual usage through `memory.refer`. The full current workspace copy is documented on the dedicated [META_PROMPT](/meta-prompt) page because it is stable enough to matter, but specific enough that it should not be duplicated across every runtime section.
 
 ## How sync actually uses manifest and cache
 
@@ -226,7 +226,7 @@ The current runtime path looks like this:
 The current implementation exposes the `memory.*` tool family:
 
 - `memory.setup`
-- `memory.search`
+- `memory.discover`
 - `memory.load`
 - `memory.refer`
 - `memory.submit`

--- a/src/client/adapter/packages/claude_code.zig
+++ b/src/client/adapter/packages/claude_code.zig
@@ -81,9 +81,9 @@ pub fn renderRuntimeAssets(
         .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_stop_refer_check_sh),
     });
     try assets.append(allocator, .{
-        .resource_id = "claude-code.skills.search",
+        .resource_id = "claude-code.skills.discover",
         .resource_kind = "plain_file",
-        .relative_path = try scopedRelativePath(allocator, scope, "skills/search/SKILL.md"),
+        .relative_path = try scopedRelativePath(allocator, scope, "skills/discover/SKILL.md"),
         .ownership = "exclusive",
         .label = "Claude Code discover skill",
         .file_mode = 0o644,

--- a/src/client/adapter/packages/claude_code.zig
+++ b/src/client/adapter/packages/claude_code.zig
@@ -85,9 +85,9 @@ pub fn renderRuntimeAssets(
         .resource_kind = "plain_file",
         .relative_path = try scopedRelativePath(allocator, scope, "skills/search/SKILL.md"),
         .ownership = "exclusive",
-        .label = "Claude Code search skill",
+        .label = "Claude Code discover skill",
         .file_mode = 0o644,
-        .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_search),
+        .content = try allocator.dupe(u8, build_options.adapter_claude_code_runtime_skill_discover),
     });
     try assets.append(allocator, .{
         .resource_id = "claude-code.skills.ntmd",

--- a/src/client/adapter/packages/codex.zig
+++ b/src/client/adapter/packages/codex.zig
@@ -81,9 +81,9 @@ pub fn renderRuntimeAssets(
         .content = try allocator.dupe(u8, build_options.adapter_codex_runtime_stop_refer_check_sh),
     });
     try assets.append(allocator, .{
-        .resource_id = "codex.skills.search",
+        .resource_id = "codex.skills.discover",
         .resource_kind = "plain_file",
-        .relative_path = try scopedRelativePath(allocator, "skills/search/SKILL.md"),
+        .relative_path = try scopedRelativePath(allocator, "skills/discover/SKILL.md"),
         .ownership = "exclusive",
         .label = "Codex discover skill",
         .file_mode = 0o644,

--- a/src/client/adapter/packages/codex.zig
+++ b/src/client/adapter/packages/codex.zig
@@ -85,9 +85,9 @@ pub fn renderRuntimeAssets(
         .resource_kind = "plain_file",
         .relative_path = try scopedRelativePath(allocator, "skills/search/SKILL.md"),
         .ownership = "exclusive",
-        .label = "Codex search skill",
+        .label = "Codex discover skill",
         .file_mode = 0o644,
-        .content = try allocator.dupe(u8, build_options.adapter_codex_runtime_skill_search),
+        .content = try allocator.dupe(u8, build_options.adapter_codex_runtime_skill_discover),
     });
     try assets.append(allocator, .{
         .resource_id = "codex.skills.ntmd",

--- a/src/client/attestation.zig
+++ b/src/client/attestation.zig
@@ -1,4 +1,4 @@
-//! Attestation event recording. Each MCP setup/search/load/refer/submit interaction
+//! Attestation event recording. Each MCP setup/discover/load/refer/submit interaction
 //! is serialized as an AttestationEvent and appended to
 //! ~/.clumsies/workspaces/{ws_id}/attestation.jsonl. The Hub later ingests these
 //! events via POST /api/attestations to compute constraint-level usage statistics.
@@ -27,7 +27,7 @@ pub const AttestationEvent = struct {
     pub const Payload = union(enum) {
         setup,
         user_prompt: UserPromptPayload,
-        search,
+        discover,
         load: LoadPayload,
         refer: ReferPayload,
         agent_report: AgentReportPayload,
@@ -90,7 +90,7 @@ pub fn payloadTypeTag(payload: AttestationEvent.Payload) []const u8 {
     return switch (payload) {
         .setup => "setup",
         .user_prompt => "user_prompt",
-        .search => "search",
+        .discover => "discover",
         .load => "load",
         .refer => "refer",
         .agent_report => "agent_report",
@@ -204,7 +204,7 @@ fn serializeAttestationEvent(allocator: std.mem.Allocator, event: AttestationEve
     );
 
     switch (event.payload) {
-        .setup, .search => {},
+        .setup, .discover => {},
         .user_prompt => |p| {
             if (p.content) |c| {
                 try writeOptionalString(allocator, &buf, "content", c);

--- a/src/client/commands/attestation_append_cmd.zig
+++ b/src/client/commands/attestation_append_cmd.zig
@@ -9,7 +9,7 @@ const styles = @import("../styles.zig");
 const Color = styles.Color;
 const P = styles.P;
 
-const ALLOWED_TYPES = [_][]const u8{ "setup", "user_prompt", "search", "load", "refer", "agent_report" };
+const ALLOWED_TYPES = [_][]const u8{ "setup", "user_prompt", "discover", "load", "refer", "agent_report" };
 
 const FLAG_TYPE: usize = 0;
 const FLAG_CONTENT: usize = 1;
@@ -66,7 +66,7 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         }
     }
     if (!allowed) {
-        try stderr.writeAll("Error: --type must be one of setup/user_prompt/search/load/refer/agent_report\n");
+        try stderr.writeAll("Error: --type must be one of setup/user_prompt/discover/load/refer/agent_report\n");
         return;
     }
 

--- a/src/client/commands/attestation_append_cmd.zig
+++ b/src/client/commands/attestation_append_cmd.zig
@@ -103,14 +103,14 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
         } }
     else if (std.mem.eql(u8, event_type, "setup"))
         .setup
-    else if (std.mem.eql(u8, event_type, "search"))
-        .search
+    else if (std.mem.eql(u8, event_type, "discover"))
+        .discover
     else if (std.mem.eql(u8, event_type, "load"))
-        .search // CLI hook doesn't carry rule_id; fallback to void variant
+        .discover // CLI hook doesn't carry rule_id; fallback to void variant
     else if (std.mem.eql(u8, event_type, "refer"))
-        .search // CLI hook doesn't carry rule_id/constraint_id; fallback to void variant
+        .discover // CLI hook doesn't carry rule_id/constraint_id; fallback to void variant
     else if (std.mem.eql(u8, event_type, "agent_report"))
-        .search // CLI hook doesn't carry summary; fallback to void variant
+        .discover // CLI hook doesn't carry summary; fallback to void variant
     else
         .setup;
 

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -666,6 +666,51 @@ test "findByCurrentPath: returns null for unknown path" {
     try testing.expect(index.findByCurrentPath(.rule, "anything") == null);
 }
 
+test "findByLocalTempId: returns entry matching temp_id" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "research/NEW.md",
+        .local_temp_id = "tmp-abc123",
+    }, "# NEW\n");
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+
+    const entry = index.findByLocalTempId("tmp-abc123").?;
+    try testing.expectEqualStrings("research/NEW.md", entry.draft_path);
+    try testing.expect(index.findByLocalTempId("nonexistent") == null);
+}
+
+test "findCreateByDraftPath: only matches create operation" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .rule,
+        .operation = .modify,
+        .draft_path = "coding/STYLE.md",
+        .current_path = "coding/STYLE.md",
+        .base_hash = "sha256:abc",
+        .rule_id = "p-style",
+    }, "# modified\n");
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+
+    try testing.expect(index.findCreateByDraftPath("coding/STYLE.md") == null);
+    try testing.expect(index.findCreateByDraftPath("nonexistent") == null);
+}
+
 test "readDraftFile: reads from drafts/{category}/{draft_path}" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -72,6 +72,24 @@ pub const DraftsIndex = struct {
         }
         return null;
     }
+
+    /// Find a draft entry by its local_temp_id.
+    pub fn findByLocalTempId(self: *const DraftsIndex, temp_id: []const u8) ?*const DraftEntry {
+        for (self.entries.items) |*entry| {
+            const tid = entry.local_temp_id orelse continue;
+            if (std.mem.eql(u8, tid, temp_id)) return entry;
+        }
+        return null;
+    }
+
+    /// Find a create-draft entry by its draft_path.
+    pub fn findCreateByDraftPath(self: *const DraftsIndex, draft_path: []const u8) ?*const DraftEntry {
+        for (self.entries.items) |*entry| {
+            if (entry.operation != .create) continue;
+            if (std.mem.eql(u8, entry.draft_path, draft_path)) return entry;
+        }
+        return null;
+    }
 };
 
 /// Load `{ws_dir}/drafts/index.json` into memory. Returns an empty index if

--- a/src/client/mcp/server.zig
+++ b/src/client/mcp/server.zig
@@ -157,7 +157,7 @@ fn buildInitializeResult(allocator: std.mem.Allocator, version: []const u8) ![]u
 
     const instructions =
         "Call " ++ tool_names.setup ++ " to bootstrap the protocol and get usage instructions, " ++
-        tool_names.search ++ " to discover rules/workflows, " ++ tool_names.load ++ " to get content, " ++
+        tool_names.discover ++ " to discover rules/workflows, " ++ tool_names.load ++ " to get content, " ++
         "and " ++ tool_names.refer ++ " to declare constraint usage.";
     const esc_instructions = try encoding.jsonEscapeAlloc(allocator, instructions);
     defer allocator.free(esc_instructions);
@@ -206,7 +206,7 @@ test "processLine: initialize then tools list" {
     )).?;
     defer testing.allocator.free(tools_response);
     try testing.expect(std.mem.indexOf(u8, tools_response, "\"memory.setup\"") != null);
-    try testing.expect(std.mem.indexOf(u8, tools_response, "\"memory.search\"") != null);
+    try testing.expect(std.mem.indexOf(u8, tools_response, "\"memory.discover\"") != null);
     try testing.expect(std.mem.indexOf(u8, tools_response, "\"memory.load\"") != null);
     try testing.expect(std.mem.indexOf(u8, tools_response, "\"memory.refer\"") != null);
 }

--- a/src/client/mcp/tool_names.zig
+++ b/src/client/mcp/tool_names.zig
@@ -1,9 +1,9 @@
-//! MCP tool name constants (memory.setup/search/load/refer/submit/reject,
+//! MCP tool name constants (memory.setup/discover/load/refer/submit/reject,
 //! context.propose_*/rule.propose_*). Shared by tools.zig (dispatch),
 //! tool_result.zig (refer reminder text), and server.zig (instruction string)
 //! to keep tool identity consistent across the protocol.
 pub const setup = "memory.setup";
-pub const search = "memory.search";
+pub const discover = "memory.discover";
 pub const load = "memory.load";
 pub const refer = "memory.refer";
 pub const submit = "memory.submit";

--- a/src/client/mcp/tool_result.zig
+++ b/src/client/mcp/tool_result.zig
@@ -121,6 +121,9 @@ fn appendRuleMetadata(
         defer allocator.free(esc_desc);
         try buf.writer(allocator).print(",\"description\":\"{s}\"", .{esc_desc});
     }
+    if (item.has_draft) {
+        try buf.appendSlice(allocator, ",\"hasDraft\":true");
+    }
     try buf.appendSlice(allocator, "}");
 }
 

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -1,5 +1,5 @@
 //! MCP tool definitions and dispatch. Exposes tools to the agent:
-//! memory.setup/search/load/refer/submit and context.*/rule.* propose
+//! memory.setup/discover/load/refer/submit and context.*/rule.* propose
 //! operations. Each call generates an attestation event.
 const std = @import("std");
 const testing = std.testing;
@@ -16,8 +16,8 @@ const setup_schema =
     "{\"name\":\"" ++ tool_names.setup ++ "\",\"title\":\"Setup\",\"description\":\"Bootstrap the protocol. Returns workspace_id and meta-rule content with usage instructions (delta based on knownHash).\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"knownHash\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
-const search_schema =
-    "{\"name\":\"" ++ tool_names.search ++ "\",\"title\":\"Search\",\"description\":\"Discover available rules, workflows, and context files. Returns fresh metadata from the workspace.\"," ++
+const discover_schema =
+    "{\"name\":\"" ++ tool_names.discover ++ "\",\"title\":\"Discover\",\"description\":\"Discover available rules, workflows, and context files. Returns fresh metadata from the workspace.\"," ++
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{\"kind\":{\"type\":\"string\",\"enum\":[\"rule\",\"workflow\",\"context\"]},\"group\":{\"type\":\"string\"},\"query\":{\"type\":\"string\"}},\"additionalProperties\":false}}";
 
 const load_schema =
@@ -85,7 +85,7 @@ pub fn buildListResult(allocator: std.mem.Allocator) ![]u8 {
         u8,
         "{\"tools\":[" ++
             setup_schema ++ "," ++
-            search_schema ++ "," ++
+            discover_schema ++ "," ++
             load_schema ++ "," ++
             refer_schema ++ "," ++
             submit_schema ++ "," ++
@@ -129,8 +129,8 @@ pub fn handleCall(
     if (std.mem.eql(u8, name, tool_names.setup)) {
         return try handleSetup(allocator, workspace_root, session, args_obj);
     }
-    if (std.mem.eql(u8, name, tool_names.search)) {
-        return try handleSearch(allocator, workspace_root, session, args_obj);
+    if (std.mem.eql(u8, name, tool_names.discover)) {
+        return try handleDiscover(allocator, workspace_root, session, args_obj);
     }
     if (std.mem.eql(u8, name, tool_names.load)) {
         return handleLoad(allocator, workspace_root, session, args_obj) catch |err| switch (err) {
@@ -234,7 +234,7 @@ fn handleSetup(
     }
 }
 
-fn handleSearch(
+fn handleDiscover(
     allocator: std.mem.Allocator,
     workspace_root: []const u8,
     session: *session_mod.Session,
@@ -256,7 +256,7 @@ fn handleSearch(
     var items = try workspace_rule.discoverSearchable(allocator, workspace_root, kind, group, query);
     defer workspace_rule.deinitRuleItems(allocator, &items);
 
-    session.recordEvent(allocator, .search);
+    session.recordEvent(allocator, .discover);
 
     const structured = try tool_result.serializeRuleList(allocator, items.items);
     defer allocator.free(structured);
@@ -693,7 +693,7 @@ test "buildListResult: exposes all memory and propose tools" {
     defer testing.allocator.free(result);
 
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.setup ++ "\"") != null);
-    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.search ++ "\"") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.discover ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.load ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.refer ++ "\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"" ++ tool_names.submit ++ "\"") != null);
@@ -718,9 +718,9 @@ test "buildListResult: exposes all memory and propose tools" {
 // aggregator was wired into client/main.zig, so they never ran — and
 // silently drifted out of sync with handleCall's actual response
 // format. Skipping them keeps CI honest while the mismatch is
-// resolved; they should be re-enabled once the MCP search / load /
+// resolved; they should be re-enabled once the MCP discover / load /
 // setup contract is re-audited.
-test "handleCall: memory.search returns rule metadata" {
+test "handleCall: memory.discover returns rule metadata" {
     return error.SkipZigTest;
 }
 

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -472,7 +472,7 @@ pub fn discoverSearchable(
             .path = path_owned,
             .name = name_owned,
             .group = group_owned,
-            .hash = "",
+            .hash = try allocator.dupe(u8, ""),
             .priority = priorityForKind(kind),
             .description = desc_owned,
             .has_draft = true,

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -36,6 +36,7 @@ pub const RuleItem = struct {
     hash: []const u8,
     priority: SetupPriority,
     description: ?[]const u8 = null,
+    has_draft: bool = false,
 };
 
 pub const KnownHash = struct {
@@ -282,11 +283,15 @@ fn matchesQuery(haystack: []const u8, query: []const u8) bool {
     return false;
 }
 
-/// Discover rules and context available for memory.search. Iterates the
+/// Discover rules and context available for memory.discover. Iterates the
 /// local manifest, classifies each entry by path prefix or category, and
 /// applies optional kind/group filters. Reserved paths (META_PROMPT.md) are
 /// excluded. Context entries have kind = .context and group derived from
 /// their path's first component.
+///
+/// Drafts are merged into the result: delete-drafts hide their manifest
+/// entries, modify/rename drafts set has_draft = true, and create-drafts
+/// (which have no manifest entry) are appended using local_temp_id as id.
 pub fn discoverSearchable(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
@@ -300,6 +305,9 @@ pub fn discoverSearchable(
     var manifest = try loadManifest(allocator, ws_dir);
     defer manifest.deinit(allocator);
 
+    var draft_index = try drafts.loadIndex(allocator, ws_dir);
+    defer draft_index.deinit(allocator);
+
     var it = manifest.rules.iterator();
     while (it.next()) |entry| {
         const m_entry = entry.value_ptr.*;
@@ -309,6 +317,12 @@ pub fn discoverSearchable(
         const kind = kindFromPath(m_entry.path) orelse continue;
         if (kind_filter) |kf| {
             if (kf != kind) continue;
+        }
+
+        // Check for a delete draft — hide this entry
+        const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
+        if (draft_entry) |de| {
+            if (de.operation == .delete) continue;
         }
 
         const group_slice = groupFromPath(m_entry.path);
@@ -352,6 +366,7 @@ pub fn discoverSearchable(
             .hash = hash_owned,
             .priority = priorityForKind(kind),
             .description = desc_owned,
+            .has_draft = draft_entry != null,
         });
     }
 
@@ -359,6 +374,12 @@ pub fn discoverSearchable(
         var ctx_it = manifest.context.iterator();
         while (ctx_it.next()) |entry| {
             const m_entry = entry.value_ptr.*;
+
+            // Check for a delete draft — hide this entry
+            const draft_entry = draft_index.findByCurrentPath(.context, m_entry.path);
+            if (draft_entry) |de| {
+                if (de.operation == .delete) continue;
+            }
 
             const group_slice = groupFromPath(m_entry.path);
             if (group_filter) |gf| {
@@ -396,8 +417,66 @@ pub fn discoverSearchable(
                 .hash = hash_owned,
                 .priority = .normal,
                 .description = ctx_desc_owned,
+                .has_draft = draft_entry != null,
             });
         }
+    }
+
+    // Append create-only drafts (no corresponding manifest entry)
+    for (draft_index.entries.items) |de| {
+        if (de.operation != .create) continue;
+
+        const kind: RuleKind = switch (de.category) {
+            .context => .context,
+            .rule => kindFromPath(de.draft_path) orelse continue,
+            .meta_prompt => continue,
+        };
+        if (kind_filter) |kf| {
+            if (kf != kind) continue;
+        }
+
+        // Use local_temp_id if available, otherwise fall back to draft_path as a stable identifier.
+        const effective_id = de.local_temp_id orelse de.draft_path;
+
+        const group_slice = groupFromPath(de.draft_path);
+        if (group_filter) |gf| {
+            const g = group_slice orelse continue;
+            if (!matchesGroup(g, gf)) continue;
+        }
+
+        if (query_filter) |q| {
+            const trimmed = std.mem.trim(u8, q, " \t");
+            if (trimmed.len > 0) {
+                const in_path = matchesQuery(de.draft_path, trimmed);
+                const in_desc = if (de.description) |desc| matchesQuery(desc, trimmed) else false;
+                if (!in_path and !in_desc) continue;
+            }
+        }
+
+        const display_name = displayNameFromFilename(std.fs.path.basename(de.draft_path));
+
+        const id_owned = try allocator.dupe(u8, effective_id);
+        errdefer allocator.free(id_owned);
+        const path_owned = try allocator.dupe(u8, de.draft_path);
+        errdefer allocator.free(path_owned);
+        const name_owned = try allocator.dupe(u8, display_name);
+        errdefer allocator.free(name_owned);
+        const group_owned = if (group_slice) |g| try allocator.dupe(u8, g) else null;
+        errdefer if (group_owned) |g| allocator.free(g);
+        const desc_owned = if (de.description) |desc| try allocator.dupe(u8, desc) else null;
+        errdefer if (desc_owned) |d| allocator.free(d);
+
+        try items.append(allocator, .{
+            .id = id_owned,
+            .kind = kind,
+            .path = path_owned,
+            .name = name_owned,
+            .group = group_owned,
+            .hash = "",
+            .priority = priorityForKind(kind),
+            .description = desc_owned,
+            .has_draft = true,
+        });
     }
 
     std.mem.sort(RuleItem, items.items, {}, lessThanRuleItem);
@@ -525,7 +604,46 @@ pub fn loadRules(
                 .draft_base_hash = draft_base,
             });
         } else {
-            return error.UnknownRuleId;
+            // Fallback: try loading a create-draft by local_temp_id or draft_path
+            const draft_entry = draft_index.findByLocalTempId(id) orelse
+                draft_index.findCreateByDraftPath(id) orelse
+                return error.UnknownRuleId;
+            if (draft_entry.operation != .create) return error.UnknownRuleId;
+
+            switch (draft_entry.category) {
+                .meta_prompt => return error.UnknownRuleId,
+                else => {},
+            }
+
+            const content = try drafts.readDraftFile(
+                allocator,
+                ws_dir,
+                draft_entry.category,
+                draft_entry.draft_path,
+            );
+            errdefer allocator.free(content);
+
+            const kind: RuleKind = if (draft_entry.category == .context)
+                .context
+            else
+                kindFromPath(draft_entry.draft_path) orelse return error.UnknownRuleId;
+            const display_name = displayNameFromFilename(
+                std.fs.path.basename(draft_entry.draft_path),
+            );
+            const group_slice = groupFromPath(draft_entry.draft_path);
+
+            try result.items.append(allocator, .{
+                .id = try allocator.dupe(u8, id),
+                .kind = kind,
+                .path = try allocator.dupe(u8, draft_entry.draft_path),
+                .name = try allocator.dupe(u8, display_name),
+                .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
+                .hash = try allocator.dupe(u8, ""),
+                .changed = true,
+                .content = content,
+                .has_draft = true,
+                .draft_base_hash = null,
+            });
         }
     }
 

--- a/src/seed/data.zig
+++ b/src/seed/data.zig
@@ -78,7 +78,7 @@ pub const META_PROMPT_CONTENT =
     \\
     \\Follow this loop every turn:
     \\
-    \\1. **Discover.** Call `memory.search()` to list all available rules,
+    \\1. **Discover.** Call `memory.discover()` to list all available rules,
     \\   workflows, and context. Read their descriptions to decide what is relevant.
     \\2. **Load.** Call `memory.load()` with the ids you need. Loaded content includes
     \\   parsed rule ids.
@@ -103,7 +103,7 @@ pub const META_PROMPT_CONTENT =
     \\
     \\Categories are organizational only (e.g. `coding/`, `zig/`, `writing/`).
     \\
-    \\Filter with `memory.search({kind: "rule"})` or `memory.search({group: "zig"})`.
+    \\Filter with `memory.discover({kind: "rule"})` or `memory.discover({group: "zig"})`.
     \\
     \\## Accountability
     \\
@@ -125,7 +125,7 @@ pub const CODING_WORKFLOW_CONTENT =
     \\
     \\## Steps
     \\
-    \\1. **Load relevant rules.** Before writing any code, search and load all applicable coding rules via `memory.search` + `memory.load`. This includes language-specific rules, general coding rules, and any domain-specific rules relevant to the task.
+    \\1. **Load relevant rules.** Before writing any code, search and load all applicable coding rules via `memory.discover` + `memory.load`. This includes language-specific rules, general coding rules, and any domain-specific rules relevant to the task.
     \\2. **Assess complexity.** For non-trivial tasks, design the approach before writing code.
     \\3. Ensure you are on `main` and up to date.
     \\4. Create a feature branch.


### PR DESCRIPTION
## Summary

Rename `memory.search` to `memory.discover` — the tool lists available
resources rather than performing full-text search, and the new name
better reflects that semantics. Also fix a gap where
`discoverSearchable` only read from the manifest: create-only drafts
(those with no manifest entry) were invisible, so `propose_create`
produced drafts that could never be discovered or loaded.

### Rename

Rename the tool name, attestation payload tag, adapter skill
directories (`skills/search/` → `skills/discover/`), build config
option names, and all documentation references.

### Draft visibility

`discoverSearchable` now loads `drafts/index.json` and merges it
with the manifest: delete-drafts hide their manifest entries,
modify/rename drafts set `hasDraft: true` on the manifest entry,
and create-only drafts are appended using `local_temp_id` (falling
back to `draft_path` when absent). `loadRules` gains a matching
fallback so create-drafts discovered by either identifier can be
loaded. Two new lookups support this: `findByLocalTempId` and
`findCreateByDraftPath` in `drafts.zig`.

## Test plan

- [ ] `zig build` compiles cleanly
- [ ] `zig build test` passes all existing tests
- [ ] Manual: call `memory.discover` and verify manifest entries
      return correctly with `hasDraft` markers on modified entries
- [ ] Manual: create a draft via `context.propose_create`, then
      verify it appears in `memory.discover` results and can be
      loaded via `memory.load`