### PR TITLE
kanban: export native Issue as Markdown

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -113,12 +113,13 @@ use util::{
 };
 pub use work_tracking::{
     AgentRun, AgentRunEventSource, AgentRunEventType, AgentRunHost, AgentRunKind, AgentRunOutcome,
-    AgentRunPhase, ApplyIssueGateRequest, CreateIssueRequest, GetIssueRequest, IssueBlockingFact,
-    IssueBlockingFactKind, IssueBlockingReason, IssueBlockingReasonKind, IssueBoardCard,
-    IssueBoardDiagnostic, IssueBoardDiagnosticCode, IssueBoardListRequest, IssueBoardResponse,
-    IssueBoardState, IssueDependencyState, IssueDetailRequest, IssueDetailResponse,
-    IssueExternalReference, IssueExternalReferenceKind, IssueGateAction, IssueLifecycle,
-    IssueMutationResponse, IssueRemovalAction, IssueRemovalResponse, IssueWorkflowMutationResponse,
-    PauseIssueRequest, RecordAgentRunEventRequest, RecordAgentRunEventResponse, RemoveIssueRequest,
+    AgentRunPhase, ApplyIssueGateRequest, CreateIssueRequest, ExportIssueRequest,
+    ExportIssueResponse, GetIssueRequest, IssueBlockingFact, IssueBlockingFactKind,
+    IssueBlockingReason, IssueBlockingReasonKind, IssueBoardCard, IssueBoardDiagnostic,
+    IssueBoardDiagnosticCode, IssueBoardListRequest, IssueBoardResponse, IssueBoardState,
+    IssueDependencyState, IssueDetailRequest, IssueDetailResponse, IssueExternalReference,
+    IssueExternalReferenceKind, IssueGateAction, IssueLifecycle, IssueMutationResponse,
+    IssueRemovalAction, IssueRemovalResponse, IssueWorkflowMutationResponse, PauseIssueRequest,
+    RecordAgentRunEventRequest, RecordAgentRunEventResponse, RemoveIssueRequest,
     RequestIssueClosureRequest, ResumeIssueRequest, StartIssueWorkRequest, UpdateIssueRequest,
 };

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -779,6 +779,39 @@ impl DaemonState {
         .await
     }
 
