### PR TITLE
tui: add external markdown viewer

### DIFF
--- a/src/client/main.zig
+++ b/src/client/main.zig
@@ -332,6 +332,7 @@ test {
     _ = @import("tui/runtime.zig");
     _ = @import("tui/runtime/drafts_reader.zig");
     _ = @import("tui/runtime/editor_host.zig");
+    _ = @import("tui/runtime/markdown_viewer.zig");
     _ = @import("tui/runtime/attestation_reader.zig");
     _ = @import("tui/models/path_tree.zig");
     _ = @import("tui/shell.zig");

--- a/src/client/tui/features/content_actions.zig
+++ b/src/client/tui/features/content_actions.zig
@@ -20,6 +20,7 @@ const workspace_context_shortcuts = [_]w.Shortcut{
     .{ .key = "n", .label = "new context" },
     .{ .key = "w", .label = "workspaces" },
     .{ .key = "y", .label = "copy id" },
+    .{ .key = "v", .label = "view" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
     .{ .key = "P", .label = "submit all" },
@@ -35,6 +36,7 @@ const workspace_rule_shortcuts = [_]w.Shortcut{
     .{ .key = "h/l", .label = "switch tab" },
     .{ .key = "w", .label = "workspaces" },
     .{ .key = "y", .label = "copy id" },
+    .{ .key = "v", .label = "view" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
     .{ .key = "P", .label = "submit all" },
@@ -50,6 +52,7 @@ const artifact_content_shortcuts = [_]w.Shortcut{
     .{ .key = "Enter", .label = "open" },
     .{ .key = "h/l", .label = "switch tab" },
     .{ .key = "y", .label = "copy id" },
+    .{ .key = "v", .label = "view" },
     .{ .key = "n", .label = "new rule" },
     .{ .key = "e", .label = "edit" },
     .{ .key = "p", .label = "submit" },
@@ -92,6 +95,11 @@ pub fn handle(
     }
     if (key.matches('e', .{})) {
         self.editSelectedDraft();
+        ctx.consumeAndRedraw();
+        return true;
+    }
+    if (key.matches('v', .{})) {
+        self.openSelectedMarkdownViewer();
         ctx.consumeAndRedraw();
         return true;
     }

--- a/src/client/tui/features/settings/root.zig
+++ b/src/client/tui/features/settings/root.zig
@@ -701,7 +701,7 @@ fn drawSettingsPreferences(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocat
     var row: u16 = 1;
     row = w.writeSectionHeader(&surface, ctx, 2, row, "Local Viewer");
     w.writeText(&surface, ctx, 4, row, "Markdown", theme.fg(theme.MUTED));
-    const command = self.markdownViewerCommandForView(ctx.arena) catch "$ open <preview.md>";
+    const command = self.markdownViewerCommandForView();
     const configured = self.markdownViewerIsConfigured();
     const command_style = theme.fg(if (configured) theme.TEXT_SOFT else theme.MUTED);
     w.writeTextMax(&surface, ctx, 18, row, size.width -| 21, command, command_style);

--- a/src/client/tui/features/settings/root.zig
+++ b/src/client/tui/features/settings/root.zig
@@ -12,6 +12,7 @@ const workspace_config = @import("../../../workspace_config.zig");
 
 pub const Tab = enum(u8) {
     account,
+    preferences,
     workspaces,
     organization,
     token,
@@ -19,6 +20,7 @@ pub const Tab = enum(u8) {
     pub fn label(self: Tab) []const u8 {
         return switch (self) {
             .account => "Account",
+            .preferences => "Preferences",
             .workspaces => "Workspaces",
             .organization => "Organization",
             .token => "Token",
@@ -39,7 +41,7 @@ pub const State = struct {
 
 pub fn drawSettings(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
     const SettingsTab = @TypeOf(self.settings.tab);
-    const settings_tabs = [_]SettingsTab{ .account, .workspaces, .organization, .token };
+    const settings_tabs = [_]SettingsTab{ .account, .preferences, .workspaces, .organization, .token };
 
     const size = ctx.max.size();
     var root = try vxfw.Surface.init(ctx.arena, self.widget(), size);
@@ -70,6 +72,7 @@ pub fn drawSettings(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Erro
     );
     const content = switch (self.settings.tab) {
         .account => try drawSettingsAccount(self, content_ctx),
+        .preferences => try drawSettingsPreferences(self, content_ctx),
         .workspaces => try drawSettingsWorkspaces(self, content_ctx),
         .organization => try drawSettingsOrg(self, content_ctx),
         .token => try drawSettingsToken(self, content_ctx),
@@ -157,6 +160,13 @@ pub fn shortcuts(self: anytype) []const w.Shortcut {
             .{ .key = "x", .label = "sign out" },
             .{ .key = "Esc", .label = "back" },
         },
+        .preferences => &.{
+            .{ .key = "e", .label = "edit viewer" },
+            .{ .key = "x", .label = "clear viewer" },
+            .{ .key = "t", .label = "test viewer" },
+            .{ .key = "Tab", .label = "switch focus" },
+            .{ .key = "Esc", .label = "back" },
+        },
         .workspaces => if (self.settings.workspace_focus == .members) &.{
             .{ .key = "j/k", .label = "move" },
             .{ .key = "a", .label = "add member" },
@@ -220,6 +230,23 @@ fn handlePageAction(
             }
             if (key.matches('u', .{})) {
                 self.openUsernameDialog();
+                ctx.consumeAndRedraw();
+                return true;
+            }
+        },
+        .preferences => {
+            if (key.matches('e', .{})) {
+                self.openMarkdownViewerDialog();
+                ctx.consumeAndRedraw();
+                return true;
+            }
+            if (key.matches('x', .{})) {
+                self.clearMarkdownViewerPreference();
+                ctx.consumeAndRedraw();
+                return true;
+            }
+            if (key.matches('t', .{})) {
+                self.testMarkdownViewerPreference();
                 ctx.consumeAndRedraw();
                 return true;
             }
@@ -311,7 +338,7 @@ fn handlePageAction(
 
 fn shiftSettingsTab(self: anytype, delta: i8) void {
     const SettingsTab = @TypeOf(self.settings.tab);
-    const settings_tabs = [_]SettingsTab{ .account, .workspaces, .organization, .token };
+    const settings_tabs = [_]SettingsTab{ .account, .preferences, .workspaces, .organization, .token };
 
     const previous_tab = self.settings.tab;
     const current: i8 = @intCast(@intFromEnum(self.settings.tab));
@@ -392,6 +419,7 @@ fn handleContentEvent(
     }
     const max_items: usize = switch (self.settings.tab) {
         .account => 0,
+        .preferences => 0,
         .workspaces => if (self.settings.workspace_focus == .members) selectedWorkspaceMemberCount(self) else accountWorkspaceCount(self),
         .organization => orgMemberCount(self),
         .token => data.ALL_SCOPES.len,
@@ -421,6 +449,7 @@ fn handleContentEvent(
 
     switch (self.settings.tab) {
         .account => handleAccountAction(self, ctx, key),
+        .preferences => handlePreferencesAction(self, ctx, key),
         .workspaces => handleWorkspacesAction(self, ctx, key),
         .organization => handleOrganizationAction(self, ctx, key),
         .token => handleTokenAction(self, ctx, key),
@@ -446,6 +475,27 @@ fn handleAccountAction(
     }
     if (key.matches('u', .{})) {
         self.openUsernameDialog();
+        ctx.consumeAndRedraw();
+    }
+}
+
+fn handlePreferencesAction(
+    self: anytype,
+    ctx: *vxfw.EventContext,
+    key: vaxis.Key,
+) void {
+    if (key.matches('e', .{})) {
+        self.openMarkdownViewerDialog();
+        ctx.consumeAndRedraw();
+        return;
+    }
+    if (key.matches('x', .{})) {
+        self.clearMarkdownViewerPreference();
+        ctx.consumeAndRedraw();
+        return;
+    }
+    if (key.matches('t', .{})) {
+        self.testMarkdownViewerPreference();
         ctx.consumeAndRedraw();
     }
 }
@@ -561,6 +611,7 @@ fn handleTokenAction(
 fn settingsTabLabel(tab: anytype) []const u8 {
     return switch (tab) {
         .account => "Account",
+        .preferences => "Preferences",
         .workspaces => "Workspaces",
         .organization => "Organization",
         .token => "Token",
@@ -635,6 +686,43 @@ fn drawSettingsAccount(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.E
         row = w.writeSectionHeader(&surface, ctx, 2, row, "Danger Zone");
         w.writeText(&surface, ctx, 4, row, "[ Sign Out ]", theme.fg(theme.DANGER));
         w.writeText(&surface, ctx, 19, row, "Revoke current token and exit", theme.fg(theme.MUTED));
+    }
+    return surface;
+}
+
+fn drawSettingsPreferences(self: anytype, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+    const size = ctx.max.size();
+    const focused = self.settings.focus == .content;
+    var surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+    w.fillSurface(&surface, theme.PANEL);
+    w.drawBorder(&surface, theme.focusBorder(focused), theme.PANEL);
+    w.writeText(&surface, ctx, 2, 0, "Preferences", theme.boldOn(theme.PANEL, theme.TEXT));
+
+    var row: u16 = 1;
+    row = w.writeSectionHeader(&surface, ctx, 2, row, "Local Viewer");
+    w.writeText(&surface, ctx, 4, row, "Markdown", theme.fg(theme.MUTED));
+    const command = self.markdownViewerCommandForView(ctx.arena) catch "$ open <preview.md>";
+    const configured = self.markdownViewerIsConfigured();
+    const command_style = theme.fg(if (configured) theme.TEXT_SOFT else theme.MUTED);
+    w.writeTextMax(&surface, ctx, 18, row, size.width -| 21, command, command_style);
+    row += 2;
+
+    w.writeText(&surface, ctx, 4, row, "[ Edit ]", theme.fg(theme.ACCENT_SOFT));
+    w.writeText(&surface, ctx, 15, row, "[ Clear ]", theme.fg(if (configured) theme.TEXT_SOFT else theme.MUTED));
+    w.writeText(&surface, ctx, 27, row, "[ Test ]", theme.fg(theme.TEXT_SOFT));
+    row += 2;
+
+    if (row < size.height -| 1) {
+        _ = w.writeWrappedTextMax(
+            &surface,
+            ctx,
+            4,
+            row,
+            size.width -| 7,
+            3,
+            "Used by the v shortcut. Configure a command prefix such as `open -a Typora`; Clumsies appends the preview file path.",
+            theme.fg(theme.MUTED),
+        );
     }
     return surface;
 }

--- a/src/client/tui/prefs.zig
+++ b/src/client/tui/prefs.zig
@@ -9,14 +9,20 @@ const model = @import("api/model.zig");
 
 pub const Prefs = struct {
     last_workspace_id: ?[]const u8 = null,
+    markdown_viewer_argv: ?[]const []const u8 = null,
 
     pub fn deinit(self: Prefs, allocator: std.mem.Allocator) void {
         if (self.last_workspace_id) |id| allocator.free(id);
+        if (self.markdown_viewer_argv) |argv| {
+            for (argv) |arg| allocator.free(arg);
+            allocator.free(argv);
+        }
     }
 };
 
 const PrefsJson = struct {
     last_workspace_id: ?[]const u8 = null,
+    markdown_viewer_argv: ?[]const []const u8 = null,
 };
 
 pub fn load(allocator: std.mem.Allocator) !Prefs {
@@ -42,10 +48,34 @@ pub fn load(allocator: std.mem.Allocator) !Prefs {
 
     return .{
         .last_workspace_id = if (parsed.value.last_workspace_id) |id| try allocator.dupe(u8, id) else null,
+        .markdown_viewer_argv = if (parsed.value.markdown_viewer_argv) |argv| try dupeArgv(allocator, argv) else null,
     };
 }
 
 pub fn saveLastWorkspaceId(allocator: std.mem.Allocator, ws_id: []const u8) !void {
+    var prefs = load(allocator) catch Prefs{};
+    defer prefs.deinit(allocator);
+    if (prefs.last_workspace_id) |id| {
+        allocator.free(id);
+        prefs.last_workspace_id = null;
+    }
+    prefs.last_workspace_id = try allocator.dupe(u8, ws_id);
+    try save(allocator, prefs);
+}
+
+pub fn saveMarkdownViewerArgv(allocator: std.mem.Allocator, argv: ?[]const []const u8) !void {
+    var prefs = load(allocator) catch Prefs{};
+    defer prefs.deinit(allocator);
+    if (prefs.markdown_viewer_argv) |old| {
+        for (old) |arg| allocator.free(arg);
+        allocator.free(old);
+        prefs.markdown_viewer_argv = null;
+    }
+    prefs.markdown_viewer_argv = if (argv) |items| try dupeArgv(allocator, items) else null;
+    try save(allocator, prefs);
+}
+
+fn save(allocator: std.mem.Allocator, prefs: Prefs) !void {
     const base = try auth.getBasePath(allocator);
     defer allocator.free(base);
     std.fs.makeDirAbsolute(base) catch |err| {
@@ -55,7 +85,10 @@ pub fn saveLastWorkspaceId(allocator: std.mem.Allocator, ws_id: []const u8) !voi
     const path = try prefsPathFromBase(allocator, base);
     defer allocator.free(path);
 
-    const body = try std.json.Stringify.valueAlloc(allocator, PrefsJson{ .last_workspace_id = ws_id }, .{});
+    const body = try std.json.Stringify.valueAlloc(allocator, PrefsJson{
+        .last_workspace_id = prefs.last_workspace_id,
+        .markdown_viewer_argv = prefs.markdown_viewer_argv,
+    }, .{});
     defer allocator.free(body);
 
     const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
@@ -64,6 +97,107 @@ pub fn saveLastWorkspaceId(allocator: std.mem.Allocator, ws_id: []const u8) !voi
     var writer = std.fs.File.Writer.init(file, &write_buf);
     try writer.interface.writeAll(body);
     try writer.interface.flush();
+}
+
+pub fn parseCommandLineArgv(allocator: std.mem.Allocator, command: []const u8) ![]const []const u8 {
+    var argv: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (argv.items) |arg| allocator.free(arg);
+        argv.deinit(allocator);
+    }
+
+    var current: std.ArrayList(u8) = .empty;
+    defer current.deinit(allocator);
+
+    var quote: ?u8 = null;
+    var escaped = false;
+    var saw_arg = false;
+
+    for (command) |byte| {
+        if (escaped) {
+            try current.append(allocator, byte);
+            saw_arg = true;
+            escaped = false;
+            continue;
+        }
+        if (byte == '\\') {
+            escaped = true;
+            saw_arg = true;
+            continue;
+        }
+        if (quote) |q| {
+            if (byte == q) {
+                quote = null;
+            } else {
+                try current.append(allocator, byte);
+            }
+            saw_arg = true;
+            continue;
+        }
+        if (byte == '"' or byte == '\'') {
+            quote = byte;
+            saw_arg = true;
+            continue;
+        }
+        if (byte == ' ' or byte == '\t' or byte == '\r' or byte == '\n') {
+            if (saw_arg) {
+                try argv.append(allocator, try current.toOwnedSlice(allocator));
+                current.clearRetainingCapacity();
+                saw_arg = false;
+            }
+            continue;
+        }
+        try current.append(allocator, byte);
+        saw_arg = true;
+    }
+    if (escaped or quote != null) return error.InvalidCommandLine;
+    if (saw_arg) try argv.append(allocator, try current.toOwnedSlice(allocator));
+    if (argv.items.len == 0) return error.EmptyCommand;
+    return try argv.toOwnedSlice(allocator);
+}
+
+pub fn commandLineFromArgv(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    for (argv, 0..) |arg, idx| {
+        if (idx > 0) try out.append(allocator, ' ');
+        if (needsQuoting(arg)) {
+            try out.append(allocator, '"');
+            for (arg) |byte| {
+                if (byte == '"' or byte == '\\') try out.append(allocator, '\\');
+                try out.append(allocator, byte);
+            }
+            try out.append(allocator, '"');
+        } else {
+            try out.appendSlice(allocator, arg);
+        }
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
+fn dupeArgv(allocator: std.mem.Allocator, argv: []const []const u8) ![]const []const u8 {
+    var out = try allocator.alloc([]const u8, argv.len);
+    var copied: usize = 0;
+    errdefer {
+        for (out[0..copied]) |arg| allocator.free(arg);
+        allocator.free(out);
+    }
+    for (argv, 0..) |arg, idx| {
+        out[idx] = try allocator.dupe(u8, arg);
+        copied += 1;
+    }
+    return out;
+}
+
+fn needsQuoting(arg: []const u8) bool {
+    if (arg.len == 0) return true;
+    for (arg) |byte| {
+        switch (byte) {
+            ' ', '\t', '\r', '\n', '"', '\\' => return true,
+            else => {},
+        }
+    }
+    return false;
 }
 
 pub fn selectWorkspaceIndex(
@@ -103,4 +237,22 @@ test "selectWorkspaceIndex falls back to first when saved workspace is stale" {
     };
     try std.testing.expectEqual(@as(usize, 0), selectWorkspaceIndex(&workspaces, "ws-gone"));
     try std.testing.expectEqual(@as(usize, 0), selectWorkspaceIndex(&workspaces, null));
+}
+
+test "parseCommandLineArgv handles quoted app names" {
+    const argv = try parseCommandLineArgv(std.testing.allocator, "open -a \"Typora Beta\"");
+    defer {
+        for (argv) |arg| std.testing.allocator.free(arg);
+        std.testing.allocator.free(argv);
+    }
+    try std.testing.expectEqual(@as(usize, 3), argv.len);
+    try std.testing.expectEqualStrings("open", argv[0]);
+    try std.testing.expectEqualStrings("-a", argv[1]);
+    try std.testing.expectEqualStrings("Typora Beta", argv[2]);
+}
+
+test "commandLineFromArgv quotes whitespace" {
+    const rendered = try commandLineFromArgv(std.testing.allocator, &.{ "open", "-a", "Typora Beta" });
+    defer std.testing.allocator.free(rendered);
+    try std.testing.expectEqualStrings("open -a \"Typora Beta\"", rendered);
 }

--- a/src/client/tui/prefs.zig
+++ b/src/client/tui/prefs.zig
@@ -113,7 +113,9 @@ pub fn parseCommandLineArgv(allocator: std.mem.Allocator, command: []const u8) !
     var escaped = false;
     var saw_arg = false;
 
-    for (command) |byte| {
+    var i: usize = 0;
+    while (i < command.len) : (i += 1) {
+        const byte = command[i];
         if (escaped) {
             try current.append(allocator, byte);
             saw_arg = true;
@@ -121,7 +123,11 @@ pub fn parseCommandLineArgv(allocator: std.mem.Allocator, command: []const u8) !
             continue;
         }
         if (byte == '\\') {
-            escaped = true;
+            if (i + 1 < command.len and shouldEscapeCommandByte(command[i + 1])) {
+                escaped = true;
+            } else {
+                try current.append(allocator, byte);
+            }
             saw_arg = true;
             continue;
         }
@@ -154,6 +160,13 @@ pub fn parseCommandLineArgv(allocator: std.mem.Allocator, command: []const u8) !
     if (saw_arg) try argv.append(allocator, try current.toOwnedSlice(allocator));
     if (argv.items.len == 0) return error.EmptyCommand;
     return try argv.toOwnedSlice(allocator);
+}
+
+fn shouldEscapeCommandByte(byte: u8) bool {
+    return switch (byte) {
+        ' ', '\t', '\r', '\n', '"', '\'', '\\' => true,
+        else => false,
+    };
 }
 
 pub fn commandLineFromArgv(allocator: std.mem.Allocator, argv: []const []const u8) ![]const u8 {
@@ -255,4 +268,14 @@ test "commandLineFromArgv quotes whitespace" {
     const rendered = try commandLineFromArgv(std.testing.allocator, &.{ "open", "-a", "Typora Beta" });
     defer std.testing.allocator.free(rendered);
     try std.testing.expectEqualStrings("open -a \"Typora Beta\"", rendered);
+}
+
+test "parseCommandLineArgv preserves Windows path backslashes" {
+    const argv = try parseCommandLineArgv(std.testing.allocator, "\"C:\\Program Files\\Typora\\Typora.exe\"");
+    defer {
+        for (argv) |arg| std.testing.allocator.free(arg);
+        std.testing.allocator.free(argv);
+    }
+    try std.testing.expectEqual(@as(usize, 1), argv.len);
+    try std.testing.expectEqualStrings("C:\\Program Files\\Typora\\Typora.exe", argv[0]);
 }

--- a/src/client/tui/runtime.zig
+++ b/src/client/tui/runtime.zig
@@ -1,3 +1,4 @@
 pub const attestation_reader = @import("runtime/attestation_reader.zig");
 pub const drafts_reader = @import("runtime/drafts_reader.zig");
 pub const editor_host = @import("runtime/editor_host.zig");
+pub const markdown_viewer = @import("runtime/markdown_viewer.zig");

--- a/src/client/tui/runtime/markdown_viewer.zig
+++ b/src/client/tui/runtime/markdown_viewer.zig
@@ -1,0 +1,139 @@
+//! Open materialized Markdown previews in an external viewer.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const util_hash = @import("clumsies_lib").util.hash;
+
+pub const Result = enum {
+    opened,
+    viewer_not_found,
+    spawn_failed,
+    failed,
+};
+
+pub fn systemOpenLabel() []const u8 {
+    return switch (builtin.os.tag) {
+        .macos => "$ open <preview.md>",
+        .windows => "$ cmd /C start \"\" <preview.md>",
+        else => "$ xdg-open <preview.md>",
+    };
+}
+
+pub fn materialize(
+    allocator: std.mem.Allocator,
+    ws_dir: []const u8,
+    source_path: []const u8,
+    content: []const u8,
+) ![]const u8 {
+    const dir_path = try std.fs.path.join(allocator, &.{ ws_dir, "viewer" });
+    defer allocator.free(dir_path);
+    std.fs.makeDirAbsolute(dir_path) catch |err| {
+        if (err != error.PathAlreadyExists) return err;
+    };
+
+    const name = try previewFileName(allocator, source_path, content);
+    defer allocator.free(name);
+    const path = try std.fs.path.join(allocator, &.{ dir_path, name });
+    errdefer allocator.free(path);
+
+    const file = try std.fs.createFileAbsolute(path, .{ .truncate = true, .mode = 0o600 });
+    defer file.close();
+    var buf: [4096]u8 = undefined;
+    var writer = std.fs.File.Writer.init(file, &buf);
+    try writer.interface.writeAll(content);
+    try writer.interface.flush();
+    return path;
+}
+
+pub fn open(
+    allocator: std.mem.Allocator,
+    configured_argv: ?[]const []const u8,
+    file_path: []const u8,
+) !Result {
+    const argv = if (configured_argv) |configured|
+        try argvWithFile(allocator, configured, file_path)
+    else
+        try systemOpenArgv(allocator, file_path);
+    defer allocator.free(argv);
+
+    if (argv.len < 2) return .spawn_failed;
+    var child = std.process.Child.init(argv, allocator);
+    child.stdin_behavior = .Ignore;
+    child.stdout_behavior = .Ignore;
+    child.stderr_behavior = .Ignore;
+
+    child.spawn() catch |err| switch (err) {
+        error.FileNotFound, error.AccessDenied, error.InvalidExe => return .viewer_not_found,
+        else => return .spawn_failed,
+    };
+    const term = child.wait() catch |err| switch (err) {
+        error.FileNotFound, error.AccessDenied, error.InvalidExe => return .viewer_not_found,
+        else => return .spawn_failed,
+    };
+    return switch (term) {
+        .Exited => |code| if (code == 0) .opened else .failed,
+        else => .failed,
+    };
+}
+
+pub fn previewFileName(allocator: std.mem.Allocator, source_path: []const u8, content: []const u8) ![]const u8 {
+    const hash = util_hash.contentHash(content);
+    var safe: std.ArrayList(u8) = .empty;
+    defer safe.deinit(allocator);
+    for (source_path) |byte| {
+        switch (byte) {
+            'a'...'z', 'A'...'Z', '0'...'9', '-', '_', '.' => try safe.append(allocator, byte),
+            else => try safe.append(allocator, '_'),
+        }
+    }
+    if (!std.mem.endsWith(u8, safe.items, ".md")) {
+        try safe.appendSlice(allocator, ".md");
+    }
+    const stem = if (safe.items.len == 0) "preview.md" else safe.items;
+    return std.fmt.allocPrint(allocator, "{s}.{s}.md", .{ stem[0..stem.len -| 3], hash[7..15] });
+}
+
+fn argvWithFile(allocator: std.mem.Allocator, argv: []const []const u8, file_path: []const u8) ![]const []const u8 {
+    var out = try allocator.alloc([]const u8, argv.len + 1);
+    @memcpy(out[0..argv.len], argv);
+    out[argv.len] = file_path;
+    return out;
+}
+
+fn systemOpenArgv(allocator: std.mem.Allocator, file_path: []const u8) ![]const []const u8 {
+    return switch (builtin.os.tag) {
+        .macos => blk: {
+            const out = try allocator.alloc([]const u8, 2);
+            out[0] = "open";
+            out[1] = file_path;
+            break :blk out;
+        },
+        .windows => blk: {
+            const out = try allocator.alloc([]const u8, 5);
+            out[0] = "cmd";
+            out[1] = "/C";
+            out[2] = "start";
+            out[3] = "";
+            out[4] = file_path;
+            break :blk out;
+        },
+        else => blk: {
+            const out = try allocator.alloc([]const u8, 2);
+            out[0] = "xdg-open";
+            out[1] = file_path;
+            break :blk out;
+        },
+    };
+}
+
+test "previewFileName keeps markdown extension and adds hash" {
+    const name = try previewFileName(std.testing.allocator, "studies/TUI_EXTERNAL_MARKDOWN_VIEWER.md", "# Title\n");
+    defer std.testing.allocator.free(name);
+    try std.testing.expect(std.mem.startsWith(u8, name, "studies_TUI_EXTERNAL_MARKDOWN_VIEWER."));
+    try std.testing.expect(std.mem.endsWith(u8, name, ".md"));
+}
+
+test "open appends file path to configured argv" {
+    const result = try open(std.testing.allocator, &.{"/usr/bin/true"}, "/tmp/ignored.md");
+    try std.testing.expectEqual(Result.opened, result);
+}

--- a/src/client/tui/runtime/markdown_viewer.zig
+++ b/src/client/tui/runtime/markdown_viewer.zig
@@ -2,7 +2,6 @@
 
 const std = @import("std");
 const builtin = @import("builtin");
-const util_hash = @import("clumsies_lib").util.hash;
 
 pub const Result = enum {
     opened,
@@ -31,7 +30,7 @@ pub fn materialize(
         if (err != error.PathAlreadyExists) return err;
     };
 
-    const name = try previewFileName(allocator, source_path, content);
+    const name = try previewFileName(allocator, source_path);
     defer allocator.free(name);
     const path = try std.fs.path.join(allocator, &.{ dir_path, name });
     errdefer allocator.free(path);
@@ -66,18 +65,16 @@ pub fn open(
         error.FileNotFound, error.AccessDenied, error.InvalidExe => return .viewer_not_found,
         else => return .spawn_failed,
     };
-    const term = child.wait() catch |err| switch (err) {
-        error.FileNotFound, error.AccessDenied, error.InvalidExe => return .viewer_not_found,
-        else => return .spawn_failed,
+    const thread = std.Thread.spawn(.{ .allocator = allocator }, waitForChild, .{child}) catch {
+        var fallback_child = child;
+        _ = fallback_child.wait() catch {};
+        return .spawn_failed;
     };
-    return switch (term) {
-        .Exited => |code| if (code == 0) .opened else .failed,
-        else => .failed,
-    };
+    thread.detach();
+    return .opened;
 }
 
-pub fn previewFileName(allocator: std.mem.Allocator, source_path: []const u8, content: []const u8) ![]const u8 {
-    const hash = util_hash.contentHash(content);
+pub fn previewFileName(allocator: std.mem.Allocator, source_path: []const u8) ![]const u8 {
     var safe: std.ArrayList(u8) = .empty;
     defer safe.deinit(allocator);
     for (source_path) |byte| {
@@ -86,11 +83,17 @@ pub fn previewFileName(allocator: std.mem.Allocator, source_path: []const u8, co
             else => try safe.append(allocator, '_'),
         }
     }
-    if (!std.mem.endsWith(u8, safe.items, ".md")) {
+    if (safe.items.len == 0) {
+        try safe.appendSlice(allocator, "preview.md");
+    } else if (!std.mem.endsWith(u8, safe.items, ".md")) {
         try safe.appendSlice(allocator, ".md");
     }
-    const stem = if (safe.items.len == 0) "preview.md" else safe.items;
-    return std.fmt.allocPrint(allocator, "{s}.{s}.md", .{ stem[0..stem.len -| 3], hash[7..15] });
+    return try safe.toOwnedSlice(allocator);
+}
+
+fn waitForChild(child: std.process.Child) void {
+    var owned_child = child;
+    _ = owned_child.wait() catch {};
 }
 
 fn argvWithFile(allocator: std.mem.Allocator, argv: []const []const u8, file_path: []const u8) ![]const []const u8 {
@@ -126,11 +129,10 @@ fn systemOpenArgv(allocator: std.mem.Allocator, file_path: []const u8) ![]const 
     };
 }
 
-test "previewFileName keeps markdown extension and adds hash" {
-    const name = try previewFileName(std.testing.allocator, "studies/TUI_EXTERNAL_MARKDOWN_VIEWER.md", "# Title\n");
+test "previewFileName keeps stable markdown path" {
+    const name = try previewFileName(std.testing.allocator, "studies/TUI_EXTERNAL_MARKDOWN_VIEWER.md");
     defer std.testing.allocator.free(name);
-    try std.testing.expect(std.mem.startsWith(u8, name, "studies_TUI_EXTERNAL_MARKDOWN_VIEWER."));
-    try std.testing.expect(std.mem.endsWith(u8, name, ".md"));
+    try std.testing.expectEqualStrings("studies_TUI_EXTERNAL_MARKDOWN_VIEWER.md", name);
 }
 
 test "open appends file path to configured argv" {

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -289,6 +289,9 @@ pub const Shell = struct {
     markdown_viewer_buf: [256]u8 = .{0} ** 256,
     markdown_viewer_len: usize = 0,
     markdown_viewer_dialog_message: []const u8 = "",
+    markdown_viewer_display_buf: [256]u8 = .{0} ** 256,
+    markdown_viewer_display_len: usize = 0,
+    markdown_viewer_configured: bool = false,
     sign_out_should_quit: bool = false,
     quit_after_sign_out: bool = false,
 
@@ -322,6 +325,7 @@ pub const Shell = struct {
             .app = app,
             .env_map = env_map,
         };
+        shell.refreshMarkdownViewerPreference();
         shell.seedLoginDefaults();
         return shell;
     }
@@ -554,6 +558,7 @@ pub const Shell = struct {
                 if (key.matches('S', .{})) {
                     log.info("settings_open", .{});
                     self.show_settings = true;
+                    self.refreshMarkdownViewerPreference();
                     self.refreshSettingsWorkspaces();
                     ctx.consumeAndRedraw();
                     return;
@@ -1233,7 +1238,7 @@ pub const Shell = struct {
     }
 
     fn seedLoginDefaults(self: *Shell) void {
-        const alloc = self.api_state.backing_allocator;
+        const alloc = self.api_state.allocator();
         const configured_url = workspace_config.loadServerUrl(alloc) catch null;
         defer if (configured_url) |url| alloc.free(url);
         const default_url = configured_url orelse DEFAULT_HUB_URL;
@@ -4620,21 +4625,47 @@ pub const Shell = struct {
         return surface;
     }
 
-    pub fn markdownViewerCommandForView(self: *Shell, allocator: std.mem.Allocator) ![]const u8 {
-        _ = self;
-        var prefs = tui_prefs.load(allocator) catch return markdown_viewer.systemOpenLabel();
-        defer prefs.deinit(allocator);
-        const argv = prefs.markdown_viewer_argv orelse return markdown_viewer.systemOpenLabel();
-        const command = try tui_prefs.commandLineFromArgv(allocator, argv);
-        defer allocator.free(command);
-        return std.fmt.allocPrint(allocator, "$ {s} <preview.md>", .{command});
+    pub fn markdownViewerCommandForView(self: *Shell) []const u8 {
+        return self.markdown_viewer_display_buf[0..self.markdown_viewer_display_len];
     }
 
     pub fn markdownViewerIsConfigured(self: *Shell) bool {
-        const alloc = self.api_state.allocator();
-        var prefs = tui_prefs.load(alloc) catch return false;
+        return self.markdown_viewer_configured;
+    }
+
+    fn refreshMarkdownViewerPreference(self: *Shell) void {
+        self.markdown_viewer_display_len = 0;
+        self.markdown_viewer_configured = false;
+        @memset(&self.markdown_viewer_display_buf, 0);
+        const alloc = self.api_state.backing_allocator;
+        var prefs = tui_prefs.load(alloc) catch {
+            self.setMarkdownViewerDisplay(markdown_viewer.systemOpenLabel());
+            return;
+        };
         defer prefs.deinit(alloc);
-        return prefs.markdown_viewer_argv != null;
+        const argv = prefs.markdown_viewer_argv orelse {
+            self.setMarkdownViewerDisplay(markdown_viewer.systemOpenLabel());
+            return;
+        };
+        self.markdown_viewer_configured = true;
+        const command = tui_prefs.commandLineFromArgv(alloc, argv) catch {
+            self.setMarkdownViewerDisplay("$ <invalid viewer command>");
+            return;
+        };
+        defer alloc.free(command);
+        var display = std.ArrayList(u8).empty;
+        defer display.deinit(alloc);
+        display.writer(alloc).print("$ {s} <preview.md>", .{command}) catch {
+            self.setMarkdownViewerDisplay("$ <viewer command too large>");
+            return;
+        };
+        self.setMarkdownViewerDisplay(display.items);
+    }
+
+    fn setMarkdownViewerDisplay(self: *Shell, value: []const u8) void {
+        const len = @min(value.len, self.markdown_viewer_display_buf.len);
+        @memcpy(self.markdown_viewer_display_buf[0..len], value[0..len]);
+        self.markdown_viewer_display_len = len;
     }
 
     pub fn openMarkdownViewerDialog(self: *Shell) void {
@@ -4642,7 +4673,7 @@ pub const Shell = struct {
         self.markdown_viewer_len = 0;
         self.markdown_viewer_dialog_message = "";
         @memset(&self.markdown_viewer_buf, 0);
-        const alloc = self.api_state.allocator();
+        const alloc = self.api_state.backing_allocator;
         var prefs = tui_prefs.load(alloc) catch tui_prefs.Prefs{};
         defer prefs.deinit(alloc);
         if (prefs.markdown_viewer_argv) |argv| {
@@ -4655,10 +4686,11 @@ pub const Shell = struct {
     }
 
     pub fn clearMarkdownViewerPreference(self: *Shell) void {
-        tui_prefs.saveMarkdownViewerArgv(self.api_state.allocator(), null) catch |err| {
+        tui_prefs.saveMarkdownViewerArgv(self.api_state.backing_allocator, null) catch |err| {
             self.notifyOp(.failure, @errorName(err));
             return;
         };
+        self.refreshMarkdownViewerPreference();
         self.notifyOp(.success, "Markdown viewer preference cleared.");
     }
 
@@ -4696,13 +4728,14 @@ pub const Shell = struct {
 
     fn submitMarkdownViewerDialog(self: *Shell) void {
         const command = std.mem.trim(u8, self.markdown_viewer_buf[0..self.markdown_viewer_len], " \t\r\n");
-        const alloc = self.api_state.allocator();
+        const alloc = self.api_state.backing_allocator;
         if (command.len == 0) {
             tui_prefs.saveMarkdownViewerArgv(alloc, null) catch |err| {
                 self.markdown_viewer_dialog_message = @errorName(err);
                 return;
             };
             self.closeMarkdownViewerDialog();
+            self.refreshMarkdownViewerPreference();
             self.notifyOp(.success, "Markdown viewer preference cleared.");
             return;
         }
@@ -4723,6 +4756,7 @@ pub const Shell = struct {
             return;
         };
         self.closeMarkdownViewerDialog();
+        self.refreshMarkdownViewerPreference();
         self.notifyOp(.success, "Markdown viewer preference saved.");
     }
 
@@ -5589,7 +5623,7 @@ pub const Shell = struct {
             self.notifyOp(.warning, "No workspace selected.");
             return;
         };
-        const alloc = self.api_state.allocator();
+        const alloc = self.api_state.backing_allocator;
         const ws_dir = workspace_config.getWsDir(alloc, ws_id) catch {
             self.notifyOp(.failure, "Could not resolve workspace directory.");
             return;

--- a/src/client/tui/shell.zig
+++ b/src/client/tui/shell.zig
@@ -37,6 +37,7 @@ const DEFAULT_HUB_URL = "http://127.0.0.1:8400";
 const CONTENT_PREFETCH_LIMIT: usize = 24;
 
 const editor_host = runtime.editor_host;
+const markdown_viewer = runtime.markdown_viewer;
 const attestation_reader = runtime.attestation_reader;
 const Modal = w.Modal;
 
@@ -284,6 +285,10 @@ pub const Shell = struct {
     invite_dialog_scope: MemberDialogScope = .org,
     invite_workspace_id_buf: [80]u8 = .{0} ** 80,
     invite_workspace_id_len: usize = 0,
+    show_markdown_viewer_dialog: bool = false,
+    markdown_viewer_buf: [256]u8 = .{0} ** 256,
+    markdown_viewer_len: usize = 0,
+    markdown_viewer_dialog_message: []const u8 = "",
     sign_out_should_quit: bool = false,
     quit_after_sign_out: bool = false,
 
@@ -423,6 +428,11 @@ pub const Shell = struct {
 
                 if (self.show_invite_dialog) {
                     self.handleInviteDialogKey(ctx, key);
+                    return;
+                }
+
+                if (self.show_markdown_viewer_dialog) {
+                    self.handleMarkdownViewerDialogKey(ctx, key);
                     return;
                 }
 
@@ -688,20 +698,21 @@ pub const Shell = struct {
         const show_workspace_drawer = self.workspace.show_drawer and self.selected_module == .workspace and
             !self.show_settings and !self.show_help and !self.show_confirm and !self.review.show_comment_editor and
             !self.workspace.show_create and !self.drafts.show_pr_composer and !self.drafts.show_new_draft_form and
-            !self.show_profile_dialog and !self.show_invite_dialog;
+            !self.show_profile_dialog and !self.show_invite_dialog and !self.show_markdown_viewer_dialog;
         const show_artifact_bundle_drawer = self.artifact.show_bundle_drawer and self.selected_module == .artifact and
             !self.show_settings and !self.show_help and !self.show_confirm and !self.review.show_comment_editor and
             !self.workspace.show_create and !self.drafts.show_pr_composer and !self.drafts.show_new_draft_form and
-            !self.show_profile_dialog and !self.show_invite_dialog;
+            !self.show_profile_dialog and !self.show_invite_dialog and !self.show_markdown_viewer_dialog;
         const show_artifact_workspace_drawer = self.artifact.show_workspace_drawer and self.selected_module == .artifact and
             !self.show_settings and !self.show_help and !self.show_confirm and !self.review.show_comment_editor and
             !self.workspace.show_create and !self.drafts.show_pr_composer and !self.drafts.show_new_draft_form and
-            !self.show_profile_dialog and !self.show_invite_dialog;
+            !self.show_profile_dialog and !self.show_invite_dialog and !self.show_markdown_viewer_dialog;
         const show_login_panel = self.shouldShowLoginPanel();
         const allow_regular_overlays = !show_login_panel;
         const modal_active = show_login_panel or self.show_help or self.show_confirm or self.review.show_comment_editor or
             self.workspace.show_create or self.drafts.show_pr_composer or
             self.drafts.show_new_draft_form or self.show_profile_dialog or self.show_invite_dialog or
+            self.show_markdown_viewer_dialog or
             show_workspace_drawer or show_artifact_bundle_drawer or show_artifact_workspace_drawer;
         const show_notice_overlay = !modal_active and self.system_notices.hasVisible();
         var child_count: usize = 3;
@@ -710,6 +721,7 @@ pub const Shell = struct {
         if (allow_regular_overlays and self.show_confirm) child_count += 1;
         if (allow_regular_overlays and self.show_profile_dialog) child_count += 1;
         if (allow_regular_overlays and self.show_invite_dialog) child_count += 1;
+        if (allow_regular_overlays and self.show_markdown_viewer_dialog) child_count += 1;
         if (allow_regular_overlays and self.review.show_comment_editor) child_count += 1;
         if (allow_regular_overlays and self.workspace.show_create) child_count += 1;
         if (allow_regular_overlays and self.drafts.show_pr_composer) child_count += 1;
@@ -786,6 +798,17 @@ pub const Shell = struct {
             children[child_idx] = .{
                 .origin = .{ .row = 0, .col = 0 },
                 .surface = try self.drawInviteDialog(full_ctx),
+            };
+            child_idx += 1;
+        }
+        if (allow_regular_overlays and self.show_markdown_viewer_dialog) {
+            const full_ctx = ctx.withConstraints(
+                .{ .width = size.width, .height = size.height },
+                .{ .width = size.width, .height = size.height },
+            );
+            children[child_idx] = .{
+                .origin = .{ .row = 0, .col = 0 },
+                .surface = try self.drawMarkdownViewerDialog(full_ctx),
             };
             child_idx += 1;
         }
@@ -1071,6 +1094,10 @@ pub const Shell = struct {
             .{ .key = "n", .label = "cancel" },
             .{ .key = "Esc", .label = "cancel" },
         };
+        if (self.show_markdown_viewer_dialog) return &.{
+            .{ .key = "Enter", .label = "save" },
+            .{ .key = "Esc", .label = "cancel" },
+        };
         if (self.show_settings) return settings_panel.shortcuts(self);
         if (self.review.show_comment_editor) return &.{
             .{ .key = "Enter", .label = "send" },
@@ -1306,6 +1333,7 @@ pub const Shell = struct {
         if (self.review.show_comment_editor) return true;
         if (self.show_profile_dialog and !self.profile_dialog_submitting) return true;
         if (self.show_invite_dialog and !self.invite_dialog_submitting) return true;
+        if (self.show_markdown_viewer_dialog) return true;
         if (self.drafts.show_new_draft_form) return true;
         if (self.drafts.show_pr_composer) return self.drafts.pr_composer_focus == .title or self.drafts.pr_composer_focus == .body;
         if (self.workspace.show_create) return self.workspace.create_focus == .name or self.workspace.create_focus == .description;
@@ -4592,6 +4620,135 @@ pub const Shell = struct {
         return surface;
     }
 
+    pub fn markdownViewerCommandForView(self: *Shell, allocator: std.mem.Allocator) ![]const u8 {
+        _ = self;
+        var prefs = tui_prefs.load(allocator) catch return markdown_viewer.systemOpenLabel();
+        defer prefs.deinit(allocator);
+        const argv = prefs.markdown_viewer_argv orelse return markdown_viewer.systemOpenLabel();
+        const command = try tui_prefs.commandLineFromArgv(allocator, argv);
+        defer allocator.free(command);
+        return std.fmt.allocPrint(allocator, "$ {s} <preview.md>", .{command});
+    }
+
+    pub fn markdownViewerIsConfigured(self: *Shell) bool {
+        const alloc = self.api_state.allocator();
+        var prefs = tui_prefs.load(alloc) catch return false;
+        defer prefs.deinit(alloc);
+        return prefs.markdown_viewer_argv != null;
+    }
+
+    pub fn openMarkdownViewerDialog(self: *Shell) void {
+        self.show_markdown_viewer_dialog = true;
+        self.markdown_viewer_len = 0;
+        self.markdown_viewer_dialog_message = "";
+        @memset(&self.markdown_viewer_buf, 0);
+        const alloc = self.api_state.allocator();
+        var prefs = tui_prefs.load(alloc) catch tui_prefs.Prefs{};
+        defer prefs.deinit(alloc);
+        if (prefs.markdown_viewer_argv) |argv| {
+            const command = tui_prefs.commandLineFromArgv(alloc, argv) catch return;
+            defer alloc.free(command);
+            const len = @min(command.len, self.markdown_viewer_buf.len);
+            @memcpy(self.markdown_viewer_buf[0..len], command[0..len]);
+            self.markdown_viewer_len = len;
+        }
+    }
+
+    pub fn clearMarkdownViewerPreference(self: *Shell) void {
+        tui_prefs.saveMarkdownViewerArgv(self.api_state.allocator(), null) catch |err| {
+            self.notifyOp(.failure, @errorName(err));
+            return;
+        };
+        self.notifyOp(.success, "Markdown viewer preference cleared.");
+    }
+
+    pub fn testMarkdownViewerPreference(self: *Shell) void {
+        self.openMarkdownViewerContent("clumsies-viewer-test.md", "# Markdown Viewer Test\n\nClumsies opened this file from Settings > Preferences.\n");
+    }
+
+    fn closeMarkdownViewerDialog(self: *Shell) void {
+        self.show_markdown_viewer_dialog = false;
+        self.markdown_viewer_len = 0;
+        self.markdown_viewer_dialog_message = "";
+        @memset(&self.markdown_viewer_buf, 0);
+    }
+
+    fn handleMarkdownViewerDialogKey(self: *Shell, ctx: *vxfw.EventContext, key: vaxis.Key) void {
+        if (key.matches(vaxis.Key.escape, .{})) {
+            self.closeMarkdownViewerDialog();
+            ctx.consumeAndRedraw();
+            return;
+        }
+        var input = w.TextInput{ .buf = &self.markdown_viewer_buf, .len = &self.markdown_viewer_len };
+        switch (input.handleKey(key)) {
+            .consumed => ctx.consumeAndRedraw(),
+            .submit => {
+                self.submitMarkdownViewerDialog();
+                ctx.consumeAndRedraw();
+            },
+            .cancel => {
+                self.closeMarkdownViewerDialog();
+                ctx.consumeAndRedraw();
+            },
+            .ignored => {},
+        }
+    }
+
+    fn submitMarkdownViewerDialog(self: *Shell) void {
+        const command = std.mem.trim(u8, self.markdown_viewer_buf[0..self.markdown_viewer_len], " \t\r\n");
+        const alloc = self.api_state.allocator();
+        if (command.len == 0) {
+            tui_prefs.saveMarkdownViewerArgv(alloc, null) catch |err| {
+                self.markdown_viewer_dialog_message = @errorName(err);
+                return;
+            };
+            self.closeMarkdownViewerDialog();
+            self.notifyOp(.success, "Markdown viewer preference cleared.");
+            return;
+        }
+        const argv = tui_prefs.parseCommandLineArgv(alloc, command) catch |err| {
+            self.markdown_viewer_dialog_message = switch (err) {
+                error.InvalidCommandLine => "Command has an unfinished quote or escape.",
+                error.EmptyCommand => "Command is required.",
+                else => @errorName(err),
+            };
+            return;
+        };
+        defer {
+            for (argv) |arg| alloc.free(arg);
+            alloc.free(argv);
+        }
+        tui_prefs.saveMarkdownViewerArgv(alloc, argv) catch |err| {
+            self.markdown_viewer_dialog_message = @errorName(err);
+            return;
+        };
+        self.closeMarkdownViewerDialog();
+        self.notifyOp(.success, "Markdown viewer preference saved.");
+    }
+
+    fn drawMarkdownViewerDialog(self: *Shell, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const modal = Modal{
+            .title = "Markdown Viewer",
+            .box_width = 72,
+            .box_height = 11,
+        };
+        const result = try modal.draw(ctx, self.widget());
+        var surface = result.surface;
+        const col = result.content_col;
+        var row = result.content_row;
+
+        w.writeText(&surface, ctx, col, row, "Command", theme.textOn(theme.PANEL_ALT, theme.MUTED));
+        w.drawTextInputSlot(&surface, ctx, col + 10, row, result.content_width -| 12, self.markdown_viewer_buf[0..self.markdown_viewer_len], theme.TEXT, true);
+        row += 2;
+        _ = w.writeWrappedTextMax(&surface, ctx, col, row, result.content_width, 2, "Enter a command prefix. Clumsies appends the preview path, for example: open -a Typora <preview.md>. Leave empty to use the system default.", theme.textOn(theme.PANEL_ALT, theme.MUTED));
+        row += 3;
+        w.writeText(&surface, ctx, col, row, "[ Save ]", theme.boldOn(theme.PANEL_ALT, theme.TEXT));
+        if (self.markdown_viewer_dialog_message.len > 0) {
+            _ = w.writeWrappedTextMax(&surface, ctx, col, row + 2, result.content_width, 2, self.markdown_viewer_dialog_message, theme.textOn(theme.PANEL_ALT, theme.DANGER));
+        }
+        return surface;
+    }
+
     pub fn openInviteMemberDialog(self: *Shell) void {
         if (!self.ensureMemberManagementAllowed()) return;
         self.show_invite_dialog = true;
@@ -5411,6 +5568,75 @@ pub const Shell = struct {
         workspace_panel.copyTextToClipboard(self.api_state.backing_allocator, id);
         self.notifyOp(.success, "Copied id to clipboard.");
         return true;
+    }
+
+    pub fn openSelectedMarkdownViewer(self: *Shell) void {
+        self.refreshDraftsCache();
+        const target = self.selectedDraftTarget() orelse {
+            self.notifyOp(.warning, "No content selection.");
+            return;
+        };
+        const content = self.selectedEffectiveMarkdownContent(target) orelse {
+            self.notifyOp(.warning, "Selected content is not loaded.");
+            return;
+        };
+
+        self.openMarkdownViewerContent(target.path, content);
+    }
+
+    fn openMarkdownViewerContent(self: *Shell, source_path: []const u8, content: []const u8) void {
+        const ws_id = self.activeWsId() orelse {
+            self.notifyOp(.warning, "No workspace selected.");
+            return;
+        };
+        const alloc = self.api_state.allocator();
+        const ws_dir = workspace_config.getWsDir(alloc, ws_id) catch {
+            self.notifyOp(.failure, "Could not resolve workspace directory.");
+            return;
+        };
+        defer alloc.free(ws_dir);
+
+        const file_path = markdown_viewer.materialize(alloc, ws_dir, source_path, content) catch |err| {
+            self.notifyOp(.failure, @errorName(err));
+            return;
+        };
+        defer alloc.free(file_path);
+
+        var prefs = tui_prefs.load(alloc) catch tui_prefs.Prefs{};
+        defer prefs.deinit(alloc);
+        const result = markdown_viewer.open(alloc, prefs.markdown_viewer_argv, file_path) catch |err| {
+            self.notifyOp(.failure, @errorName(err));
+            return;
+        };
+        switch (result) {
+            .opened => self.notifyOp(.success, "Opened Markdown viewer."),
+            .viewer_not_found => self.notifyOp(.failure, "Markdown viewer not found. Configure it in Settings > Preferences."),
+            .spawn_failed => self.notifyOp(.failure, "Markdown viewer spawn failed."),
+            .failed => self.notifyOp(.failure, "Markdown viewer exited non-zero."),
+        }
+    }
+
+    fn selectedEffectiveMarkdownContent(self: *Shell, target: DraftTarget) ?[]const u8 {
+        if (self.draftContentForView(target.category, target.path)) |draft| return draft;
+        if (self.selected_module == .workspace) {
+            const live = self.workspaceDetailForView(target.ws_id);
+            if (self.currentWorkspaceFileSelection(live)) |selection| {
+                return switch (selection) {
+                    .context => |c| blk: {
+                        const cache_path = self.workspaceLocalContextPathForView(c.path, c.context_id) orelse c.path;
+                        break :blk self.localWorkspaceContextBody(target.ws_id, cache_path) orelse
+                            self.cachedWorkspaceContextBody(target.ws_id, c.path);
+                    },
+                    .rule => |r| blk: {
+                        const cache_path = self.workspaceLocalRulePathForView(r.path, r.rule_id) orelse r.path;
+                        const cache_category = self.artifactCategoryForPath(cache_path);
+                        break :blk self.localArtifactRuleBody(cache_category, cache_path) orelse
+                            self.cachedArtifactRuleBody(r.category, r.path);
+                    },
+                };
+            }
+        }
+        return self.seedContentForTarget(target);
     }
 
     /// Entry point for the `e` key. Finds or creates an update draft for
@@ -7947,6 +8173,7 @@ pub const Shell = struct {
         if (self.show_confirm) return "confirm";
         if (self.show_profile_dialog) return "profile_dialog";
         if (self.show_invite_dialog) return "invite_dialog";
+        if (self.show_markdown_viewer_dialog) return "markdown_viewer_dialog";
         if (self.show_help) return "help";
         if (self.shouldShowLoginPanel()) return "login";
         if (self.workspace.show_drawer) return "workspace_drawer";


### PR DESCRIPTION
## Summary

Add a read-only external Markdown viewer for TUI rule and context
previews. The viewer opens the effective draft-or-cache content via the
`v` shortcut, stores local viewer preferences in TUI prefs, and exposes
a Preferences screen for editing, clearing, and testing the configured
command.

The preview materialization now uses the same workspace cache path
resolution as the in-TUI content pane, so selecting a canonicalized
display path no longer writes an empty Markdown file when the local
cache still uses the original path.

## Test plan

- [x] Run `zig build test`
- [x] Run `zig build`
- [x] Manually verify the branch is pushed to `origin/feat/tui-markdown-viewer`
