### PR TITLE
client: harden login defaults and artifact drafts

### DIFF
--- a/src/client/commands/login_cmd.zig
+++ b/src/client/commands/login_cmd.zig
@@ -3,6 +3,7 @@ const testing = std.testing;
 const flag = @import("../flags.zig");
 const hub_client = @import("../hub_client.zig");
 const auth_mod = @import("../auth.zig");
+const workspace_config = @import("../workspace_config.zig");
 const auth_api = @import("clumsies_lib").protocol.auth_api;
 const LoginResponse = auth_api.LoginResponse;
 const HubClient = hub_client.HubClient;
@@ -47,7 +48,10 @@ pub fn run(stdout: *std.Io.Writer, stderr: *std.Io.Writer, allocator: std.mem.Al
     };
     defer result.deinit(allocator);
 
-    const hub_url = normalizeHubUrl(allocator, result.value(0) orelse DEFAULT_HUB_URL) catch |err| switch (err) {
+    const hub_url_raw = try resolveHubUrlRaw(allocator, result.value(0));
+    defer allocator.free(hub_url_raw);
+
+    const hub_url = normalizeHubUrl(allocator, hub_url_raw) catch |err| switch (err) {
         error.InvalidHubUrl => {
             try stderr.print("{s}{s}{s}Error:{s} Invalid hub URL. Use a full URL like http://127.0.0.1:8400 or localhost:8400.\n", .{
                 P,
@@ -332,6 +336,15 @@ fn normalizeHubUrl(allocator: std.mem.Allocator, raw: []const u8) HubUrlError![]
     return normalized;
 }
 
+fn resolveHubUrlRaw(allocator: std.mem.Allocator, explicit: ?[]const u8) ![]const u8 {
+    if (explicit) |value| return try allocator.dupe(u8, value);
+
+    return workspace_config.loadServerUrl(allocator) catch |err| switch (err) {
+        error.NoConfigFound => try allocator.dupe(u8, DEFAULT_HUB_URL),
+        else => return err,
+    };
+}
+
 test "LoginResponse parsing ignores expires_in" {
     const body =
         \\{"access_token":"acc","refresh_token":"ref","expires_in":3600}
@@ -373,6 +386,13 @@ test "normalizeHubUrl rejects unsupported schemes" {
     try testing.expectError(error.UnsupportedHubUrlScheme, normalizeHubUrl(testing.allocator, "ftp://localhost:8410"));
 }
 
+test "resolveHubUrlRaw prefers explicit value" {
+    const resolved = try resolveHubUrlRaw(testing.allocator, "http://example.test:8400");
+    defer testing.allocator.free(resolved);
+
+    try testing.expectEqualStrings("http://example.test:8400", resolved);
+}
+
 test "printHubRequestError formats connection refused without stack-oriented detail" {
     var capture = std.Io.Writer.Allocating.init(testing.allocator);
     defer capture.deinit();
@@ -412,6 +432,6 @@ fn printHelp(out: *std.Io.Writer) !void {
     try out.print("{s}Usage: {s}clumsies login [--hub-url <url>] [--username <user>]{s}\n", .{ P, Color.cyan, Color.reset });
     try out.print("{s}Authenticate with a Clumsies Hub instance.\n", .{P});
     try out.print("{s}Flags:\n", .{P});
-    try out.print("{s}  {s}--hub-url <url>{s}   Hub URL (default: {s})\n", .{ P, Color.cyan, Color.reset, DEFAULT_HUB_URL });
+    try out.print("{s}  {s}--hub-url <url>{s}   Hub URL (default: configured server URL, then {s})\n", .{ P, Color.cyan, Color.reset, DEFAULT_HUB_URL });
     try out.print("{s}  {s}--username <user>{s} Username (prompted if omitted)\n", .{ P, Color.cyan, Color.reset });
 }

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -285,10 +285,12 @@ fn localTempIdPrefix(category: DraftCategory) []const u8 {
 
 pub const DraftIdentity = struct {
     draft_path: []const u8,
+    previous_path: ?[]const u8 = null,
     local_temp_id: ?[]const u8 = null,
 
     pub fn deinit(self: DraftIdentity, allocator: std.mem.Allocator) void {
         allocator.free(self.draft_path);
+        if (self.previous_path) |path| allocator.free(path);
         if (self.local_temp_id) |id| allocator.free(id);
     }
 };
@@ -483,7 +485,7 @@ pub fn renameCreateDraftById(
     }
 
     const old_path = try allocator.dupe(u8, entry.draft_path);
-    defer allocator.free(old_path);
+    errdefer allocator.free(old_path);
     const local_temp_id = if (entry.local_temp_id) |temp_id|
         try allocator.dupe(u8, temp_id)
     else
@@ -495,18 +497,21 @@ pub fn renameCreateDraftById(
     const content = try readDraftFile(allocator, ws_dir, category, old_path);
     defer allocator.free(content);
     try writeDraftFileAbs(allocator, ws_dir, category, new_path, content);
-    discardDraftFile(allocator, ws_dir, category, old_path) catch |err| switch (err) {
-        error.FileNotFound => {},
-        else => return err,
-    };
+    errdefer discardDraftFile(allocator, ws_dir, category, new_path) catch {};
 
     entry.draft_path = new_path;
     if (description) |desc| entry.description = desc;
     entry.status = .draft;
     try writeIndexAtomic(allocator, ws_dir, index.entries.items);
 
+    discardDraftFile(allocator, ws_dir, category, old_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+
     return .{
         .draft_path = new_path_owned,
+        .previous_path = old_path,
         .local_temp_id = local_temp_id,
     };
 }

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -439,6 +439,78 @@ pub fn updateCreateDraftContentById(
     };
 }
 
+pub fn renameCreateDraftById(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    category: DraftCategory,
+    id: []const u8,
+    new_path: []const u8,
+    description: ?[]const u8,
+) !?DraftIdentity {
+    if (!path_util.isSafeRelative(new_path)) return error.UnsafeDraftPath;
+
+    var index = try loadIndex(allocator, ws_dir);
+    defer index.deinit(allocator);
+
+    var entry_opt: ?*DraftEntry = null;
+    for (index.entries.items) |*candidate| {
+        if (candidate.category != category) continue;
+        if (std.mem.eql(u8, candidate.draft_path, id)) {
+            entry_opt = candidate;
+            break;
+        }
+        if (candidate.local_temp_id) |value| {
+            if (std.mem.eql(u8, value, id)) {
+                entry_opt = candidate;
+                break;
+            }
+        }
+        if (candidate.current_path) |value| {
+            if (std.mem.eql(u8, value, id)) {
+                entry_opt = candidate;
+                break;
+            }
+        }
+    }
+    const entry = entry_opt orelse return null;
+    if (entry.operation != .create) return null;
+
+    for (index.entries.items) |*other| {
+        if (other == entry) continue;
+        if (other.category != category) continue;
+        if (isTerminalStatus(other.status)) continue;
+        if (std.mem.eql(u8, other.draft_path, new_path)) return error.DraftAlreadyExists;
+    }
+
+    const old_path = try allocator.dupe(u8, entry.draft_path);
+    defer allocator.free(old_path);
+    const local_temp_id = if (entry.local_temp_id) |temp_id|
+        try allocator.dupe(u8, temp_id)
+    else
+        null;
+    errdefer if (local_temp_id) |temp_id| allocator.free(temp_id);
+    const new_path_owned = try allocator.dupe(u8, new_path);
+    errdefer allocator.free(new_path_owned);
+
+    const content = try readDraftFile(allocator, ws_dir, category, old_path);
+    defer allocator.free(content);
+    try writeDraftFileAbs(allocator, ws_dir, category, new_path, content);
+    discardDraftFile(allocator, ws_dir, category, old_path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => return err,
+    };
+
+    entry.draft_path = new_path;
+    if (description) |desc| entry.description = desc;
+    entry.status = .draft;
+    try writeIndexAtomic(allocator, ws_dir, index.entries.items);
+
+    return .{
+        .draft_path = new_path_owned,
+        .local_temp_id = local_temp_id,
+    };
+}
+
 /// Remove a draft: delete its content file (if any) and drop its entry
 /// from the index. Idempotent when the entry is already absent.
 pub fn discardDraft(
@@ -465,6 +537,15 @@ pub fn discardDraft(
 
     if (removed) try writeIndexAtomic(allocator, ws_dir, kept.items);
 
+    try discardDraftFile(allocator, ws_dir, category, draft_path);
+}
+
+fn discardDraftFile(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    category: DraftCategory,
+    draft_path: []const u8,
+) !void {
     const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "drafts", category.toString(), draft_path });
     defer allocator.free(abs_path);
     std.fs.deleteFileAbsolute(abs_path) catch |err| switch (err) {

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -1000,7 +1000,7 @@ fn handleProposeRename(
             if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
                 defer draft.deinit(allocator);
                 const event_id = draft.local_temp_id orelse id;
-                session.recordEvent(allocator, .{ .context_propose_rename = .{ .id = event_id, .path = id, .new_path = draft.draft_path } });
+                session.recordEvent(allocator, .{ .context_propose_rename = .{ .id = event_id, .path = draft.previous_path.?, .new_path = draft.draft_path } });
                 return buildOkDraftIdentity(allocator, draft.draft_path, draft.local_temp_id);
             }
             return error.FileNotFound;
@@ -1009,7 +1009,7 @@ fn handleProposeRename(
             if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
                 defer draft.deinit(allocator);
                 const event_id = draft.local_temp_id orelse id;
-                session.recordEvent(allocator, .{ .rule_propose_rename = .{ .id = event_id, .path = id, .new_path = draft.draft_path } });
+                session.recordEvent(allocator, .{ .rule_propose_rename = .{ .id = event_id, .path = draft.previous_path.?, .new_path = draft.draft_path } });
                 return buildOkDraftIdentity(allocator, draft.draft_path, draft.local_temp_id);
             }
             return error.FileNotFound;
@@ -1165,6 +1165,21 @@ fn writeTestFile(dir: std.fs.Dir, sub_path: []const u8, content: []const u8) !vo
 
 fn tmpDirAbsolutePath(tmp: *std.testing.TmpDir, buf: *[std.fs.max_path_bytes]u8) []const u8 {
     return tmp.dir.realpath(".", buf) catch "";
+}
+
+fn draftRenameEventUsesPath(
+    allocator: std.mem.Allocator,
+    ws_id: []const u8,
+    session_id: []const u8,
+    path: []const u8,
+) bool {
+    const attestation_path = attestation.sessionAttestationFilePath(allocator, ws_id, session_id) catch return false;
+    defer allocator.free(attestation_path);
+    const content = std.fs.cwd().readFileAlloc(allocator, attestation_path, 1024 * 1024) catch return false;
+    defer allocator.free(content);
+    const needle = std.fmt.allocPrint(allocator, "\"path\":\"{s}\"", .{path}) catch return false;
+    defer allocator.free(needle);
+    return std.mem.indexOf(u8, content, needle) != null;
 }
 
 test "buildListResult: exposes memory tools and unified artifact tool" {
@@ -1426,6 +1441,7 @@ test "artifact tool renames newly created context draft" {
     try testing.expectEqualStrings("draft body", content);
 
     try testing.expectError(error.FileNotFound, drafts_mod.readDraftFile(testing.allocator, root, .context, "notes/UI.md"));
+    try testing.expect(draftRenameEventUsesPath(testing.allocator, "ws-test", "test-session", "notes/UI.md"));
 
     var index = try drafts_mod.loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -745,7 +745,7 @@ fn handleReject(
 fn proposeErr(allocator: std.mem.Allocator, err: anyerror) []u8 {
     return tool_result.buildErrorResult(allocator, switch (err) {
         error.InvalidParams => "invalid parameters",
-        error.FileNotFound => "file not found in cache",
+        error.FileNotFound => "artifact or draft not found",
         error.DraftAlreadyExists => "draft already exists for this path",
         error.DraftOperationConflict => "artifact already has an incompatible local change",
         error.UnsafeDraftPath => "unsafe path",
@@ -827,7 +827,10 @@ fn handleDraftDiscard(
     const id = resourceId(args, category) orelse return error.InvalidParams;
     if (id.len == 0) return error.InvalidParams;
 
-    const draft_path = try drafts_mod.discardDraftById(allocator, workspace_root, category, id) orelse return error.FileNotFound;
+    const draft_path = (try drafts_mod.discardDraftById(allocator, workspace_root, category, id)) orelse blk: {
+        if (category != .meta_prompt) return error.FileNotFound;
+        break :blk (try drafts_mod.discardDraftById(allocator, workspace_root, category, "META_PROMPT.md")) orelse return error.FileNotFound;
+    };
     defer allocator.free(draft_path);
 
     session.recordEvent(allocator, .{ .draft_discard = .{
@@ -993,8 +996,24 @@ fn handleProposeRename(
     defer manifest.deinit(allocator);
 
     const m_entry = switch (category) {
-        .context => manifest.context.get(id) orelse return error.FileNotFound,
-        .rule => manifest.rules.get(id) orelse return error.FileNotFound,
+        .context => manifest.context.get(id) orelse {
+            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
+                defer draft.deinit(allocator);
+                const event_id = draft.local_temp_id orelse id;
+                session.recordEvent(allocator, .{ .context_propose_rename = .{ .id = event_id, .path = id, .new_path = draft.draft_path } });
+                return buildOkDraftIdentity(allocator, draft.draft_path, draft.local_temp_id);
+            }
+            return error.FileNotFound;
+        },
+        .rule => manifest.rules.get(id) orelse {
+            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
+                defer draft.deinit(allocator);
+                const event_id = draft.local_temp_id orelse id;
+                session.recordEvent(allocator, .{ .rule_propose_rename = .{ .id = event_id, .path = id, .new_path = draft.draft_path } });
+                return buildOkDraftIdentity(allocator, draft.draft_path, draft.local_temp_id);
+            }
+            return error.FileNotFound;
+        },
         .meta_prompt => return error.InvalidParams,
     };
 
@@ -1359,6 +1378,63 @@ test "artifact tool updates newly created context draft" {
     try testing.expectEqualStrings("second", entry.description.?);
 }
 
+test "artifact tool renames newly created context draft" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try drafts_mod.createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "notes/UI.md",
+        .local_temp_id = "tmp-context-1",
+        .description = "first",
+    }, "draft body");
+
+    const args_json =
+        \\{
+        \\  "resource": "context",
+        \\  "op": {
+        \\    "rename": {
+        \\      "id": "tmp-context-1",
+        \\      "new_path": "specs/UI_MODULE_PLAN.md",
+        \\      "description": "move to specs"
+        \\    }
+        \\  }
+        \\}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var session: session_mod.Session = .{
+        .ws_id = try testing.allocator.dupe(u8, "ws-test"),
+        .workspace_root = try testing.allocator.dupe(u8, root),
+    };
+    defer session.deinit(testing.allocator);
+    try session.bind(testing.allocator, "test-session");
+
+    const result = try handleArtifact(testing.allocator, root, &session, parsed.value.object);
+    defer testing.allocator.free(result);
+
+    try testing.expect(std.mem.indexOf(u8, result, "\"ok\":true") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"id\":\"tmp-context-1\"") != null);
+
+    const content = try drafts_mod.readDraftFile(testing.allocator, root, .context, "specs/UI_MODULE_PLAN.md");
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("draft body", content);
+
+    try testing.expectError(error.FileNotFound, drafts_mod.readDraftFile(testing.allocator, root, .context, "notes/UI.md"));
+
+    var index = try drafts_mod.loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expect(index.findCreateByDraftPath("notes/UI.md") == null);
+    const entry = index.findCreateByDraftPath("specs/UI_MODULE_PLAN.md") orelse return error.TestUnexpectedResult;
+    try testing.expectEqualStrings("tmp-context-1", entry.local_temp_id.?);
+    try testing.expectEqualStrings("move to specs", entry.description.?);
+}
+
 test "artifact tool discards rule change by local temp id" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1401,6 +1477,51 @@ test "artifact tool discards rule change by local temp id" {
     var index = try drafts_mod.loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
     try testing.expect(index.findByLocalTempId("tmp-rule-1") == null);
+}
+
+test "artifact tool discards MPF draft by manifest id" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try drafts_mod.createDraft(testing.allocator, root, .{
+        .category = .meta_prompt,
+        .operation = .modify,
+        .draft_path = "META_PROMPT.md",
+        .current_path = "META_PROMPT.md",
+        .base_hash = "sha256:old",
+    }, "draft mpf");
+
+    const args_json =
+        \\{
+        \\  "resource": "mpf",
+        \\  "op": {
+        \\    "discard": {
+        \\      "id": "p-0cba8168-fcc6-4151-b06b-b5e1b1c6bc29"
+        \\    }
+        \\  }
+        \\}
+    ;
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, args_json, .{});
+    defer parsed.deinit();
+
+    var session: session_mod.Session = .{
+        .ws_id = try testing.allocator.dupe(u8, "ws-test"),
+        .workspace_root = try testing.allocator.dupe(u8, root),
+    };
+    defer session.deinit(testing.allocator);
+    try session.bind(testing.allocator, "test-session");
+
+    const result = try handleArtifact(testing.allocator, root, &session, parsed.value.object);
+    defer testing.allocator.free(result);
+
+    try testing.expect(std.mem.indexOf(u8, result, "\"ok\":true") != null);
+
+    var index = try drafts_mod.loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expect(index.findByCurrentPath(.meta_prompt, "META_PROMPT.md") == null);
 }
 
 test "artifact tool updates MPF change" {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -33,6 +33,7 @@ const util_hash = @import("clumsies_lib").util.hash;
 const tui_prefs = @import("prefs.zig");
 
 const log = std.log.scoped(.tui_event);
+const DEFAULT_HUB_URL = "http://127.0.0.1:8400";
 
 const editor_host = runtime.editor_host;
 const attestation_reader = runtime.attestation_reader;
@@ -1085,9 +1086,13 @@ pub const Shell = struct {
     }
 
     fn seedLoginDefaults(self: *Shell) void {
-        const default_url = "http://127.0.0.1:8400";
-        @memcpy(self.login_hub_url_buf[0..default_url.len], default_url);
-        self.login_hub_url_len = default_url.len;
+        const alloc = self.api_state.backing_allocator;
+        const configured_url = workspace_config.loadServerUrl(alloc) catch null;
+        defer if (configured_url) |url| alloc.free(url);
+        const default_url = configured_url orelse DEFAULT_HUB_URL;
+        const url = if (default_url.len <= self.login_hub_url_buf.len) default_url else DEFAULT_HUB_URL;
+        @memcpy(self.login_hub_url_buf[0..url.len], url);
+        self.login_hub_url_len = url.len;
         self.login_focus = .username;
     }
 

--- a/src/client/workspace_config.zig
+++ b/src/client/workspace_config.zig
@@ -87,6 +87,13 @@ pub fn listWorkspaces(allocator: std.mem.Allocator) ![]WorkspaceListEntry {
     return try list.toOwnedSlice(allocator);
 }
 
+pub fn loadServerUrl(allocator: std.mem.Allocator) ![]const u8 {
+    var parsed = try loadConfig(allocator);
+    defer parsed.deinit();
+
+    return try allocator.dupe(u8, parsed.value.server.url);
+}
+
 pub fn deinitWorkspaceList(allocator: std.mem.Allocator, list: []WorkspaceListEntry) void {
     for (list) |entry| {
         allocator.free(entry.ws_id);


### PR DESCRIPTION
## Summary

Fix two client-side stability gaps that showed up in normal multi-device
and MCP draft workflows. Login now uses the configured Hub URL before
falling back to localhost, and artifact draft operations resolve local
draft identities for create-draft rename and MPF discard instead of
reporting misleading cache misses.

## Test plan

- [x] `zig build test`
- [x] `zig build`
