### PR TITLE
hub: add structured request diagnostics

### DIFF
--- a/src/hub/api_error.zig
+++ b/src/hub/api_error.zig
@@ -1,8 +1,25 @@
 //! Structured JSON error responses for Hub endpoints. Provides a consistent error envelope
-//! format ({"error": message, "status": code}) across all API handlers.
+//! format across all API handlers.
+const std = @import("std");
 const httpz = @import("httpz");
 
 pub fn send(res: *httpz.Response, status: u16, code: []const u8, message: []const u8) !void {
     res.status = status;
+    res.header("x-clumsies-error-code", try headerSafe(res.arena, code));
+    res.header("x-clumsies-error-message", try headerSafe(res.arena, message));
     try res.json(.{ .@"error" = .{ .code = code, .message = message } }, .{});
+}
+
+fn headerSafe(allocator: std.mem.Allocator, raw: []const u8) ![]const u8 {
+    const out = try allocator.alloc(u8, raw.len);
+    for (raw, 0..) |byte, idx| {
+        out[idx] = if (byte < 0x20 or byte == 0x7f) '?' else byte;
+    }
+    return out;
+}
+
+test "headerSafe replaces invalid header bytes" {
+    const out = try headerSafe(std.testing.allocator, "bad\nvalue");
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("bad?value", out);
 }

--- a/src/hub/collab.zig
+++ b/src/hub/collab.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const httpz = @import("httpz");
 const collab_api = @import("clumsies_lib").protocol.collab_api;
+const logger = @import("clumsies_lib").logger;
 const util_hash = @import("clumsies_lib").util.hash;
 const Server = @import("server.zig");
 const auth = @import("auth.zig");
@@ -123,6 +124,16 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     }
 
     res.status = 201;
+    logger.hubEventLogFn(.info, .{
+        .name = "rule_pr.created",
+        .action = "create",
+        .target_kind = "rule_pr",
+        .actor_user_id = user.user_id,
+        .org_id = user.org_id,
+        .ws_id = req_body.ws_id orelse "-",
+        .pr_id = pr_id,
+        .op_count = req_body.operations.len,
+    });
     try res.json(.{
         .pr_id = pr_id,
         .status = "open",
@@ -589,6 +600,7 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     }
 
     const is_accept = std.mem.eql(u8, body.action, "accept");
+    const op_count = countRulePrOperations(conn, id) catch null;
 
     if (is_accept) {
         if (!try applyPr(conn, req.arena, user.org_id, id, res)) return;
@@ -601,6 +613,15 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         };
     }
 