+    pub async fn export_issue(
+        &self,
+        request: ExportIssueRequest,
+    ) -> Result<ExportIssueResponse, DaemonError> {
+        self.ensure_native_issues_imported(&request.project_id)
+            .await?;
+        let issue_number = work_tracking::parse_issue_reference(&request.issue_key)?;
+        let runs = work_tracking::load_project_runs(&self.inner.pool, &request.project_id).await?;
+        let (now, stale_before): (String, String) = sqlx::query_as(
+            "SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-24 hours')",
+        )
+        .fetch_one(&self.inner.pool)
+        .await?;
+        let detail = work_tracking::load_native_issue_detail(
+            &self.inner.pool,
+            &request.project_id,
+            issue_number,
+            &runs,
+            &now,
+            &stale_before,
+        )
+        .await?;
+        Ok(ExportIssueResponse {
+            issue_key: detail.issue.issue_key.clone(),
+            filename: work_tracking::issue_export_filename(issue_number),
+            markdown: work_tracking::render_issue_markdown(
+                &detail.issue,
+                &detail.body,
+                &detail.acceptance_criteria,
+            ),
+        })
+    }
     pub async fn create_issue(
         &self,
         request: CreateIssueRequest,
@@ -1517,6 +1550,13 @@ impl DaemonIpcService {
         self.state.get_issue(request).await
     }
 
+    pub async fn export_issue(
+        &self,
+        request: ExportIssueRequest,
+    ) -> Result<ExportIssueResponse, DaemonError> {
+        self.state.export_issue(request).await
+    }
+
     pub async fn create_issue(
         &self,
         request: CreateIssueRequest,
@@ -1718,6 +1758,7 @@ impl DaemonIpcService {
             "list_issue_board" => dispatch_async!(self, request.payload, list_issue_board),
             "get_issue_detail" => dispatch_async!(self, request.payload, get_issue_detail),
             "get_issue" => dispatch_async!(self, request.payload, get_issue),
+            "export_issue" => dispatch_async!(self, request.payload, export_issue),
             "create_issue" => dispatch_async!(self, request.payload, create_issue),
             "update_issue" => dispatch_async!(self, request.payload, update_issue),
             "apply_issue_gate" => dispatch_async!(self, request.payload, apply_issue_gate),

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -591,6 +591,66 @@ pub struct IssueDetailResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ExportIssueRequest {
+    pub project_id: String,
+    pub issue_key: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ExportIssueResponse {
+    pub issue_key: String,
+    pub filename: String,
+    pub markdown: String,
+}
+
+/// Renders a structured Issue as a stable, portable Markdown snapshot.
+/// The output is deterministic for a given Issue state, so repeated exports
+/// produce the same document (suitable for version control).
+pub fn render_issue_markdown(
+    issue: &IssueBoardCard,
+    body: &str,
+    acceptance_criteria: &[String],
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# {}\n\n", issue.title));
+    out.push_str(&format!("- **Issue**: {}\n", issue.issue_key));
+    out.push_str(&format!("- **Status**: {}\n", issue.board_state.as_str()));
+    if let Some(closure_summary) = &issue.closure_summary {
+        out.push_str(&format!("- **Closure**: {}\n", closure_summary));
+    }
+    if let Some(created_at) = &issue.created_at {
+        out.push_str(&format!("- **Created**: {}\n", created_at));
+    }
+    if let Some(started_at) = &issue.started_at {
+        out.push_str(&format!("- **Started**: {}\n", started_at));
+    }
+    if let Some(closed_at) = &issue.closed_at {
+        out.push_str(&format!("- **Closed**: {}\n", closed_at));
+    }
+    out.push('\n');
+    let body = body.trim();
+    if !body.is_empty() {
+        out.push_str("## 描述\n\n");
+        out.push_str(body);
+        out.push_str("\n\n");
+    }
+    if !acceptance_criteria.is_empty() {
+        out.push_str("## 验收标准\n\n");
+        for criteria in acceptance_criteria {
+            out.push_str(&format!("- [ ] {}\n", criteria));
+        }
+        out.push('\n');
+    }
+    out.push_str("---\n");
+    out
+}
+
+/// Stable filename for an exported Issue: ISSUE-<NNN>.md
+pub fn issue_export_filename(issue_number: i64) -> String {
+    format!("ISSUE-{issue_number:03}.md")
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct IssueBoardResponse {
     pub project_id: String,
     pub effective_hash: String,
@@ -5053,6 +5113,61 @@ mod tests {
             cards[0].changed_by_run_id.as_deref(),
             Some(started.run.run_id.as_str())
         );
+    }
+
+    #[test]
+    fn render_issue_markdown_is_deterministic_and_complete() {
+        let issue = IssueBoardCard {
+            issue_id: "issue_0123456789abcdef0123456789abcdef".to_owned(),
+            project_id: "project-1".to_owned(),
+            issue_number: 7,
+            issue_key: "ISSUE-007".to_owned(),
+            resource_id: "issue_0123456789abcdef0123456789abcdef".to_owned(),
+            path: String::new(),
+            lifecycle: IssueLifecycle::Open,
+            title: "Export native Issues".to_owned(),
+            description: "body".to_owned(),
+            description_excerpt: "body".to_owned(),
+            external_references: Vec::new(),
+            found_at: Some("2026-08-07T03:00:00Z".to_owned()),
+            created_at: Some("2026-08-07T03:00:00Z".to_owned()),
+            started_at: Some("2026-08-08T03:00:00Z".to_owned()),
+            closed_at: None,
+            archived_at: None,
+            content_hash: "native:1".to_owned(),
+            source_commit_id: None,
+            draft_id: None,
+            draft_revision: None,
+            board_state: IssueBoardState::InProgress,
+            state_revision: 1,
+            state_updated_at: Some("2026-08-08T03:00:00Z".to_owned()),
+            closure_summary: None,
+            is_stale: false,
+            blocked: false,
+            blocking_reasons: Vec::new(),
+            dependencies: Vec::new(),
+            blocking_facts: Vec::new(),
+            active_runs: Vec::new(),
+            latest_run: None,
+            changed_by_run_id: None,
+            verification_level: VerificationLevel::AgentSelf,
+            verification_steps: Vec::new(),
+        };
+        let criteria = vec![
+            "Preserve stable keys".to_owned(),
+            "Deterministic output".to_owned(),
+        ];
+        let first = render_issue_markdown(&issue, "## 背景\n\n正文。", &criteria);
+        let second = render_issue_markdown(&issue, "## 背景\n\n正文。", &criteria);
+        assert_eq!(first, second);
+        assert!(first.contains("# Export native Issues"));
+        assert!(first.contains("- **Issue**: ISSUE-007"));
+        assert!(first.contains("- **Status**: in_progress"));
+        assert!(first.contains("## 背景"));
+        assert!(first.contains("## 验收标准"));
+        assert!(first.contains("- [ ] Preserve stable keys"));
+        assert!(first.contains("- [ ] Deterministic output"));
+        assert_eq!(issue_export_filename(7), "ISSUE-007.md");
     }
 
     #[tokio::test]

--- a/src/client/daemon/ipc.zig
+++ b/src/client/daemon/ipc.zig
@@ -470,6 +470,21 @@ pub fn resumeIssueOperation(
     return try operationResultFromResponse(allocator, response_json);
 }
 
+pub fn exportIssueOperation(
+    allocator: std.mem.Allocator,
+    project_id: []const u8,
+    issue_key: []const u8,
+) !OperationResult {
+    const request_json = try requestWithPayloadJsonAlloc(allocator, "export_issue", .{
+        .project_id = project_id,
+        .issue_key = issue_key,
+    });
+    defer allocator.free(request_json);
+    const response_json = try callJson(allocator, MACH_SERVICE_NAME, request_json);
+    defer allocator.free(response_json);
+    return try operationResultFromResponse(allocator, response_json);
+}
+
 pub fn callEmpty(allocator: std.mem.Allocator, service_name: []const u8, method: []const u8) ![]u8 {
     const request_json = try requestJsonAlloc(allocator, method);
     defer allocator.free(request_json);

--- a/src/client/mcp/tools.zig
+++ b/src/client/mcp/tools.zig
@@ -83,6 +83,7 @@ const issue_schema =
     "\"begin_work\":{\"type\":\"object\",\"description\":\"Call this first before starting work on any Issue. Bind the current AgentRun to this Issue and enter In Progress. run_id and expected_revision (the AgentRun revision) are required only when the caller has a hook-issued AgentRun; omit both to let the daemon issue a manual run. One session holds at most one In Progress Issue: provide session_id for manual runs so the daemon can enforce it.\",\"properties\":{\"run_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"},\"expected_revision\":{\"type\":\"integer\",\"minimum\":1,\"description\":\"AgentRun revision, not the Issue state revision. With a hook-issued run use the run context revision; omit for a manual run.\"},\"session_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256,\"description\":\"Session identity for a manual run (hook-issued runs carry host_session_id already). Enables the one-session-one-In-Progress-issue rule.\"}},\"required\":[\"issue_key\"],\"additionalProperties\":false}," ++
     "\"pause_issue\":{\"type\":\"object\",\"description\":\"Pause an In Progress Issue held by the given run, moving it to Paused so the session can start another Issue. Only the run that holds the Issue may pause it.\",\"properties\":{\"run_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"}},\"required\":[\"run_id\",\"issue_key\"],\"additionalProperties\":false}," ++
     "\"resume_issue\":{\"type\":\"object\",\"description\":\"Resume a Paused Issue to In Progress. The pausing run resumes it, or pass takeover=true to explicitly take it over with another run.\",\"properties\":{\"run_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"},\"takeover\":{\"type\":\"boolean\",\"description\":\"Explicitly take over an Issue paused by another run.\"}},\"required\":[\"run_id\",\"issue_key\"],\"additionalProperties\":false}," ++
+    "\"export\":{\"type\":\"object\",\"description\":\"Export a single Issue as a stable, portable Markdown snapshot (key, status, body, acceptance criteria, closure summary, timeline). Deterministic for a given Issue state; does not create Context Drafts or live document mapping.\",\"properties\":{\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"}},\"required\":[\"issue_key\"],\"additionalProperties\":false}," ++
     "\"request_closure\":{\"type\":\"object\",\"description\":\"Request user approval to close an In Progress Issue. With run_id, expected_revision (the AgentRun revision from begin_work, not the Issue state revision) is required. Without run_id, issue_key is required and the daemon verifies no active AgentRun holds the Issue before issuing a manual run.\",\"properties\":{\"run_id\":{\"type\":\"string\",\"minLength\":1,\"maxLength\":256},\"issue_key\":{\"type\":\"string\",\"pattern\":\"^ISSUE-(?!000$)[0-9]{3}$\"},\"summary\":{\"type\":\"string\",\"maxLength\":1000},\"expected_revision\":{\"type\":\"integer\",\"minimum\":1,\"description\":\"AgentRun revision (run.revision from the begin_work response), not the Issue state revision.\"}},\"additionalProperties\":false}" ++
     "},\"additionalProperties\":false}" ++
     "},\"required\":[\"op\"],\"additionalProperties\":false,\"$defs\":{\"externalReference\":" ++ issue_external_reference_definition ++ ",\"blockingFact\":" ++ issue_blocking_fact_definition ++ "}}}";
