### PR TITLE
kanban: expose changed_by_run_id on board cards

### DIFF
--- a/apps/macos/Sources/Features/IssueBoardView.swift
+++ b/apps/macos/Sources/Features/IssueBoardView.swift
@@ -545,6 +545,21 @@ struct IssueDetailView: View {
                     if issue.verificationLevel != .agentSelf || !issue.verificationSteps.isEmpty {
                         VerificationProtocolSection(issue: issue)
                     }
+
+                    if let changedBy = issue.changedByRunId,
+                       let run = issue.activeRuns.first(where: { $0.runId == changedBy })
+                           ?? issue.latestRun
+                    {
+                        HStack(spacing: 6) {
+                            Image(systemName: "pencil.circle")
+                                .foregroundStyle(.secondary)
+                            Text("Last changed by \(run.host.title) · \(run.runId)")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
                 .frame(
                     maxWidth: DocumentContentMetrics.maximumWidth,

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -739,6 +739,7 @@ struct IssueBoardCard: Codable, Identifiable, Equatable, Sendable {
     let blockingFacts: [IssueBlockingFact]
     let activeRuns: [AgentRun]
     let latestRun: AgentRun?
+    let changedByRunId: String?
     let verificationLevel: VerificationLevel
     let verificationSteps: [String]
 }
@@ -782,6 +783,7 @@ extension IssueBoardCard {
         case blockingFacts
         case activeRuns
         case latestRun
+        case changedByRunId
         case verificationLevel
         case verificationSteps
     }
@@ -834,6 +836,7 @@ extension IssueBoardCard {
         ) ?? []
         activeRuns = try container.decode([AgentRun].self, forKey: .activeRuns)
         latestRun = try container.decodeIfPresent(AgentRun.self, forKey: .latestRun)
+        changedByRunId = try container.decodeIfPresent(String.self, forKey: .changedByRunId)
         verificationLevel = try container.decodeIfPresent(
             VerificationLevel.self,
             forKey: .verificationLevel

--- a/apps/macos/Tests/IssueBoardTests.swift
+++ b/apps/macos/Tests/IssueBoardTests.swift
@@ -509,6 +509,7 @@ final class IssueBoardModelTests: XCTestCase {
                     blockingFacts: [],
                     activeRuns: [],
                     latestRun: nil,
+                    changedByRunId: nil,
                     verificationLevel: .agentSelf,
                     verificationSteps: []
                 ),
@@ -730,6 +731,7 @@ final class IssueBoardModelTests: XCTestCase {
             blockingFacts: [],
             activeRuns: [run],
             latestRun: run,
+            changedByRunId: run.runId,
             verificationLevel: .agentSelf,
             verificationSteps: []
         )

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -656,6 +656,7 @@ pub struct IssueBoardCard {
     pub blocking_facts: Vec<IssueBlockingFact>,
     pub active_runs: Vec<AgentRun>,
     pub latest_run: Option<AgentRun>,
+    pub changed_by_run_id: Option<String>,
     pub verification_level: VerificationLevel,
     pub verification_steps: Vec<String>,
 }
@@ -2202,6 +2203,7 @@ fn native_issue_card(
         blocking_facts: issue.blocking_facts,
         active_runs: projection.active_runs,
         latest_run: projection.latest_run,
+        changed_by_run_id: issue.changed_by_run_id.clone(),
         verification_level: issue.verification_level,
         verification_steps: issue.verification_steps,
     }
@@ -3918,6 +3920,7 @@ impl ParsedIssue {
             blocking_facts: Vec::new(),
             active_runs: projection.active_runs,
             latest_run: projection.latest_run,
+            changed_by_run_id: None,
             verification_level: VerificationLevel::AgentSelf,
             verification_steps: Vec::new(),
         }
@@ -5022,6 +5025,34 @@ mod tests {
         assert_eq!(cards[0].description_excerpt, "首段摘要内容。");
         assert!(cards[0].description.contains("## 背景"));
         assert!(created.issue_id == cards[0].issue_id);
+        assert!(cards[0].changed_by_run_id.is_none());
+
+        // After a run starts work, the board exposes who changed it.
+        let started = start_issue_work(
+            &pool,
+            StartIssueWorkRequest {
+                project_id: "project-1".to_owned(),
+                run_id: None,
+                issue_key: created.issue_key.clone(),
+                expected_revision: None,
+                session_id: Some("session-excerpt".to_owned()),
+            },
+        )
+        .await
+        .unwrap();
+        let cards = project_native_issue_board(
+            &pool,
+            "project-1",
+            &[],
+            "2026-08-06T02:00:00.000Z",
+            "2026-08-05T01:00:00.000Z",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cards[0].changed_by_run_id.as_deref(),
+            Some(started.run.run_id.as_str())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The board interface and macOS UI now surface who last changed an Issue's state. Kanban detail shows the last-change source (host + run id) when the run is present in active/latest runs.

## Verification
- cargo lib 98, clippy 1.97 clean, xcodebuild 121
- MCP end-to-end: get returns changed_by_run_id (ISSUE-026 -> its closing run)
