### PR TITLE
client: avoid false draft and adapt conflicts

### DIFF
--- a/src/client/adapter/primitives/json_ops.zig
+++ b/src/client/adapter/primitives/json_ops.zig
@@ -192,6 +192,7 @@ fn inspectManagedItem(items: []const std.json.Value, managed_item: std.json.Valu
     }
 
     if (related_non_exact) return .conflict;
+    if (exact_index != null and replace_index != null) return .conflict;
     if (exact_index) |index| return .{ .exact = index };
     if (replace_index) |index| return .{ .replace = index };
     return .absent;
@@ -552,6 +553,59 @@ test "prepareJsonHooksRegistry rejects drifted stale clumsies hook entries" {
         \\    "SessionStart": [
         \\      {
         \\        "matcher": "resume-only",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/old/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const managed =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "startup|resume",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/new/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+
+    const result = try prepareJsonHooksRegistry(allocator, existing, managed);
+    switch (result) {
+        .conflict => |message| try std.testing.expectEqualStrings(conflict_incompatible_item, message),
+        else => return error.ExpectedConflict,
+    }
+}
+
+test "prepareJsonHooksRegistry rejects exact hook plus stale duplicate" {
+    const allocator = std.testing.allocator;
+    const existing =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "startup|resume",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/new/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      },
+        \\      {
+        \\        "matcher": "startup|resume",
         \\        "hooks": [
         \\          {
         \\            "type": "command",

--- a/src/client/adapter/primitives/json_ops.zig
+++ b/src/client/adapter/primitives/json_ops.zig
@@ -70,6 +70,10 @@ pub fn prepareJsonHooksRegistry(
         for (managed_items.items) |managed_item| {
             switch (inspectManagedItem(current_items.items, managed_item)) {
                 .exact => {},
+                .replace => |index| {
+                    current_items.items[index] = try cloneValue(arena, managed_item);
+                    did_change = true;
+                },
                 .absent => {
                     try current_items.append(try cloneValue(arena, managed_item));
                     did_change = true;
@@ -126,6 +130,7 @@ pub fn removeJsonHooksRegistry(
             switch (match) {
                 .exact => |index| try indexes_to_remove.append(allocator, index),
                 .absent => {},
+                .replace => return .{ .conflict = conflict_incompatible_item },
                 .conflict => return .{ .conflict = conflict_incompatible_item },
             }
         }
@@ -158,11 +163,13 @@ pub fn removeJsonHooksRegistry(
 const ItemMatch = union(enum) {
     absent,
     exact: usize,
+    replace: usize,
     conflict,
 };
 
 fn inspectManagedItem(items: []const std.json.Value, managed_item: std.json.Value) ItemMatch {
     var exact_index: ?usize = null;
+    var replace_index: ?usize = null;
     var related_non_exact = false;
 
     for (items, 0..) |item, index| {
@@ -171,13 +178,22 @@ fn inspectManagedItem(items: []const std.json.Value, managed_item: std.json.Valu
             exact_index = index;
             continue;
         }
+        if (managedHookItemCanReplace(item, managed_item)) {
+            if (replace_index != null) return .conflict;
+            replace_index = index;
+            continue;
+        }
         if (itemsOverlapOnCommand(item, managed_item)) {
+            related_non_exact = true;
+        }
+        if (itemsOverlapOnClumsiesHookKind(item, managed_item)) {
             related_non_exact = true;
         }
     }
 
     if (related_non_exact) return .conflict;
     if (exact_index) |index| return .{ .exact = index };
+    if (replace_index) |index| return .{ .replace = index };
     return .absent;
 }
 
@@ -283,6 +299,95 @@ fn itemsOverlapOnCommand(left: std.json.Value, right: std.json.Value) bool {
     return false;
 }
 
+fn itemsOverlapOnClumsiesHookKind(left: std.json.Value, right: std.json.Value) bool {
+    const left_hooks = nestedHooksArray(left) orelse return false;
+    const right_hooks = nestedHooksArray(right) orelse return false;
+
+    for (left_hooks) |left_hook| {
+        const left_command = hookCommand(left_hook) orelse continue;
+        const left_kind = clumsiesHookScriptName(left_command) orelse continue;
+        for (right_hooks) |right_hook| {
+            const right_command = hookCommand(right_hook) orelse continue;
+            const right_kind = clumsiesHookScriptName(right_command) orelse continue;
+            if (std.mem.eql(u8, left_kind, right_kind)) return true;
+        }
+    }
+    return false;
+}
+
+fn managedHookItemCanReplace(current_item: std.json.Value, managed_item: std.json.Value) bool {
+    const current_object = asObject(current_item) orelse return false;
+    const managed_object = asObject(managed_item) orelse return false;
+    if (current_object.count() != managed_object.count()) return false;
+
+    var it = managed_object.iterator();
+    while (it.next()) |entry| {
+        const current_value = current_object.get(entry.key_ptr.*) orelse return false;
+        if (std.mem.eql(u8, entry.key_ptr.*, "hooks")) {
+            if (!hookArraysCanReplace(current_value, entry.value_ptr.*)) return false;
+            continue;
+        }
+        if (!valueEql(current_value, entry.value_ptr.*)) return false;
+    }
+    return true;
+}
+
+fn hookArraysCanReplace(current_hooks_value: std.json.Value, managed_hooks_value: std.json.Value) bool {
+    const current_hooks = switch (current_hooks_value) {
+        .array => |array| array.items,
+        else => return false,
+    };
+    const managed_hooks = switch (managed_hooks_value) {
+        .array => |array| array.items,
+        else => return false,
+    };
+    if (current_hooks.len != managed_hooks.len) return false;
+
+    var replaced_command = false;
+    for (current_hooks, managed_hooks) |current_hook, managed_hook| {
+        const current_object = asObject(current_hook) orelse return false;
+        const managed_object = asObject(managed_hook) orelse return false;
+        if (current_object.count() != managed_object.count()) return false;
+
+        var it = managed_object.iterator();
+        while (it.next()) |entry| {
+            const current_value = current_object.get(entry.key_ptr.*) orelse return false;
+            if (std.mem.eql(u8, entry.key_ptr.*, "command")) {
+                const current_command = switch (current_value) {
+                    .string => |string| string,
+                    else => return false,
+                };
+                const managed_command = switch (entry.value_ptr.*) {
+                    .string => |string| string,
+                    else => return false,
+                };
+                if (std.mem.eql(u8, current_command, managed_command)) continue;
+                const current_kind = clumsiesHookScriptName(current_command) orelse return false;
+                const managed_kind = clumsiesHookScriptName(managed_command) orelse return false;
+                if (!std.mem.eql(u8, current_kind, managed_kind)) return false;
+                replaced_command = true;
+                continue;
+            }
+            if (!valueEql(current_value, entry.value_ptr.*)) return false;
+        }
+    }
+    return replaced_command;
+}
+
+fn clumsiesHookScriptName(command: []const u8) ?[]const u8 {
+    const names = [_][]const u8{
+        "session-start.sh",
+        "user-prompt-submit.sh",
+        "stop-refer-check.sh",
+    };
+    for (names) |name| {
+        const name_pos = std.mem.indexOf(u8, command, name) orelse continue;
+        if (std.mem.indexOf(u8, command[0..name_pos], "/.codex/hooks/") != null) return name;
+        if (std.mem.indexOf(u8, command[0..name_pos], "/hooks/") != null and std.mem.endsWith(u8, command, "\"")) return name;
+    }
+    return null;
+}
+
 fn nestedHooksArray(item: std.json.Value) ?[]const std.json.Value {
     const object = asObject(item) orelse return null;
     const hooks = object.get("hooks") orelse return null;
@@ -381,6 +486,105 @@ test "prepareJsonHooksRegistry appends managed entries without dropping foreign 
             try std.testing.expect(std.mem.indexOf(u8, prepared.rendered_content, "echo foreign") != null);
             try std.testing.expect(std.mem.indexOf(u8, prepared.rendered_content, "session-start.sh") != null);
         },
+    }
+}
+
+test "prepareJsonHooksRegistry replaces stale clumsies hook paths" {
+    const allocator = std.testing.allocator;
+    const existing =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "startup|resume",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/old/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const managed =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "startup|resume",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/new/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+
+    const result = try prepareJsonHooksRegistry(allocator, existing, managed);
+    switch (result) {
+        .conflict => |message| {
+            std.debug.print("unexpected conflict: {s}\n", .{message});
+            return error.UnexpectedConflict;
+        },
+        .prepared => |prepared| {
+            defer {
+                var owned = prepared;
+                owned.deinit(allocator);
+            }
+            try std.testing.expectEqualStrings("update", prepared.action);
+            try std.testing.expect(std.mem.indexOf(u8, prepared.rendered_content, "/old/.codex") == null);
+            try std.testing.expect(std.mem.indexOf(u8, prepared.rendered_content, "/new/.codex/hooks/session-start.sh") != null);
+        },
+    }
+}
+
+test "prepareJsonHooksRegistry rejects drifted stale clumsies hook entries" {
+    const allocator = std.testing.allocator;
+    const existing =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "resume-only",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/old/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+    const managed =
+        \\{
+        \\  "hooks": {
+        \\    "SessionStart": [
+        \\      {
+        \\        "matcher": "startup|resume",
+        \\        "hooks": [
+        \\          {
+        \\            "type": "command",
+        \\            "command": "bash \"/new/.codex/hooks/session-start.sh\""
+        \\          }
+        \\        ]
+        \\      }
+        \\    ]
+        \\  }
+        \\}
+    ;
+
+    const result = try prepareJsonHooksRegistry(allocator, existing, managed);
+    switch (result) {
+        .conflict => |message| try std.testing.expectEqualStrings(conflict_incompatible_item, message),
+        else => return error.ExpectedConflict,
     }
 }
 

--- a/src/client/commands/adapt_cmd.zig
+++ b/src/client/commands/adapt_cmd.zig
@@ -607,7 +607,10 @@ fn bindExistingWorkspaceByName(
         allocator,
         me_response.body,
         .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
-    ) catch return false;
+    ) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return false,
+    };
     defer parsed.deinit();
 
     const existing = findAccessibleWorkspaceByName(parsed.value.workspaces, workspace_name) orelse return false;

--- a/src/client/commands/adapt_cmd.zig
+++ b/src/client/commands/adapt_cmd.zig
@@ -7,6 +7,7 @@ const styles = @import("../styles.zig");
 const workspace_config = @import("../workspace_config.zig");
 const HubClient = @import("../hub_client.zig").HubClient;
 const workspace_api = @import("clumsies_lib").protocol.workspace_api;
+const auth_api = @import("clumsies_lib").protocol.auth_api;
 const api_error = @import("clumsies_lib").protocol.api_error;
 const sync_cmd = @import("sync_cmd.zig");
 
@@ -540,28 +541,35 @@ fn createAndBindCurrentWorkspace(
     );
     defer allocator.free(body);
 
-    const response = try hub.post("/api/workspaces", body);
-    defer response.deinit();
-    if (response.status != .ok and response.status != .created) {
+    const created = blk: {
+        const response = try hub.post("/api/workspaces", body);
+        defer response.deinit();
+        if (response.status == .ok or response.status == .created) {
+            const parsed = try std.json.parseFromSlice(
+                workspace_api.CreateWorkspaceResponse,
+                allocator,
+                response.body,
+                .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+            );
+            break :blk parsed;
+        }
+        if (response.status == .conflict) {
+            if (try bindExistingWorkspaceByName(stdout, stderr, allocator, &hub, auth_info.hub_url, cwd_path, workspace_name)) {
+                return cwd_path;
+            }
+        }
         try reportApiError(stderr, allocator, "Failed to create workspace", response.status, response.body);
         return error.WorkspaceCreateFailed;
-    }
+    };
+    defer created.deinit();
 
-    const parsed = try std.json.parseFromSlice(
-        workspace_api.CreateWorkspaceResponse,
-        allocator,
-        response.body,
-        .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
-    );
-    defer parsed.deinit();
-
-    try workspace_config.addWorkspace(allocator, auth_info.hub_url, parsed.value.name, parsed.value.ws_id, cwd_path);
+    try workspace_config.addWorkspace(allocator, auth_info.hub_url, created.value.name, created.value.ws_id, cwd_path);
     try stdout.print(
         "{s}  {s}{s}Workspace \"{s}\" bound to current directory (ws_id: {s}){s}\n",
-        .{ P, Color.bold, Color.green, parsed.value.name, parsed.value.ws_id, Color.reset },
+        .{ P, Color.bold, Color.green, created.value.name, created.value.ws_id, Color.reset },
     );
 
-    const summary = sync_cmd.materializeWorkspace(allocator, &hub, parsed.value.ws_id, .{ .errors = stderr }) catch |err| {
+    const summary = sync_cmd.materializeWorkspace(allocator, &hub, created.value.ws_id, .{ .errors = stderr }) catch |err| {
         try stderr.print(
             "{s}{s}{s}Warning:{s} Initial sync failed: {s}. The adapter install will continue.\n",
             .{ P, Color.bold, Color.orange, Color.reset, @errorName(err) },
@@ -573,6 +581,64 @@ fn createAndBindCurrentWorkspace(
         .{ P, Color.bold, Color.green, Color.reset, summary.rules_total, summary.context_total },
     );
     return cwd_path;
+}
+
+fn bindExistingWorkspaceByName(
+    stdout: *std.Io.Writer,
+    stderr: *std.Io.Writer,
+    allocator: std.mem.Allocator,
+    hub: *HubClient,
+    hub_url: []const u8,
+    cwd_path: []const u8,
+    workspace_name: []const u8,
+) !bool {
+    const me_response = hub.get("/api/auth/me") catch |err| {
+        try stderr.print(
+            "{s}{s}{s}Warning:{s} Workspace \"{s}\" already exists, but lookup failed: {s}.\n",
+            .{ P, Color.bold, Color.orange, Color.reset, workspace_name, @errorName(err) },
+        );
+        return false;
+    };
+    defer me_response.deinit();
+    if (me_response.status != .ok) return false;
+
+    const parsed = std.json.parseFromSlice(
+        auth_api.MeResponse,
+        allocator,
+        me_response.body,
+        .{ .allocate = .alloc_always, .ignore_unknown_fields = true },
+    ) catch return false;
+    defer parsed.deinit();
+
+    const existing = findAccessibleWorkspaceByName(parsed.value.workspaces, workspace_name) orelse return false;
+    try workspace_config.addWorkspace(allocator, hub_url, existing.name, existing.ws_id, cwd_path);
+    try stdout.print(
+        "{s}  {s}{s}Workspace \"{s}\" already exists; bound current directory (ws_id: {s}){s}\n",
+        .{ P, Color.bold, Color.green, existing.name, existing.ws_id, Color.reset },
+    );
+
+    const summary = sync_cmd.materializeWorkspace(allocator, hub, existing.ws_id, .{ .errors = stderr }) catch |err| {
+        try stderr.print(
+            "{s}{s}{s}Warning:{s} Initial sync failed: {s}. The adapter install will continue.\n",
+            .{ P, Color.bold, Color.orange, Color.reset, @errorName(err) },
+        );
+        return true;
+    };
+    try stdout.print(
+        "{s}  {s}{s}Synced:{s} {d} rules, {d} context files into local cache\n",
+        .{ P, Color.bold, Color.green, Color.reset, summary.rules_total, summary.context_total },
+    );
+    return true;
+}
+
+fn findAccessibleWorkspaceByName(workspaces: []const auth_api.MeWorkspace, name: []const u8) ?auth_api.MeWorkspace {
+    var found: ?auth_api.MeWorkspace = null;
+    for (workspaces) |workspace| {
+        if (!std.mem.eql(u8, workspace.name, name)) continue;
+        if (found != null) return null;
+        found = workspace;
+    }
+    return found;
 }
 
 fn currentDirectoryName(allocator: std.mem.Allocator) ![]const u8 {
@@ -941,4 +1007,24 @@ fn countWorkflowSkills(plan: *const adapter.model.Plan) usize {
         }
     }
     return count;
+}
+
+test "findAccessibleWorkspaceByName returns unique matching workspace" {
+    const workspaces = [_]auth_api.MeWorkspace{
+        .{ .ws_id = "ws-one", .name = "duckweed", .description = "", .role = "admin", .owner = "wei" },
+        .{ .ws_id = "ws-two", .name = "okra", .description = "", .role = "admin", .owner = "wei" },
+    };
+
+    const found = findAccessibleWorkspaceByName(&workspaces, "duckweed") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings("ws-one", found.ws_id);
+}
+
+test "findAccessibleWorkspaceByName rejects missing or ambiguous names" {
+    const workspaces = [_]auth_api.MeWorkspace{
+        .{ .ws_id = "ws-one", .name = "duckweed", .description = "", .role = "admin", .owner = "wei" },
+        .{ .ws_id = "ws-two", .name = "duckweed", .description = "", .role = "member", .owner = "wei" },
+    };
+
+    try std.testing.expect(findAccessibleWorkspaceByName(&workspaces, "missing") == null);
+    try std.testing.expect(findAccessibleWorkspaceByName(&workspaces, "duckweed") == null);
 }

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -2657,6 +2657,64 @@ test "reconcileDrafts: restores conflicted create when target is absent from cac
     try testing.expectEqual(DraftStatus.draft, index.entries.items[0].status);
 }
 
+test "reconcileDraftsWithOptions: can keep conflicted update sticky" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    const seed = "v1 body\n";
+    const seed_hash = util_hash.contentHash(seed);
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .update,
+        .draft_path = "spec/API.md",
+        .current_path = "spec/API.md",
+        .context_id = "ctx-api",
+        .base_hash = seed_hash[0..],
+    }, "local edit\n");
+    try setDraftStatus(testing.allocator, root, .context, "spec/API.md", .conflicted);
+
+    try tmp.dir.makePath("cache/context/spec");
+    try writeFile(tmp.dir, "cache/context/spec/API.md", seed);
+
+    const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
+    defer testing.allocator.free(cache_dir);
+
+    const summary = try reconcileDraftsWithOptions(testing.allocator, root, cache_dir, .{ .restore_conflicted = false });
+    try testing.expectEqual(@as(usize, 0), summary.restored);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(DraftStatus.conflicted, index.entries.items[0].status);
+}
+
+test "reconcileDraftsWithOptions: can keep conflicted create sticky" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "todo/NEXT.md",
+    }, "new todo\n");
+    try setDraftStatus(testing.allocator, root, .context, "todo/NEXT.md", .conflicted);
+
+    const cache_dir = try std.fs.path.join(testing.allocator, &.{ root, "cache" });
+    defer testing.allocator.free(cache_dir);
+
+    const summary = try reconcileDraftsWithOptions(testing.allocator, root, cache_dir, .{ .restore_conflicted = false });
+    try testing.expectEqual(@as(usize, 0), summary.restored);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(DraftStatus.conflicted, index.entries.items[0].status);
+}
+
 test "reconcileDrafts: leaves terminal applied and declined statuses sticky" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -55,7 +55,7 @@ fn isTerminalStatus(status: DraftStatus) bool {
     };
 }
 
