### PR TITLE
adapter: add Gemini CLI adapter

### DIFF
--- a/assets/adapters/gemini-cli/runtime/hooks/resolve-binary.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/resolve-binary.sh.tpl
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Resolve the clumsies binary path for Gemini CLI hooks.
+# Sets CLUMSIES variable used by all hook scripts.
+set -euo pipefail
+
+if [ -n "${CLUMSIES:-}" ]; then
+    return 0
+fi
+
+# Check GEMINI_PROJECT_DIR for workspace-scoped installs
+project_dir="${GEMINI_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-}}"
+if [ -n "$project_dir" ]; then
+    candidate="$project_dir/.gemini/hooks/.clumsies-bin"
+    if [ -x "$candidate" ]; then
+        CLUMSIES="$candidate"
+        export CLUMSIES
+        return 0
+    fi
+fi
+
+# Fall back to PATH lookup
+if command -v clumsies >/dev/null 2>&1; then
+    CLUMSIES="$(command -v clumsies)"
+    export CLUMSIES
+    return 0
+fi
+
+echo "clumsies: could not resolve clumsies binary" >&2
+exit 1

--- a/assets/adapters/gemini-cli/runtime/hooks/resolve-binary.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/resolve-binary.sh.tpl
@@ -26,4 +26,6 @@ if command -v clumsies >/dev/null 2>&1; then
 fi
 
 echo "clumsies: could not resolve clumsies binary" >&2
-exit 1
+if (return 0 2>/dev/null); then
+    return 1
+fi

--- a/assets/adapters/gemini-cli/runtime/hooks/session-start.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/session-start.sh.tpl
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# clumsies SessionStart hook for Gemini CLI.
+# Injects META_PROMPT context via hookSpecificOutput.additionalContext.
+# Communicates via JSON stdin/stdout protocol.
+set -euo pipefail
+
+input=$(cat)
+
+source "$(dirname "$0")/resolve-binary.sh"
+
+meta_prompt=$($CLUMSIES _agent setup 2>/dev/null) || meta_prompt=""
+
+if [ -n "$meta_prompt" ]; then
+    escaped=$(printf '%s' "$meta_prompt" | jq -Rs .)
+    echo "{\"decision\":\"allow\",\"hookSpecificOutput\":{\"additionalContext\":$escaped}}"
+else
+    echo '{"decision":"allow"}'
+fi

--- a/assets/adapters/gemini-cli/runtime/hooks/session-start.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/session-start.sh.tpl
@@ -8,11 +8,15 @@ input=$(cat)
 
 source "$(dirname "$0")/resolve-binary.sh"
 
-meta_prompt=$($CLUMSIES _agent setup 2>/dev/null) || meta_prompt=""
+meta_prompt=$("$CLUMSIES" _agent setup 2>/dev/null) || meta_prompt=""
 
 if [ -n "$meta_prompt" ]; then
-    escaped=$(printf '%s' "$meta_prompt" | jq -Rs .)
-    echo "{\"decision\":\"allow\",\"hookSpecificOutput\":{\"additionalContext\":$escaped}}"
+    if command -v jq >/dev/null 2>&1; then
+        escaped=$(printf '%s' "$meta_prompt" | jq -Rs .)
+        echo "{\"decision\":\"allow\",\"hookSpecificOutput\":{\"additionalContext\":$escaped}}"
+    else
+        echo '{"decision":"allow"}'
+    fi
 else
     echo '{"decision":"allow"}'
 fi

--- a/assets/adapters/gemini-cli/runtime/hooks/stop-refer-check.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/stop-refer-check.sh.tpl
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# clumsies AfterAgent hook for Gemini CLI.
+# Denies the response if memory.submit was not called, triggering automatic retry.
+# Communicates via JSON stdin/stdout protocol.
+set -euo pipefail
+
+input=$(cat)
+
+source "$(dirname "$0")/resolve-binary.sh"
+
+if ! $CLUMSIES _agent submit-check 2>/dev/null; then
+    echo '{"decision":"deny","reason":"You must call memory.submit with a summary of your work before finishing."}'
+else
+    echo '{"decision":"allow"}'
+fi

