### PR TITLE
drafts: fix discovery of renamed artifact drafts

### DIFF
--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -275,6 +275,89 @@ pub fn createDraftLocalTempId(
     );
 }
 
+const ArtifactPathCase = enum {
+    lower_snake,
+    upper_snake,
+};
+
+pub fn canonicalArtifactDraftPath(
+    allocator: std.mem.Allocator,
+    category: DraftCategory,
+    path: []const u8,
+) ![]u8 {
+    if (category == .meta_prompt) return allocator.dupe(u8, path);
+    if (path.len == 0 or path[0] == '/') return error.UnsafeDraftPath;
+
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var it = std.mem.splitScalar(u8, path, '/');
+    var component_count: usize = 0;
+    var pending_component: ?[]const u8 = null;
+    while (it.next()) |component| {
+        try validateArtifactPathComponent(component);
+        if (pending_component) |prev| {
+            if (component_count > 0) try out.append(allocator, '/');
+            try appendCanonicalArtifactPathComponent(allocator, &out, prev, .lower_snake);
+            component_count += 1;
+        }
+        pending_component = component;
+    }
+
+    const basename = pending_component orelse return error.UnsafeDraftPath;
+    const stem = stripMarkdownExtension(basename);
+    if (stem.len == 0) return error.UnsafeDraftPath;
+    if (component_count > 0) try out.append(allocator, '/');
+    try appendCanonicalArtifactPathComponent(allocator, &out, stem, .upper_snake);
+    try out.appendSlice(allocator, ".md");
+    return out.toOwnedSlice(allocator);
+}
+
+fn shouldCanonicalizeDraftPath(category: DraftCategory, operation: DraftOperation) bool {
+    if (category == .meta_prompt) return false;
+    return operation == .create or operation == .rename;
+}
+
+fn validateArtifactPathComponent(component: []const u8) !void {
+    if (component.len == 0) return error.UnsafeDraftPath;
+    if (std.mem.eql(u8, component, ".") or std.mem.eql(u8, component, "..")) return error.UnsafeDraftPath;
+    if (std.mem.indexOfScalar(u8, component, '\\') != null) return error.UnsafeDraftPath;
+}
+
+fn stripMarkdownExtension(basename: []const u8) []const u8 {
+    if (basename.len < ".md".len) return basename;
+    const suffix = basename[basename.len - ".md".len ..];
+    if (std.ascii.eqlIgnoreCase(suffix, ".md")) return basename[0 .. basename.len - ".md".len];
+    return basename;
+}
+
+fn appendCanonicalArtifactPathComponent(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(u8),
+    raw: []const u8,
+    path_case: ArtifactPathCase,
+) !void {
+    const start_len = out.items.len;
+    var last_was_separator = true;
+    for (raw) |ch| {
+        if (std.ascii.isAlphanumeric(ch)) {
+            const normalized = switch (path_case) {
+                .lower_snake => std.ascii.toLower(ch),
+                .upper_snake => std.ascii.toUpper(ch),
+            };
+            try out.append(allocator, normalized);
+            last_was_separator = false;
+        } else if (!last_was_separator) {
+            try out.append(allocator, '_');
+            last_was_separator = true;
+        }
+    }
+    while (out.items.len > 0 and out.items[out.items.len - 1] == '_') {
+        _ = out.pop();
+    }
+    if (out.items.len == start_len) return error.UnsafeDraftPath;
+}
+
 fn localTempIdPrefix(category: DraftCategory) []const u8 {
     return switch (category) {
         .rule => "rule",
@@ -397,7 +480,9 @@ pub fn upsertRenameDraft(
     new_path: []const u8,
     base_content: []const u8,
 ) !DraftIdentity {
-    if (!path_util.isSafeRelative(new_path)) return error.UnsafeDraftPath;
+    const canonical_new_path = try canonicalArtifactDraftPath(allocator, params.category, new_path);
+    defer allocator.free(canonical_new_path);
+    if (!path_util.isSafeRelative(canonical_new_path)) return error.UnsafeDraftPath;
 
     var index = try loadIndex(allocator, ws_dir);
     defer index.deinit(allocator);
@@ -405,7 +490,7 @@ pub fn upsertRenameDraft(
     if (findExistingDraftIndex(index.entries.items, params)) |entry_index| {
         var entry = &index.entries.items[entry_index];
         if (entry.operation == .delete) return error.DraftOperationConflict;
-        if (!draftPathAvailable(index.entries.items, params.category, new_path, entry_index)) return error.DraftAlreadyExists;
+        if (!draftPathAvailable(index.entries.items, params.category, canonical_new_path, entry_index)) return error.DraftAlreadyExists;
 
         const old_path = try allocator.dupe(u8, entry.draft_path);
         defer allocator.free(old_path);
@@ -415,12 +500,12 @@ pub fn upsertRenameDraft(
         };
         defer allocator.free(content);
 
-        try writeDraftFileAbs(allocator, ws_dir, params.category, new_path, content);
-        errdefer discardDraftFile(allocator, ws_dir, params.category, new_path) catch {};
+        try writeDraftFileAbs(allocator, ws_dir, params.category, canonical_new_path, content);
+        errdefer discardDraftFile(allocator, ws_dir, params.category, canonical_new_path) catch {};
 
         entry.operation = .rename;
         entry.current_path = params.current_path;
-        entry.draft_path = new_path;
+        entry.draft_path = canonical_new_path;
         if (entry.rule_id == null) entry.rule_id = params.rule_id;
         if (entry.context_id == null) entry.context_id = params.context_id;
         if (entry.base_hash == null) entry.base_hash = params.base_hash;
@@ -428,7 +513,7 @@ pub fn upsertRenameDraft(
         entry.status = .draft;
         try writeIndexAtomic(allocator, ws_dir, index.entries.items);
 
-        if (!std.mem.eql(u8, old_path, new_path)) {
+        if (!std.mem.eql(u8, old_path, canonical_new_path)) {
             discardDraftFile(allocator, ws_dir, params.category, old_path) catch |err| switch (err) {
                 error.FileNotFound => {},
                 else => return err,
@@ -440,7 +525,7 @@ pub fn upsertRenameDraft(
     try createDraft(allocator, ws_dir, .{
         .category = params.category,
         .operation = .rename,
-        .draft_path = new_path,
+        .draft_path = canonical_new_path,
         .current_path = params.current_path,
         .base_hash = params.base_hash,
         .rule_id = params.rule_id,
@@ -448,7 +533,7 @@ pub fn upsertRenameDraft(
         .description = params.description,
     }, base_content);
     return .{
-        .draft_path = try allocator.dupe(u8, new_path),
+        .draft_path = try allocator.dupe(u8, canonical_new_path),
         .previous_path = try allocator.dupe(u8, params.current_path),
     };
 }
@@ -507,7 +592,12 @@ pub fn createDraft(
     params: CreateDraftParams,
     initial_content: []const u8,
 ) !void {
-    if (!path_util.isSafeRelative(params.draft_path)) return error.UnsafeDraftPath;
+    const canonical_draft_path = if (shouldCanonicalizeDraftPath(params.category, params.operation))
+        try canonicalArtifactDraftPath(allocator, params.category, params.draft_path)
+    else
+        try allocator.dupe(u8, params.draft_path);
+    defer allocator.free(canonical_draft_path);
+    if (!path_util.isSafeRelative(canonical_draft_path)) return error.UnsafeDraftPath;
 
     var index = try loadIndex(allocator, ws_dir);
     defer index.deinit(allocator);
@@ -515,16 +605,16 @@ pub fn createDraft(
     for (index.entries.items) |entry| {
         if (entry.category != params.category) continue;
         if (isTerminalStatus(entry.status)) continue;
-        if (std.mem.eql(u8, entry.draft_path, params.draft_path)) return error.DraftAlreadyExists;
+        if (std.mem.eql(u8, entry.draft_path, canonical_draft_path)) return error.DraftAlreadyExists;
     }
 
     if (params.operation != .delete) {
-        try writeDraftFileAbs(allocator, ws_dir, params.category, params.draft_path, initial_content);
+        try writeDraftFileAbs(allocator, ws_dir, params.category, canonical_draft_path, initial_content);
     }
 
     const arena = index.arena_state.allocator();
     const local_temp_id = params.local_temp_id orelse if (params.operation == .create)
-        try createDraftLocalTempId(arena, params.category, params.draft_path)
+        try createDraftLocalTempId(arena, params.category, canonical_draft_path)
     else
         null;
 
@@ -534,7 +624,7 @@ pub fn createDraft(
         .context_id = params.context_id,
         .local_temp_id = local_temp_id,
         .current_path = params.current_path,
-        .draft_path = params.draft_path,
+        .draft_path = canonical_draft_path,
         .operation = params.operation,
         .base_hash = params.base_hash,
         .status = .draft,
@@ -648,7 +738,9 @@ pub fn renameCreateDraftById(
     new_path: []const u8,
     description: ?[]const u8,
 ) !?DraftIdentity {
-    if (!path_util.isSafeRelative(new_path)) return error.UnsafeDraftPath;
+    const canonical_new_path = try canonicalArtifactDraftPath(allocator, category, new_path);
+    defer allocator.free(canonical_new_path);
+    if (!path_util.isSafeRelative(canonical_new_path)) return error.UnsafeDraftPath;
 
     var index = try loadIndex(allocator, ws_dir);
     defer index.deinit(allocator);
@@ -680,7 +772,7 @@ pub fn renameCreateDraftById(
         if (other == entry) continue;
         if (other.category != category) continue;
         if (isTerminalStatus(other.status)) continue;
-        if (std.mem.eql(u8, other.draft_path, new_path)) return error.DraftAlreadyExists;
+        if (std.mem.eql(u8, other.draft_path, canonical_new_path)) return error.DraftAlreadyExists;
     }
 
     const old_path = try allocator.dupe(u8, entry.draft_path);
@@ -690,15 +782,15 @@ pub fn renameCreateDraftById(
     else
         null;
     errdefer if (local_temp_id) |temp_id| allocator.free(temp_id);
-    const new_path_owned = try allocator.dupe(u8, new_path);
+    const new_path_owned = try allocator.dupe(u8, canonical_new_path);
     errdefer allocator.free(new_path_owned);
 
     const content = try readDraftFile(allocator, ws_dir, category, old_path);
     defer allocator.free(content);
-    try writeDraftFileAbs(allocator, ws_dir, category, new_path, content);
-    errdefer discardDraftFile(allocator, ws_dir, category, new_path) catch {};
+    try writeDraftFileAbs(allocator, ws_dir, category, canonical_new_path, content);
+    errdefer discardDraftFile(allocator, ws_dir, category, canonical_new_path) catch {};
 
-    entry.draft_path = new_path;
+    entry.draft_path = canonical_new_path;
     if (description) |desc| entry.description = desc;
     entry.status = .draft;
     try writeIndexAtomic(allocator, ws_dir, index.entries.items);
@@ -1313,6 +1405,44 @@ test "findByLocalTempId: returns entry matching temp_id" {
     try testing.expect(index.findByLocalTempId("nonexistent") == null);
 }
 
+test "canonicalArtifactDraftPath: normalizes directories and filenames" {
+    const context_path = try canonicalArtifactDraftPath(testing.allocator, .context, "Mission/duckweed-project.md");
+    defer testing.allocator.free(context_path);
+    try testing.expectEqualStrings("mission/DUCKWEED_PROJECT.md", context_path);
+
+    const rule_path = try canonicalArtifactDraftPath(testing.allocator, .rule, "PITFALL/path format");
+    defer testing.allocator.free(rule_path);
+    try testing.expectEqualStrings("pitfall/PATH_FORMAT.md", rule_path);
+}
+
+test "canonicalArtifactDraftPath: rejects unsafe traversal" {
+    try testing.expectError(error.UnsafeDraftPath, canonicalArtifactDraftPath(testing.allocator, .context, "../MISSION.md"));
+    try testing.expectError(error.UnsafeDraftPath, canonicalArtifactDraftPath(testing.allocator, .rule, "mission/../BAD.md"));
+}
+
+test "createDraft: canonicalizes create draft artifact paths" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "Mission/duckweed-project.md",
+    }, "# Mission\n");
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    const entry = index.findCreateByDraftPath("mission/DUCKWEED_PROJECT.md") orelse return error.TestUnexpectedResult;
+    try testing.expect(entry.local_temp_id != null);
+
+    const content = try readDraftFile(testing.allocator, root, .context, "mission/DUCKWEED_PROJECT.md");
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("# Mission\n", content);
+}
+
 test "createDraft: generates local temp id for create operation" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -1641,7 +1771,7 @@ test "discardCreateDraftById: accepts local temp id and returns draft path" {
         return error.TestExpectedEqual;
     defer testing.allocator.free(draft_path);
 
-    try testing.expectEqualStrings("projects/eth-p2p-z/project-context.md", draft_path);
+    try testing.expectEqualStrings("projects/eth_p2p_z/PROJECT_CONTEXT.md", draft_path);
     try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .context, draft_path));
 
     var index = try loadIndex(testing.allocator, root);
@@ -1665,7 +1795,8 @@ test "discardCreateDraftById: rejects draft path identity" {
 
     try testing.expect(try discardCreateDraftById(testing.allocator, root, .rule, path) == null);
 
-    const content = try readDraftFile(testing.allocator, root, .rule, path);
+    const canonical_path = "learning/zig_libp2p/ETH_P2P_Z.md";
+    const content = try readDraftFile(testing.allocator, root, .rule, canonical_path);
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("draft body", content);
 }
@@ -1726,6 +1857,28 @@ test "upsertRenameDraft: folds update draft into rename draft" {
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("updated body", content);
     try testing.expectError(error.FileNotFound, readDraftFile(testing.allocator, root, .rule, "design/UI.md"));
+}
+
+test "upsertRenameDraft: canonicalizes renamed artifact path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var rename_identity = try upsertRenameDraft(testing.allocator, root, .{
+        .category = .context,
+        .current_path = "mission/OLD.md",
+        .context_id = "ctx-old",
+        .base_hash = "sha256:base",
+    }, "Mission/duckweed-project.md", "base body");
+    defer rename_identity.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("mission/DUCKWEED_PROJECT.md", rename_identity.draft_path);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqualStrings("mission/DUCKWEED_PROJECT.md", index.entries.items[0].draft_path);
 }
 
 test "upsertUpdateDraft: updates rename draft without previous path identity" {
@@ -1972,7 +2125,7 @@ test "discardUnchangedUpdateDraft: ignores create draft" {
         "# ADR-004\n",
     ));
 
-    const content = try readDraftFile(testing.allocator, root, .rule, "adr/ADR-004.md");
+    const content = try readDraftFile(testing.allocator, root, .rule, "adr/ADR_004.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("# ADR-004\n", content);
 }

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -873,26 +873,28 @@ fn handleProposeCreate(
     if (path.len == 0 or body.len == 0) return error.InvalidParams;
     const description = optionalString(args, "description");
     if (category == .meta_prompt and !std.mem.eql(u8, path, "META_PROMPT.md")) return error.InvalidParams;
+    const draft_path = try drafts_mod.canonicalArtifactDraftPath(allocator, category, path);
+    defer allocator.free(draft_path);
 
-    const local_temp_id = try drafts_mod.createDraftLocalTempId(allocator, category, path);
+    const local_temp_id = try drafts_mod.createDraftLocalTempId(allocator, category, draft_path);
     defer allocator.free(local_temp_id);
 
     try drafts_mod.createDraft(allocator, workspace_root, .{
         .category = category,
         .operation = .create,
-        .draft_path = path,
+        .draft_path = draft_path,
         .local_temp_id = local_temp_id,
         .description = description,
     }, body);
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
-        .context => .{ .context_propose_create = .{ .path = path } },
-        .rule => .{ .rule_propose_create = .{ .path = path } },
-        .meta_prompt => .{ .mpf_propose_create = .{ .path = path } },
+        .context => .{ .context_propose_create = .{ .path = draft_path } },
+        .rule => .{ .rule_propose_create = .{ .path = draft_path } },
+        .meta_prompt => .{ .mpf_propose_create = .{ .path = draft_path } },
     };
     session.recordEvent(allocator, payload);
 
-    return buildOkDraftIdentity(allocator, path, local_temp_id);
+    return buildOkDraftIdentity(allocator, draft_path, local_temp_id);
 }
 
 fn handleProposeUpdate(
@@ -982,13 +984,15 @@ fn handleProposeRename(
     if (new_path.len == 0) return error.InvalidParams;
     if (category == .meta_prompt) return error.InvalidParams;
     const description = optionalString(args, "description");
+    const canonical_new_path = try drafts_mod.canonicalArtifactDraftPath(allocator, category, new_path);
+    defer allocator.free(canonical_new_path);
 
     var manifest = try workspace_rule.loadManifest(allocator, workspace_root);
     defer manifest.deinit(allocator);
 
     const m_entry = switch (category) {
         .context => manifest.context.get(id) orelse {
-            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
+            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, canonical_new_path, description)) |draft| {
                 defer draft.deinit(allocator);
                 const event_id = draft.local_temp_id orelse id;
                 session.recordEvent(allocator, .{ .context_propose_rename = .{ .id = event_id, .path = draft.previous_path.?, .new_path = draft.draft_path } });
@@ -997,7 +1001,7 @@ fn handleProposeRename(
             return error.FileNotFound;
         },
         .rule => manifest.rules.get(id) orelse {
-            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, new_path, description)) |draft| {
+            if (try drafts_mod.renameCreateDraftById(allocator, workspace_root, category, id, canonical_new_path, description)) |draft| {
                 defer draft.deinit(allocator);
                 const event_id = draft.local_temp_id orelse id;
                 session.recordEvent(allocator, .{ .rule_propose_rename = .{ .id = event_id, .path = draft.previous_path.?, .new_path = draft.draft_path } });
@@ -1024,12 +1028,12 @@ fn handleProposeRename(
         .rule_id = if (category == .rule) id else null,
         .context_id = if (category == .context) id else null,
         .description = description,
-    }, new_path, cache_content);
+    }, canonical_new_path, cache_content);
     defer draft.deinit(allocator);
 
     const payload: attestation.AttestationEvent.Payload = switch (category) {
-        .context => .{ .context_propose_rename = .{ .id = id, .path = m_entry.path, .new_path = new_path } },
-        .rule => .{ .rule_propose_rename = .{ .id = id, .path = m_entry.path, .new_path = new_path } },
+        .context => .{ .context_propose_rename = .{ .id = id, .path = m_entry.path, .new_path = canonical_new_path } },
+        .rule => .{ .rule_propose_rename = .{ .id = id, .path = m_entry.path, .new_path = canonical_new_path } },
         .meta_prompt => return error.InvalidParams,
     };
     session.recordEvent(allocator, payload);
@@ -1311,11 +1315,12 @@ test "artifact tool creates context change through tagged op" {
     defer testing.allocator.free(result);
 
     try testing.expect(std.mem.indexOf(u8, result, "\"ok\":true") != null);
+    try testing.expect(std.mem.indexOf(u8, result, "\"draft_path\":\"research/NEW_CONTEXT.md\"") != null);
     try testing.expect(std.mem.indexOf(u8, result, "\"id\":\"tmp-context-") != null);
 
     var index = try drafts_mod.loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
-    const entry = index.findCreateByDraftPath("research/new-context.md") orelse return error.TestUnexpectedResult;
+    const entry = index.findCreateByDraftPath("research/NEW_CONTEXT.md") orelse return error.TestUnexpectedResult;
     try testing.expectEqual(drafts_mod.DraftCategory.context, entry.category);
 }
 
@@ -1356,7 +1361,7 @@ test "artifact tool updates newly created context draft" {
         \\  "resource": "context",
         \\  "op": {
         \\    "update": {
-        \\      "id": "research/new-context.md",
+        \\      "id": "research/NEW_CONTEXT.md",
         \\      "body": "second body",
         \\      "description": "second"
         \\    }
@@ -1370,14 +1375,14 @@ test "artifact tool updates newly created context draft" {
     try testing.expect(std.mem.indexOf(u8, update_result, "\"ok\":true") != null);
     try testing.expect(std.mem.indexOf(u8, update_result, "\"id\":\"tmp-context-") != null);
 
-    const content = try drafts_mod.readDraftFile(testing.allocator, root, .context, "research/new-context.md");
+    const content = try drafts_mod.readDraftFile(testing.allocator, root, .context, "research/NEW_CONTEXT.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("second body", content);
 
     var index = try drafts_mod.loadIndex(testing.allocator, root);
     defer index.deinit(testing.allocator);
     try testing.expectEqual(@as(usize, 1), index.entries.items.len);
-    const entry = index.findCreateByDraftPath("research/new-context.md") orelse return error.TestUnexpectedResult;
+    const entry = index.findCreateByDraftPath("research/NEW_CONTEXT.md") orelse return error.TestUnexpectedResult;
     try testing.expectEqual(drafts_mod.DraftOperation.create, entry.operation);
     try testing.expectEqualStrings("second", entry.description.?);
 }
@@ -1403,7 +1408,7 @@ test "artifact tool renames newly created context draft" {
         \\  "op": {
         \\    "rename": {
         \\      "id": "tmp-context-1",
-        \\      "new_path": "specs/UI_MODULE_PLAN.md",
+        \\      "new_path": "Specs/UI module-plan.md",
         \\      "description": "move to specs"
         \\    }
         \\  }
@@ -1660,7 +1665,9 @@ test "context propose delete discards create-only draft by local temp id" {
 
     var before_index = try drafts_mod.loadIndex(testing.allocator, root);
     defer before_index.deinit(testing.allocator);
-    const local_temp_id = before_index.findCreateByDraftPath(draft_path).?.local_temp_id.?;
+    const canonical_draft_path = try drafts_mod.canonicalArtifactDraftPath(testing.allocator, .context, draft_path);
+    defer testing.allocator.free(canonical_draft_path);
+    const local_temp_id = before_index.findCreateByDraftPath(canonical_draft_path).?.local_temp_id.?;
 
     const args_json =
         try std.fmt.allocPrint(

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -274,16 +274,23 @@ fn groupFromPath(path: []const u8) ?[]const u8 {
     const first_slash = std.mem.indexOfScalar(u8, path, '/') orelse return null;
     if (std.mem.startsWith(u8, path, "workflow/")) {
         const after_kind = path[first_slash + 1 ..];
-        const next_slash = std.mem.indexOfScalar(u8, after_kind, '/') orelse return null;
-        return after_kind[0..next_slash];
+        const last_slash = std.mem.lastIndexOfScalar(u8, after_kind, '/') orelse return null;
+        return after_kind[0..last_slash];
     }
-    return path[0..first_slash];
+    const last_slash = std.mem.lastIndexOfScalar(u8, path, '/') orelse return null;
+    return path[0..last_slash];
 }
 
 fn matchesGroup(item_group: []const u8, filter: []const u8) bool {
     if (std.mem.eql(u8, item_group, filter)) return true;
-    if (std.mem.startsWith(u8, item_group, filter) and filter.len < item_group.len and item_group[filter.len] == '/') return true;
-    return false;
+    var item_it = std.mem.splitScalar(u8, item_group, '/');
+    var filter_it = std.mem.splitScalar(u8, filter, '/');
+    while (filter_it.next()) |filter_part| {
+        if (filter_part.len == 0) return false;
+        const item_part = item_it.next() orelse return false;
+        if (!normalizedIdentifierEqual(item_part, filter_part)) return false;
+    }
+    return true;
 }
 
 fn matchesQuery(haystack: []const u8, query: []const u8) bool {
@@ -356,6 +363,14 @@ fn loadAliasMatchesPath(alias: LoadAlias, path: []const u8, kind: RuleKind) bool
     return normalizedNameMatches(path, alias.target);
 }
 
+fn effectivePath(manifest_path: []const u8, draft_entry: ?*const drafts.DraftEntry) []const u8 {
+    const entry = draft_entry orelse return manifest_path;
+    return switch (entry.operation) {
+        .rename => entry.draft_path,
+        else => manifest_path,
+    };
+}
+
 fn resolveLoadId(
     id: []const u8,
     manifest: *const Manifest,
@@ -368,7 +383,12 @@ fn resolveLoadId(
 
     var rule_it = manifest.rules.iterator();
     while (rule_it.next()) |entry| {
-        const path = entry.value_ptr.path;
+        const manifest_path = entry.value_ptr.path;
+        const draft_entry = draft_index.findByCurrentPath(.rule, manifest_path);
+        if (draft_entry) |de| {
+            if (de.operation == .delete) continue;
+        }
+        const path = effectivePath(manifest_path, draft_entry);
         const kind = kindFromPath(path) orelse continue;
         if (loadAliasMatchesPath(alias, path, kind)) return .{
             .requested_id = id,
@@ -379,7 +399,13 @@ fn resolveLoadId(
     if (alias.kind == null or alias.kind.? == .context) {
         var ctx_it = manifest.context.iterator();
         while (ctx_it.next()) |entry| {
-            if (loadAliasMatchesPath(alias, entry.value_ptr.path, .context)) return .{
+            const manifest_path = entry.value_ptr.path;
+            const draft_entry = draft_index.findByCurrentPath(.context, manifest_path);
+            if (draft_entry) |de| {
+                if (de.operation == .delete) continue;
+            }
+            const path = effectivePath(manifest_path, draft_entry);
+            if (loadAliasMatchesPath(alias, path, .context)) return .{
                 .requested_id = id,
                 .actual_id = entry.key_ptr.*,
             };
@@ -434,18 +460,19 @@ pub fn discoverSearchable(
 
         if (std.mem.eql(u8, m_entry.path, "META_PROMPT.md")) continue;
 
-        const kind = kindFromPath(m_entry.path) orelse continue;
-        if (kind_filter) |kf| {
-            if (kf != kind) continue;
-        }
-
         // Check for a delete draft — hide this entry
         const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
         if (draft_entry) |de| {
             if (de.operation == .delete) continue;
         }
 
-        const group_slice = groupFromPath(m_entry.path);
+        const path = effectivePath(m_entry.path, draft_entry);
+        const kind = kindFromPath(path) orelse continue;
+        if (kind_filter) |kf| {
+            if (kf != kind) continue;
+        }
+
+        const group_slice = groupFromPath(path);
         if (group_filter) |gf| {
             const g = group_slice orelse continue;
             if (!matchesGroup(g, gf)) continue;
@@ -456,17 +483,17 @@ pub fn discoverSearchable(
             if (trimmed.len == 0) {
                 // empty/whitespace-only query is treated as no filter
             } else {
-                const in_path = matchesQuery(m_entry.path, trimmed);
+                const in_path = matchesQuery(path, trimmed);
                 const in_desc = m_entry.description.len > 0 and matchesQuery(m_entry.description, trimmed);
                 if (!in_path and !in_desc) continue;
             }
         }
 
-        const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
+        const display_name = displayNameFromFilename(std.fs.path.basename(path));
 
         const id_owned = try allocator.dupe(u8, entry.key_ptr.*);
         errdefer allocator.free(id_owned);
-        const path_owned = try allocator.dupe(u8, m_entry.path);
+        const path_owned = try allocator.dupe(u8, path);
         errdefer allocator.free(path_owned);
         const name_owned = try allocator.dupe(u8, display_name);
         errdefer allocator.free(name_owned);
@@ -501,23 +528,27 @@ pub fn discoverSearchable(
                 if (de.operation == .delete) continue;
             }
 
-            const group_slice = groupFromPath(m_entry.path);
+            const path = effectivePath(m_entry.path, draft_entry);
+            const group_slice = groupFromPath(path);
             if (group_filter) |gf| {
                 const g = group_slice orelse continue;
                 if (!matchesGroup(g, gf)) continue;
             }
 
             if (query_filter) |q| {
-                const in_path = matchesQuery(m_entry.path, q);
-                const in_desc = m_entry.description.len > 0 and matchesQuery(m_entry.description, q);
-                if (!in_path and !in_desc) continue;
+                const trimmed = std.mem.trim(u8, q, " \t");
+                if (trimmed.len > 0) {
+                    const in_path = matchesQuery(path, trimmed);
+                    const in_desc = m_entry.description.len > 0 and matchesQuery(m_entry.description, trimmed);
+                    if (!in_path and !in_desc) continue;
+                }
             }
 
-            const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
+            const display_name = displayNameFromFilename(std.fs.path.basename(path));
 
             const id_owned = try allocator.dupe(u8, entry.key_ptr.*);
             errdefer allocator.free(id_owned);
-            const path_owned = try allocator.dupe(u8, m_entry.path);
+            const path_owned = try allocator.dupe(u8, path);
             errdefer allocator.free(path_owned);
             const name_owned = try allocator.dupe(u8, display_name);
             errdefer allocator.free(name_owned);
@@ -644,13 +675,13 @@ pub fn loadRules(
         };
 
         if (manifest.rules.get(resolved_id.actual_id)) |m_entry| {
-            const kind = kindFromPath(m_entry.path) orelse return error.UnknownRuleId;
-
             const known_hash = knownHashFor(resolved_id.actual_id, known) orelse knownHashFor(resolved_id.requested_id, known);
             const draft_entry = draft_index.findByCurrentPath(.rule, m_entry.path);
             if (draft_entry) |entry| {
                 if (entry.operation == .delete) return error.UnknownRuleId;
             }
+            const path = effectivePath(m_entry.path, draft_entry);
+            const kind = kindFromPath(path) orelse return error.UnknownRuleId;
 
             var resolved = try resolveLoadContent(
                 allocator,
@@ -663,8 +694,8 @@ pub fn loadRules(
             );
             errdefer resolved.deinit(allocator);
 
-            const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
-            const group_slice = groupFromPath(m_entry.path);
+            const display_name = displayNameFromFilename(std.fs.path.basename(path));
+            const group_slice = groupFromPath(path);
 
             const has_draft = draft_entry != null;
             const draft_base = if (draft_entry) |entry|
@@ -676,7 +707,7 @@ pub fn loadRules(
             try result.items.append(allocator, .{
                 .id = try allocator.dupe(u8, resolved_id.actual_id),
                 .kind = kind,
-                .path = try allocator.dupe(u8, m_entry.path),
+                .path = try allocator.dupe(u8, path),
                 .name = try allocator.dupe(u8, display_name),
                 .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
                 .hash = resolved.hash,
@@ -691,6 +722,7 @@ pub fn loadRules(
             if (draft_entry) |entry| {
                 if (entry.operation == .delete) return error.UnknownRuleId;
             }
+            const path = effectivePath(m_entry.path, draft_entry);
 
             var resolved = try resolveLoadContent(
                 allocator,
@@ -703,8 +735,8 @@ pub fn loadRules(
             );
             errdefer resolved.deinit(allocator);
 
-            const display_name = displayNameFromFilename(std.fs.path.basename(m_entry.path));
-            const group_slice = groupFromPath(m_entry.path);
+            const display_name = displayNameFromFilename(std.fs.path.basename(path));
+            const group_slice = groupFromPath(path);
 
             const has_draft = draft_entry != null;
             const draft_base = if (draft_entry) |entry|
@@ -716,7 +748,7 @@ pub fn loadRules(
             try result.items.append(allocator, .{
                 .id = try allocator.dupe(u8, resolved_id.actual_id),
                 .kind = .context,
-                .path = try allocator.dupe(u8, m_entry.path),
+                .path = try allocator.dupe(u8, path),
                 .name = try allocator.dupe(u8, display_name),
                 .group = if (group_slice) |g| try allocator.dupe(u8, g) else null,
                 .hash = resolved.hash,
@@ -1233,7 +1265,7 @@ test "discoverSearchable: kind filter narrows results" {
     try testing.expectEqualStrings("p-style", rules.items[0].id);
 }
 
-test "discoverSearchable: group filter matches first path component" {
+test "discoverSearchable: group filter matches nested path groups" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1241,7 +1273,8 @@ test "discoverSearchable: group filter matches first path component" {
         \\{
         \\  "rules": {
         \\    "p-1": {"path": "coding/STYLE.md", "hash": "sha256:1"},
-        \\    "p-2": {"path": "zig/NAMING.md", "hash": "sha256:2"}
+        \\    "p-2": {"path": "zig/NAMING.md", "hash": "sha256:2"},
+        \\    "p-3": {"path": "book-writing/scaffold/VITEPRESS_BOOK_SITE.md", "hash": "sha256:3"}
         \\  }
         \\}
     );
@@ -1254,6 +1287,64 @@ test "discoverSearchable: group filter matches first path component" {
 
     try testing.expectEqual(@as(usize, 1), zig_rules.items.len);
     try testing.expectEqualStrings("p-2", zig_rules.items[0].id);
+
+    var scaffold_rules = try discoverSearchable(testing.allocator, root, .rule, "book-writing/scaffold", null);
+    defer deinitRuleItems(testing.allocator, &scaffold_rules);
+
+    try testing.expectEqual(@as(usize, 1), scaffold_rules.items.len);
+    try testing.expectEqualStrings("p-3", scaffold_rules.items[0].id);
+    try testing.expectEqualStrings("book-writing/scaffold", scaffold_rules.items[0].group.?);
+
+    var book_rules = try discoverSearchable(testing.allocator, root, .rule, "book-writing", null);
+    defer deinitRuleItems(testing.allocator, &book_rules);
+
+    try testing.expectEqual(@as(usize, 1), book_rules.items.len);
+    try testing.expectEqualStrings("p-3", book_rules.items[0].id);
+}
+
+test "discoverSearchable: rename draft uses effective path for filtering" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "rules": {
+        \\    "p-site": {"path": "coding/STYLE.md", "hash": "sha256:1", "description": "old style"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var identity = try drafts.upsertRenameDraft(testing.allocator, root, .{
+        .category = .rule,
+        .current_path = "coding/STYLE.md",
+        .rule_id = "p-site",
+        .base_hash = "sha256:1",
+        .description = "VitePress booklet scaffold",
+    }, "book-writing/scaffold/VITEPRESS_BOOK_SITE.md", "draft body");
+    defer identity.deinit(testing.allocator);
+
+    var scaffold_rules = try discoverSearchable(testing.allocator, root, .rule, "book-writing/scaffold", null);
+    defer deinitRuleItems(testing.allocator, &scaffold_rules);
+
+    try testing.expectEqual(@as(usize, 1), scaffold_rules.items.len);
+    try testing.expectEqualStrings("p-site", scaffold_rules.items[0].id);
+    try testing.expectEqualStrings("book_writing/scaffold/VITEPRESS_BOOK_SITE.md", scaffold_rules.items[0].path);
+    try testing.expectEqualStrings("book_writing/scaffold", scaffold_rules.items[0].group.?);
+    try testing.expect(scaffold_rules.items[0].has_draft);
+
+    var query_rules = try discoverSearchable(testing.allocator, root, .rule, null, "VITEPRESS_BOOK_SITE");
+    defer deinitRuleItems(testing.allocator, &query_rules);
+
+    try testing.expectEqual(@as(usize, 1), query_rules.items.len);
+    try testing.expectEqualStrings("p-site", query_rules.items[0].id);
+
+    var old_group_rules = try discoverSearchable(testing.allocator, root, .rule, "coding", null);
+    defer deinitRuleItems(testing.allocator, &old_group_rules);
+
+    try testing.expectEqual(@as(usize, 0), old_group_rules.items.len);
 }
 
 test "discoverSearchable: META_PROMPT.md is excluded" {
@@ -1411,6 +1502,41 @@ test "loadRules: create draft alias known hash suppresses unchanged content" {
     try testing.expectEqualStrings("tmp-rule-error", result.items.items[0].id);
     try testing.expect(!result.items.items[0].changed);
     try testing.expect(result.items.items[0].content == null);
+}
+
+test "loadRules: alias resolves renamed draft effective path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeTestManifest(tmp.dir,
+        \\{
+        \\  "rules": {
+        \\    "p-site": {"path": "coding/STYLE.md", "hash": "sha256:style"}
+        \\  }
+        \\}
+    );
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    var identity = try drafts.upsertRenameDraft(testing.allocator, root, .{
+        .category = .rule,
+        .current_path = "coding/STYLE.md",
+        .rule_id = "p-site",
+        .base_hash = "sha256:style",
+    }, "book-writing/scaffold/VITEPRESS_BOOK_SITE.md", "draft body");
+    defer identity.deinit(testing.allocator);
+
+    var result = try loadRules(testing.allocator, root, &.{"rule:vitepress book site"}, &.{});
+    defer result.deinit(testing.allocator);
+
+    try testing.expectEqual(@as(usize, 1), result.items.items.len);
+    const item = result.items.items[0];
+    try testing.expectEqualStrings("p-site", item.id);
+    try testing.expectEqualStrings("book_writing/scaffold/VITEPRESS_BOOK_SITE.md", item.path);
+    try testing.expectEqualStrings("book_writing/scaffold", item.group.?);
+    try testing.expect(item.has_draft);
+    try testing.expectEqualStrings("draft body", item.content.?);
 }
 
 test "loadRules: unknown id returns UnknownRuleId" {

--- a/src/client/rule.zig
+++ b/src/client/rule.zig
@@ -430,10 +430,12 @@ fn resolveLoadId(
 }
 
 /// Discover rules and context available for memdisc. Iterates the
-/// local manifest, classifies each entry by path prefix or category, and
-/// applies optional kind/group filters. Reserved paths (META_PROMPT.md) are
-/// excluded. Context entries have kind = .context and group derived from
-/// their path's first component.
+/// local manifest, overlays draft paths for renamed entries, classifies
+/// each effective path by prefix or category, and applies optional
+/// kind/group filters. Reserved paths (META_PROMPT.md) are excluded.
+/// Context entries have kind = .context. Groups are derived from the
+/// effective path's containing directory and may include nested path
+/// components.
 ///
 /// Drafts are merged into the result: delete-drafts hide their manifest
 /// entries, update/rename drafts set has_draft = true, and create-drafts


### PR DESCRIPTION
## Summary

Renamed local artifact drafts could disappear from agent discovery under
their new group or file name before the draft was applied. Draft create
and rename paths are now canonicalized in the shared draft layer, and
rule discovery plus alias loading use the draft overlay's effective path
for renamed drafts.

## Test plan

- [x] `zig build test`
- [x] `zig build`
- [x] `git diff --check`