-fn isRetiredStatus(status: DraftStatus) bool {
+pub fn isRetiredStatus(status: DraftStatus) bool {
     return switch (status) {
         .applied, .declined => true,
         .draft, .in_review, .conflicted => false,
@@ -478,7 +478,7 @@ pub fn upsertUpdateDraft(
 
     if (findDraftPathIndex(index.entries.items, params.category, params.current_path)) |entry_index| {
         var entry = &index.entries.items[entry_index];
-        if (entry.operation != .create) return error.DraftAlreadyExists;
+        if (entry.operation != .create or entry.status != .conflicted) return error.DraftAlreadyExists;
 
         try writeDraftFileAbs(allocator, ws_dir, params.category, entry.draft_path, content);
         entry.operation = .update;
@@ -1211,6 +1211,33 @@ pub fn setDraftStatus(
             found = true;
             break;
         }
+    }
+    if (!found) return error.DraftNotFound;
+
+    try writeIndexAtomic(allocator, ws_dir, index.entries.items);
+}
+
+pub fn setActiveDraftStatus(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    category: DraftCategory,
+    draft_path: []const u8,
+    new_status: DraftStatus,
+) !void {
+    if (!path_util.isSafeRelative(draft_path)) return error.UnsafeDraftPath;
+
+    var index = try loadIndex(allocator, ws_dir);
+    defer index.deinit(allocator);
+
+    var found = false;
+    for (index.entries.items) |*entry| {
+        if (entry.category != category) continue;
+        if (isRetiredStatus(entry.status)) continue;
+        if (!std.mem.eql(u8, entry.draft_path, draft_path)) continue;
+        if (entry.status == new_status) return;
+        entry.status = new_status;
+        found = true;
+        break;
     }
     if (!found) return error.DraftNotFound;
 
@@ -2092,6 +2119,81 @@ test "upsertUpdateDraft: converts conflicted create with same path" {
     const content = try readDraftFile(testing.allocator, root, .context, "spec/OVERVIEW.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("# Updated overview\n", content);
+}
+
+test "upsertUpdateDraft: active create with same path stays create" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "spec/OVERVIEW.md",
+        .local_temp_id = "tmp-context-overview",
+    }, "# Created overview\n");
+
+    try testing.expectError(error.DraftAlreadyExists, upsertUpdateDraft(testing.allocator, root, .{
+        .category = .context,
+        .current_path = "spec/OVERVIEW.md",
+        .context_id = "ctx-overview",
+        .base_hash = "sha256:base",
+    }, "# Updated overview\n"));
+
+    try setDraftStatus(testing.allocator, root, .context, "spec/OVERVIEW.md", .in_review);
+    try testing.expectError(error.DraftAlreadyExists, upsertUpdateDraft(testing.allocator, root, .{
+        .category = .context,
+        .current_path = "spec/OVERVIEW.md",
+        .context_id = "ctx-overview",
+        .base_hash = "sha256:base",
+    }, "# Updated overview\n"));
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), index.entries.items.len);
+    const entry = index.entries.items[0];
+    try testing.expectEqual(DraftOperation.create, entry.operation);
+    try testing.expectEqual(DraftStatus.in_review, entry.status);
+    try testing.expect(entry.current_path == null);
+    try testing.expectEqualStrings("tmp-context-overview", entry.local_temp_id.?);
+
+    const content = try readDraftFile(testing.allocator, root, .context, "spec/OVERVIEW.md");
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("# Created overview\n", content);
+}
+
+test "setActiveDraftStatus: skips retired entries with same path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .rule,
+        .operation = .update,
+        .draft_path = "coding/A.md",
+        .current_path = "coding/A.md",
+        .base_hash = "sha256:old",
+    }, "old");
+    try setDraftStatus(testing.allocator, root, .rule, "coding/A.md", .applied);
+    try createDraft(testing.allocator, root, .{
+        .category = .rule,
+        .operation = .update,
+        .draft_path = "coding/A.md",
+        .current_path = "coding/A.md",
+        .base_hash = "sha256:new",
+    }, "new");
+
+    try setActiveDraftStatus(testing.allocator, root, .rule, "coding/A.md", .conflicted);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 2), index.entries.items.len);
+    try testing.expectEqual(DraftStatus.applied, index.entries.items[0].status);
+    try testing.expectEqual(DraftStatus.conflicted, index.entries.items[1].status);
 }
 
 test "normalizeDrafts: folds duplicate update and rename entries" {

--- a/src/client/drafts.zig
+++ b/src/client/drafts.zig
@@ -55,6 +55,13 @@ fn isTerminalStatus(status: DraftStatus) bool {
     };
 }
 