--- a/assets/adapters/gemini-cli/runtime/hooks/stop-refer-check.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/stop-refer-check.sh.tpl
@@ -8,7 +8,7 @@ input=$(cat)
 
 source "$(dirname "$0")/resolve-binary.sh"
 
-if ! $CLUMSIES _agent submit-check 2>/dev/null; then
+if ! "$CLUMSIES" _agent submit-check 2>/dev/null; then
     echo '{"decision":"deny","reason":"You must call memory.submit with a summary of your work before finishing."}'
 else
     echo '{"decision":"allow"}'

--- a/assets/adapters/gemini-cli/runtime/hooks/user-prompt-submit.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/user-prompt-submit.sh.tpl
@@ -8,9 +8,12 @@ input=$(cat)
 
 source "$(dirname "$0")/resolve-binary.sh"
 
-prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+prompt=''
+if command -v jq >/dev/null 2>&1; then
+    prompt=$(printf '%s' "$input" | jq -r '.prompt // empty' 2>/dev/null || printf '')
+fi
 if [ -n "$prompt" ]; then
-    $CLUMSIES _agent attestation-append --type user_prompt --content "$prompt" 2>/dev/null || true
+    "$CLUMSIES" _agent attestation-append --type user_prompt --content "$prompt" 2>/dev/null || true
 fi
 
 echo '{"decision":"allow"}'

--- a/assets/adapters/gemini-cli/runtime/hooks/user-prompt-submit.sh.tpl
+++ b/assets/adapters/gemini-cli/runtime/hooks/user-prompt-submit.sh.tpl
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# clumsies BeforeAgent hook for Gemini CLI.
+# Captures user prompt for attestation, then allows the turn.
+# Communicates via JSON stdin/stdout protocol.
+set -euo pipefail
+
+input=$(cat)
+
+source "$(dirname "$0")/resolve-binary.sh"
+
+prompt=$(printf '%s' "$input" | jq -r '.prompt // empty')
+if [ -n "$prompt" ]; then
+    $CLUMSIES _agent attestation-append --type user_prompt --content "$prompt" 2>/dev/null || true
+fi
+
+echo '{"decision":"allow"}'

--- a/assets/adapters/gemini-cli/runtime/settings.json.tpl
+++ b/assets/adapters/gemini-cli/runtime/settings.json.tpl
@@ -1,0 +1,46 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": __CLUMSIES_SESSION_START_COMMAND_JSON__,
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": __CLUMSIES_USER_PROMPT_SUBMIT_COMMAND_JSON__,
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": __CLUMSIES_STOP_CHECK_COMMAND_JSON__,
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {
+    "clumsies": {
+      "command": "clumsies",
+      "args": ["mcp", "serve"]
+    }
+  }
+}

--- a/assets/adapters/gemini-cli/runtime/skills/discover/SKILL.toml
+++ b/assets/adapters/gemini-cli/runtime/skills/discover/SKILL.toml
@@ -1,0 +1,6 @@
+description = "Discover available rules in the Library"
+prompt = """
+Call the `memory.discover` MCP tool to discover available rules.
+
+{{args}}
+"""

--- a/assets/adapters/gemini-cli/runtime/skills/ntmd/SKILL.toml
+++ b/assets/adapters/gemini-cli/runtime/skills/ntmd/SKILL.toml
@@ -1,0 +1,6 @@
+description = "Reject the current turn as unsatisfactory"
+prompt = """
+The user is rejecting this turn. Call `memory.reject()` with the reason below (or without arguments if empty). Then acknowledge and correct your approach.
+
+{{args}}
+"""

--- a/assets/adapters/gemini-cli/runtime/skills/setup/SKILL.toml
+++ b/assets/adapters/gemini-cli/runtime/skills/setup/SKILL.toml
@@ -1,0 +1,6 @@
+description = "Bootstrap the clumsies protocol and re-import META_PROMPT"
+prompt = """
+Call the `memory.setup` MCP tool to bootstrap the protocol. Read the returned `mpf.content` field carefully — it is the META_PROMPT that governs how you interact with the clumsies constraint system.
+
+After loading, briefly summarize the key protocol rules (discover → load → refer → submit cycle and the priority model) to confirm the bootstrap succeeded.
+"""

--- a/build.zig
+++ b/build.zig
@@ -304,6 +304,40 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/codex/runtime/skills/setup/SKILL.md",
     ));
