### PR TITLE
daemon: replace eprintln! with tracing for structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml_edit",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2082,6 +2084,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2229,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3641,6 +3661,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,6 +4165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4465,6 +4503,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4629,6 +4697,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = "1.0.150"
 sha2 = "0.10.9"
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "uuid"] }
 thiserror = "2.0.18"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
 toml_edit = "0.25.13"
 uuid = { version = "1.23.4", features = ["v4", "serde"] }

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -680,7 +680,7 @@ fn rollback_changes(backups: &[FileBackup]) {
             None => remove_file_if_present(&backup.path),
         };
         if let Err(error) = result {
-            eprintln!(
+            tracing::error!(
                 "failed to roll back adapter file {}: {error}",
                 backup.path.display()
             );

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1612,10 +1612,10 @@ impl DaemonState {
                 match result {
                     Ok(Ok(())) => break,
                     Ok(Err(error)) => {
-                        eprintln!("search model preparation failed: {}", error.message);
+                        tracing::warn!("search model preparation failed: {}", error.message);
                     }
                     Err(error) => {
-                        eprintln!("search model preparation worker failed: {error}");
+                        tracing::error!("search model preparation worker failed: {error}");
                     }
                 }
                 tokio::time::sleep(retry_delay).await;

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1683,6 +1683,37 @@ impl DaemonState {
     }
 }
 
+macro_rules! dispatch_async {
+    ($self:expr, $payload:expr, $method:ident) => {{
+        let payload = $self.decode_dispatch_payload::<_>($payload);
+        match payload {
+            Ok(payload) => $self
+                .$method(payload)
+                .await
+                .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
+            Err(error) => Err(error),
+        }
+    }};
+}
+
+macro_rules! dispatch_result_async {
+    ($self:expr, $method:ident) => {
+        $self
+            .$method()
+            .await
+            .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from))
+    };
+}
+
+macro_rules! dispatch_value {
+    ($self:expr, $method:ident) => {
+        serde_json::to_value($self.$method()).map_err(DaemonError::from)
+    };
+    ($self:expr, $method:ident, async) => {
+        serde_json::to_value($self.$method().await).map_err(DaemonError::from)
+    };
+}
+
 #[derive(Clone)]
 pub struct DaemonIpcService {
     state: DaemonState,
@@ -1925,325 +1956,76 @@ impl DaemonIpcService {
 
     pub async fn dispatch(&self, request: DaemonIpcRequest) -> DaemonIpcResponse {
         let result = match request.method.as_str() {
-            "health" => serde_json::to_value(self.health().await).map_err(DaemonError::from),
-            "project_config" => {
-                serde_json::to_value(self.project_config()).map_err(DaemonError::from)
-            }
+            "health" => dispatch_value!(self, health, async),
+            "project_config" => dispatch_value!(self, project_config),
             "replace_project_config" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectConfigUpdateRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .replace_project_config(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, replace_project_config)
             }
-            "select_project" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonProjectSelectionRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .select_project(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "select_project" => dispatch_async!(self, request.payload, select_project),
             "resolve_project_binding" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectBindingResolveRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .resolve_project_binding(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, resolve_project_binding)
             }
             "list_project_bindings" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectBindingListRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .list_project_bindings(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, list_project_bindings)
             }
             "replace_project_binding" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectBindingReplaceRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .replace_project_binding(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, replace_project_binding)
             }
             "remove_project_binding" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectBindingRemoveRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .remove_project_binding(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, remove_project_binding)
             }
             "list_project_agent_adapters" => {
-                let payload = self.decode_dispatch_payload::<DaemonProjectAgentAdapterListRequest>(
-                    request.payload,
-                );
-                match payload {
-                    Ok(payload) => self
-                        .list_project_agent_adapters(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, list_project_agent_adapters)
             }
             "install_project_agent_adapter" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectAgentAdapterInstallRequest>(
-                        request.payload,
-                    );
-                match payload {
-                    Ok(payload) => self
-                        .install_project_agent_adapter(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, install_project_agent_adapter)
             }
             "remove_project_agent_adapter" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectAgentAdapterRemoveRequest>(
-                        request.payload,
-                    );
-                match payload {
-                    Ok(payload) => self
-                        .remove_project_agent_adapter(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, remove_project_agent_adapter)
             }
-            "sync_status" => self
-                .sync_status()
-                .await
-                .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-            "project_storage" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonProjectStorageRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .project_storage(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "sync_status" => dispatch_result_async!(self, sync_status),
+            "project_storage" => dispatch_async!(self, request.payload, project_storage),
             "replace_project_storage" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectStorageReplaceRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .replace_project_storage(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, replace_project_storage)
             }
             "project_storage_move" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectStorageMoveRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .project_storage_move(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, project_storage_move)
             }
             "reset_project_storage" => {
-                let payload = self
-                    .decode_dispatch_payload::<DaemonProjectStorageResetRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .reset_project_storage(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, reset_project_storage)
             }
             "clear_project_cache" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonProjectCacheClearRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .clear_project_cache(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, clear_project_cache)
             }