+fn isRetiredStatus(status: DraftStatus) bool {
+    return switch (status) {
+        .applied, .declined => true,
+        .draft, .in_review, .conflicted => false,
+    };
+}
+
 /// Parsed drafts index. Strings borrow from an arena; deinit drops the arena.
 pub const DraftsIndex = struct {
     arena_state: *std.heap.ArenaAllocator,
@@ -413,10 +420,19 @@ fn draftPathAvailable(entries: []const DraftEntry, category: DraftCategory, draf
     for (entries, 0..) |entry, i| {
         if (skip_index != null and i == skip_index.?) continue;
         if (entry.category != category) continue;
-        if (isTerminalStatus(entry.status)) continue;
+        if (isRetiredStatus(entry.status)) continue;
         if (std.mem.eql(u8, entry.draft_path, draft_path)) return false;
     }
     return true;
+}
+
+fn findDraftPathIndex(entries: []DraftEntry, category: DraftCategory, draft_path: []const u8) ?usize {
+    for (entries, 0..) |entry, i| {
+        if (entry.category != category) continue;
+        if (isRetiredStatus(entry.status)) continue;
+        if (std.mem.eql(u8, entry.draft_path, draft_path)) return i;
+    }
+    return null;
 }
 
 fn identityFromEntry(allocator: std.mem.Allocator, entry: DraftEntry, previous_path: ?[]const u8) !DraftIdentity {
@@ -456,6 +472,23 @@ pub fn upsertUpdateDraft(
             entry.operation = .update;
             entry.current_path = params.current_path;
         }
+        try writeIndexAtomic(allocator, ws_dir, index.entries.items);
+        return try identityFromEntry(allocator, entry.*, null);
+    }
+
+    if (findDraftPathIndex(index.entries.items, params.category, params.current_path)) |entry_index| {
+        var entry = &index.entries.items[entry_index];
+        if (entry.operation != .create) return error.DraftAlreadyExists;
+
+        try writeDraftFileAbs(allocator, ws_dir, params.category, entry.draft_path, content);
+        entry.operation = .update;
+        entry.current_path = params.current_path;
+        entry.local_temp_id = null;
+        if (entry.rule_id == null) entry.rule_id = params.rule_id;
+        if (entry.context_id == null) entry.context_id = params.context_id;
+        entry.base_hash = params.base_hash;
+        if (params.description) |desc| entry.description = desc;
+        entry.status = .draft;
         try writeIndexAtomic(allocator, ws_dir, index.entries.items);
         return try identityFromEntry(allocator, entry.*, null);
     }
@@ -604,7 +637,7 @@ pub fn createDraft(
 
     for (index.entries.items) |entry| {
         if (entry.category != params.category) continue;
-        if (isTerminalStatus(entry.status)) continue;
+        if (isRetiredStatus(entry.status)) continue;
         if (std.mem.eql(u8, entry.draft_path, canonical_draft_path)) return error.DraftAlreadyExists;
     }
 
@@ -771,7 +804,7 @@ pub fn renameCreateDraftById(
     for (index.entries.items) |*other| {
         if (other == entry) continue;
         if (other.category != category) continue;
-        if (isTerminalStatus(other.status)) continue;
+        if (isRetiredStatus(other.status)) continue;
         if (std.mem.eql(u8, other.draft_path, canonical_new_path)) return error.DraftAlreadyExists;
     }
 
@@ -1050,6 +1083,10 @@ pub const ReconcileSummary = struct {
     restored: usize = 0,
 };
 
+pub const ReconcileOptions = struct {
+    restore_conflicted: bool = true,
+};
+
 /// Re-run drift detection on active drafts in `{ws_dir}/drafts/index.json`.
 /// When an update / rename / delete draft's `base_hash` no longer matches
 /// the current cache content at `current_path`, the entry is moved to
@@ -1060,6 +1097,15 @@ pub fn reconcileDrafts(
     allocator: std.mem.Allocator,
     ws_dir: []const u8,
     cache_dir: []const u8,
+) !ReconcileSummary {
+    return reconcileDraftsWithOptions(allocator, ws_dir, cache_dir, .{});
+}
+
+pub fn reconcileDraftsWithOptions(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    cache_dir: []const u8,
+    options: ReconcileOptions,
 ) !ReconcileSummary {
     var index = try loadIndex(allocator, ws_dir);
     defer index.deinit(allocator);
@@ -1072,7 +1118,7 @@ pub fn reconcileDrafts(
             else => {},
         }
         if (entry.operation == .create) {
-            if (entry.status == .conflicted) {
+            if (options.restore_conflicted and entry.status == .conflicted) {
                 if (!try cacheFileExists(allocator, cache_dir, entry.category, entry.draft_path)) {
                     entry.status = .draft;
                     summary.restored += 1;
@@ -1097,7 +1143,7 @@ pub fn reconcileDrafts(
 
         const current_hash = util_hash.contentHash(content);
         if (std.mem.eql(u8, current_hash[0..], base_hash)) {
-            if (entry.status == .conflicted) {
+            if (options.restore_conflicted and entry.status == .conflicted) {
                 entry.status = .draft;
                 summary.restored += 1;
                 changed = true;
@@ -1651,7 +1697,7 @@ test "createDraft: rejects duplicate draft for same (category, draft_path)" {
     }, "# NEW again\n"));
 }
 
-test "createDraft: terminal entries do not block a new draft for same path" {
+test "createDraft: retired entries do not block a new draft for same path" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
@@ -1679,6 +1725,30 @@ test "createDraft: terminal entries do not block a new draft for same path" {
     try testing.expectEqual(@as(usize, 2), index.entries.items.len);
     try testing.expectEqual(DraftStatus.applied, index.entries.items[0].status);
     try testing.expectEqual(DraftStatus.draft, index.entries.items[1].status);
+}
+
+test "createDraft: conflicted create still blocks same path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "spec/OVERVIEW.md",
+    }, "# Overview\n");
+    try setDraftStatus(testing.allocator, root, .context, "spec/OVERVIEW.md", .conflicted);
+
+    try testing.expectError(error.DraftAlreadyExists, createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .update,
+        .draft_path = "spec/OVERVIEW.md",
+        .current_path = "spec/OVERVIEW.md",
+        .context_id = "ctx-overview",
+        .base_hash = "sha256:base",
+    }, "# Overview updated\n"));
 }
 
 test "createDraft: delete operation does not write a content file" {
@@ -1979,6 +2049,49 @@ test "upsertUpdateDraft: updates rename draft without previous path identity" {
     const content = try readDraftFile(testing.allocator, root, .rule, "design/UIUX.md");
     defer testing.allocator.free(content);
     try testing.expectEqualStrings("renamed and updated body", content);
+}
+
+test "upsertUpdateDraft: converts conflicted create with same path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const root = tmpDirAbsolutePath(&tmp, &buf);
+
+    try createDraft(testing.allocator, root, .{
+        .category = .context,
+        .operation = .create,
+        .draft_path = "spec/OVERVIEW.md",
+        .local_temp_id = "tmp-context-overview",
+    }, "# Created overview\n");
+    try setDraftStatus(testing.allocator, root, .context, "spec/OVERVIEW.md", .conflicted);
+
+    var identity = try upsertUpdateDraft(testing.allocator, root, .{
+        .category = .context,
+        .current_path = "spec/OVERVIEW.md",
+        .context_id = "ctx-overview",
+        .base_hash = "sha256:base",
+        .description = "Update overview",
+    }, "# Updated overview\n");
+    defer identity.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("spec/OVERVIEW.md", identity.draft_path);
+    try testing.expect(identity.local_temp_id == null);
+
+    var index = try loadIndex(testing.allocator, root);
+    defer index.deinit(testing.allocator);
+    try testing.expectEqual(@as(usize, 1), index.entries.items.len);
+    const entry = index.entries.items[0];
+    try testing.expectEqual(DraftOperation.update, entry.operation);
+    try testing.expectEqual(DraftStatus.draft, entry.status);
+    try testing.expect(entry.local_temp_id == null);
+    try testing.expectEqualStrings("spec/OVERVIEW.md", entry.current_path.?);
+    try testing.expectEqualStrings("ctx-overview", entry.context_id.?);
+    try testing.expectEqualStrings("sha256:base", entry.base_hash.?);
+
+    const content = try readDraftFile(testing.allocator, root, .context, "spec/OVERVIEW.md");
+    defer testing.allocator.free(content);
+    try testing.expectEqualStrings("# Updated overview\n", content);
 }
 
 test "normalizeDrafts: folds duplicate update and rename entries" {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -2177,6 +2177,17 @@ pub const Shell = struct {
         return null;
     }
 
+    fn findContextAtPath(items: []const api.model.WorkspaceContextData, path: []const u8, context_id: ?[]const u8) ?api.model.WorkspaceContextData {
+        for (items) |item| {
+            if (!std.mem.eql(u8, item.path, path)) continue;
+            if (context_id) |id| {
+                if (item.context_id.len == 0 or !std.mem.eql(u8, item.context_id, id)) continue;
+            }
+            return item;
+        }
+        return null;
+    }
+
     fn localContextEntryFor(
         self: *Shell,
         path: []const u8,
@@ -2212,6 +2223,22 @@ pub const Shell = struct {
                 if (item.rule_id.len > 0 and std.mem.eql(u8, item.rule_id, id)) return item;
             }
             if (std.mem.eql(u8, self.pathForWorkspaceRule(item), path)) return item;
+        }
+        return null;
+    }
+
+    fn findRuleAtPath(
+        self: *Shell,
+        items: []const api.model.WorkspaceRuleData,
+        path: []const u8,
+        rule_id: ?[]const u8,
+    ) ?api.model.WorkspaceRuleData {
+        for (items) |item| {
+            if (!std.mem.eql(u8, self.pathForWorkspaceRule(item), path)) continue;
+            if (rule_id) |id| {
+                if (item.rule_id.len == 0 or !std.mem.eql(u8, item.rule_id, id)) continue;
+            }
+            return item;
         }
         return null;
     }
@@ -6139,6 +6166,7 @@ pub const Shell = struct {
             .operation = draft_entry.operation,
             .draft_path = draft_path,
             .rule_id = if (draft_entry.rule_id) |id| (alloc.dupe(u8, id) catch null) else null,
+            .context_id = if (draft_entry.context_id) |id| (alloc.dupe(u8, id) catch null) else null,
             .base_hash = if (draft_entry.base_hash) |h| (alloc.dupe(u8, h) catch null) else null,
         };
 
@@ -6149,6 +6177,7 @@ pub const Shell = struct {
         _ = self;
         for (index.entries.items) |*entry| {
             if (entry.category != target.category) continue;
+            if (drafts_mod.isRetiredStatus(entry.status)) continue;
             if (entry.current_path) |current_path| {
                 if (std.mem.eql(u8, current_path, target.path)) return entry;
             } else if (entry.operation == .create and std.mem.eql(u8, entry.draft_path, target.path)) {
@@ -6158,6 +6187,7 @@ pub const Shell = struct {
 
         for (index.entries.items) |*entry| {
             if (entry.category != target.category) continue;
+            if (drafts_mod.isRetiredStatus(entry.status)) continue;
             if (std.mem.eql(u8, entry.draft_path, target.path)) return entry;
             if (entry.local_temp_id) |value| {
                 if (std.mem.eql(u8, value, target.path)) return entry;
@@ -6210,8 +6240,16 @@ pub const Shell = struct {
         operation: drafts_mod.DraftOperation,
         draft_path: []const u8,
         rule_id: ?[]const u8,
+        context_id: ?[]const u8,
         base_hash: ?[]const u8,
     };
+
+    fn freeDraftSubmitEntry(alloc: std.mem.Allocator, entry: DraftSubmitEntry) void {
+        alloc.free(entry.draft_path);
+        if (entry.rule_id) |id| alloc.free(id);
+        if (entry.context_id) |id| alloc.free(id);
+        if (entry.base_hash) |h| alloc.free(h);
+    }
 
     const ConflictSettlement = struct {
         applied: usize = 0,
@@ -6235,13 +6273,15 @@ pub const Shell = struct {
                     .context => hash: {
                         const remote = self.api_state.workspace_context_cache.lookup(.{ .value = target.ws_id }) orelse break :hash null;
                         const path = if (effective_operation == .rename or effective_operation == .create) entry.draft_path else target.path;
-                        const item = findContextByPath(remote, path) orelse break :hash null;
+                        const context_id: ?[]const u8 = if (effective_operation == .create) null else target.context_id orelse entry.context_id orelse break :hash null;
+                        const item = findContextAtPath(remote, path, context_id) orelse break :hash null;
                         break :hash item.hash;
                     },
                     .rule, .meta_prompt => hash: {
                         const remote = self.api_state.workspace_manifest_cache.lookup(.{ .value = target.ws_id }) orelse break :hash null;
                         const path = if (effective_operation == .rename or effective_operation == .create) entry.draft_path else target.path;
-                        const item = self.findRuleFor(remote, path, target.rule_id orelse entry.rule_id) orelse break :hash null;
+                        const rule_id: ?[]const u8 = if (effective_operation == .create) null else target.rule_id orelse entry.rule_id orelse break :hash null;
+                        const item = self.findRuleAtPath(remote, path, rule_id) orelse break :hash null;
                         break :hash item.content_hash;
                     },
                 }) orelse break :blk false;
@@ -6260,7 +6300,7 @@ pub const Shell = struct {
         const alloc = self.api_state.allocator();
         const ws_dir = workspace_config.getWsDir(alloc, ws_id) catch return false;
         defer alloc.free(ws_dir);
-        drafts_mod.setDraftStatus(alloc, ws_dir, category, draft_path, status) catch |err| {
+        drafts_mod.setActiveDraftStatus(alloc, ws_dir, category, draft_path, status) catch |err| {
             log.warn("draft_status_update_failed path={s} status={s} error={s}", .{
                 draft_path,
                 @tagName(status),
@@ -6314,9 +6354,7 @@ pub const Shell = struct {
         defer alloc.free(read.ws_dir);
         defer if (read.content) |content| alloc.free(content);
         defer if (read.entry) |e| {
-            alloc.free(e.draft_path);
-            if (e.rule_id) |id| alloc.free(id);
-            if (e.base_hash) |h| alloc.free(h);
+            freeDraftSubmitEntry(alloc, e);
         };
 
         const entry = read.entry orelse {
@@ -6474,6 +6512,7 @@ pub const Shell = struct {
                 _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
                 alloc.free(entry.draft_path);
                 if (entry.base_hash) |h| alloc.free(h);
+                if (entry.context_id) |id| alloc.free(id);
                 continue;
             }
 
@@ -6488,6 +6527,7 @@ pub const Shell = struct {
                     break :blk target.rule_id orelse entry.rule_id orelse self.lookupRuleId(target.path) orelse {
                         alloc.free(entry.draft_path);
                         if (entry.base_hash) |h| alloc.free(h);
+                        if (entry.context_id) |id| alloc.free(id);
                         self.notifyOp(.warning, "Unknown rule id for a selected draft.");
                         return;
                     };
@@ -6990,8 +7030,7 @@ pub const Shell = struct {
         defer alloc.free(read.ws_dir);
         defer if (read.content) |content| alloc.free(content);
         defer if (read.entry) |e| {
-            alloc.free(e.draft_path);
-            if (e.base_hash) |h| alloc.free(h);
+            freeDraftSubmitEntry(alloc, e);
         };
 
         const entry = read.entry orelse {
@@ -7114,6 +7153,7 @@ pub const Shell = struct {
                 self.notifyOp(.warning, "Draft entry missing; try again.");
                 return;
             };
+            if (entry.context_id) |id| owned.append(alloc, id) catch return;
             const existing_context = if (entry.operation == .create) self.existingContextTarget(target) else null;
             const effective_operation: drafts_mod.DraftOperation = if (existing_context != null) .update else entry.operation;
             const operation_type: []const u8 = switch (effective_operation) {
@@ -7657,6 +7697,7 @@ pub const Shell = struct {
             .operation = entry.operation,
             .draft_path = entry.draft_path,
             .rule_id = entry.rule_id,
+            .context_id = entry.context_id,
             .base_hash = entry.base_hash,
         };
         const existing_remote = switch (target.category) {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -5131,7 +5131,9 @@ pub const Shell = struct {
         drafts_mod.normalizeDrafts(self.api_state.backing_allocator, ws_dir) catch {};
         const cache_dir = workspace_config.getCachePath(arena, ws_id) catch null;
         if (cache_dir) |dir| {
-            _ = drafts_mod.reconcileDrafts(self.api_state.backing_allocator, ws_dir, dir) catch |err| {
+            _ = drafts_mod.reconcileDraftsWithOptions(self.api_state.backing_allocator, ws_dir, dir, .{
+                .restore_conflicted = false,
+            }) catch |err| {
                 log.warn("draft_reconcile_failed ws_id={s} error={s}", .{ ws_id, @errorName(err) });
             };
         }
@@ -6143,6 +6145,36 @@ pub const Shell = struct {
         return .{ .ws_dir = ws_dir, .content = content, .entry = entry_out };
     }
 
+    fn findDraftEntryForSettlement(self: *Shell, index: *const drafts_mod.DraftsIndex, target: DraftTarget) ?*const drafts_mod.DraftEntry {
+        _ = self;
+        for (index.entries.items) |*entry| {
+            if (entry.category != target.category) continue;
+            if (entry.current_path) |current_path| {
+                if (std.mem.eql(u8, current_path, target.path)) return entry;
+            } else if (entry.operation == .create and std.mem.eql(u8, entry.draft_path, target.path)) {
+                return entry;
+            }
+        }
+
+        for (index.entries.items) |*entry| {
+            if (entry.category != target.category) continue;
+            if (std.mem.eql(u8, entry.draft_path, target.path)) return entry;
+            if (entry.local_temp_id) |value| {
+                if (std.mem.eql(u8, value, target.path)) return entry;
+            }
+            switch (target.category) {
+                .rule, .meta_prompt => if (entry.rule_id) |value| {
+                    if (std.mem.eql(u8, value, target.path)) return entry;
+                },
+                .context => if (entry.context_id) |value| {
+                    if (std.mem.eql(u8, value, target.path)) return entry;
+                },
+            }
+        }
+
+        return null;
+    }
+
     fn findDraftEntryForSubmit(self: *Shell, index: *const drafts_mod.DraftsIndex, target: DraftTarget) ?*const drafts_mod.DraftEntry {
         for (index.entries.items) |*entry| {
             if (entry.category != target.category) continue;
@@ -6180,6 +6212,64 @@ pub const Shell = struct {
         rule_id: ?[]const u8,
         base_hash: ?[]const u8,
     };
+
+    const ConflictSettlement = struct {
+        applied: usize = 0,
+        conflicted: usize = 0,
+        failed: usize = 0,
+    };
+
+    fn draftAlreadyMatchesRemote(
+        self: *Shell,
+        target: DraftTarget,
+        entry: DraftSubmitEntry,
+        effective_operation: drafts_mod.DraftOperation,
+        content: ?[]const u8,
+    ) bool {
+        return switch (effective_operation) {
+            .delete => false,
+            .create, .update, .rename => blk: {
+                const body = content orelse break :blk false;
+                const body_hash = util_hash.contentHash(body);
+                const remote_hash = (switch (target.category) {
+                    .context => hash: {
+                        const remote = self.api_state.workspace_context_cache.lookup(.{ .value = target.ws_id }) orelse break :hash null;
+                        const path = if (effective_operation == .rename or effective_operation == .create) entry.draft_path else target.path;
+                        const item = findContextByPath(remote, path) orelse break :hash null;
+                        break :hash item.hash;
+                    },
+                    .rule, .meta_prompt => hash: {
+                        const remote = self.api_state.workspace_manifest_cache.lookup(.{ .value = target.ws_id }) orelse break :hash null;
+                        const path = if (effective_operation == .rename or effective_operation == .create) entry.draft_path else target.path;
+                        const item = self.findRuleFor(remote, path, target.rule_id orelse entry.rule_id) orelse break :hash null;
+                        break :hash item.content_hash;
+                    },
+                }) orelse break :blk false;
+                break :blk local_content.hashesEqual(body_hash[0..], remote_hash);
+            },
+        };
+    }
+
+    fn markDraftStatusByPath(
+        self: *Shell,
+        ws_id: []const u8,
+        category: drafts_mod.DraftCategory,
+        draft_path: []const u8,
+        status: drafts_mod.DraftStatus,
+    ) bool {
+        const alloc = self.api_state.allocator();
+        const ws_dir = workspace_config.getWsDir(alloc, ws_id) catch return false;
+        defer alloc.free(ws_dir);
+        drafts_mod.setDraftStatus(alloc, ws_dir, category, draft_path, status) catch |err| {
+            log.warn("draft_status_update_failed path={s} status={s} error={s}", .{
+                draft_path,
+                @tagName(status),
+                @errorName(err),
+            });
+            return false;
+        };
+        return true;
+    }
 
     fn validateContentFormatForSubmit(self: *Shell, path: []const u8, content: []const u8) bool {
         const issue = contentFormatIssue(content) orelse return true;
@@ -6256,6 +6346,16 @@ pub const Shell = struct {
         defer if (content_copy) |c| alloc.free(c);
         if (content_copy) |content| {
             if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
+        }
+
+        if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
+            _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+            self.refreshDraftsCache();
+            workspace_panel.syncWsRows(self);
+            artifact_panel.syncArtifactTree(self);
+            self.closePrComposer();
+            self.notifyOp(.success, "Draft already applied.");
+            return;
         }
 
         // Update/rename/delete need rule_id; resolve from the draft
@@ -6370,6 +6470,13 @@ pub const Shell = struct {
                 if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
             }
 
+            if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
+                _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+                alloc.free(entry.draft_path);
+                if (entry.base_hash) |h| alloc.free(h);
+                continue;
+            }
+
             const rule_id: ?[]const u8 = switch (effective_operation) {
                 .create => null,
                 else => blk: {
@@ -6418,6 +6525,15 @@ pub const Shell = struct {
                 rule_id orelse "",
                 base_hash orelse "",
             });
+        }
+
+        if (ops.items.len == 0) {
+            self.refreshDraftsCache();
+            workspace_panel.syncWsRows(self);
+            artifact_panel.syncArtifactTree(self);
+            self.closePrComposer();
+            self.notifyOp(.success, "Drafts already applied.");
+            return;
         }
 
         const title_copy = alloc.dupe(u8, self.drafts.pr_composer_title_buf[0..self.drafts.pr_composer_title_len]) catch return;
@@ -6906,6 +7022,17 @@ pub const Shell = struct {
         if (content_copy) |content| {
             if (!self.validateContentFormatForSubmit(entry.draft_path, content)) return;
         }
+
+        if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
+            _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+            self.refreshDraftsCache();
+            workspace_panel.syncWsRows(self);
+            artifact_panel.syncArtifactTree(self);
+            self.closePrComposer();
+            self.notifyOp(.success, "Draft already applied.");
+            return;
+        }
+
         const ws_id_copy = alloc.dupe(u8, target.ws_id) catch return;
         defer alloc.free(ws_id_copy);
         const path_copy_opt: ?[]const u8 = switch (effective_operation) {
@@ -7001,6 +7128,13 @@ pub const Shell = struct {
                 if (!self.validateContentFormatForSubmit(entry.draft_path, body)) return;
             }
 
+            if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content)) {
+                _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+                alloc.free(entry.draft_path);
+                if (entry.base_hash) |h| alloc.free(h);
+                continue;
+            }
+
             const context_id: ?[]const u8 = switch (effective_operation) {
                 .create => null,
                 else => blk: {
@@ -7049,6 +7183,15 @@ pub const Shell = struct {
                 context_id orelse "",
                 base_hash orelse "",
             });
+        }
+
+        if (ops.items.len == 0) {
+            self.refreshDraftsCache();
+            workspace_panel.syncWsRows(self);
+            artifact_panel.syncArtifactTree(self);
+            self.closePrComposer();
+            self.notifyOp(.success, "Drafts already applied.");
+            return;
         }
 
         const title_copy = alloc.dupe(u8, self.drafts.pr_composer_title_buf[0..self.drafts.pr_composer_title_len]) catch return;
@@ -7495,14 +7638,89 @@ pub const Shell = struct {
         }
     }
 
+    fn settleDraftAfterConflict(self: *Shell, target: DraftTarget) ?drafts_mod.DraftStatus {
+        const alloc = self.api_state.allocator();
+        const ws_dir = workspace_config.getWsDir(alloc, target.ws_id) catch return null;
+        defer alloc.free(ws_dir);
+
+        var index = drafts_mod.loadIndex(alloc, ws_dir) catch return null;
+        defer index.deinit(alloc);
+
+        const entry = self.findDraftEntryForSettlement(&index, target) orelse return null;
+        const content: ?[]const u8 = if (entry.operation == .delete)
+            null
+        else
+            drafts_mod.readDraftFile(alloc, ws_dir, target.category, entry.draft_path) catch null;
+        defer if (content) |value| alloc.free(value);
+
+        const submit_entry = DraftSubmitEntry{
+            .operation = entry.operation,
+            .draft_path = entry.draft_path,
+            .rule_id = entry.rule_id,
+            .base_hash = entry.base_hash,
+        };
+        const existing_remote = switch (target.category) {
+            .context => self.existingContextTarget(target) != null,
+            .rule, .meta_prompt => self.existingRuleTarget(target) != null,
+        };
+        const effective_operation: drafts_mod.DraftOperation = if (entry.operation == .create and existing_remote) .update else entry.operation;
+        const status: drafts_mod.DraftStatus = if (self.draftAlreadyMatchesRemote(target, submit_entry, effective_operation, content)) .applied else .conflicted;
+        if (!self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, status)) return null;
+        return status;
+    }
+
+    fn settleComposerDraftsAfterConflict(self: *Shell) ConflictSettlement {
+        var settlement: ConflictSettlement = .{};
+        if (self.drafts.pr_composer_batch_targets.len > 0) {
+            for (self.drafts.pr_composer_batch_targets) |target| {
+                const status = self.settleDraftAfterConflict(target) orelse {
+                    settlement.failed += 1;
+                    continue;
+                };
+                switch (status) {
+                    .applied => settlement.applied += 1,
+                    .conflicted => settlement.conflicted += 1,
+                    .draft, .in_review, .declined => {},
+                }
+            }
+        } else if (self.drafts.pr_composer_target) |target| {
+            const status = self.settleDraftAfterConflict(target) orelse {
+                settlement.failed += 1;
+                return settlement;
+            };
+            switch (status) {
+                .applied => settlement.applied += 1,
+                .conflicted => settlement.conflicted += 1,
+                .draft, .in_review, .declined => {},
+            }
+        } else {
+            settlement.failed += 1;
+        }
+        self.refreshDraftsCache();
+        workspace_panel.syncWsRows(self);
+        artifact_panel.syncArtifactTree(self);
+        return settlement;
+    }
+
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
-        if (err.status == .conflict and self.markComposerDraftsStatus(.conflicted)) {
-            const message: []const u8 = if (self.drafts.pr_composer_batch_targets.len > 1)
-                "PR submit conflict; drafts marked conflicted"
-            else
-                "PR submit conflict; draft marked conflicted";
-            self.failPrComposerSubmit(.failure, writeErrorStatus(self, message, err));
-            return;
+        if (err.status == .conflict) {
+            const settlement = self.settleComposerDraftsAfterConflict();
+            if (settlement.applied > 0 and settlement.conflicted == 0 and settlement.failed == 0) {
+                self.closePrComposer();
+                const message: []const u8 = if (settlement.applied > 1) "Drafts already applied." else "Draft already applied.";
+                self.notifyOp(.success, message);
+                return;
+            }
+            if (settlement.applied > 0 or settlement.conflicted > 0) {
+                const message: []const u8 = if (settlement.applied > 0 and settlement.conflicted > 0)
+                    "PR submit conflict; matching drafts marked applied, remaining drafts marked conflicted"
+                else if (settlement.conflicted > 1)
+                    "PR submit conflict; drafts marked conflicted"
+                else
+                    "PR submit conflict; draft marked conflicted";
+                self.failPrComposerSubmit(.failure, writeErrorStatus(self, message, err));
+                return;
+            }
         }
         self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, "PR submit failed", err));
     }

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -6162,12 +6162,42 @@ pub const Shell = struct {
                 return null;
             };
         errdefer if (content) |value| alloc.free(value);
+        var rule_id: ?[]const u8 = null;
+        errdefer if (rule_id) |id| alloc.free(id);
+        if (draft_entry.rule_id) |id| {
+            rule_id = alloc.dupe(u8, id) catch {
+                self.notifyOp(.failure, "Out of memory reading draft.");
+                return null;
+            };
+        }
+
+        var context_id: ?[]const u8 = null;
+        errdefer if (context_id) |id| alloc.free(id);
+        if (draft_entry.context_id) |id| {
+            context_id = alloc.dupe(u8, id) catch {
+                if (rule_id) |value| alloc.free(value);
+                self.notifyOp(.failure, "Out of memory reading draft.");
+                return null;
+            };
+        }
+
+        var base_hash: ?[]const u8 = null;
+        errdefer if (base_hash) |h| alloc.free(h);
+        if (draft_entry.base_hash) |h| {
+            base_hash = alloc.dupe(u8, h) catch {
+                if (rule_id) |value| alloc.free(value);
+                if (context_id) |value| alloc.free(value);
+                self.notifyOp(.failure, "Out of memory reading draft.");
+                return null;
+            };
+        }
+
         const entry_out = DraftSubmitEntry{
             .operation = draft_entry.operation,
             .draft_path = draft_path,
-            .rule_id = if (draft_entry.rule_id) |id| (alloc.dupe(u8, id) catch null) else null,
-            .context_id = if (draft_entry.context_id) |id| (alloc.dupe(u8, id) catch null) else null,
-            .base_hash = if (draft_entry.base_hash) |h| (alloc.dupe(u8, h) catch null) else null,
+            .rule_id = rule_id,
+            .context_id = context_id,
+            .base_hash = base_hash,
         };
 
         return .{ .ws_dir = ws_dir, .content = content, .entry = entry_out };
@@ -6387,7 +6417,10 @@ pub const Shell = struct {
         }
 
         if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
-            _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+            if (!self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied)) {
+                self.keepPrComposerAfterSubmitFailure(.failure, "Draft already applied, but local draft status could not be updated.");
+                return;
+            }
             self.refreshDraftsCache();
             workspace_panel.syncWsRows(self);
             artifact_panel.syncArtifactTree(self);
@@ -6509,7 +6542,13 @@ pub const Shell = struct {
             }
 
             if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
-                _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+                if (!self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied)) {
+                    alloc.free(entry.draft_path);
+                    if (entry.base_hash) |h| alloc.free(h);
+                    if (entry.context_id) |id| alloc.free(id);
+                    self.keepPrComposerAfterSubmitFailure(.failure, "Draft already applied, but local draft status could not be updated.");
+                    return;
+                }
                 alloc.free(entry.draft_path);
                 if (entry.base_hash) |h| alloc.free(h);
                 if (entry.context_id) |id| alloc.free(id);
@@ -7063,7 +7102,10 @@ pub const Shell = struct {
         }
 
         if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content_copy)) {
-            _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+            if (!self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied)) {
+                self.keepPrComposerAfterSubmitFailure(.failure, "Draft already applied, but local draft status could not be updated.");
+                return;
+            }
             self.refreshDraftsCache();
             workspace_panel.syncWsRows(self);
             artifact_panel.syncArtifactTree(self);
@@ -7169,7 +7211,12 @@ pub const Shell = struct {
             }
 
             if (self.draftAlreadyMatchesRemote(target, entry, effective_operation, content)) {
-                _ = self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied);
+                if (!self.markDraftStatusByPath(target.ws_id, target.category, entry.draft_path, .applied)) {
+                    alloc.free(entry.draft_path);
+                    if (entry.base_hash) |h| alloc.free(h);
+                    self.keepPrComposerAfterSubmitFailure(.failure, "Draft already applied, but local draft status could not be updated.");
+                    return;
+                }
                 alloc.free(entry.draft_path);
                 if (entry.base_hash) |h| alloc.free(h);
                 continue;
@@ -7746,6 +7793,14 @@ pub const Shell = struct {
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
         if (err.status == .conflict) {
             const settlement = self.settleComposerDraftsAfterConflict();
+            if (settlement.failed > 0) {
+                const message: []const u8 = if (settlement.failed > 1)
+                    "PR submit conflict; some draft statuses could not be updated"
+                else
+                    "PR submit conflict; a draft status could not be updated";
+                self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, message, err));
+                return;
+            }
             if (settlement.applied > 0 and settlement.conflicted == 0 and settlement.failed == 0) {
                 self.closePrComposer();
                 const message: []const u8 = if (settlement.applied > 1) "Drafts already applied." else "Draft already applied.";

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -7042,6 +7042,13 @@ pub const Shell = struct {
                 self.notifyOp(.failure, "Out of memory creating PR.");
                 return;
             };
+            log.info("context_pr_batch_op idx={d} type={s} target_path={s} context_id={s} base_hash={s}", .{
+                ops.items.len - 1,
+                operation_type,
+                target.path,
+                context_id orelse "",
+                base_hash orelse "",
+            });
         }
 
         const title_copy = alloc.dupe(u8, self.drafts.pr_composer_title_buf[0..self.drafts.pr_composer_title_len]) catch return;
@@ -7489,12 +7496,12 @@ pub const Shell = struct {
     }
 
     fn handlePrSubmitApiError(self: *Shell, err: api.request.ApiErrorPayload) void {
-        if (err.status == .conflict and self.drafts.pr_composer_batch_targets.len > 1) {
-            self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, "PR submit conflict; drafts unchanged", err));
-            return;
-        }
         if (err.status == .conflict and self.markComposerDraftsStatus(.conflicted)) {
-            self.failPrComposerSubmit(.failure, writeErrorStatus(self, "PR submit conflict; draft marked conflicted", err));
+            const message: []const u8 = if (self.drafts.pr_composer_batch_targets.len > 1)
+                "PR submit conflict; drafts marked conflicted"
+            else
+                "PR submit conflict; draft marked conflicted";
+            self.failPrComposerSubmit(.failure, writeErrorStatus(self, message, err));
             return;
         }
         self.keepPrComposerAfterSubmitFailure(.failure, writeErrorStatus(self, "PR submit failed", err));


### PR DESCRIPTION
## Summary

Draft PR submission could leave already-applied changes marked as
conflicted when the local base hash was stale. This PR treats draft
content that matches the latest remote hash as applied, keeps real drift
as conflicted, and preserves conflicted create drafts as active path
claims.

Workspace adapter setup also failed when the Hub already had a workspace
with the current directory name. A 409 create response now resolves
through the authenticated workspace list and binds the current directory
when the name has a single accessible match.

## Test plan

- [x] Run `zig fmt --check src/client/drafts.zig src/client/tui/shell.zig src/client/commands/adapt_cmd.zig`
- [x] Run `zig build test`
- [x] Run `zig build`