+
+    // Gemini CLI adapter assets
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_settings_json", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/settings.json.tpl",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_resolve_binary_sh", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/hooks/resolve-binary.sh.tpl",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_session_start_sh", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/hooks/session-start.sh.tpl",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_user_prompt_submit_sh", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/hooks/user-prompt-submit.sh.tpl",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_stop_refer_check_sh", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/hooks/stop-refer-check.sh.tpl",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_skill_discover", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/skills/discover/SKILL.toml",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_skill_ntmd", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/skills/ntmd/SKILL.toml",
+    ));
+    options.addOption([]const u8, "adapter_gemini_cli_runtime_skill_setup", readSourceAsset(
+        b,
+        "assets/adapters/gemini-cli/runtime/skills/setup/SKILL.toml",
+    ));
 }
 
 fn readSourceAsset(b: *std.Build, relative_path: []const u8) []const u8 {

--- a/build.zig
+++ b/build.zig
@@ -13,6 +13,7 @@ pub fn build(b: *std.Build) void {
     options.addOption(bool, "enable_keychain", enable_keychain);
     addCodexAdapterAssetOptions(b, options);
     addClaudeCodeAdapterAssetOptions(b, options);
+    addGeminiCliAdapterAssetOptions(b, options);
     const build_options_module = options.createModule();
     const toml_dep = b.dependency("toml", .{ .target = target, .optimize = optimize });
 
@@ -304,8 +305,9 @@ fn addClaudeCodeAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Opti
         b,
         "assets/adapters/codex/runtime/skills/setup/SKILL.md",
     ));
+}
 