@@ -258,7 +259,7 @@ fn handleStore(
     return try buildDaemonOperationResult(allocator, operation);
 }
 
-const IssueOp = enum { list, get, create, update, begin_work, pause_issue, resume_issue, request_closure };
+const IssueOp = enum { list, get, create, update, begin_work, pause_issue, resume_issue, request_closure, export_issue };
 
 fn handleIssue(
     allocator: std.mem.Allocator,
@@ -273,7 +274,7 @@ fn handleIssue(
         else => return try tool_result.buildErrorResult(allocator, "op must be a JSON object"),
     };
     const op = parseIssueOp(tagged) orelse
-        return try tool_result.buildErrorResult(allocator, "op must contain exactly one of list, get, create, update, begin_work, or request_closure");
+        return try tool_result.buildErrorResult(allocator, "op must contain exactly one of list, get, create, update, begin_work, pause_issue, resume_issue, request_closure, or export");
     const op_args = switch (tagged.get(issueOpName(op)).?) {
         .object => |object| object,
         else => return try tool_result.buildErrorResult(allocator, "operation details must be a JSON object"),
@@ -370,6 +371,17 @@ fn handleIssue(
                 optionalBool(op_args, "takeover") orelse false,
             );
         },
+        .export_issue => blk: {
+            if (try rejectUnexpectedFields(allocator, op_args, &.{"issue_key"}, "export")) |result| return result;
+            const issue_key = requiredString(op_args, "issue_key") orelse
+                return try tool_result.buildErrorResult(allocator, "issue_key is required and must be a string");
+            if (!isIssueKey(issue_key)) return try tool_result.buildErrorResult(allocator, "issue_key must use the ISSUE-NNN form");
+            break :blk try daemon_ipc.exportIssueOperation(
+                allocator,
+                session.project_id,
+                issue_key,
+            );
+        },
     };
     defer operation.deinit(allocator);
     return try buildDaemonOperationResult(allocator, operation);