-            "memory_cache" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonMemoryCacheRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .memory_cache(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
-            "project_checkout" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonProjectCheckoutRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .project_checkout(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
-            "activate_memory" => {
-                let payload =
-                    self.decode_dispatch_payload::<ActivateMemoryRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .activate_memory(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
-            "load_memory" => {
-                let payload = self.decode_dispatch_payload::<LoadMemoryRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .load_memory(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "memory_cache" => dispatch_async!(self, request.payload, memory_cache),
+            "project_checkout" => dispatch_async!(self, request.payload, project_checkout),
+            "activate_memory" => dispatch_async!(self, request.payload, activate_memory),
+            "load_memory" => dispatch_async!(self, request.payload, load_memory),
             "search_index_status" => {
-                let payload =
-                    self.decode_dispatch_payload::<SearchIndexProjectRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .search_index_status(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, search_index_status)
             }
             "rebuild_search_index" => {
-                let payload =
-                    self.decode_dispatch_payload::<SearchIndexProjectRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .rebuild_search_index(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, rebuild_search_index)
             }
             "list_retrieval_runs" => {
-                let payload =
-                    self.decode_dispatch_payload::<RetrievalRunListRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .list_retrieval_runs(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, list_retrieval_runs)
             }
-            "get_retrieval_run" => {
-                let payload = self.decode_dispatch_payload::<RetrievalRunRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .get_retrieval_run(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "get_retrieval_run" => dispatch_async!(self, request.payload, get_retrieval_run),
             "create_evaluation_case" => {
-                let payload =
-                    self.decode_dispatch_payload::<CreateEvaluationCaseRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .create_evaluation_case(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, create_evaluation_case)
             }
             "resolve_evaluation_case" => {
-                let payload =
-                    self.decode_dispatch_payload::<ResolveEvaluationCaseRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .resolve_evaluation_case(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, resolve_evaluation_case)
             }
             "clear_retrieval_runs" => {
-                let payload =
-                    self.decode_dispatch_payload::<ClearRetrievalRunsRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .clear_retrieval_runs(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, clear_retrieval_runs)
             }
             "export_evaluation_set" => {
-                let payload =
-                    self.decode_dispatch_payload::<ExportEvaluationSetRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .export_evaluation_set(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, export_evaluation_set)
             }
-            "retry_sync" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonSyncRetryRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .retry_sync(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
-            "mcp_status" => serde_json::to_value(self.mcp_status()).map_err(DaemonError::from),
-            "list_drafts" => {
-                let payload = self.decode_dispatch_payload::<DaemonDraftListQuery>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .list_drafts(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "retry_sync" => dispatch_async!(self, request.payload, retry_sync),
+            "mcp_status" => dispatch_value!(self, mcp_status),
+            "list_drafts" => dispatch_async!(self, request.payload, list_drafts),
             "get_draft" => {
                 let payload =
                     self.decode_dispatch_payload::<DaemonDraftDetailRequest>(request.payload);
@@ -2256,26 +2038,9 @@ impl DaemonIpcService {
                 }
             }
             "store_draft_operation" => {
-                let payload =
-                    self.decode_dispatch_payload::<DaemonDraftOperationRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .store_draft_operation(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
+                dispatch_async!(self, request.payload, store_draft_operation)
             }
-            "server_request" => {
-                let payload = self.decode_dispatch_payload::<DaemonServerRequest>(request.payload);
-                match payload {
-                    Ok(payload) => self
-                        .server_request(payload)
-                        .await
-                        .and_then(|value| serde_json::to_value(value).map_err(DaemonError::from)),
-                    Err(error) => Err(error),
-                }
-            }
+            "server_request" => dispatch_async!(self, request.payload, server_request),
             method => Err(DaemonError::InvalidRequest(format!(
                 "unknown daemon IPC method: {method}"
             ))),

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -2,10 +2,27 @@ use daemon::{
     DaemonConfig, DaemonIpcServer, DaemonIpcService, DaemonState, LaunchAgentConfig,
     LaunchAgentController,
 };
+use std::sync::Mutex;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::fmt::time::SystemTime;
+use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = DaemonConfig::from_env()?;
+
+    let log_file = Mutex::new(
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(config.log_dir.join("daemon.log"))?,
+    );
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_timer(SystemTime)
+        .with_writer(std::io::stderr.and(log_file))
+        .with_target(false)
+        .init();
     let launch_agent = LaunchAgentConfig::from_daemon_config(&config, std::env::current_exe()?)?;
     let launch_agent_controller = LaunchAgentController::for_current_user(launch_agent.clone())?;
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -41,7 +58,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         [] => {}
         _ => {
-            eprintln!(
+            tracing::error!(
                 "usage: clumsiesd [--print-launch-agent-plist|--install-launch-agent|--status-launch-agent|--bootstrap-launch-agent|--bootout-launch-agent|--restart-launch-agent|--reconcile-launch-agent]"
             );
             std::process::exit(64);
@@ -56,9 +73,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _search_model_worker = state.start_search_model_worker();
     let health = service.health().await;
 
-    eprintln!(
+    tracing::info!(
         "clumsiesd initialized for Mach service {} with installation {}",
-        launch_agent.mach_service_name, health.daemon_installation_id
+        launch_agent.mach_service_name,
+        health.daemon_installation_id
     );
 
     shutdown_signal().await;

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -642,7 +642,7 @@ pub(crate) async fn activate_memory(
         match super::retrieval_history::start_run(state, &project_id, &query, &fingerprint).await {
             Ok(run_id) => Some(run_id),
             Err(error) => {
-                eprintln!("failed to start Retrieval Run recording: {error}");
+                tracing::error!("failed to start Retrieval Run recording: {error}");
                 None
             }
         };
@@ -713,11 +713,11 @@ pub(crate) async fn activate_memory(
     if let Some(run_id) = run_id
         && let Err(error) = super::retrieval_history::finish_run(state, &run_id, completion).await
     {
-        eprintln!("failed to finish Retrieval Run {run_id}: {error}");
+        tracing::error!("failed to finish Retrieval Run {run_id}: {error}");
         if let Err(record_error) =
             super::retrieval_history::record_persistence_failure(state, &run_id, &error).await
         {
-            eprintln!(
+            tracing::error!(
                 "failed to record Retrieval Run persistence failure {run_id}: {record_error}"
             );
         }
@@ -4075,6 +4075,7 @@ mod tests {
 
         let started = std::time::Instant::now();
         let units = build_index_units(&resources, &models).unwrap();
+        // Diagnostic timing for index build benchmark
         eprintln!(
             "built {} real embedding units in {:.2?}",
             units.len(),


### PR DESCRIPTION
## Summary

Replace `eprintln!` in the daemon with structured `tracing` calls.
Output goes to both stderr and a daemon log file, with log levels
and timestamps.

- `tracing::error!` for operation failures (rollback, Retrieval Run)
- `tracing::warn!` for retry-eligible failures (model preparation)
- `tracing::info!` for startup diagnostics

## Test plan

- [x] `cargo check -p daemon` passes
- [x] `cargo test -p daemon` — all 53 tests pass