-    // Gemini CLI adapter assets
+fn addGeminiCliAdapterAssetOptions(b: *std.Build, options: *std.Build.Step.Options) void {
     options.addOption([]const u8, "adapter_gemini_cli_runtime_settings_json", readSourceAsset(
         b,
         "assets/adapters/gemini-cli/runtime/settings.json.tpl",

--- a/src/client/adapter/packages/gemini_cli.zig
+++ b/src/client/adapter/packages/gemini_cli.zig
@@ -1,0 +1,248 @@
+//! Gemini CLI adapter. Handles the unified settings.json (hooks + MCP in one file),
+//! JSON stdin/stdout hook protocol, and TOML-based custom slash commands.
+const build_options = @import("build_options");
+const model = @import("../model.zig");
+const std = @import("std");
+const types = @import("types.zig");
+const workflow_skills = @import("../workflow_skills.zig");
+
+pub const package: types.AdapterPackage = .{
+    .id = "gemini-cli",
+    .display_name = "Gemini CLI",
+    .choice_description = "Google Gemini CLI adapter",
+    .workspace_scope_description = "Only this workspace (.gemini)",
+    .user_scope_description = "All Gemini CLI sessions on this machine (~/.gemini)",
+    .remove_workspace_scope_description = "Current workspace install (.gemini)",
+    .remove_user_scope_description = "Machine-wide install (~/.gemini)",
+    .resolve_target_root_fn = resolveTargetRoot,
+    .render_runtime_assets_fn = renderRuntimeAssets,
+    .deinit_rendered_assets_fn = deinitRenderedAssets,
+    .render_managed_resource_fn = renderManagedResource,
+};
+
+pub fn renderRuntimeAssets(
+    allocator: std.mem.Allocator,
+    scope: model.Scope,
+    target_root: []const u8,
+) ![]model.RenderedAsset {
+    var assets: std.ArrayList(model.RenderedAsset) = .empty;
+    errdefer deinitRenderedAssets(allocator, assets.items);
+
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.settings",
+        .resource_kind = "json_hooks_registry",
+        .relative_path = try scopedRelativePath(allocator, "settings"),
+        .ownership = "shared",
+        .label = "Gemini CLI settings (hooks + MCP)",
+        .file_mode = 0o644,
+        .content = try renderSettingsJson(allocator, scope, target_root),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.hooks.resolve_binary",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "hooks/resolve-binary.sh"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI hook helper",
+        .file_mode = 0o755,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_resolve_binary_sh),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.hooks.session_start",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "hooks/session-start.sh"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI SessionStart hook",
+        .file_mode = 0o755,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_session_start_sh),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.hooks.user_prompt_submit",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "hooks/user-prompt-submit.sh"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI BeforeAgent hook",
+        .file_mode = 0o755,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_user_prompt_submit_sh),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.hooks.stop_check",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "hooks/stop-refer-check.sh"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI AfterAgent hook",
+        .file_mode = 0o755,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_stop_refer_check_sh),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.skills.discover",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "commands/discover.toml"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI discover command",
+        .file_mode = 0o644,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_skill_discover),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.skills.ntmd",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "commands/ntmd.toml"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI ntmd command",
+        .file_mode = 0o644,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_skill_ntmd),
+    });
+    try assets.append(allocator, .{
+        .resource_id = "gemini-cli.skills.setup",
+        .resource_kind = "plain_file",
+        .relative_path = try scopedRelativePath(allocator, "commands/setup.toml"),
+        .ownership = "exclusive",
+        .label = "Gemini CLI setup command",
+        .file_mode = 0o644,
+        .content = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_skill_setup),
+    });
+
+    if (scope == .workspace) {
+        const commands_root_absolute = try std.fs.path.join(allocator, &.{ target_root, ".gemini", "commands" });
+        defer allocator.free(commands_root_absolute);
+
+        const imported = try workflow_skills.renderImportedWorkflowSkills(
+            allocator,
+            target_root,
+            commands_root_absolute,
+            ".gemini/commands",
+            "gemini-cli.skills",
+            .gemini_cli,
+        );
+        defer workflow_skills.deinitRenderedAssets(allocator, imported);
+
+        for (imported) |asset| {
+            try assets.append(allocator, .{
+                .resource_id = try allocator.dupe(u8, asset.resource_id),
+                .resource_kind = asset.resource_kind,
+                .relative_path = try allocator.dupe(u8, asset.relative_path),
+                .absolute_path = if (asset.absolute_path) |absolute_path| try allocator.dupe(u8, absolute_path) else null,
+                .ownership = asset.ownership,
+                .label = try allocator.dupe(u8, asset.label),
+                .file_mode = asset.file_mode,
+                .content = try allocator.dupe(u8, asset.content),
+            });
+        }
+    }
+
+    return try assets.toOwnedSlice(allocator);
+}
+
+pub fn deinitRenderedAssets(allocator: std.mem.Allocator, assets: []const model.RenderedAsset) void {
+    for (assets) |asset| {
+        const is_dynamic_workflow_skill = std.mem.startsWith(u8, asset.resource_id, "gemini-cli.skills.workflow.");
+        if (is_dynamic_workflow_skill) allocator.free(asset.resource_id);
+        allocator.free(asset.relative_path);
+        if (asset.absolute_path) |absolute_path| allocator.free(absolute_path);
+        if (is_dynamic_workflow_skill) allocator.free(asset.label);
+        allocator.free(asset.content);
+    }
+    allocator.free(assets);
+}
+
+pub fn resolveTargetRoot(
+    allocator: std.mem.Allocator,
+    scope: model.Scope,
+    workspace_root_opt: ?[]const u8,
+) !?[]u8 {
+    return switch (scope) {
+        .workspace => if (workspace_root_opt) |workspace_root| try allocator.dupe(u8, workspace_root) else null,
+        .user => blk: {
+            const home = std.process.getEnvVarOwned(allocator, "HOME") catch |err| switch (err) {
+                error.EnvironmentVariableNotFound => std.process.getEnvVarOwned(allocator, "USERPROFILE") catch |fallback_err| switch (fallback_err) {
+                    error.EnvironmentVariableNotFound => return error.EnvironmentVariableNotFound,
+                    else => return fallback_err,
+                },
+                else => return err,
+            };
+            defer allocator.free(home);
+            break :blk try allocator.dupe(u8, home);
+        },
+    };
+}
+
+pub fn renderManagedResource(
+    allocator: std.mem.Allocator,
+    resource_id: []const u8,
+    scope: model.Scope,
+    target_root: []const u8,
+) !?[]u8 {
+    if (std.mem.eql(u8, resource_id, "gemini-cli.settings")) {
+        return try renderSettingsJson(allocator, scope, target_root);
+    }
+    return null;
+}
+
+fn renderSettingsJson(
+    allocator: std.mem.Allocator,
+    scope: model.Scope,
+    target_root: []const u8,
+) ![]u8 {
+    const session_start_cmd_json = try commandJsonLiteral(allocator, scope, target_root, "session-start.sh");
+    defer allocator.free(session_start_cmd_json);
+    const user_prompt_submit_cmd_json = try commandJsonLiteral(allocator, scope, target_root, "user-prompt-submit.sh");
+    defer allocator.free(user_prompt_submit_cmd_json);
+    const stop_check_cmd_json = try commandJsonLiteral(allocator, scope, target_root, "stop-refer-check.sh");
+    defer allocator.free(stop_check_cmd_json);
+
+    var rendered = try allocator.dupe(u8, build_options.adapter_gemini_cli_runtime_settings_json);
+    errdefer allocator.free(rendered);
+
+    rendered = try replaceOwned(allocator, rendered, "__CLUMSIES_SESSION_START_COMMAND_JSON__", session_start_cmd_json);
+    rendered = try replaceOwned(allocator, rendered, "__CLUMSIES_USER_PROMPT_SUBMIT_COMMAND_JSON__", user_prompt_submit_cmd_json);
+    rendered = try replaceOwned(allocator, rendered, "__CLUMSIES_STOP_CHECK_COMMAND_JSON__", stop_check_cmd_json);
+    return rendered;
+}
+
+fn scopedRelativePath(
+    allocator: std.mem.Allocator,
+    resource_key: []const u8,
+) ![]u8 {
+    if (std.mem.eql(u8, resource_key, "settings")) {
+        return std.fs.path.join(allocator, &.{ ".gemini", "settings.json" });
+    }
+    return std.fs.path.join(allocator, &.{ ".gemini", resource_key });
+}
+
+fn commandJsonLiteral(
+    allocator: std.mem.Allocator,
+    scope: model.Scope,
+    target_root: []const u8,
+    script_name: []const u8,
+) ![]u8 {
+    _ = scope;
+    const script_path = try std.fs.path.join(allocator, &.{ target_root, ".gemini", "hooks", script_name });
+    defer allocator.free(script_path);
+
+    const command = try std.fmt.allocPrint(allocator, "bash \"{s}\"", .{script_path});
+    defer allocator.free(command);
+
+    return std.json.Stringify.valueAlloc(
+        allocator,
+        std.json.Value{ .string = command },
+        .{},
+    );
+}
+
+fn replaceOwned(
+    allocator: std.mem.Allocator,
+    original: []u8,
+    needle: []const u8,
+    replacement: []const u8,
+) ![]u8 {
+    const replaced = try std.mem.replaceOwned(u8, allocator, original, needle, replacement);
+    allocator.free(original);
+    return replaced;
+}
+
+test "renderRuntimeAssets uses workspace-local Gemini CLI hook paths" {
+    const allocator = std.testing.allocator;
+    const assets = try renderRuntimeAssets(allocator, .workspace, "/tmp/workspace");
+    defer deinitRenderedAssets(allocator, assets);
+
+    try std.testing.expect(std.mem.indexOf(u8, assets[0].content, "/tmp/workspace/.gemini/hooks/session-start.sh") != null);
+}