@@ -377,7 +389,7 @@ fn handleIssue(
 
 fn parseIssueOp(object: std.json.ObjectMap) ?IssueOp {
     if (object.count() != 1) return null;
-    inline for (.{ IssueOp.list, IssueOp.get, IssueOp.create, IssueOp.update, IssueOp.begin_work, IssueOp.pause_issue, IssueOp.resume_issue, IssueOp.request_closure }) |op| {
+    inline for (.{ IssueOp.list, IssueOp.get, IssueOp.create, IssueOp.update, IssueOp.begin_work, IssueOp.pause_issue, IssueOp.resume_issue, IssueOp.request_closure, IssueOp.export_issue }) |op| {
         if (object.get(issueOpName(op)) != null) return op;
     }
     return null;
@@ -393,6 +405,7 @@ fn issueOpName(op: IssueOp) []const u8 {
         .pause_issue => "pause_issue",
         .resume_issue => "resume_issue",
         .request_closure => "request_closure",
+        .export_issue => "export",
     };
 }
 


### PR DESCRIPTION
## Summary

Add an explicit single-Issue export to portable, deterministic Markdown: a snapshot with stable Issue key, status, timeline, body, acceptance criteria (checkbox list), and closure summary. No Context Draft or live document mapping is created. Repeated exports of the same state are byte-identical.

## Verification
- zig 405/405, cargo lib 99, clippy 1.97 clean
- MCP end-to-end: kanban export ISSUE-007 returns ISSUE-007.md with full structured Markdown