### PR TITLE
tui: add search filtering to rule trees

### DIFF
--- a/src/client/tui/features/artifact/root.zig
+++ b/src/client/tui/features/artifact/root.zig
@@ -380,6 +380,7 @@ pub fn syncArtifactTree(self: anytype) void {
     const rules = self.getRules();
     const create_paths = self.drafts.create_rule_paths;
     const selected_bundle_rule_ids = selectedBundleRuleIds(self);
+    const search_query = self.searchQuery();
 
     const allocator = self.api_state.allocator();
     const path_capacity = rules.len + create_paths.len;
@@ -392,7 +393,7 @@ pub fn syncArtifactTree(self: anytype) void {
         if (selected_bundle_rule_ids) |rule_ids| {
             if (!bundleContainsRule(rule_ids, p.rule_id)) continue;
         }
-        if (!self.searchMatches(p.path)) continue;
+        if (search_query.len > 0 and !self.searchMatchesQuery(p.path, search_query)) continue;
         filtered_paths[filtered_len] = p.path;
         filtered_orig[filtered_len] = pidx;
         filtered_len += 1;
@@ -404,7 +405,7 @@ pub fn syncArtifactTree(self: anytype) void {
         // this bundle"; showing unrelated draft rows there makes a
         // partially-loaded bundle look like it contains only the draft.
         for (create_paths, 0..) |path, k| {
-            if (!self.searchMatches(path)) continue;
+            if (search_query.len > 0 and !self.searchMatchesQuery(path, search_query)) continue;
             filtered_paths[filtered_len] = path;
             filtered_orig[filtered_len] = rules.len + k;
             filtered_len += 1;

--- a/src/client/tui/features/artifact/root.zig
+++ b/src/client/tui/features/artifact/root.zig
@@ -392,6 +392,7 @@ pub fn syncArtifactTree(self: anytype) void {
         if (selected_bundle_rule_ids) |rule_ids| {
             if (!bundleContainsRule(rule_ids, p.rule_id)) continue;
         }
+        if (!self.searchMatches(p.path)) continue;
         filtered_paths[filtered_len] = p.path;
         filtered_orig[filtered_len] = pidx;
         filtered_len += 1;
@@ -403,6 +404,7 @@ pub fn syncArtifactTree(self: anytype) void {
         // this bundle"; showing unrelated draft rows there makes a
         // partially-loaded bundle look like it contains only the draft.
         for (create_paths, 0..) |path, k| {
+            if (!self.searchMatches(path)) continue;
             filtered_paths[filtered_len] = path;
             filtered_orig[filtered_len] = rules.len + k;
             filtered_len += 1;

--- a/src/client/tui/features/workspace/root.zig
+++ b/src/client/tui/features/workspace/root.zig
@@ -951,11 +951,12 @@ pub fn syncWsRows(self: anytype) void {
     switch (self.workspace.tab) {
         .context => {
             const context_count = if (live_ws) |ws_d| ws_d.workspace_context.len else 0;
-            item_count = context_count;
             if (live_ws) |ws_d| {
-                for (0..item_count) |i| {
-                    paths_buf[i] = ws_d.workspace_context[i].path;
-                    orig_idx[i] = i;
+                for (ws_d.workspace_context, 0..) |item, i| {
+                    if (!self.searchMatches(item.path)) continue;
+                    paths_buf[item_count] = item.path;
+                    orig_idx[item_count] = i;
+                    item_count += 1;
                 }
             }
             // Append local create-op context drafts as virtual rows.
@@ -964,6 +965,7 @@ pub fn syncWsRows(self: anytype) void {
             // create-only drafts.
             const create_paths = self.drafts.create_context_paths;
             for (create_paths, 0..) |path, k| {
+                if (!self.searchMatches(path)) continue;
                 paths_buf[item_count] = path;
                 orig_idx[item_count] = context_count + k;
                 item_count += 1;
@@ -972,11 +974,12 @@ pub fn syncWsRows(self: anytype) void {
         .rules => {
             const rule_count = if (live_ws) |ws_d| ws_d.workspace_rules.len else 0;
             if (live_ws) |ws_d| {
-                item_count = rule_count;
-                for (0..item_count) |i| {
-                    const wp = ws_d.workspace_rules[i];
-                    paths_buf[i] = self.pathForWorkspaceRule(wp);
-                    orig_idx[i] = i;
+                for (ws_d.workspace_rules, 0..) |wp, i| {
+                    const path = self.pathForWorkspaceRule(wp);
+                    if (!self.searchMatches(path)) continue;
+                    paths_buf[item_count] = path;
+                    orig_idx[item_count] = i;
+                    item_count += 1;
                 }
             }
             // Append local create-op rule drafts as virtual rows so
@@ -984,6 +987,7 @@ pub fn syncWsRows(self: anytype) void {
             // hub manifest knows about them.
             const create_paths = self.drafts.create_rule_paths;
             for (create_paths, 0..) |path, k| {
+                if (!self.searchMatches(path)) continue;
                 paths_buf[item_count] = path;
                 orig_idx[item_count] = rule_count + k;
                 item_count += 1;

--- a/src/client/tui/features/workspace/root.zig
+++ b/src/client/tui/features/workspace/root.zig
@@ -930,6 +930,7 @@ pub fn syncWsRows(self: anytype) void {
         self.workspaceDetailForView(ws_id)
     else
         null;
+    const search_query = self.searchQuery();
 
     const allocator = self.api_state.allocator();
     const path_capacity = switch (self.workspace.tab) {
@@ -953,7 +954,7 @@ pub fn syncWsRows(self: anytype) void {
             const context_count = if (live_ws) |ws_d| ws_d.workspace_context.len else 0;
             if (live_ws) |ws_d| {
                 for (ws_d.workspace_context, 0..) |item, i| {
-                    if (!self.searchMatches(item.path)) continue;
+                    if (search_query.len > 0 and !self.searchMatchesQuery(item.path, search_query)) continue;
                     paths_buf[item_count] = item.path;
                     orig_idx[item_count] = i;
                     item_count += 1;
@@ -965,7 +966,7 @@ pub fn syncWsRows(self: anytype) void {
             // create-only drafts.
             const create_paths = self.drafts.create_context_paths;
             for (create_paths, 0..) |path, k| {
-                if (!self.searchMatches(path)) continue;
+                if (search_query.len > 0 and !self.searchMatchesQuery(path, search_query)) continue;
                 paths_buf[item_count] = path;
                 orig_idx[item_count] = context_count + k;
                 item_count += 1;
@@ -976,7 +977,7 @@ pub fn syncWsRows(self: anytype) void {
             if (live_ws) |ws_d| {
                 for (ws_d.workspace_rules, 0..) |wp, i| {
                     const path = self.pathForWorkspaceRule(wp);
-                    if (!self.searchMatches(path)) continue;
+                    if (search_query.len > 0 and !self.searchMatchesQuery(path, search_query)) continue;
                     paths_buf[item_count] = path;
                     orig_idx[item_count] = i;
                     item_count += 1;
@@ -987,7 +988,7 @@ pub fn syncWsRows(self: anytype) void {
             // hub manifest knows about them.
             const create_paths = self.drafts.create_rule_paths;
             for (create_paths, 0..) |path, k| {
-                if (!self.searchMatches(path)) continue;
+                if (search_query.len > 0 and !self.searchMatchesQuery(path, search_query)) continue;
                 paths_buf[item_count] = path;
                 orig_idx[item_count] = rule_count + k;
                 item_count += 1;

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -138,21 +138,9 @@ fn containsSearchText(haystack: []const u8, needle: []const u8) bool {
 
     var i: usize = 0;
     while (i + needle.len <= haystack.len) : (i += 1) {
-        if (asciiEqlIgnoreCase(haystack[i .. i + needle.len], needle)) return true;
+        if (std.ascii.eqlIgnoreCase(haystack[i .. i + needle.len], needle)) return true;
     }
     return false;
-}
-
-fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
-    if (a.len != b.len) return false;
-    for (a, b) |ca, cb| {
-        if (asciiLower(ca) != asciiLower(cb)) return false;
-    }
-    return true;
-}
-
-fn asciiLower(c: u8) u8 {
-    return if (c >= 'A' and c <= 'Z') c + ('a' - 'A') else c;
 }
 
 const top_tabs = [_]TopModule{ .dashboard, .workspace, .artifact, .review, .analysis };
@@ -1133,6 +1121,11 @@ pub const Shell = struct {
 
     pub fn searchMatches(self: *const Shell, text: []const u8) bool {
         return containsSearchText(text, self.searchQuery());
+    }
+
+    pub fn searchMatchesQuery(self: *const Shell, text: []const u8, query: []const u8) bool {
+        _ = self;
+        return containsSearchText(text, query);
     }
 
     fn handleSearchKey(self: *Shell, ctx: *vxfw.EventContext, key: vaxis.Key) void {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -131,6 +131,30 @@ fn keyTextLen(key: vaxis.Key) usize {
     return 0;
 }
 
+fn containsSearchText(haystack: []const u8, needle: []const u8) bool {
+    if (needle.len == 0) return true;
+    if (std.mem.indexOf(u8, haystack, needle) != null) return true;
+    if (needle.len > haystack.len) return false;
+
+    var i: usize = 0;
+    while (i + needle.len <= haystack.len) : (i += 1) {
+        if (asciiEqlIgnoreCase(haystack[i .. i + needle.len], needle)) return true;
+    }
+    return false;
+}
+
+fn asciiEqlIgnoreCase(a: []const u8, b: []const u8) bool {
+    if (a.len != b.len) return false;
+    for (a, b) |ca, cb| {
+        if (asciiLower(ca) != asciiLower(cb)) return false;
+    }
+    return true;
+}
+
+fn asciiLower(c: u8) u8 {
+    return if (c >= 'A' and c <= 'Z') c + ('a' - 'A') else c;
+}
+
 const top_tabs = [_]TopModule{ .dashboard, .workspace, .artifact, .review, .analysis };
 
 const WORKSPACE_METADATA_REFRESH_TICKS = 600;
@@ -186,6 +210,9 @@ pub const Shell = struct {
     last_workspace_id: ?[]const u8 = null,
     workspace_pref_applied: bool = false,
     tick_count: u64 = 0,
+    search_active: bool = false,
+    search_buf: [160]u8 = .{0} ** 160,
+    search_len: usize = 0,
     login_hub_url_buf: [160]u8 = .{0} ** 160,
     login_hub_url_len: usize = 0,
     login_username_buf: [80]u8 = .{0} ** 80,
@@ -437,6 +464,11 @@ pub const Shell = struct {
                     return;
                 }
 
+                if (self.search_active) {
+                    self.handleSearchKey(ctx, key);
+                    return;
+                }
+
                 // Global quit
                 if (key.matches('c', .{ .ctrl = true })) {
                     log.info("quit_direct", .{});
@@ -457,6 +489,13 @@ pub const Shell = struct {
                 if (key.matches('?', .{})) {
                     log.info("help_open", .{});
                     self.show_help = true;
+                    ctx.consumeAndRedraw();
+                    return;
+                }
+
+                if (self.searchAvailable() and key.matches('/', .{})) {
+                    log.info("search_open module={s}", .{moduleName(self.selected_module)});
+                    self.search_active = true;
                     ctx.consumeAndRedraw();
                     return;
                 }
@@ -835,7 +874,7 @@ pub const Shell = struct {
 
     fn drawHeader(self: *Shell, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
         var surface = try vxfw.Surface.init(ctx.arena, self.widget(), ctx.max.size());
-        w.fillSurface(&surface, theme.PANEL_ALT);
+        w.fillSurface(&surface, theme.PANEL);
 
         // Row 0: Accent band with org/user context
         w.paintBand(&surface, 0, theme.ACCENT, theme.PANEL);
@@ -863,8 +902,26 @@ pub const Shell = struct {
             col = w.drawTabBadge(&surface, ctx, 2, col, label, is_active);
             col +|= 1;
         }
+        self.drawSearchBar(&surface, ctx, 2, col +| 1);
 
         return surface;
+    }
+
+    fn drawSearchBar(
+        self: *Shell,
+        surface: *vxfw.Surface,
+        ctx: vxfw.DrawContext,
+        row: u16,
+        min_col: u16,
+    ) void {
+        if (!self.searchAvailable()) return;
+        var bar = w.SearchBar{
+            .buf = &self.search_buf,
+            .len = &self.search_len,
+            .active = self.search_active,
+            .placeholder = self.searchPlaceholder(),
+        };
+        bar.drawRight(surface, ctx, row, min_col, 34);
     }
 
     fn drawBody(self: *Shell, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
@@ -1056,6 +1113,76 @@ pub const Shell = struct {
         };
     }
 
+    fn searchAvailable(self: *const Shell) bool {
+        if (self.show_settings) return false;
+        return self.selected_module == .workspace or self.selected_module == .artifact;
+    }
+
+    fn searchPlaceholder(self: *const Shell) []const u8 {
+        return switch (self.selected_module) {
+            .workspace => "Search context or rules...",
+            .artifact => "Search rules...",
+            else => "Search",
+        };
+    }
+
+    pub fn searchQuery(self: *const Shell) []const u8 {
+        if (!self.searchAvailable()) return "";
+        return std.mem.trim(u8, self.search_buf[0..self.search_len], " \t\r\n");
+    }
+
+    pub fn searchMatches(self: *const Shell, text: []const u8) bool {
+        return containsSearchText(text, self.searchQuery());
+    }
+
+    fn handleSearchKey(self: *Shell, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches('c', .{ .ctrl = true })) {
+            log.info("quit_direct", .{});
+            ctx.consumeEvent();
+            ctx.quit = true;
+            return;
+        }
+        if (!self.searchAvailable()) {
+            self.search_active = false;
+            ctx.consumeAndRedraw();
+            return;
+        }
+
+        var bar = w.SearchBar{
+            .buf = &self.search_buf,
+            .len = &self.search_len,
+            .active = true,
+        };
+        const before = self.search_len;
+        switch (bar.handleKey(key)) {
+            .submit => {
+                self.search_active = false;
+                ctx.consumeAndRedraw();
+            },
+            .cancel => {
+                self.search_active = false;
+                if (self.search_len != 0) {
+                    self.search_len = 0;
+                    self.refreshSearchResults();
+                }
+                ctx.consumeAndRedraw();
+            },
+            .consumed => {
+                if (self.search_len != before) self.refreshSearchResults();
+                ctx.consumeAndRedraw();
+            },
+            .ignored => ctx.consumeEvent(),
+        }
+    }
+
+    fn refreshSearchResults(self: *Shell) void {
+        switch (self.selected_module) {
+            .artifact => artifact_panel.syncArtifactTree(self),
+            .workspace => workspace_panel.syncWsRows(self),
+            else => {},
+        }
+    }
+
     fn hasNativeCursorInput(self: *const Shell) bool {
         if (self.shouldShowLoginPanel()) return true;
         if (self.review.show_comment_editor) return true;
@@ -1064,6 +1191,7 @@ pub const Shell = struct {
         if (self.drafts.show_new_draft_form) return true;
         if (self.drafts.show_pr_composer) return self.drafts.pr_composer_focus == .title or self.drafts.pr_composer_focus == .body;
         if (self.workspace.show_create) return self.workspace.create_focus == .name or self.workspace.create_focus == .description;
+        if (self.search_active) return true;
         return false;
     }
 
@@ -6841,6 +6969,7 @@ pub const Shell = struct {
     fn selectTab(self: *Shell, ctx: *vxfw.EventContext, tab: TopModule) void {
         const previous = self.selected_module;
         self.selected_module = tab;
+        if (!self.searchAvailable()) self.search_active = false;
         log.info("tab_select from={s} to={s}", .{ moduleName(previous), moduleName(tab) });
         self.analysis.show_member_detail = false;
         self.analysis.expanded_rule = null;
@@ -6879,6 +7008,7 @@ pub const Shell = struct {
         if (self.review.show_comment_editor) return "comment_editor";
         if (self.drafts.show_pr_composer) return "pr_composer";
         if (self.drafts.show_new_draft_form) return "new_draft_form";
+        if (self.search_active) return "search";
         if (self.show_settings) return "settings";
         return "module";
     }

--- a/src/client/tui/widgets.zig
+++ b/src/client/tui/widgets.zig
@@ -21,6 +21,7 @@ const surface_size = @import("widgets/surface_size.zig");
 const diff_viewer = @import("widgets/diff_viewer.zig");
 const shortcut_bar = @import("widgets/shortcut_bar.zig");
 const tree_list = @import("widgets/tree_list.zig");
+const search_bar = @import("widgets/search_bar.zig");
 
 pub const fillSurface = draw.fillSurface;
 pub const paintBand = draw.paintBand;
@@ -102,6 +103,7 @@ pub const drawShortcutBar = shortcut_bar.drawInline;
 pub const shortcutBarRows = shortcut_bar.requiredRows;
 pub const sortedShortcuts = shortcut_bar.sortedCopy;
 pub const TreeList = tree_list;
+pub const SearchBar = search_bar.SearchBar;
 
 pub fn countLines(text: []const u8) usize {
     if (text.len == 0) return 0;

--- a/src/client/tui/widgets/content_view.zig
+++ b/src/client/tui/widgets/content_view.zig
@@ -149,7 +149,12 @@ fn appendWrappedDiffLines(
         const lineno = row.new_line orelse row.old_line orelse 0;
         const prefix = try std.fmt.allocPrint(arena, "{d:>4} {c} ", .{ lineno, marker });
         const continuation = "       ";
-        try appendWrappedLine(out, arena, ctx, prefix, continuation, row.text, gutterStyle(), gutterRowStyle(row.marker), max_width);
+        const row_style = gutterRowStyle(row.marker);
+        const prefix_style = switch (row.marker) {
+            .unchanged => gutterStyle(),
+            .added, .removed => row_style,
+        };
+        try appendWrappedLine(out, arena, ctx, prefix, continuation, row.text, prefix_style, row_style, max_width);
     }
 }
 

--- a/src/client/tui/widgets/search_bar.zig
+++ b/src/client/tui/widgets/search_bar.zig
@@ -1,0 +1,111 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+const theme = @import("../theme.zig");
+const d = @import("draw.zig");
+const text_input = @import("text_input.zig");
+
+pub const SearchBar = struct {
+    buf: []u8,
+    len: *usize,
+    active: bool,
+    placeholder: []const u8 = "Search",
+
+    pub fn handleKey(self: *SearchBar, key: vaxis.Key) text_input.TextInputResult {
+        var input = text_input.TextInput{
+            .buf = self.buf,
+            .len = self.len,
+            .bg = theme.PANEL,
+        };
+        return input.handleKey(key);
+    }
+
+    pub fn drawRight(
+        self: *const SearchBar,
+        surface: *vxfw.Surface,
+        ctx: vxfw.DrawContext,
+        row: u16,
+        min_col: u16,
+        preferred_width: u16,
+    ) void {
+        if (row == 0 or row + 1 >= surface.size.height or surface.size.width <= min_col + 8) return;
+
+        const max_width = surface.size.width - min_col - 1;
+        const width = @min(preferred_width, max_width);
+        if (width < 12) return;
+
+        const col = surface.size.width - width - 1;
+        const bg = theme.PANEL;
+        paintSlot(surface, col, row - 1, width, bg);
+        paintSlot(surface, col, row, width, bg);
+        paintSlot(surface, col, row + 1, width, bg);
+        drawFrame(surface, col, row - 1, width, 3, bg, if (self.active) theme.ACCENT_SOFT else theme.BORDER);
+
+        const icon = "⌕";
+        const is_placeholder = self.len.* == 0 and !self.active;
+        const icon_fg = if (is_placeholder) theme.DIM else theme.TEXT_SOFT;
+        d.writeText(surface, ctx, col + 2, row, icon, .{ .fg = icon_fg, .bg = bg });
+        const icon_width: u16 = @intCast(ctx.stringWidth(icon));
+        const text_col = col + 2 + icon_width + 1;
+        const text_width = width -| 5 -| icon_width;
+        const text = self.buf[0..self.len.*];
+        if (is_placeholder) {
+            d.writeTextMax(surface, ctx, text_col, row, text_width, self.placeholder, .{
+                .fg = theme.DIM,
+                .bg = bg,
+            });
+            return;
+        }
+
+        text_input.drawValue(surface, ctx, text_col, row, text_width, text, bg, theme.TEXT, self.active);
+    }
+};
+
+fn paintSlot(surface: *vxfw.Surface, col: u16, row: u16, width: u16, bg: vaxis.Color) void {
+    var i: u16 = 0;
+    while (i < width and col + i < surface.size.width and row < surface.size.height) : (i += 1) {
+        surface.writeCell(col + i, row, theme.blank(bg));
+    }
+}
+
+fn drawFrame(
+    surface: *vxfw.Surface,
+    col: u16,
+    row: u16,
+    width: u16,
+    height: u16,
+    bg: vaxis.Color,
+    fg: vaxis.Color,
+) void {
+    if (width < 2 or height < 2) return;
+    const right = col + width - 1;
+    const bottom = row + height - 1;
+    if (right >= surface.size.width or bottom >= surface.size.height) return;
+
+    const style = vaxis.Style{ .fg = fg, .bg = bg, .bold = true };
+    surface.writeCell(col, row, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = style });
+    surface.writeCell(right, row, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = style });
+    surface.writeCell(col, bottom, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = style });
+    surface.writeCell(right, bottom, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = style });
+
+    var x = col + 1;
+    while (x < right) : (x += 1) {
+        surface.writeCell(x, row, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = style });
+        surface.writeCell(x, bottom, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = style });
+    }
+
+    var y = row + 1;
+    while (y < bottom) : (y += 1) {
+        surface.writeCell(col, y, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = style });
+        surface.writeCell(right, y, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = style });
+    }
+}
+
+test "SearchBar handleKey updates buffer" {
+    var buf: [16]u8 = undefined;
+    var len: usize = 0;
+    var search = SearchBar{ .buf = &buf, .len = &len, .active = true };
+
+    try std.testing.expectEqual(text_input.TextInputResult.consumed, search.handleKey(.{ .codepoint = 'x' }));
+    try std.testing.expectEqualStrings("x", buf[0..len]);
+}

--- a/src/client/tui/widgets/search_bar.zig
+++ b/src/client/tui/widgets/search_bar.zig
@@ -39,7 +39,7 @@ pub const SearchBar = struct {
         paintSlot(surface, col, row - 1, width, bg);
         paintSlot(surface, col, row, width, bg);
         paintSlot(surface, col, row + 1, width, bg);
-        drawFrame(surface, col, row - 1, width, 3, bg, if (self.active) theme.ACCENT_SOFT else theme.BORDER);
+        drawFrame(surface, col, row - 1, width, 3, bg, theme.ACCENT_SOFT);
 
         const icon = "⌕";
         const is_placeholder = self.len.* == 0 and !self.active;

--- a/src/client/tui/widgets/search_bar.zig
+++ b/src/client/tui/widgets/search_bar.zig
@@ -39,7 +39,7 @@ pub const SearchBar = struct {
         paintSlot(surface, col, row - 1, width, bg);
         paintSlot(surface, col, row, width, bg);
         paintSlot(surface, col, row + 1, width, bg);
-        drawFrame(surface, col, row - 1, width, 3, bg, theme.ACCENT_SOFT);
+        drawFrame(surface, col, row - 1, width, 3, bg, theme.focusBorder(self.active));
 
         const icon = "⌕";
         const is_placeholder = self.len.* == 0 and !self.active;

--- a/src/client/tui/widgets/system_notice.zig
+++ b/src/client/tui/widgets/system_notice.zig
@@ -5,7 +5,7 @@ const theme = @import("../theme.zig");
 const draw = @import("draw.zig");
 
 const CAPACITY = 8;
-const TRANSIENT_TICKS = 100;
+const TRANSIENT_TICKS = 67;
 const WIDTH: u16 = 56;
 const MIN_WIDTH: u16 = 28;
 const MAX_VISIBLE_HEIGHT: u16 = 18;


### PR DESCRIPTION
## Summary

Add a header search control for Workspace and Artifact views so users can
filter context and rule trees without leaving the current page. The search
bar reuses the TUI panel border semantics, keeps the header on the shared
panel background, and routes text input through the shell before applying
page-specific tree filtering. This also tightens related review UX by
coloring changed diff gutters with their row state and shortening transient
toast lifetime.

## Test plan

- [x] Run `zig build`
- [ ] Open the TUI and verify Workspace search filters context and rules
- [ ] Open the TUI and verify Artifact search filters rules
- [ ] Check Review diff rows show changed gutter color for added/removed lines