--- a/src/client/adapter/packages/root.zig
+++ b/src/client/adapter/packages/root.zig
@@ -2,12 +2,14 @@ const std = @import("std");
 const types = @import("types.zig");
 const claude_code = @import("claude_code.zig");
 const codex = @import("codex.zig");
+const gemini_cli = @import("gemini_cli.zig");
 
 pub const AdapterPackage = types.AdapterPackage;
 
 const packages = [_]AdapterPackage{
     codex.package,
     claude_code.package,
+    gemini_cli.package,
 };
 
 pub fn all() []const AdapterPackage {

--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -100,7 +100,11 @@ fn skillFilePath(
 ) ![]u8 {
     return switch (host) {
         .codex, .claude_code => std.fs.path.join(allocator, &.{ root, slug, "SKILL.md" }),
-        .gemini_cli => std.fmt.allocPrint(allocator, "{s}/{s}.toml", .{ root, slug }),
+        .gemini_cli => blk: {
+            const filename = try std.fmt.allocPrint(allocator, "{s}.toml", .{slug});
+            defer allocator.free(filename);
+            break :blk try std.fs.path.join(allocator, &.{ root, filename });
+        },
     };
 }
 

--- a/src/client/adapter/workflow_skills.zig
+++ b/src/client/adapter/workflow_skills.zig
@@ -7,6 +7,7 @@ const workspace_config = @import("../workspace_config.zig");
 pub const Host = enum {
     codex,
     claude_code,
+    gemini_cli,
 };
 
 pub fn renderImportedWorkflowSkills(
@@ -60,8 +61,8 @@ pub fn renderImportedWorkflowSkills(
         defer allocator.free(relative_id);
 
         const skill_content = try renderSkillContent(allocator, host, slug, filename, relative_id);
-        const relative_path = try std.fs.path.join(allocator, &.{ skill_root_display, slug, "SKILL.md" });
-        const absolute_path = try std.fs.path.join(allocator, &.{ skill_root_absolute, slug, "SKILL.md" });
+        const relative_path = try skillFilePath(allocator, host, skill_root_display, slug);
+        const absolute_path = try skillFilePath(allocator, host, skill_root_absolute, slug);
         const resource_id = try std.fmt.allocPrint(allocator, "{s}.workflow.{s}", .{ resource_prefix, slug });
         const label = try std.fmt.allocPrint(allocator, "Workflow skill {s}", .{slug});
 
@@ -89,6 +90,18 @@ pub fn deinitRenderedAssets(allocator: std.mem.Allocator, assets: []const model.
         allocator.free(asset.content);
     }
     allocator.free(assets);
+}
+
+fn skillFilePath(
+    allocator: std.mem.Allocator,
+    host: Host,
+    root: []const u8,
+    slug: []const u8,
+) ![]u8 {
+    return switch (host) {
+        .codex, .claude_code => std.fs.path.join(allocator, &.{ root, slug, "SKILL.md" }),
+        .gemini_cli => std.fmt.allocPrint(allocator, "{s}/{s}.toml", .{ root, slug }),
+    };
 }
 
 fn uniqueSlug(
@@ -176,6 +189,17 @@ fn renderSkillContent(
             \\$ARGUMENTS
         ,
             .{ slug, filename, workflow_id },
+        ),
+        .gemini_cli => std.fmt.allocPrint(
+            allocator,
+            \\description = "Run {s} workflow"
+            \\prompt = """
+            \\Call the `memory.load` MCP tool with ids: ["{s}"]
+            \\
+            \\{{{{args}}}}
+            \\"""
+        ,
+            .{ filename, workflow_id },
         ),
     };
 }


### PR DESCRIPTION
## Summary

Add a third adapter for Google's Gemini CLI. Gemini CLI consolidates
hooks and MCP server config into a single settings.json (unlike
Claude Code and Codex which use separate files), and requires hook
scripts to communicate via strict JSON stdin/stdout protocol.

The adapter reuses the existing `json_hooks_registry` merge logic for
the unified settings.json — `prepareJsonHooksRegistry` only touches
the `hooks` key, preserving `mcpServers` and other user settings.
Hook templates use jq for JSON parsing/output. Skills are rendered
as TOML custom commands in `.gemini/commands/`, matching Gemini CLI's
slash command format. The `AfterAgent` hook leverages Gemini CLI's
deny-retry mechanism for `memory.submit` enforcement.

### Assets

- `settings.json.tpl`: hooks (SessionStart, BeforeAgent, AfterAgent)
  + mcpServers in one file
- `resolve-binary.sh.tpl`: binary resolution using $GEMINI_PROJECT_DIR
- `session-start.sh.tpl`: injects META_PROMPT via additionalContext
- `user-prompt-submit.sh.tpl`: captures prompt for attestation
- `stop-refer-check.sh.tpl`: deny-retry if memory.submit not called
- `discover.toml`, `setup.toml`, `ntmd.toml`: skill commands

### Infrastructure

- `workflow_skills.zig` extended with `gemini_cli` host that renders
  TOML output and uses flat `slug.toml` paths instead of
  `slug/SKILL.md` subdirectories

## Test plan
- [ ] `zig build` compiles
- [ ] `zig build test` passes
- [ ] `clumsies adapt --agent gemini-cli --scope workspace`
      generates correct `.gemini/settings.json`, hooks, and commands
- [ ] Hook scripts produce valid JSON on stdout when given JSON input