+    logger.hubEventLogFn(.info, .{
+        .name = if (is_accept) "rule_pr.accepted" else "rule_pr.rejected",
+        .action = body.action,
+        .target_kind = "rule_pr",
+        .actor_user_id = user.user_id,
+        .org_id = user.org_id,
+        .pr_id = id,
+        .op_count = op_count,
+    });
     try res.json(.{
         .pr_id = id,
         .status = if (is_accept) @as([]const u8, "accepted") else @as([]const u8, "rejected"),
@@ -970,6 +991,19 @@ fn bumpWorkspaceRevision(conn: anytype, ws_id: []const u8) void {
         "UPDATE workspaces SET revision = revision + 1 WHERE ws_id = $1",
         .{ws_id},
     ) catch {};
+}
+
+fn countRulePrOperations(conn: anytype, pr_id: []const u8) !usize {
+    var row = conn.row(
+        "SELECT count(*) FROM rule_pr_operations WHERE pr_id = $1",
+        .{pr_id},
+    ) catch return error.QueryFailed;
+    if (row) |*r| {
+        defer r.deinit() catch {};
+        const count = try r.get(i64, 0);
+        return @intCast(@max(count, 0));
+    }
+    return 0;
 }
 
 const CommentRequest = struct {

--- a/src/hub/context.zig
+++ b/src/hub/context.zig
@@ -2,6 +2,7 @@
 //! by each workspace independently. These endpoints list, serve, and track context files.
 const std = @import("std");
 const httpz = @import("httpz");
+const logger = @import("clumsies_lib").logger;
 const util_hash = @import("clumsies_lib").util.hash;
 const workspace_api = @import("clumsies_lib").protocol.workspace_api;
 const Server = @import("server.zig");
@@ -225,6 +226,16 @@ pub fn handleCreatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
     }
 
     res.status = 201;
+    logger.hubEventLogFn(.info, .{
+        .name = "context_pr.created",
+        .action = "create",
+        .target_kind = "context_pr",
+        .actor_user_id = user.user_id,
+        .org_id = user.org_id,
+        .ws_id = ws_id,
+        .pr_id = pr_id,
+        .op_count = req_body.operations.len,
+    });
     try res.json(.{
         .pr_id = pr_id,
         .status = "open",
@@ -660,12 +671,23 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         return apiError(res, 400, "BAD_REQUEST", "PR is not open");
     }
 
+    const op_count = countContextPrOperations(conn, pr_id) catch null;
     if (std.mem.eql(u8, body.action, "merge")) {
         if (!std.mem.eql(u8, user.role, "maintainer") and !auth.checkWorkspaceAdmin(conn, ws_id, user.user_id)) {
             return apiError(res, 403, "FORBIDDEN", "only maintainers or ws admins can merge");
         }
         if (!try applyPr(conn, req.arena, ws_id, pr_id, user.username, res)) return;
 
+        logger.hubEventLogFn(.info, .{
+            .name = "context_pr.merged",
+            .action = body.action,
+            .target_kind = "context_pr",
+            .actor_user_id = user.user_id,
+            .org_id = user.org_id,
+            .ws_id = ws_id,
+            .pr_id = pr_id,
+            .op_count = op_count,
+        });
         try res.json(.{ .pr_id = pr_id, .status = "merged" }, .{});
     } else {
         _ = conn.exec(
@@ -674,6 +696,16 @@ pub fn handleUpdatePr(ctx: *Server.Context, req: *httpz.Request, res: *httpz.Res
         ) catch {
             return apiError(res, 500, "INTERNAL_ERROR", "failed to reject PR");
         };
+        logger.hubEventLogFn(.info, .{
+            .name = "context_pr.rejected",
+            .action = body.action,
+            .target_kind = "context_pr",
+            .actor_user_id = user.user_id,
+            .org_id = user.org_id,
+            .ws_id = ws_id,
+            .pr_id = pr_id,
+            .op_count = op_count,
+        });
         try res.json(.{ .pr_id = pr_id, .status = "rejected" }, .{});
     }
 }
@@ -909,6 +941,19 @@ fn applyPr(conn: anytype, arena: std.mem.Allocator, ws_id: []const u8, pr_id: []
         return false;
     };
     return true;
+}
+
+fn countContextPrOperations(conn: anytype, pr_id: []const u8) !usize {
+    var row = conn.row(
+        "SELECT count(*) FROM context_pr_operations WHERE pr_id = $1",
+        .{pr_id},
+    ) catch return error.QueryFailed;
+    if (row) |*r| {
+        defer r.deinit() catch {};
+        const count = try r.get(i64, 0);
+        return @intCast(@max(count, 0));
+    }
+    return 0;
 }
 
 const CommentRequest = struct {

--- a/src/hub/request_logger.zig
+++ b/src/hub/request_logger.zig
@@ -153,7 +153,7 @@ const routes = [_]Route{
     .{ .method = "GET", .pattern = "/api/stats", .name = "stats.org" },
     .{ .method = "GET", .pattern = "/api/stats/workspace/:ws_id", .name = "stats.workspace" },
     .{ .method = "GET", .pattern = "/api/stats/rule/:rule_id", .name = "stats.rule" },
-    .{ .method = "GET", .pattern = "/api/prs", .name = "rule_prs.list" },
+    .{ .method = "GET", .pattern = "/api/prs", .name = "review_prs.list" },
     .{ .method = "POST", .pattern = "/api/prs", .name = "rule_prs.create" },
     .{ .method = "GET", .pattern = "/api/prs/:id", .name = "rule_prs.read" },
     .{ .method = "PUT", .pattern = "/api/prs/:id", .name = "rule_prs.update" },
@@ -244,6 +244,8 @@ test "remoteHost strips ephemeral ports" {
 }
 
 test "classifyRoute gives stable route names" {
+    try std.testing.expectEqualStrings("review_prs.list", classifyRoute("GET", "/api/prs"));
+    try std.testing.expectEqualStrings("rule_prs.create", classifyRoute("POST", "/api/prs"));
     try std.testing.expectEqualStrings("rule_prs.update", classifyRoute("PUT", "/api/prs/ppr-1"));
     try std.testing.expectEqualStrings("workspaces.context.list", classifyRoute("GET", "/api/workspaces/ws-1/context"));
     try std.testing.expectEqualStrings("workspaces.rules.content", classifyRoute("POST", "/api/workspaces/ws-1/rules/content"));

--- a/src/hub/request_logger.zig
+++ b/src/hub/request_logger.zig
@@ -3,6 +3,10 @@ const httpz = @import("httpz");
 const logger = @import("clumsies_lib").logger;
 
 const Middleware = @This();
+const ERROR_CODE_HEADER = "x-clumsies-error-code";
+const ERROR_MESSAGE_HEADER = "x-clumsies-error-message";
+
+var next_request_id = std.atomic.Value(u64).init(0);
 
 pub fn init(config: Config) !Middleware {
     _ = config;
@@ -11,13 +15,32 @@ pub fn init(config: Config) !Middleware {
 
 pub fn execute(_: *const Middleware, req: *httpz.Request, res: *httpz.Response, executor: anytype) !void {
     const start = std.time.nanoTimestamp();
+    const request_id = ensureRequestId(req, res);
     defer {
         const elapsed_ns = std.time.nanoTimestamp() - start;
         var client_buf: [64]u8 = undefined;
         var ip_buf: [128]u8 = undefined;
         const client_id = sanitizedClientId(req.header("x-client-id"), &client_buf);
         const ip = clientIp(req, &ip_buf);
-        logRequest(methodText(req), redactedPath(req.url.path), ip, client_id, res.status, elapsed_ns);
+        const method = methodText(req);
+        const path = redactedPath(req.url.path);
+        logRequest(.{
+            .status = res.status,
+            .elapsed_ns = elapsed_ns,
+            .ip = ip,
+            .client_id = client_id,
+            .request_id = request_id,
+            .method = method,
+            .path = path,
+            .route = classifyRoute(method, path),
+            .ws_id = requestParam(req, "ws_id"),
+            .pr_id = requestParamAny(req, &.{ "pr_id", "id" }),
+            .rule_id = requestParam(req, "rule_id"),
+            .context_id = requestParam(req, "context_id"),
+            .target_user_id = requestParam(req, "user_id"),
+            .error_code = responseHeader(res, ERROR_CODE_HEADER),
+            .error_message = responseHeader(res, ERROR_MESSAGE_HEADER),
+        });
     }
     try executor.next();
 }
@@ -36,8 +59,8 @@ fn redactedPath(path: []const u8) []const u8 {
     return path[0..query_start];
 }
 
-fn logRequest(method: []const u8, path: []const u8, ip: []const u8, client_id: []const u8, status: u16, elapsed_ns: i128) void {
-    logger.httpAccessLogFn(requestLogLevel(status), status, elapsed_ns, ip, client_id, method, path);
+fn logRequest(access: logger.HttpAccess) void {
+    logger.httpAccessLogFn(requestLogLevel(access.status), access);
 }
 
 fn requestLogLevel(status: u16) std.log.Level {
@@ -49,6 +72,112 @@ fn requestLogLevel(status: u16) std.log.Level {
 fn sanitizedClientId(raw_opt: ?[]const u8, buf: *[64]u8) []const u8 {
     const raw = raw_opt orelse return "-";
     return sanitizedText(raw, buf);
+}
+
+fn ensureRequestId(req: *httpz.Request, res: *httpz.Response) []const u8 {
+    if (req.header("x-request-id")) |raw| {
+        const request_id = sanitizedTextAlloc(req.arena, raw, 96) catch "-";
+        res.header("x-request-id", request_id);
+        return request_id;
+    }
+
+    const counter = next_request_id.fetchAdd(1, .monotonic) + 1;
+    const request_id = std.fmt.allocPrint(req.arena, "req-{x}-{x}", .{ @as(u64, @intCast(std.time.nanoTimestamp())), counter }) catch "-";
+    res.header("x-request-id", request_id);
+    return request_id;
+}
+
+fn responseHeader(res: *const httpz.Response, name: []const u8) []const u8 {
+    return res.headers.get(name) orelse "-";
+}
+
+fn requestParam(req: *httpz.Request, name: []const u8) []const u8 {
+    return req.param(name) orelse "-";
+}
+
+fn requestParamAny(req: *httpz.Request, names: []const []const u8) []const u8 {
+    for (names) |name| {
+        if (req.param(name)) |value| return value;
+    }
+    return "-";
+}
+
+const Route = struct {
+    method: []const u8,
+    pattern: []const u8,
+    name: []const u8,
+};
+
+const routes = [_]Route{
+    .{ .method = "GET", .pattern = "/api/health", .name = "health.check" },
+    .{ .method = "POST", .pattern = "/api/auth/login", .name = "auth.login" },
+    .{ .method = "POST", .pattern = "/api/auth/activate", .name = "auth.activate" },
+    .{ .method = "POST", .pattern = "/api/auth/refresh", .name = "auth.refresh" },
+    .{ .method = "GET", .pattern = "/api/auth/me", .name = "auth.me.read" },
+    .{ .method = "PATCH", .pattern = "/api/auth/me", .name = "auth.me.update" },
+    .{ .method = "DELETE", .pattern = "/api/auth/token", .name = "auth.token.delete" },
+    .{ .method = "GET", .pattern = "/api/members", .name = "members.list" },
+    .{ .method = "POST", .pattern = "/api/members", .name = "members.invite" },
+    .{ .method = "PATCH", .pattern = "/api/members/:user_id", .name = "members.role.update" },
+    .{ .method = "DELETE", .pattern = "/api/members/:user_id", .name = "members.remove" },
+    .{ .method = "POST", .pattern = "/api/members/:user_id/reissue-invite", .name = "members.invite.reissue" },
+    .{ .method = "POST", .pattern = "/api/workspaces", .name = "workspaces.create" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id", .name = "workspaces.read" },
+    .{ .method = "PATCH", .pattern = "/api/workspaces/:ws_id", .name = "workspaces.update" },
+    .{ .method = "DELETE", .pattern = "/api/workspaces/:ws_id", .name = "workspaces.delete" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/manifest", .name = "workspaces.manifest" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/rules", .name = "workspaces.rules.add" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/rules/content", .name = "workspaces.rules.content" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/rules/detach", .name = "workspaces.rules.detach" },
+    .{ .method = "DELETE", .pattern = "/api/workspaces/:ws_id/rules/:rule_id", .name = "workspaces.rules.remove" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/context", .name = "workspaces.context.list" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/context/content", .name = "workspaces.context.content" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/context/prs", .name = "context_prs.create" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/context/prs", .name = "context_prs.list" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/context/prs/:pr_id", .name = "context_prs.read" },
+    .{ .method = "PUT", .pattern = "/api/workspaces/:ws_id/context/prs/:pr_id", .name = "context_prs.update" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/context/prs/:pr_id/comments", .name = "context_prs.comments.add" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/context/prs/:pr_id/comments", .name = "context_prs.comments.list" },
+    .{ .method = "GET", .pattern = "/api/workspaces/:ws_id/members", .name = "workspaces.members.list" },
+    .{ .method = "POST", .pattern = "/api/workspaces/:ws_id/members", .name = "workspaces.members.invite" },
+    .{ .method = "PATCH", .pattern = "/api/workspaces/:ws_id/members/:user_id", .name = "workspaces.members.role.update" },
+    .{ .method = "DELETE", .pattern = "/api/workspaces/:ws_id/members/:user_id", .name = "workspaces.members.remove" },
+    .{ .method = "GET", .pattern = "/api/artifact/rules", .name = "artifact.rules.list" },
+    .{ .method = "POST", .pattern = "/api/artifact/rules/content", .name = "artifact.rules.content" },
+    .{ .method = "GET", .pattern = "/api/bundles", .name = "bundles.list" },
+    .{ .method = "GET", .pattern = "/api/bundles/:name", .name = "bundles.read" },
+    .{ .method = "POST", .pattern = "/api/bundles", .name = "bundles.create" },
+    .{ .method = "PUT", .pattern = "/api/bundles/:name", .name = "bundles.update" },
+    .{ .method = "DELETE", .pattern = "/api/bundles/:name", .name = "bundles.delete" },
+    .{ .method = "POST", .pattern = "/api/attestations", .name = "attestations.upload" },
+    .{ .method = "GET", .pattern = "/api/stats", .name = "stats.org" },
+    .{ .method = "GET", .pattern = "/api/stats/workspace/:ws_id", .name = "stats.workspace" },
+    .{ .method = "GET", .pattern = "/api/stats/rule/:rule_id", .name = "stats.rule" },
+    .{ .method = "GET", .pattern = "/api/prs", .name = "rule_prs.list" },
+    .{ .method = "POST", .pattern = "/api/prs", .name = "rule_prs.create" },
+    .{ .method = "GET", .pattern = "/api/prs/:id", .name = "rule_prs.read" },
+    .{ .method = "PUT", .pattern = "/api/prs/:id", .name = "rule_prs.update" },
+    .{ .method = "POST", .pattern = "/api/prs/:id/comments", .name = "rule_prs.comments.add" },
+    .{ .method = "GET", .pattern = "/api/prs/:id/comments", .name = "rule_prs.comments.list" },
+};
+
+fn classifyRoute(method: []const u8, path: []const u8) []const u8 {
+    for (&routes) |route| {
+        if (std.mem.eql(u8, method, route.method) and pathMatches(route.pattern, path)) return route.name;
+    }
+    return "unknown";
+}
+
+fn pathMatches(pattern: []const u8, path: []const u8) bool {
+    var pattern_iter = std.mem.splitScalar(u8, pattern, '/');
+    var path_iter = std.mem.splitScalar(u8, path, '/');
+    while (true) {
+        const pattern_part = pattern_iter.next();
+        const path_part = path_iter.next();
+        if (pattern_part == null or path_part == null) return pattern_part == null and path_part == null;
+        if (pattern_part.?.len > 0 and pattern_part.?[0] == ':') continue;
+        if (!std.mem.eql(u8, pattern_part.?, path_part.?)) return false;
+    }
 }
 
 fn clientIp(req: *const httpz.Request, buf: *[128]u8) []const u8 {
@@ -90,6 +219,15 @@ fn sanitizedText(raw: []const u8, buf: []u8) []const u8 {
     return buf[0..len];
 }
 
+fn sanitizedTextAlloc(allocator: std.mem.Allocator, raw: []const u8, max_len: usize) ![]const u8 {
+    const len = @min(raw.len, max_len);
+    const out = try allocator.alloc(u8, len);
+    for (raw[0..len], 0..) |byte, idx| {
+        out[idx] = if (byte < 0x20 or byte == 0x7f) '?' else byte;
+    }
+    return out;
+}
+
 test "requestLogLevel maps HTTP status classes to severity" {
     try std.testing.expectEqual(std.log.Level.info, requestLogLevel(200));
     try std.testing.expectEqual(std.log.Level.info, requestLogLevel(302));
@@ -103,4 +241,18 @@ test "remoteHost strips ephemeral ports" {
     try std.testing.expectEqualStrings("192.168.10.127", remoteHost("192.168.10.127:56669"));
     try std.testing.expectEqualStrings("::1", remoteHost("[::1]:8400"));
     try std.testing.expectEqualStrings("fe80::1", remoteHost("fe80::1"));
+}
+
+test "classifyRoute gives stable route names" {
+    try std.testing.expectEqualStrings("rule_prs.update", classifyRoute("PUT", "/api/prs/ppr-1"));
+    try std.testing.expectEqualStrings("workspaces.context.list", classifyRoute("GET", "/api/workspaces/ws-1/context"));
+    try std.testing.expectEqualStrings("workspaces.rules.content", classifyRoute("POST", "/api/workspaces/ws-1/rules/content"));
+    try std.testing.expectEqualStrings("context_prs.update", classifyRoute("PUT", "/api/workspaces/ws-1/context/prs/cpr-1"));
+    try std.testing.expectEqualStrings("unknown", classifyRoute("GET", "/api/not-real"));
+}
+
+test "pathMatches handles literal and parameter segments" {
+    try std.testing.expect(pathMatches("/api/prs/:id", "/api/prs/ppr-1"));
+    try std.testing.expect(!pathMatches("/api/prs/:id", "/api/prs/ppr-1/comments"));
+    try std.testing.expect(!pathMatches("/api/prs/:id/comments", "/api/prs/ppr-1"));
 }

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -294,9 +294,10 @@ pub fn writeHttpAccessLine(
         );
     }
     if (show_client_id) {
-        try writer.print(" client_id={s}", .{access.client_id});
+        try writeField(writer, "client_id", access.client_id);
     }
-    try writer.print(" request_id={s} route={s}", .{ access.request_id, access.route });
+    try writeField(writer, "request_id", access.request_id);
+    try writeField(writer, "route", access.route);
     try writeOptionalField(writer, "target_user_id", access.target_user_id);
     try writeOptionalField(writer, "org_id", access.org_id);
     try writeOptionalField(writer, "ws_id", access.ws_id);
@@ -304,11 +305,10 @@ pub fn writeHttpAccessLine(
     try writeOptionalField(writer, "rule_id", access.rule_id);
     try writeOptionalField(writer, "context_id", access.context_id);
     if (!std.mem.eql(u8, access.error_code, "-")) {
-        try writer.print(" error_code={s}", .{access.error_code});
+        try writeField(writer, "error_code", access.error_code);
     }
     if (!std.mem.eql(u8, access.error_message, "-")) {
-        try writer.writeAll(" error_message=");
-        try writeQuotedValue(writer, access.error_message);
+        try writeField(writer, "error_message", access.error_message);
     }
     try writer.writeByte('\n');
 }
@@ -331,7 +331,24 @@ pub fn writeHubEventLine(writer: *std.Io.Writer, event: HubEvent) std.Io.Writer.
 
 fn writeOptionalField(writer: *std.Io.Writer, name: []const u8, value: []const u8) std.Io.Writer.Error!void {
     if (value.len == 0 or std.mem.eql(u8, value, "-")) return;
-    try writer.print(" {s}={s}", .{ name, value });
+    try writeField(writer, name, value);
+}
+
+fn writeField(writer: *std.Io.Writer, name: []const u8, value: []const u8) std.Io.Writer.Error!void {
+    try writer.print(" {s}=", .{name});
+    if (isBareLogValue(value)) {
+        try writer.writeAll(value);
+    } else {
+        try writeQuotedValue(writer, value);
+    }
+}
+
+fn isBareLogValue(value: []const u8) bool {
+    if (value.len == 0) return false;
+    for (value) |byte| {
+        if (!(std.ascii.isAlphanumeric(byte) or byte == '_' or byte == '-' or byte == '.' or byte == ':' or byte == '/')) return false;
+    }
+    return true;
 }
 
 fn writeQuotedValue(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
@@ -809,7 +826,7 @@ test "writeHttpAccessLine omits application log prefix" {
         .elapsed_ns = 1_234_000,
         .ip = "127.0.0.1",
         .client_id = "client-1",
-        .request_id = "req-1",
+        .request_id = "req-1 error_code=OK",
         .method = "GET",
         .path = "/bad",
         .route = "unknown.read",
@@ -824,7 +841,7 @@ test "writeHttpAccessLine omits application log prefix" {
     try testing.expect(std.mem.indexOf(u8, output, "(hub_request)") == null);
     try testing.expect(std.mem.indexOf(u8, output, "| 400 |   1.23ms | 127.0.0.1       |") != null);
     try testing.expect(std.mem.indexOf(u8, output, "client_id=client-1") != null);
-    try testing.expect(std.mem.indexOf(u8, output, "request_id=req-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "request_id=\"req-1 error_code=OK\"") != null);
     try testing.expect(std.mem.indexOf(u8, output, "route=unknown.read") != null);
     try testing.expect(std.mem.indexOf(u8, output, "ws_id=ws-1") != null);
     try testing.expect(std.mem.indexOf(u8, output, "pr_id=ppr-1") != null);

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -167,12 +167,7 @@ pub fn logFn(
 
 pub fn httpAccessLogFn(
     message_level: std.log.Level,
-    status: u16,
-    elapsed_ns: i128,
-    ip: []const u8,
-    client_id: []const u8,
-    method: []const u8,
-    path: []const u8,
+    access: HttpAccess,
 ) void {
     mutex.lock();
     defer mutex.unlock();
@@ -185,7 +180,7 @@ pub fn httpAccessLogFn(
         return;
     };
 
-    writeHttpAccessLine(&writer.interface, status, elapsed_ns, ip, client_id, method, path, color_enabled) catch {
+    writeHttpAccessLine(&writer.interface, access, color_enabled) catch {
         disableLocked();
         return;
     };
@@ -194,6 +189,62 @@ pub fn httpAccessLogFn(
         return;
     };
 }
+
+pub fn hubEventLogFn(
+    message_level: std.log.Level,
+    event: HubEvent,
+) void {
+    mutex.lock();
+    defer mutex.unlock();
+
+    if (active_sink == .disabled) return;
+    if (@intFromEnum(message_level) > @intFromEnum(active_level)) return;
+
+    const writer = if (active_writer) |*writer| writer else {
+        active_sink = .disabled;
+        return;
+    };
+
+    writeHubEventLine(&writer.interface, event) catch {
+        disableLocked();
+        return;
+    };
+    writer.interface.flush() catch {
+        disableLocked();
+        return;
+    };
+}
+
+pub const HttpAccess = struct {
+    status: u16,
+    elapsed_ns: i128,
+    ip: []const u8,
+    client_id: []const u8,
+    request_id: []const u8,
+    method: []const u8,
+    path: []const u8,
+    route: []const u8,
+    ws_id: []const u8 = "-",
+    pr_id: []const u8 = "-",
+    rule_id: []const u8 = "-",
+    context_id: []const u8 = "-",
+    target_user_id: []const u8 = "-",
+    org_id: []const u8 = "-",
+    error_code: []const u8 = "-",
+    error_message: []const u8 = "-",
+};
+
+pub const HubEvent = struct {
+    name: []const u8,
+    outcome: []const u8 = "ok",
+    action: []const u8 = "-",
+    target_kind: []const u8 = "-",
+    actor_user_id: []const u8 = "-",
+    org_id: []const u8 = "-",
+    ws_id: []const u8 = "-",
+    pr_id: []const u8 = "-",
+    op_count: ?usize = null,
+};
 
 pub fn writeLogLine(
     writer: *std.Io.Writer,
@@ -220,37 +271,86 @@ pub fn writeLogLine(
 
 pub fn writeHttpAccessLine(
     writer: *std.Io.Writer,
-    status: u16,
-    elapsed_ns: i128,
-    ip: []const u8,
-    client_id: []const u8,
-    method: []const u8,
-    path: []const u8,
+    access: HttpAccess,
     use_color: bool,
 ) std.Io.Writer.Error!void {
     var ts_buf: [19]u8 = undefined;
     formatTimestamp(&ts_buf);
     var duration_buf: [16]u8 = undefined;
-    const duration = formatDuration(&duration_buf, elapsed_ns);
-    const show_client_id = client_id.len > 0 and !std.mem.eql(u8, client_id, "-");
+    const duration = formatDuration(&duration_buf, access.elapsed_ns);
+    const show_client_id = access.client_id.len > 0 and !std.mem.eql(u8, access.client_id, "-");
 
     if (use_color) {
         const dim = "\x1b[2m";
         const reset = "\x1b[0m";
         try writer.print(
             dim ++ "{s}" ++ reset ++ " |{s} {d: >3} {s}| {s: >8} | {s: <15} |{s} {s: ^6} {s}| {s}",
-            .{ ts_buf, statusColor(status), status, reset, duration, ip, methodColor(method), method, reset, path },
+            .{ ts_buf, statusColor(access.status), access.status, reset, duration, access.ip, methodColor(access.method), access.method, reset, access.path },
         );
     } else {
         try writer.print(
             "{s} | {d: >3} | {s: >8} | {s: <15} | {s: <6} {s}",
-            .{ ts_buf, status, duration, ip, method, path },
+            .{ ts_buf, access.status, duration, access.ip, access.method, access.path },
         );
     }
     if (show_client_id) {
-        try writer.print(" client_id={s}", .{client_id});
+        try writer.print(" client_id={s}", .{access.client_id});
+    }
+    try writer.print(" request_id={s} route={s}", .{ access.request_id, access.route });
+    try writeOptionalField(writer, "target_user_id", access.target_user_id);
+    try writeOptionalField(writer, "org_id", access.org_id);
+    try writeOptionalField(writer, "ws_id", access.ws_id);
+    try writeOptionalField(writer, "pr_id", access.pr_id);
+    try writeOptionalField(writer, "rule_id", access.rule_id);
+    try writeOptionalField(writer, "context_id", access.context_id);
+    if (!std.mem.eql(u8, access.error_code, "-")) {
+        try writer.print(" error_code={s}", .{access.error_code});
+    }
+    if (!std.mem.eql(u8, access.error_message, "-")) {
+        try writer.writeAll(" error_message=");
+        try writeQuotedValue(writer, access.error_message);
     }
     try writer.writeByte('\n');
+}
+
+pub fn writeHubEventLine(writer: *std.Io.Writer, event: HubEvent) std.Io.Writer.Error!void {
+    var ts_buf: [19]u8 = undefined;
+    formatTimestamp(&ts_buf);
+    try writer.print("{s} [EVENT] hub.{s} outcome={s}", .{ ts_buf, event.name, event.outcome });
+    try writeOptionalField(writer, "action", event.action);
+    try writeOptionalField(writer, "target_kind", event.target_kind);
+    try writeOptionalField(writer, "actor_user_id", event.actor_user_id);
+    try writeOptionalField(writer, "org_id", event.org_id);
+    try writeOptionalField(writer, "ws_id", event.ws_id);
+    try writeOptionalField(writer, "pr_id", event.pr_id);
+    if (event.op_count) |op_count| {
+        try writer.print(" op_count={d}", .{op_count});
+    }
+    try writer.writeByte('\n');
+}
+
+fn writeOptionalField(writer: *std.Io.Writer, name: []const u8, value: []const u8) std.Io.Writer.Error!void {
+    if (value.len == 0 or std.mem.eql(u8, value, "-")) return;
+    try writer.print(" {s}={s}", .{ name, value });
+}
+
+fn writeQuotedValue(writer: *std.Io.Writer, value: []const u8) std.Io.Writer.Error!void {
+    try writer.writeByte('"');
+    for (value) |byte| {
+        switch (byte) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            else => if (byte < 0x20 or byte == 0x7f) {
+                try writer.writeByte('?');
+            } else {
+                try writer.writeByte(byte);
+            },
+        }
+    }
+    try writer.writeByte('"');
 }
 
 pub fn noteInvalidLevel(raw: []const u8) void {
@@ -701,29 +801,82 @@ test "writeLogLine omits ANSI codes when color disabled" {
 }
 
 test "writeHttpAccessLine omits application log prefix" {
-    var buffer: [256]u8 = undefined;
+    var buffer: [512]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buffer);
 
-    try writeHttpAccessLine(&writer, 400, 1_234_000, "127.0.0.1", "client-1", "GET", "/bad", false);
+    try writeHttpAccessLine(&writer, .{
+        .status = 400,
+        .elapsed_ns = 1_234_000,
+        .ip = "127.0.0.1",
+        .client_id = "client-1",
+        .request_id = "req-1",
+        .method = "GET",
+        .path = "/bad",
+        .route = "unknown.read",
+        .ws_id = "ws-1",
+        .pr_id = "ppr-1",
+        .target_user_id = "usr-1",
+        .error_code = "BAD_REQUEST",
+        .error_message = "bad \"value\"",
+    }, false);
     const output = writer.buffered();
     try testing.expect(std.mem.indexOf(u8, output, "[WARN ]") == null);
     try testing.expect(std.mem.indexOf(u8, output, "(hub_request)") == null);
     try testing.expect(std.mem.indexOf(u8, output, "| 400 |   1.23ms | 127.0.0.1       |") != null);
     try testing.expect(std.mem.indexOf(u8, output, "client_id=client-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "request_id=req-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "route=unknown.read") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "ws_id=ws-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "pr_id=ppr-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "target_user_id=usr-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "error_code=BAD_REQUEST") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "error_message=\"bad \\\"value\\\"\"") != null);
     try testing.expect(std.mem.indexOf(u8, output, "| GET    /bad") != null);
+}
+
+test "writeHubEventLine emits business event fields" {
+    var buffer: [512]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buffer);
+
+    try writeHubEventLine(&writer, .{
+        .name = "rule_pr.accepted",
+        .action = "accept",
+        .target_kind = "rule_pr",
+        .actor_user_id = "usr-1",
+        .org_id = "org-1",
+        .ws_id = "ws-1",
+        .pr_id = "ppr-1",
+        .op_count = 3,
+    });
+    const output = writer.buffered();
+    try testing.expect(std.mem.indexOf(u8, output, "[EVENT] hub.rule_pr.accepted outcome=ok") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "action=accept") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "target_kind=rule_pr") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "actor_user_id=usr-1") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "op_count=3") != null);
 }
 
 test "writeHttpAccessLine colors only status and method" {
     var buffer: [512]u8 = undefined;
     var writer: std.Io.Writer = .fixed(&buffer);
 
-    try writeHttpAccessLine(&writer, 200, 7_917_000, "127.0.0.1", "-", "GET", "/api/auth/me", true);
+    try writeHttpAccessLine(&writer, .{
+        .status = 200,
+        .elapsed_ns = 7_917_000,
+        .ip = "127.0.0.1",
+        .client_id = "-",
+        .request_id = "req-2",
+        .method = "GET",
+        .path = "/api/auth/me",
+        .route = "auth.read",
+    }, true);
     const output = writer.buffered();
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[30;42m 200 \x1b[0m") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[97;44m  GET   \x1b[0m| /api/auth/me") != null);
     try testing.expect(std.mem.indexOf(u8, output, "|\x1b[30;42m 200 \x1b[0m|   7.91ms") != null);
     try testing.expect(std.mem.indexOf(u8, output, "127.0.0.1       ") != null);
     try testing.expect(std.mem.indexOf(u8, output, "client_id=") == null);
+    try testing.expect(std.mem.indexOf(u8, output, "request_id=req-2") != null);
 }
 
 test "formatDuration adapts units" {


### PR DESCRIPTION
## Summary

Hub server logs now include enough structured context to diagnose API
failures and PR mutations without reconstructing state from the client.
Error responses expose sanitized metadata to the request logger, access
logs include request ids, stable route names, selected route parameters,
and error details, and rule/context PR mutations emit business event
lines with actor and target metadata.

## Test plan

- [x] Run `zig build`
- [x] Run `zig build test`
