### PR TITLE
kanban: get by issue_key or issue number

### DIFF
--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -729,11 +729,38 @@ impl DaemonState {
         &self,
         request: GetIssueRequest,
     ) -> Result<IssueDetailResponse, DaemonError> {
-        let issue_id = request.issue_id.trim();
         let (project_id, issue_number) =
-            work_tracking::resolve_native_issue_identity(&self.inner.pool, issue_id)
-                .await?
-                .ok_or_else(|| DaemonError::NotFound(format!("Issue {issue_id}")))?;
+            match (request.issue_id.as_deref(), request.issue_key.as_deref()) {
+                (Some(issue_id), None) => {
+                    work_tracking::resolve_native_issue_identity(&self.inner.pool, issue_id)
+                        .await?
+                        .ok_or_else(|| DaemonError::NotFound(format!("Issue {issue_id}")))?
+                }
+                (None, Some(issue_key)) => {
+                    let project_id = request.project_id.as_deref().ok_or_else(|| {
+                        DaemonError::InvalidRequest(
+                            "project_id is required when resolving by issue_key".to_owned(),
+                        )
+                    })?;
+                    let issue_number = work_tracking::parse_issue_reference(issue_key)?;
+                    let project_id = project_id.trim();
+                    work_tracking::ensure_native_issue_in_project(
+                        &self.inner.pool,
+                        project_id,
+                        issue_number,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        DaemonError::NotFound(format!("{issue_key} in project {project_id}"))
+                    })?;
+                    (project_id.to_owned(), issue_number)
+                }
+                _ => {
+                    return Err(DaemonError::InvalidRequest(
+                        "get_issue requires exactly one of issue_id or issue_key".to_owned(),
+                    ));
+                }
+            };
         let runs = work_tracking::load_project_runs(&self.inner.pool, &project_id).await?;
         let (now, stale_before): (String, String) = sqlx::query_as(
             "SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -514,7 +514,12 @@ pub struct IssueDetailRequest {
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct GetIssueRequest {
-    pub issue_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -1800,6 +1805,24 @@ pub(crate) async fn resolve_native_issue_identity(
         .map_err(Into::into)
 }
 
+/// Confirms an Issue with the given number exists in the given project.
+/// Returns the issue_number when found, or None when the project has no such Issue.
+pub(crate) async fn ensure_native_issue_in_project(
+    pool: &SqlitePool,
+    project_id: &str,
+    issue_number: i64,
+) -> Result<Option<i64>, DaemonError> {
+    let found: Option<i64> = sqlx::query_scalar(
+        "SELECT issue_number FROM native_issues
+         WHERE project_id = $1 AND issue_number = $2",
+    )
+    .bind(project_id)
+    .bind(issue_number)
+    .fetch_optional(pool)
+    .await?;
+    Ok(found)
+}
+
 pub(crate) fn native_board_hash(cards: &[IssueBoardCard]) -> String {
     let mut hasher = Sha256::new();
     for card in cards {
@@ -3023,7 +3046,7 @@ fn ensure_revision(run: &AgentRun, expected_revision: i64) -> Result<(), DaemonE
     Ok(())
 }
 
-fn parse_issue_reference(issue_key: &str) -> Result<i64, DaemonError> {
+pub(crate) fn parse_issue_reference(issue_key: &str) -> Result<i64, DaemonError> {
     let digits = issue_key.strip_prefix("ISSUE-").ok_or_else(|| {
         DaemonError::InvalidRequest("issue_key must use the ISSUE-NNN form".to_owned())
     })?;
@@ -3978,7 +4001,9 @@ mod tests {
         );
         assert_eq!(
             serde_json::to_value(GetIssueRequest {
-                issue_id: "issue_0123456789abcdef0123456789abcdef".to_owned(),
+                issue_id: Some("issue_0123456789abcdef0123456789abcdef".to_owned()),
+                issue_key: None,
+                project_id: None,
             })
             .unwrap(),
             serde_json::json!({
@@ -4362,6 +4387,49 @@ mod tests {
         assert_eq!(cards[0].issue_id, created.issue_id);
         assert!(cards[0].path.is_empty());
         assert!(cards[0].draft_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn ensure_native_issue_in_project_confirms_existence_and_missing() {
+        let pool = run_pool().await;
+        let created = create_issue(
+            &pool,
+            CreateIssueRequest {
+                project_id: "project-1".to_owned(),
+                title: "Issue for key lookup".to_owned(),
+                description: "body".to_owned(),
+                acceptance_criteria: vec![],
+                external_references: Vec::new(),
+                dependencies: Vec::new(),
+                blocking_facts: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(created.issue_key, "ISSUE-001");
+
+        assert_eq!(
+            ensure_native_issue_in_project(&pool, "project-1", 1)
+                .await
+                .unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            ensure_native_issue_in_project(&pool, "project-1", 999)
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            ensure_native_issue_in_project(&pool, "other-project", 1)
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(parse_issue_reference("ISSUE-001").unwrap(), 1);
+        assert_eq!(parse_issue_reference("ISSUE-026").unwrap(), 26);
+        assert!(parse_issue_reference("ISSUE-000").is_err());
+        assert!(parse_issue_reference("issue-001").is_err());
     }
 
     #[tokio::test]

--- a/src/client/daemon/ipc.zig
+++ b/src/client/daemon/ipc.zig
@@ -263,12 +263,35 @@ pub fn getIssueOperation(
     return try operationResultFromResponse(allocator, response_json);
 }
 
+pub fn getIssueByKeyOperation(
+    allocator: std.mem.Allocator,
+    project_id: []const u8,
+    issue_key: []const u8,
+) !OperationResult {
+    const request_json = try getIssueByKeyRequestJsonAlloc(allocator, project_id, issue_key);
+    defer allocator.free(request_json);
+    const response_json = try callJson(allocator, MACH_SERVICE_NAME, request_json);
+    defer allocator.free(response_json);
+    return try operationResultFromResponse(allocator, response_json);
+}
+
 pub fn getIssueRequestJsonAlloc(
     allocator: std.mem.Allocator,
     issue_id: []const u8,
 ) ![]u8 {
     return requestWithPayloadJsonAlloc(allocator, "get_issue", .{
         .issue_id = issue_id,
+    });
+}
+
+pub fn getIssueByKeyRequestJsonAlloc(
+    allocator: std.mem.Allocator,
+    project_id: []const u8,
+    issue_key: []const u8,
+) ![]u8 {
+    return requestWithPayloadJsonAlloc(allocator, "get_issue", .{
+        .issue_key = issue_key,
+        .project_id = project_id,
     });
 }
 

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -77,7 +77,7 @@ const issue_schema =
     "\"inputSchema\":{\"type\":\"object\",\"properties\":{" ++
     "\"op\":{\"type\":\"object\",\"minProperties\":1,\"maxProperties\":1,\"properties\":{" ++
     "\"list\":{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}," ++
-    "\"get\":{\"type\":\"object\",\"properties\":{\"issue_id\":{\"type\":\"string\",\"pattern\":\"^issue_[0-9a-f]{32}$\",\"description\":\"Globally unique Issue ID copied from Kanban.\"}},\"required\":[\"issue_id\"],\"additionalProperties\":false}," ++
+    "\"get\":{\"type\":\"object\",\"description\":\"Fetch a single Issue by exactly one of: issue_id (globally unique, copied from Kanban) or issue_key (stable per-project number, e.g. ISSUE-038).\",\"properties\":{\"issue_id\":{\"type\":\"string\",\"pattern\":\"^issue_[0-9a-f]{32}$\",\"description\":\"Globally unique Issue ID copied from Kanban.\"},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\",\"description\":\"Stable per-project Issue number, e.g. ISSUE-038.\"}},\"oneOf\":[{\"required\":[\"issue_id\"]},{\"required\":[\"issue_key\"]}],\"additionalProperties\":false}," ++
     "\"create\":{\"type\":\"object\",\"description\":\"Create a durable Todo Issue; first call list and verify no existing Issue already covers the same problem.\",\"properties\":{\"title\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":240},\"description\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":65536},\"acceptance_criteria\":{\"type\":\"array\",\"maxItems\":64,\"items\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":2000}},\"external_references\":" ++ issue_external_references_schema ++ ",\"dependencies\":" ++ issue_dependencies_schema ++ ",\"blocking_facts\":" ++ issue_blocking_facts_schema ++ "},\"required\":[\"title\",\"description\"],\"additionalProperties\":false}," ++
     "\"update\":{\"type\":\"object\",\"properties\":{\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"},\"expected_revision\":{\"type\":\"integer\",\"minimum\":1},\"title\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":240},\"description\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":65536},\"acceptance_criteria\":{\"type\":\"array\",\"maxItems\":64,\"items\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":2000}},\"external_references\":" ++ issue_external_references_schema ++ ",\"dependencies\":" ++ issue_dependencies_schema ++ ",\"blocking_facts\":" ++ issue_blocking_facts_schema ++ "},\"required\":[\"issue_key\",\"expected_revision\"],\"additionalProperties\":false}," ++
     "\"begin_work\":{\"type\":\"object\",\"description\":\"Call this first before starting work on any Issue. Bind the current AgentRun to this Issue and enter In Progress. run_id and expected_revision (the AgentRun revision) are required only when the caller has a hook-issued AgentRun; omit both to let the daemon issue a manual run.\",\"properties\":{\"run_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"},\"expected_revision\":{\"type\":\"integer\",\"minimum\":1,\"description\":\"AgentRun revision, not the Issue state revision. With a hook-issued run use the run context revision; omit for a manual run.\"}},\"required\":[\"issue_key\"],\"additionalProperties\":false}," ++
@@ -283,13 +283,31 @@ fn handleIssue(
             break :blk try daemon_ipc.listIssueBoardOperation(allocator, session.project_id);
         },
         .get => blk: {
-            if (try rejectUnexpectedFields(allocator, op_args, &.{"issue_id"}, "get")) |result| return result;
-            const issue_id = requiredString(op_args, "issue_id") orelse
-                return try tool_result.buildErrorResult(allocator, "issue_id is required and must be a string");
-            if (!isIssueId(issue_id)) {
-                return try tool_result.buildErrorResult(allocator, "issue_id must match issue_<32 lowercase hexadecimal characters>");
+            if (try rejectUnexpectedFields(allocator, op_args, &.{ "issue_id", "issue_key" }, "get")) |result| return result;
+            const issue_id = if (op_args.get("issue_id")) |value| switch (value) {
+                .string => |string| string,
+                else => return try tool_result.buildErrorResult(allocator, "issue_id must be a string"),
+            } else null;
+            const issue_key = if (op_args.get("issue_key")) |value| switch (value) {
+                .string => |string| string,
+                else => return try tool_result.buildErrorResult(allocator, "issue_key must be a string"),
+            } else null;
+            if (issue_id != null and issue_key != null) {
+                return try tool_result.buildErrorResult(allocator, "provide exactly one of issue_id or issue_key");
             }
-            break :blk try daemon_ipc.getIssueOperation(allocator, issue_id);
+            if (issue_id) |id| {
+                if (!isIssueId(id)) {
+                    return try tool_result.buildErrorResult(allocator, "issue_id must match issue_<32 lowercase hexadecimal characters>");
+                }
+                break :blk try daemon_ipc.getIssueOperation(allocator, id);
+            }
+            if (issue_key) |key| {
+                if (!isIssueKey(key)) {
+                    return try tool_result.buildErrorResult(allocator, "issue_key must match ISSUE-<three digits>");
+                }
+                break :blk try daemon_ipc.getIssueByKeyOperation(allocator, session.project_id, key);
+            }
+            return try tool_result.buildErrorResult(allocator, "provide exactly one of issue_id or issue_key");
         },
         .create => blk: {
             if (try validateIssueCreate(allocator, op_args)) |result| return result;


### PR DESCRIPTION
## Summary

kanban get only accepted the long issue_id hash; agents and humans communicate in stable per-project numbers (ISSUE-038). Accept exactly one of issue_id (global) or issue_key (per-project, resolved against the MCP session project).

## Changes
- daemon: `GetIssueRequest` takes issue_id | issue_key + project_id; resolve by issue_id globally or issue_key within a project
- zig MCP: kanban get schema adds issue_key with oneOf; resolves via session.project_id
- tests: ensure_native_issue_in_project existence/missing, parse ISSUE-NNN cases

## Verification
- zig 405/405, cargo 157/157, clippy 1.97 clean
- End-to-end over MCP stdio: get by key and by id return the same Issue; missing key, no identifier, both identifiers, bad format all return clear errors