### PR TITLE
tui: add batch draft PR submission

### DIFF
--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -325,7 +325,7 @@ fn pruneCacheDir(
         const rel_path = if (rel_dir.len == 0)
             try allocator.dupe(u8, entry.name)
         else
-            try std.fs.path.join(allocator, &.{ rel_dir, entry.name });
+            try joinManifestPath(allocator, rel_dir, entry.name);
         defer allocator.free(rel_path);
 
         switch (entry.kind) {
@@ -346,6 +346,10 @@ fn pruneCacheDir(
         }
     }
     return removed;
+}
+
+fn joinManifestPath(allocator: std.mem.Allocator, dir: []const u8, name: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s}/{s}", .{ dir, name });
 }
 
 /// Batch-fetch rule bodies in a single POST. Per-item errors from
@@ -605,6 +609,12 @@ test "cacheSubDirForRulePath routes META_PROMPT to cache root" {
 test "cacheSubDirForRulePath routes regular paths under rule/" {
     try testing.expectEqualStrings("rule", cacheSubDirForRulePath("coding/STYLE.md"));
     try testing.expectEqualStrings("rule", cacheSubDirForRulePath("workflow/CODING.md"));
+}
+
+test "joinManifestPath preserves manifest separator" {
+    const result = try joinManifestPath(testing.allocator, "keep/nested", "A.md");
+    defer testing.allocator.free(result);
+    try testing.expectEqualStrings("keep/nested/A.md", result);
 }
 
 test "pruneCacheNamespace removes files absent from manifest keep set" {

--- a/src/client/commands/sync_cmd.zig
+++ b/src/client/commands/sync_cmd.zig
@@ -245,6 +245,10 @@ pub fn materializeWorkspace(
         try w.interface.writeAll(manifest_response.body);
         try w.interface.flush();
     }
+    _ = pruneStaleWorkspaceCache(allocator, cache_dir, manifest) catch |err| blk: {
+        log.warn("stale_cache_prune_failed ws_id={s} error={s}", .{ ws_id, @errorName(err) });
+        break :blk 0;
+    };
 
     const reconcile = drafts_mod.reconcileDrafts(allocator, ws_dir, cache_dir) catch drafts_mod.ReconcileSummary{};
     return .{
@@ -256,6 +260,92 @@ pub fn materializeWorkspace(
         .context_unchanged = context_skipped,
         .conflicted_drafts = reconcile.conflicted,
     };
+}
+
+fn pruneStaleWorkspaceCache(
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    manifest: workspace_api.WorkspaceManifestResponse,
+) !usize {
+    var context_keep: std.StringHashMapUnmanaged(void) = .empty;
+    defer context_keep.deinit(allocator);
+    for (manifest.context.items) |entry| {
+        try context_keep.put(allocator, entry.value.path, {});
+    }
+
+    var rule_keep: std.StringHashMapUnmanaged(void) = .empty;
+    defer rule_keep.deinit(allocator);
+    for (manifest.rules.items) |entry| {
+        const rule_path = entry.value.path;
+        if (std.mem.eql(u8, rule_path, "META_PROMPT.md")) continue;
+        try rule_keep.put(allocator, rule_path, {});
+    }
+
+    var removed: usize = 0;
+    const context_dir = try std.fs.path.join(allocator, &.{ cache_dir, "context" });
+    defer allocator.free(context_dir);
+    removed += try pruneCacheNamespace(allocator, context_dir, &context_keep);
+    const rule_dir = try std.fs.path.join(allocator, &.{ cache_dir, "rule" });
+    defer allocator.free(rule_dir);
+    removed += try pruneCacheNamespace(allocator, rule_dir, &rule_keep);
+    return removed;
+}
+
+fn pruneCacheNamespace(
+    allocator: std.mem.Allocator,
+    namespace_dir: []const u8,
+    keep: *const std.StringHashMapUnmanaged(void),
+) !usize {
+    var dir = std.fs.openDirAbsolute(namespace_dir, .{ .iterate = true }) catch |err| switch (err) {
+        error.FileNotFound => return 0,
+        else => return err,
+    };
+    dir.close();
+    return pruneCacheDir(allocator, namespace_dir, "", keep);
+}
+
+fn pruneCacheDir(
+    allocator: std.mem.Allocator,
+    namespace_dir: []const u8,
+    rel_dir: []const u8,
+    keep: *const std.StringHashMapUnmanaged(void),
+) !usize {
+    const current_dir = if (rel_dir.len == 0)
+        try allocator.dupe(u8, namespace_dir)
+    else
+        try std.fs.path.join(allocator, &.{ namespace_dir, rel_dir });
+    defer allocator.free(current_dir);
+
+    var dir = try std.fs.openDirAbsolute(current_dir, .{ .iterate = true });
+    defer dir.close();
+
+    var removed: usize = 0;
+    var it = dir.iterate();
+    while (try it.next()) |entry| {
+        const rel_path = if (rel_dir.len == 0)
+            try allocator.dupe(u8, entry.name)
+        else
+            try std.fs.path.join(allocator, &.{ rel_dir, entry.name });
+        defer allocator.free(rel_path);
+
+        switch (entry.kind) {
+            .file, .sym_link => {
+                if (!keep.contains(rel_path)) {
+                    try dir.deleteFile(entry.name);
+                    removed += 1;
+                }
+            },
+            .directory => {
+                removed += try pruneCacheDir(allocator, namespace_dir, rel_path, keep);
+                dir.deleteDir(entry.name) catch |err| switch (err) {
+                    error.DirNotEmpty, error.FileNotFound => {},
+                    else => return err,
+                };
+            },
+            else => {},
+        }
+    }
+    return removed;
 }
 
 /// Batch-fetch rule bodies in a single POST. Per-item errors from
@@ -515,6 +605,39 @@ test "cacheSubDirForRulePath routes META_PROMPT to cache root" {
 test "cacheSubDirForRulePath routes regular paths under rule/" {
     try testing.expectEqualStrings("rule", cacheSubDirForRulePath("coding/STYLE.md"));
     try testing.expectEqualStrings("rule", cacheSubDirForRulePath("workflow/CODING.md"));
+}
+
+test "pruneCacheNamespace removes files absent from manifest keep set" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("cache/context/keep");
+    try tmp.dir.makePath("cache/context/stale");
+    {
+        const f = try tmp.dir.createFile("cache/context/keep/A.md", .{});
+        defer f.close();
+        try f.writeAll("keep");
+    }
+    {
+        const f = try tmp.dir.createFile("cache/context/stale/B.md", .{});
+        defer f.close();
+        try f.writeAll("stale");
+    }
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const namespace_path = try tmp.dir.realpath("cache/context", &buf);
+
+    var keep: std.StringHashMapUnmanaged(void) = .empty;
+    defer keep.deinit(testing.allocator);
+    try keep.put(testing.allocator, "keep/A.md", {});
+
+    const removed = try pruneCacheNamespace(testing.allocator, namespace_path, &keep);
+    try testing.expectEqual(@as(usize, 1), removed);
+    {
+        const f = try tmp.dir.openFile("cache/context/keep/A.md", .{});
+        defer f.close();
+    }
+    try testing.expectError(error.FileNotFound, tmp.dir.openFile("cache/context/stale/B.md", .{}));
 }
 
 test "localFileMatchesHash returns true on hash match" {

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -1047,15 +1047,15 @@ pub fn discardCreateDraftById(
 
 pub const ReconcileSummary = struct {
     conflicted: usize = 0,
+    restored: usize = 0,
 };
 
-/// Re-run drift detection on every non-terminal draft in
-/// `{ws_dir}/drafts/index.json`. When an update / rename / delete draft's
-/// `base_hash` no longer matches the current cache content at
-/// `current_path`, the entry is moved to `.conflicted`. Create-ops
-/// have no cache base to compare against and are skipped. Drafts
-/// already in `.applied`, `.declined`, or `.conflicted` are left
-/// untouched — terminal and already-flagged states are sticky.
+/// Re-run drift detection on active drafts in `{ws_dir}/drafts/index.json`.
+/// When an update / rename / delete draft's `base_hash` no longer matches
+/// the current cache content at `current_path`, the entry is moved to
+/// `.conflicted`. Already-conflicted entries are restored to `.draft` when
+/// sync proves they are no longer conflicted: create targets are absent from
+/// cache, and update / rename / delete bases match again.
 pub fn reconcileDrafts(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
@@ -1068,23 +1068,23 @@ pub fn reconcileDrafts(
     var changed = false;
     for (index.entries.items) |*entry| {
         switch (entry.status) {
-            .applied, .declined, .conflicted => continue,
+            .applied, .declined => continue,
             else => {},
         }
-        if (entry.operation == .create) continue;
+        if (entry.operation == .create) {
+            if (entry.status == .conflicted) {
+                if (!try cacheFileExists(allocator, cache_dir, entry.category, entry.draft_path)) {
+                    entry.status = .draft;
+                    summary.restored += 1;
+                    changed = true;
+                }
+            }
+            continue;
+        }
         const base_hash = entry.base_hash orelse continue;
         const cur = entry.current_path orelse continue;
 
-        const cache_path = if (entry.category == .meta_prompt)
-            try std.fs.path.join(allocator, &.{ cache_dir, cur })
-        else blk: {
-            const rel_dir: []const u8 = switch (entry.category) {
-                .rule => "rule",
-                .context => "context",
-                else => unreachable,
-            };
-            break :blk try std.fs.path.join(allocator, &.{ cache_dir, rel_dir, cur });
-        };
+        const cache_path = try cacheFilePath(allocator, cache_dir, entry.category, cur);
         defer allocator.free(cache_path);
 
         const file = std.fs.openFileAbsolute(cache_path, .{}) catch continue;
@@ -1096,7 +1096,13 @@ pub fn reconcileDrafts(
         defer allocator.free(content);
 
         const current_hash = util_hash.contentHash(content);
-        if (!std.mem.eql(u8, current_hash[0..], base_hash)) {
+        if (std.mem.eql(u8, current_hash[0..], base_hash)) {
+            if (entry.status == .conflicted) {
+                entry.status = .draft;
+                summary.restored += 1;
+                changed = true;
+            }
+        } else if (entry.status != .conflicted) {
             entry.status = .conflicted;
             summary.conflicted += 1;
             changed = true;
@@ -1104,6 +1110,37 @@ pub fn reconcileDrafts(
     }
     if (changed) try writeIndexAtomic(allocator, ws_dir, index.entries.items);
     return summary;
+}
+
+fn cacheFileExists(
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    category: DraftCategory,
+    rel_path: []const u8,
+) !bool {
+    const path = try cacheFilePath(allocator, cache_dir, category, rel_path);
+    defer allocator.free(path);
+    const file = std.fs.openFileAbsolute(path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    defer file.close();
+    return true;
+}
+
+fn cacheFilePath(
+    allocator: std.mem.Allocator,
+    cache_dir: []const u8,
+    category: DraftCategory,
+    rel_path: []const u8,
+) ![]const u8 {
+    if (category == .meta_prompt) return std.fs.path.join(allocator, &.{ cache_dir, rel_path });
+    const rel_dir: []const u8 = switch (category) {
+        .rule => "rule",
+        .context => "context",
+        .meta_prompt => unreachable,
+    };
+    return std.fs.path.join(allocator, &.{ cache_dir, rel_dir, rel_path });
 }
 
 /// Transition the status of an existing draft. Fails if the draft does
@@ -2347,7 +2384,65 @@ test "reconcileDrafts: skips create-operation drafts" {
     try testing.expectEqual(DraftStatus.draft, index.entries.items[0].status);
 }
 
-test "reconcileDrafts: leaves terminal states sticky" {
+test "reconcileDrafts: restores conflicted update when base matches cache" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    const seed = "v1 body\n";
+    const seed_hash = util_hash.contentHash(seed);
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .update,
+        .draft_path = "spec/API.md",
+        .current_path = "spec/API.md",
+        .context_id = "ctx-api",
+        .base_hash = seed_hash[0..],
+    }, "local edit\n");
+    try setDraftStatus(testing.allocator, root, .context, "spec/API.md", .conflicted);
+
+    try tmp.dir.makePath("cache/context/spec");
+    try writeFile(tmp.dir, "cache/context/spec/API.md", seed);
+
+    const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
+    defer testing.allocator.free(cache_dir);
+
+    const summary = try reconcileDrafts(testing.allocator, root, cache_dir);
+    try testing.expectEqual(@as(usize, 1), summary.restored);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(DraftStatus.draft, index.entries.items[0].status);
+}
+
+test "reconcileDrafts: restores conflicted create when target is absent from cache" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "todo/NEXT.md",
+    }, "new todo\n");
+    try setDraftStatus(testing.allocator, root, .context, "todo/NEXT.md", .conflicted);
+
+    const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
+    defer testing.allocator.free(cache_dir);
+
+    const summary = try reconcileDrafts(testing.allocator, root, cache_dir);
+    try testing.expectEqual(@as(usize, 1), summary.restored);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(DraftStatus.draft, index.entries.items[0].status);
+}
+
+test "reconcileDrafts: leaves terminal applied and declined statuses sticky" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -853,7 +853,6 @@ fn discardDraftFile(
 pub fn normalizeDrafts(allocator: std.mem.Allocator, ws_dir: []const u8) !void {
     var index = try loadIndex(allocator, ws_dir);
     defer index.deinit(allocator);
-    if (index.entries.items.len < 2) return;
 
     const arena = index.arena_state.allocator();
     const dropped = try arena.alloc(bool, index.entries.items.len);
@@ -861,6 +860,13 @@ pub fn normalizeDrafts(allocator: std.mem.Allocator, ws_dir: []const u8) !void {
 
     var changed = false;
     for (index.entries.items, 0..) |*entry, i| {
+        if (!isTerminalStatus(entry.status) and entry.operation != .delete) {
+            if (!try draftFileExists(allocator, ws_dir, entry.category, entry.draft_path)) {
+                dropped[i] = true;
+                changed = true;
+                continue;
+            }
+        }
         if (dropped[i] or !isMergeableDraft(entry.*)) continue;
         var j = i + 1;
         while (j < index.entries.items.len) : (j += 1) {
@@ -931,6 +937,23 @@ pub fn normalizeDrafts(allocator: std.mem.Allocator, ws_dir: []const u8) !void {
         try kept.append(arena, entry);
     }
     try writeIndexAtomic(allocator, ws_dir, kept.items);
+}
+
+fn draftFileExists(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    category: DraftCategory,
+    draft_path: []const u8,
+) !bool {
+    if (!path_util.isSafeRelative(draft_path)) return error.UnsafeDraftPath;
+    const abs_path = try std.fs.path.join(allocator, &.{ ws_dir, "drafts", category.toString(), draft_path });
+    defer allocator.free(abs_path);
+    const file = std.fs.openFileAbsolute(abs_path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return false,
+        else => return err,
+    };
+    file.close();
+    return true;
 }
 
 fn isMergeableDraft(entry: DraftEntry) bool {
@@ -1958,6 +1981,35 @@ test "normalizeDrafts: folds duplicate update and rename entries" {
     const content = try readDraftFile(testing.allocator, root, .rule, "design/UIUX.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("updated body", content);
+}
+
+test "normalizeDrafts: drops active non-delete entries with missing files" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "spec/MISSING.md",
+    }, "body");
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .delete,
+        .draft_path = "spec/DELETE.md",
+        .current_path = "spec/DELETE.md",
+        .context_id = "ctx-delete",
+    }, "");
+
+    try discardDraftFile(testing.allocator, root, .context, "spec/MISSING.md");
+    try normalizeDrafts(testing.allocator, root);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expect(index.findDraftById(.context, "spec/MISSING.md") == null);
+    try testing.expect(index.findDraftById(.context, "ctx-delete") != null);
 }
 
 test "upsertDeleteDraft: folds update draft into delete draft" {

--- a/src/client/tui/api/dispatcher.zig
+++ b/src/client/tui/api/dispatcher.zig
@@ -476,11 +476,12 @@ fn methodName(method: std.http.Method) []const u8 {
 fn logResult(comptime RespT: type, method: std.http.Method, path: []const u8, result: Result(RespT)) void {
     switch (result) {
         .ok => log.info("result ok {s} {s}", .{ methodName(method), logger.redactedPath(path) }),
-        .api_error => |err| log.warn("result api_error {s} {s} status={d} code={s}", .{
+        .api_error => |err| log.warn("result api_error {s} {s} status={d} code={s} message=\"{s}\"", .{
             methodName(method),
             logger.redactedPath(path),
             @intFromEnum(err.status),
             err.code,
+            err.message,
         }),
         .network_error => log.warn("result network_error {s} {s}", .{ methodName(method), logger.redactedPath(path) }),
         .invalid_response => log.warn("result invalid_response {s} {s}", .{ methodName(method), logger.redactedPath(path) }),

--- a/src/client/tui/features/content_actions.zig
+++ b/src/client/tui/features/content_actions.zig
@@ -118,13 +118,13 @@ pub fn handle(
         ctx.consumeAndRedraw();
         return true;
     }
-    if (key.matches('p', .{})) {
-        self.openPrComposer();
+    if (key.matches('P', .{}) or key.matches('p', .{ .shift = true })) {
+        self.openAllDraftsPrComposer();
         ctx.consumeAndRedraw();
         return true;
     }
-    if (key.matches('P', .{}) or key.matches('p', .{ .shift = true })) {
-        self.openAllDraftsPrComposer();
+    if (key.matches('p', .{})) {
+        self.openPrComposer();
         ctx.consumeAndRedraw();
         return true;
     }

--- a/src/client/tui/features/content_actions.zig
+++ b/src/client/tui/features/content_actions.zig
@@ -22,6 +22,7 @@ const workspace_context_shortcuts = [_]w.Shortcut{
     .{ .key = "y", .label = "copy id" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
+    .{ .key = "P", .label = "submit all" },
     .{ .key = "u", .label = "pull" },
     .{ .key = "d", .label = "toggle diff" },
     .{ .key = "D", .label = "discard draft" },
@@ -36,6 +37,7 @@ const workspace_rule_shortcuts = [_]w.Shortcut{
     .{ .key = "y", .label = "copy id" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
+    .{ .key = "P", .label = "submit all" },
     .{ .key = "u", .label = "pull" },
     .{ .key = "d", .label = "toggle diff" },
     .{ .key = "D", .label = "discard draft" },
@@ -51,6 +53,7 @@ const artifact_content_shortcuts = [_]w.Shortcut{
     .{ .key = "n", .label = "new rule" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
+    .{ .key = "P", .label = "submit all" },
     .{ .key = "u", .label = "pull" },
     .{ .key = "d", .label = "toggle diff" },
     .{ .key = "D", .label = "discard" },
@@ -117,6 +120,11 @@ pub fn handle(
     }
     if (key.matches('p', .{})) {
         self.openPrComposer();
+        ctx.consumeAndRedraw();
+        return true;
+    }
+    if (key.matches('P', .{}) or key.matches('p', .{ .shift = true })) {
+        self.openAllDraftsPrComposer();
         ctx.consumeAndRedraw();
         return true;
     }

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -7324,8 +7324,8 @@ pub const Shell = struct {
                 self.markComposerInReview(resp.pr_id, resp.status);
             },
             .api_error => |e| self.handlePrSubmitApiError(e),
-            .network_error => self.failPrComposerSubmit(.failure, "PR submit failed: network error."),
-            .invalid_response => self.failPrComposerSubmit(.failure, "PR submit failed: malformed response."),
+            .network_error => self.keepPrComposerAfterSubmitFailure(.failure, "PR submit failed: network error."),
+            .invalid_response => self.keepPrComposerAfterSubmitFailure(.failure, "PR submit failed: malformed response."),
         }
     }
 
@@ -7483,25 +7483,30 @@ pub const Shell = struct {
                 self.markComposerInReview(resp.pr_id, resp.status);
             },
             .api_error => |e| self.handlePrSubmitApiError(e),
-            .network_error => self.failPrComposerSubmit(.failure, "PR submit failed: network error."),
-            .invalid_response => self.failPrComposerSubmit(.failure, "PR submit failed: malformed response."),
+            .network_error => self.keepPrComposerAfterSubmitFailure(.failure, "PR submit failed: network error."),
+            .invalid_response => self.keepPrComposerAfterSubmitFailure(.failure, "PR submit failed: malformed response."),
         }
     }
 
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
         if (err.status == .conflict and self.drafts.pr_composer_batch_targets.len > 1) {
-            self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; drafts unchanged", err));
+            self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, "PR submit conflict; drafts unchanged", err));
             return;
         }
         if (err.status == .conflict and self.markComposerDraftsStatus(.conflicted)) {
             self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; draft marked conflicted", err));
             return;
         }
-        self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit failed", err));
+        self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, "PR submit failed", err));
     }
 
     fn failPrComposerSubmit(self: *Shell, kind: w.SystemNoticeKind, text: []const u8) void {
         self.closePrComposer();
+        self.notifyOp(kind, text);
+    }
+
+    fn keepPrComposerAfterSubmitFailure(self: *Shell, kind: w.SystemNoticeKind, text: []const u8) void {
+        self.drafts.pr_composer_submitting = false;
         self.notifyOp(kind, text);
     }
 

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -5705,6 +5705,37 @@ pub const Shell = struct {
         self.drafts.show_pr_composer = true;
     }
 
+    /// Handler for the `P` key. Opens a batch PR Composer containing every
+    /// draft in the active workspace scope: Context tab gathers Context
+    /// drafts, Rules/Artifact gather Rule drafts.
+    pub fn openAllDraftsPrComposer(self: *Shell) void {
+        self.refreshDraftsCache();
+        const alloc = self.api_state.allocator();
+        const targets = self.collectAllDraftTargetsForComposer(alloc) orelse return;
+        if (targets.len == 0) {
+            self.notifyOp(.warning, switch (self.selected_module) {
+                .workspace => switch (self.workspace.tab) {
+                    .context => "No context drafts in this workspace.",
+                    .rules => "No rule drafts in this workspace.",
+                },
+                .artifact => "No rule drafts in this workspace.",
+                else => "No draft files in this workspace.",
+            });
+            alloc.free(targets);
+            return;
+        }
+
+        self.releaseComposerTarget();
+        self.drafts.pr_composer_batch_targets = targets;
+        self.drafts.pr_composer_target = targets[0];
+        self.drafts.pr_composer_operation = self.lookupDraftOperation(targets[0]) orelse .update;
+        self.drafts.pr_composer_title_len = 0;
+        self.drafts.pr_composer_body_len = 0;
+        self.drafts.pr_composer_focus = .title;
+        self.drafts.pr_composer_submitting = false;
+        self.drafts.show_pr_composer = true;
+    }
+
     fn openSelectedDraftsPrComposer(self: *Shell) bool {
         const selection_mode = switch (self.selected_module) {
             .artifact => self.artifact.list_machine.selection_mode,
@@ -5796,6 +5827,61 @@ pub const Shell = struct {
         if (!self.validateComposerBatchTargets(targets.items)) {
             return null;
         }
+        const owned = targets.toOwnedSlice(alloc) catch return null;
+        success = true;
+        return owned;
+    }
+
+    fn collectAllDraftTargetsForComposer(self: *Shell, alloc: std.mem.Allocator) ?[]DraftTarget {
+        const ws_id = self.activeWsId() orelse {
+            self.notifyOp(.warning, "No workspace selected.");
+            return null;
+        };
+        const category_filter: drafts_mod.DraftCategory = switch (self.selected_module) {
+            .workspace => switch (self.workspace.tab) {
+                .context => .context,
+                .rules => .rule,
+            },
+            .artifact => .rule,
+            else => {
+                self.notifyOp(.warning, "No draft list in this view.");
+                return null;
+            },
+        };
+
+        const ws_dir = workspace_config.getWsDir(alloc, ws_id) catch {
+            self.notifyOp(.failure, "Could not resolve workspace directory.");
+            return null;
+        };
+        defer alloc.free(ws_dir);
+
+        var index = drafts_mod.loadIndex(alloc, ws_dir) catch |err| {
+            self.notifyOp(.failure, @errorName(err));
+            return null;
+        };
+        defer index.deinit(alloc);
+
+        var targets: std.ArrayList(DraftTarget) = .empty;
+        var success = false;
+        defer if (!success) {
+            for (targets.items) |target| freeDraftTarget(alloc, target);
+            targets.deinit(alloc);
+        };
+
+        for (index.entries.items) |entry| {
+            if (entry.category != category_filter) continue;
+            if (entry.status != .draft) continue;
+            const target = DraftTarget{
+                .ws_id = ws_id,
+                .category = entry.category,
+                .path = entry.current_path orelse entry.draft_path,
+                .rule_id = entry.rule_id,
+                .context_id = entry.context_id,
+            };
+            if (!self.appendComposerDraftTarget(alloc, &targets, target)) return null;
+        }
+
+        if (!self.validateComposerBatchTargets(targets.items)) return null;
         const owned = targets.toOwnedSlice(alloc) catch return null;
         success = true;
         return owned;

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -5670,7 +5670,7 @@ pub const Shell = struct {
             self.notifyOp(.warning, "No draft for this selection.");
             return;
         };
-        if (status != .draft) {
+        if (!self.canSubmitDraftStatus(target, status)) {
             self.notifyOp(.warning, "Draft is not editable.");
             return;
         }
@@ -5870,7 +5870,6 @@ pub const Shell = struct {
 
         for (index.entries.items) |entry| {
             if (entry.category != category_filter) continue;
-            if (entry.status != .draft) continue;
             const target = DraftTarget{
                 .ws_id = ws_id,
                 .category = entry.category,
@@ -5878,6 +5877,7 @@ pub const Shell = struct {
                 .rule_id = entry.rule_id,
                 .context_id = entry.context_id,
             };
+            if (!self.canSubmitDraftStatus(target, entry.status)) continue;
             if (!self.appendComposerDraftTarget(alloc, &targets, target)) return null;
         }
 
@@ -5885,6 +5885,45 @@ pub const Shell = struct {
         const owned = targets.toOwnedSlice(alloc) catch return null;
         success = true;
         return owned;
+    }
+
+    const ExistingContextTarget = struct {
+        context_id: []const u8,
+        base_hash: []const u8,
+    };
+
+    const ExistingRuleTarget = struct {
+        rule_id: []const u8,
+        base_hash: []const u8,
+    };
+
+    fn existingContextTarget(self: *Shell, target: DraftTarget) ?ExistingContextTarget {
+        return switch (target.category) {
+            .context => blk: {
+                const remote = self.api_state.workspace_context_cache.lookup(.{ .value = target.ws_id }) orelse break :blk null;
+                if (findContextByPath(remote, target.path)) |context| {
+                    if (context.context_id.len > 0 and context.hash.len > 0) {
+                        break :blk .{ .context_id = context.context_id, .base_hash = context.hash };
+                    }
+                }
+                break :blk null;
+            },
+            .rule, .meta_prompt => null,
+        };
+    }
+
+    fn existingRuleTarget(self: *Shell, target: DraftTarget) ?ExistingRuleTarget {
+        return switch (target.category) {
+            .rule, .meta_prompt => blk: {
+                if (self.lookupRuleViewByPath(target.path)) |rule| {
+                    if (rule.rule_id.len > 0 and rule.content_hash.len > 0) {
+                        break :blk .{ .rule_id = rule.rule_id, .base_hash = rule.content_hash };
+                    }
+                }
+                break :blk null;
+            },
+            .context => null,
+        };
     }
 
     fn appendComposerDraftTarget(
@@ -5897,7 +5936,7 @@ pub const Shell = struct {
             self.notifyOp(.warning, "Select draft files only.");
             return false;
         };
-        if (status != .draft) {
+        if (!self.canSubmitDraftStatus(target, status)) {
             self.notifyOp(.warning, "Selected draft is not editable.");
             return false;
         }
@@ -5911,6 +5950,27 @@ pub const Shell = struct {
             return false;
         };
         return true;
+    }
+
+    fn canSubmitDraftStatus(
+        self: *Shell,
+        target: DraftTarget,
+        status: drafts_mod.DraftStatus,
+    ) bool {
+        return switch (status) {
+            .draft => true,
+            .conflicted => self.conflictedCreateDraftCanBecomeUpdate(target),
+            .in_review, .applied, .declined => false,
+        };
+    }
+
+    fn conflictedCreateDraftCanBecomeUpdate(self: *Shell, target: DraftTarget) bool {
+        const operation = self.lookupDraftOperation(target) orelse return false;
+        if (operation != .create) return false;
+        return switch (target.category) {
+            .context => self.existingContextTarget(target) != null,
+            .rule, .meta_prompt => self.existingRuleTarget(target) != null,
+        };
     }
 
     fn validateComposerBatchTargets(self: *Shell, targets: []const DraftTarget) bool {
@@ -6082,6 +6142,43 @@ pub const Shell = struct {
         base_hash: ?[]const u8,
     };
 
+    fn validateContentFormatForSubmit(self: *Shell, path: []const u8, content: []const u8) bool {
+        const issue = contentFormatIssue(content) orelse return true;
+        const message = std.fmt.allocPrint(
+            self.api_state.allocator(),
+            "Invalid draft {s}: {s}.",
+            .{ path, issue },
+        ) catch "Invalid draft content.";
+        self.failPrComposerSubmit(.failure, message);
+        return false;
+    }
+
+    fn contentFormatIssue(content: []const u8) ?[]const u8 {
+        var lines = std.mem.splitSequence(u8, content, "\n");
+        var found_heading = false;
+        var found_description = false;
+        var found_section = false;
+        while (lines.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (trimmed.len == 0) continue;
+            if (std.mem.eql(u8, trimmed, "---")) continue;
+            if (trimmed.len >= 2 and trimmed[0] == '#' and trimmed[1] == '#') {
+                found_section = true;
+                break;
+            }
+            if (!found_heading) {
+                if (trimmed[0] != '#') return "missing H1 heading";
+                found_heading = true;
+            } else {
+                found_description = true;
+            }
+        }
+        if (!found_heading) return "missing H1 heading";
+        if (!found_description) return "missing description paragraph before first H2";
+        if (!found_section) return "missing H2 section";
+        return null;
+    }
+
     fn submitRulePr(self: *Shell, target: DraftTarget) void {
         const alloc = self.api_state.allocator();
         const read = self.readDraftForSubmit(alloc, target) orelse return;
@@ -6097,9 +6194,9 @@ pub const Shell = struct {
             self.notifyOp(.warning, "Draft entry missing; try again.");
             return;
         };
-        // Existing-rule operations need identity and base metadata;
-        // create operations carry the new path and content.
-        const operation_type: []const u8 = switch (entry.operation) {
+        const existing_rule = if (entry.operation == .create) self.existingRuleTarget(target) else null;
+        const effective_operation: drafts_mod.DraftOperation = if (existing_rule != null) .update else entry.operation;
+        const operation_type: []const u8 = switch (effective_operation) {
             .create => "create",
             .update => "update",
             .rename => "rename",
@@ -6118,40 +6215,49 @@ pub const Shell = struct {
                 return;
             }) catch return);
         defer if (content_copy) |c| alloc.free(c);
+        if (content_copy) |content| {
+            if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
+        }
 
         // Update/rename/delete need rule_id; resolve from the draft
         // target first (authoritative) then fall back to an artifact
         // lookup by path. Create drafts have neither — that's the
         // expected missing rule_id, not an error.
-        const rule_id_copy_opt: ?[]const u8 = if (entry.operation == .create)
-            null
-        else blk: {
-            const pid = target.rule_id orelse entry.rule_id orelse self.lookupRuleId(target.path) orelse {
-                self.notifyOp(.warning, "Unknown rule id for this draft.");
-                return;
-            };
-            break :blk (alloc.dupe(u8, pid) catch return);
+        const rule_id_copy_opt: ?[]const u8 = switch (effective_operation) {
+            .create => null,
+            else => blk: {
+                const pid = if (existing_rule) |rule|
+                    rule.rule_id
+                else
+                    target.rule_id orelse entry.rule_id orelse self.lookupRuleId(target.path) orelse {
+                        self.notifyOp(.warning, "Unknown rule id for this draft.");
+                        return;
+                    };
+                break :blk (alloc.dupe(u8, pid) catch return);
+            },
         };
         defer if (rule_id_copy_opt) |pid| alloc.free(pid);
 
-        const path_copy_opt: ?[]const u8 = switch (entry.operation) {
+        const path_copy_opt: ?[]const u8 = switch (effective_operation) {
             .create => alloc.dupe(u8, entry.draft_path) catch return,
             else => null,
         };
         defer if (path_copy_opt) |p| alloc.free(p);
-        const new_path_copy_opt: ?[]const u8 = switch (entry.operation) {
+        const new_path_copy_opt: ?[]const u8 = switch (effective_operation) {
             .rename => alloc.dupe(u8, entry.draft_path) catch return,
             else => null,
         };
         defer if (new_path_copy_opt) |p| alloc.free(p);
 
-        const base_hash_copy_opt: ?[]const u8 = if (entry.base_hash) |h|
+        const base_hash_copy_opt: ?[]const u8 = if (existing_rule) |rule|
+            (alloc.dupe(u8, rule.base_hash) catch return)
+        else if (entry.base_hash) |h|
             (alloc.dupe(u8, h) catch return)
         else
             null;
         defer if (base_hash_copy_opt) |h| alloc.free(h);
 
-        if (entry.operation == .update or entry.operation == .rename) {
+        if (effective_operation == .update or effective_operation == .rename) {
             if (base_hash_copy_opt == null) {
                 self.notifyOp(.warning, "Missing base_hash for update/rename draft.");
                 return;
@@ -6211,32 +6317,49 @@ pub const Shell = struct {
                 return;
             };
             if (entry.rule_id) |id| owned.append(alloc, id) catch return;
-            const operation_type: []const u8 = switch (entry.operation) {
+            const existing_rule = if (entry.operation == .create) self.existingRuleTarget(target) else null;
+            const effective_operation: drafts_mod.DraftOperation = if (existing_rule != null) .update else entry.operation;
+            const operation_type: []const u8 = switch (effective_operation) {
                 .create => "create",
                 .update => "update",
                 .rename => "rename",
                 .delete => "delete",
             };
-            const content_copy: ?[]const u8 = if (entry.operation == .delete) null else read.content;
+            const content_copy: ?[]const u8 = if (effective_operation == .delete) null else read.content;
             if (content_copy) |content| owned.append(alloc, content) catch return;
+            if (content_copy) |content| {
+                if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
+            }
 
-            const rule_id = if (entry.operation == .create)
-                null
-            else
-                target.rule_id orelse entry.rule_id orelse self.lookupRuleId(target.path) orelse {
-                    alloc.free(entry.draft_path);
-                    if (entry.base_hash) |h| alloc.free(h);
-                    self.notifyOp(.warning, "Unknown rule id for a selected draft.");
-                    return;
-                };
-            const path: ?[]const u8 = if (entry.operation == .create) entry.draft_path else null;
-            const new_path: ?[]const u8 = if (entry.operation == .rename) entry.draft_path else null;
+            const rule_id: ?[]const u8 = switch (effective_operation) {
+                .create => null,
+                else => blk: {
+                    if (existing_rule) |rule| {
+                        const id = alloc.dupe(u8, rule.rule_id) catch return;
+                        owned.append(alloc, id) catch return;
+                        break :blk id;
+                    }
+                    break :blk target.rule_id orelse entry.rule_id orelse self.lookupRuleId(target.path) orelse {
+                        alloc.free(entry.draft_path);
+                        if (entry.base_hash) |h| alloc.free(h);
+                        self.notifyOp(.warning, "Unknown rule id for a selected draft.");
+                        return;
+                    };
+                },
+            };
+            const path: ?[]const u8 = if (effective_operation == .create) entry.draft_path else null;
+            const new_path: ?[]const u8 = if (effective_operation == .rename) entry.draft_path else null;
             if (path == null and new_path == null) alloc.free(entry.draft_path) else owned.append(alloc, entry.draft_path) catch return;
-            if ((entry.operation == .update or entry.operation == .rename) and entry.base_hash == null) {
+            const base_hash: ?[]const u8 = if (existing_rule) |rule| blk: {
+                const hash = alloc.dupe(u8, rule.base_hash) catch return;
+                owned.append(alloc, hash) catch return;
+                break :blk hash;
+            } else entry.base_hash;
+            if ((effective_operation == .update or effective_operation == .rename) and base_hash == null) {
                 self.notifyOp(.warning, "Missing base_hash for a selected draft.");
                 return;
             }
-            if (entry.base_hash) |h| owned.append(alloc, h) catch return;
+            if (existing_rule == null) if (entry.base_hash) |h| owned.append(alloc, h) catch return;
 
             ops.append(alloc, .{
                 .operation_type = operation_type,
@@ -6244,7 +6367,7 @@ pub const Shell = struct {
                 .path = path,
                 .new_path = new_path,
                 .content = content_copy,
-                .base_hash = entry.base_hash,
+                .base_hash = base_hash,
             }) catch {
                 self.notifyOp(.failure, "Out of memory creating PR.");
                 return;
@@ -6713,7 +6836,9 @@ pub const Shell = struct {
             self.notifyOp(.warning, "Draft entry missing; try again.");
             return;
         };
-        const operation_type: []const u8 = switch (entry.operation) {
+        const existing_context = if (entry.operation == .create) self.existingContextTarget(target) else null;
+        const effective_operation: drafts_mod.DraftOperation = if (existing_context != null) .update else entry.operation;
+        const operation_type: []const u8 = switch (effective_operation) {
             .create => "create",
             .update => "update",
             .rename => "rename",
@@ -6732,32 +6857,48 @@ pub const Shell = struct {
                 return;
             }) catch return);
         defer if (content_copy) |content| alloc.free(content);
+        if (content_copy) |content| {
+            if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
+        }
         const ws_id_copy = alloc.dupe(u8, target.ws_id) catch return;
         defer alloc.free(ws_id_copy);
-        const path_copy_opt: ?[]const u8 = switch (entry.operation) {
+        const path_copy_opt: ?[]const u8 = switch (effective_operation) {
             .create => alloc.dupe(u8, entry.draft_path) catch return,
             else => null,
         };
         defer if (path_copy_opt) |p| alloc.free(p);
-        const new_path_copy_opt: ?[]const u8 = switch (entry.operation) {
+        const new_path_copy_opt: ?[]const u8 = switch (effective_operation) {
             .rename => alloc.dupe(u8, entry.draft_path) catch return,
             else => null,
         };
         defer if (new_path_copy_opt) |p| alloc.free(p);
-        const context_id_copy_opt: ?[]const u8 = if (entry.operation != .create)
-            if (target.context_id) |cid| (alloc.dupe(u8, cid) catch return) else null
-        else
-            null;
+        const context_id_copy_opt: ?[]const u8 = switch (effective_operation) {
+            .create => null,
+            else => if (existing_context) |context|
+                (alloc.dupe(u8, context.context_id) catch return)
+            else if (target.context_id) |cid|
+                (alloc.dupe(u8, cid) catch return)
+            else
+                null,
+        };
         defer if (context_id_copy_opt) |cid| alloc.free(cid);
-        const base_hash_copy_opt: ?[]const u8 = if (entry.base_hash) |h|
+        const base_hash_copy_opt: ?[]const u8 = if (existing_context) |context|
+            (alloc.dupe(u8, context.base_hash) catch return)
+        else if (entry.base_hash) |h|
             (alloc.dupe(u8, h) catch return)
         else
             null;
         defer if (base_hash_copy_opt) |h| alloc.free(h);
 
-        if (entry.operation != .create and context_id_copy_opt == null) {
+        if (effective_operation != .create and context_id_copy_opt == null) {
             self.notifyOp(.warning, "Missing context_id for update/rename/delete.");
             return;
+        }
+        if (effective_operation == .update or effective_operation == .rename) {
+            if (base_hash_copy_opt == null) {
+                self.notifyOp(.warning, "Missing base_hash for update/rename draft.");
+                return;
+            }
         }
 
         api.specs.dispatchFromState(
@@ -6800,35 +6941,57 @@ pub const Shell = struct {
                 self.notifyOp(.warning, "Draft entry missing; try again.");
                 return;
             };
-            const operation_type: []const u8 = switch (entry.operation) {
+            const existing_context = if (entry.operation == .create) self.existingContextTarget(target) else null;
+            const effective_operation: drafts_mod.DraftOperation = if (existing_context != null) .update else entry.operation;
+            const operation_type: []const u8 = switch (effective_operation) {
                 .create => "create",
                 .update => "update",
                 .rename => "rename",
                 .delete => "delete",
             };
-            if (read.content) |content| owned.append(alloc, content) catch return;
+            const content: ?[]const u8 = if (effective_operation == .delete) null else read.content;
+            if (content) |body| owned.append(alloc, body) catch return;
+            if (content) |body| {
+                if (!self.validateContentFormatForSubmit(entry.draft_path, body)) return;
+            }
 
-            const context_id = if (entry.operation == .create)
-                null
-            else
-                target.context_id orelse {
-                    alloc.free(entry.draft_path);
-                    if (entry.base_hash) |h| alloc.free(h);
-                    self.notifyOp(.warning, "Missing context_id for a selected draft.");
-                    return;
-                };
-            const path: ?[]const u8 = if (entry.operation == .create) entry.draft_path else null;
-            const new_path: ?[]const u8 = if (entry.operation == .rename) entry.draft_path else null;
+            const context_id: ?[]const u8 = switch (effective_operation) {
+                .create => null,
+                else => blk: {
+                    if (existing_context) |context| {
+                        const id = alloc.dupe(u8, context.context_id) catch return;
+                        owned.append(alloc, id) catch return;
+                        break :blk id;
+                    }
+                    break :blk target.context_id orelse {
+                        alloc.free(entry.draft_path);
+                        if (entry.base_hash) |h| alloc.free(h);
+                        self.notifyOp(.warning, "Missing context_id for a selected draft.");
+                        return;
+                    };
+                },
+            };
+            const path: ?[]const u8 = if (effective_operation == .create) entry.draft_path else null;
+            const new_path: ?[]const u8 = if (effective_operation == .rename) entry.draft_path else null;
             if (path == null and new_path == null) alloc.free(entry.draft_path) else owned.append(alloc, entry.draft_path) catch return;
-            if (entry.base_hash) |h| owned.append(alloc, h) catch return;
+            const base_hash: ?[]const u8 = if (existing_context) |context| blk: {
+                const hash = alloc.dupe(u8, context.base_hash) catch return;
+                owned.append(alloc, hash) catch return;
+                break :blk hash;
+            } else entry.base_hash;
+            if ((effective_operation == .update or effective_operation == .rename) and base_hash == null) {
+                self.notifyOp(.warning, "Missing base_hash for a selected draft.");
+                return;
+            }
+            if (existing_context == null) if (entry.base_hash) |h| owned.append(alloc, h) catch return;
 
             ops.append(alloc, .{
                 .operation_type = operation_type,
                 .context_id = context_id,
                 .path = path,
                 .new_path = new_path,
-                .content = read.content,
-                .base_hash = entry.base_hash,
+                .content = content,
+                .base_hash = base_hash,
             }) catch {
                 self.notifyOp(.failure, "Out of memory creating PR.");
                 return;
@@ -7115,8 +7278,8 @@ pub const Shell = struct {
                 self.markComposerInReview(resp.pr_id, resp.status);
             },
             .api_error => |e| self.handlePrSubmitApiError(e),
-            .network_error => self.notifyOp(.failure, "PR submit failed: network error."),
-            .invalid_response => self.notifyOp(.failure, "PR submit failed: malformed response."),
+            .network_error => self.failPrComposerSubmit(.failure, "PR submit failed: network error."),
+            .invalid_response => self.failPrComposerSubmit(.failure, "PR submit failed: malformed response."),
         }
     }
 
@@ -7274,18 +7437,22 @@ pub const Shell = struct {
                 self.markComposerInReview(resp.pr_id, resp.status);
             },
             .api_error => |e| self.handlePrSubmitApiError(e),
-            .network_error => self.notifyOp(.failure, "PR submit failed: network error."),
-            .invalid_response => self.notifyOp(.failure, "PR submit failed: malformed response."),
+            .network_error => self.failPrComposerSubmit(.failure, "PR submit failed: network error."),
+            .invalid_response => self.failPrComposerSubmit(.failure, "PR submit failed: malformed response."),
         }
     }
 
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
         if (err.status == .conflict and self.markComposerDraftsStatus(.conflicted)) {
-            self.closePrComposer();
-            self.notifyOp(.failure, writeErrorStatus(self, "PR submit conflict; draft marked conflicted", err));
+            self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; draft marked conflicted", err));
             return;
         }
-        self.notifyOp(.failure, writeErrorStatus(self, "PR submit failed", err));
+        self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit failed", err));
+    }
+
+    fn failPrComposerSubmit(self: *Shell, kind: w.SystemNoticeKind, text: []const u8) void {
+        self.closePrComposer();
+        self.notifyOp(kind, text);
     }
 
     fn closePrComposer(self: *Shell) void {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -5915,6 +5915,14 @@ pub const Shell = struct {
     fn existingRuleTarget(self: *Shell, target: DraftTarget) ?ExistingRuleTarget {
         return switch (target.category) {
             .rule, .meta_prompt => blk: {
+                const remote = self.api_state.workspace_manifest_cache.lookup(.{ .value = target.ws_id });
+                if (remote) |rules| {
+                    if (self.findRuleFor(rules, target.path, target.rule_id)) |rule| {
+                        if (rule.rule_id.len > 0 and rule.content_hash.len > 0) {
+                            break :blk .{ .rule_id = rule.rule_id, .base_hash = rule.content_hash };
+                        }
+                    }
+                }
                 if (self.lookupRuleViewByPath(target.path)) |rule| {
                     if (rule.rule_id.len > 0 and rule.content_hash.len > 0) {
                         break :blk .{ .rule_id = rule.rule_id, .base_hash = rule.content_hash };
@@ -6111,7 +6119,7 @@ pub const Shell = struct {
         };
         defer index.deinit(alloc);
 
-        const draft_entry = index.findDraftById(target.category, target.path) orelse {
+        const draft_entry = self.findDraftEntryForSubmit(&index, target) orelse {
             self.notifyOp(.warning, "Draft entry missing; try again.");
             return null;
         };
@@ -6133,6 +6141,37 @@ pub const Shell = struct {
         };
 
         return .{ .ws_dir = ws_dir, .content = content, .entry = entry_out };
+    }
+
+    fn findDraftEntryForSubmit(self: *Shell, index: *const drafts_mod.DraftsIndex, target: DraftTarget) ?*const drafts_mod.DraftEntry {
+        for (index.entries.items) |*entry| {
+            if (entry.category != target.category) continue;
+            if (!self.canSubmitDraftStatus(target, entry.status)) continue;
+            if (entry.current_path) |current_path| {
+                if (std.mem.eql(u8, current_path, target.path)) return entry;
+            } else if (entry.operation == .create and std.mem.eql(u8, entry.draft_path, target.path)) {
+                return entry;
+            }
+        }
+
+        for (index.entries.items) |*entry| {
+            if (entry.category != target.category) continue;
+            if (!self.canSubmitDraftStatus(target, entry.status)) continue;
+            if (std.mem.eql(u8, entry.draft_path, target.path)) return entry;
+            if (entry.local_temp_id) |value| {
+                if (std.mem.eql(u8, value, target.path)) return entry;
+            }
+            switch (target.category) {
+                .rule, .meta_prompt => if (entry.rule_id) |value| {
+                    if (std.mem.eql(u8, value, target.path)) return entry;
+                },
+                .context => if (entry.context_id) |value| {
+                    if (std.mem.eql(u8, value, target.path)) return entry;
+                },
+            }
+        }
+
+        return null;
     }
 
     const DraftSubmitEntry = struct {
@@ -6372,6 +6411,13 @@ pub const Shell = struct {
                 self.notifyOp(.failure, "Out of memory creating PR.");
                 return;
             };
+            log.info("rule_pr_batch_op idx={d} type={s} target_path={s} rule_id={s} base_hash={s}", .{
+                ops.items.len - 1,
+                operation_type,
+                target.path,
+                rule_id orelse "",
+                base_hash orelse "",
+            });
         }
 
         const title_copy = alloc.dupe(u8, self.drafts.pr_composer_title_buf[0..self.drafts.pr_composer_title_len]) catch return;
@@ -7443,6 +7489,10 @@ pub const Shell = struct {
     }
 
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
+        if (err.status == .conflict and self.drafts.pr_composer_batch_targets.len > 1) {
+            self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; drafts unchanged", err));
+            return;
+        }
         if (err.status == .conflict and self.markComposerDraftsStatus(.conflicted)) {
             self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; draft marked conflicted", err));
             return;


### PR DESCRIPTION
## Summary

This PR adds a `P` shortcut to the TUI for submitting all draft changes
in the active workspace scope. Pressing `P` from the Context tab opens a
single PR composer for all Context drafts, while pressing it from the
Rules or Artifact views opens one composer for Rule drafts. Context and
Rule changes still submit as separate PRs so their review paths stay
independent.

The PR also hardens stale draft recovery around batch submission. Sync
prunes stale cache files, restores drafts whose conflicts are no longer
valid, and drops active draft entries whose backing file has disappeared.
Submit paths convert create drafts into updates when the target already
exists, close the composer on non-editable errors, and avoid marking an
entire batch as conflicted when the server rejects one batch request.

Rule batch submission now resolves the active draft by submit-eligible
status and current path before falling back to broader draft identifiers.
This prevents stale rename drafts that share a target path from sending
obsolete base hashes. Client error logs now include the server message and
batch Rule PR submission records each operation summary for diagnosis.

## Test plan

- [x] Press `P` from a workspace Context tab and verify one Context PR composer opens for all Context drafts.
- [x] Press `P` from a workspace Rules tab and verify one Rule PR composer opens for all Rule drafts.
- [x] Press `P` from the Artifact view and verify Rule drafts submit separately from Context drafts.
- [x] Submit Rule drafts after a stale rename draft exists locally and verify obsolete base hashes are not sent.
- [x] Run `zig build`.
- [x] Run `zig build test`.
