### PR TITLE
adapter: fix Claude Code session-start workflow dead path

### DIFF
--- a/assets/adapters/claude-code/runtime/hooks/session-start.sh.tpl
+++ b/assets/adapters/claude-code/runtime/hooks/session-start.sh.tpl
@@ -24,8 +24,11 @@ if [ -n "$WS_INFO" ]; then
 fi
 
 WORKFLOW_SKILLS_DIR="__CLUMSIES_WORKFLOW_SKILLS_DIR__"
-if [ -n "$WORKFLOW_SKILLS_DIR" ] && [ -d "$CACHE_DIR/workflow" ]; then
-  WORKFLOW_DIR="$CACHE_DIR/workflow"
+# Workflow rules are synced under cache/rule/workflow (the rule namespace);
+# scanning that directory keeps the session-start sync consistent with
+# `clumsies sync` and with workflow_skills.zig at install time.
+if [ -n "$WORKFLOW_SKILLS_DIR" ] && [ -d "$CACHE_DIR/rule/workflow" ]; then
+  WORKFLOW_DIR="$CACHE_DIR/rule/workflow"
   find "$WORKFLOW_DIR" -name '*.md' -type f | while read -r filepath; do
     filename="$(basename "$filepath")"
     slug="$(echo "$filename" | sed 's/^[0-9]*_//; s/\.md$//; s/_/-/g' | tr '[:upper:]' '[:lower:]')"

--- a/src/client/adapter/packages/claude_code.zig
+++ b/src/client/adapter/packages/claude_code.zig
@@ -331,4 +331,9 @@ test "renderSessionStartHook generates workflow proxies for the load contract" {
     try std.testing.expect(std.mem.indexOf(u8, rendered, "ids: [\"workflow/$filename\"]") != null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "retrieve") == null);
     try std.testing.expect(std.mem.indexOf(u8, rendered, "_agent setup") == null);
+    // Workflow rules are synced under the rule namespace; the hook must scan
+    // cache/rule/workflow, not the dead cache/workflow path.
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "CACHE_DIR/rule/workflow") != null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "\"$CACHE_DIR/workflow\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, rendered, "CACHE_DIR/workflow\"") == null);
 }


### PR DESCRIPTION
## Summary

session-start.sh scanned CACHE_DIR/workflow, but clumsies sync writes workflow rules under CACHE_DIR/rule/workflow (the rule namespace). The session-start dynamic workflow sync therefore never ran. Point the hook at cache/rule/workflow, consistent with sync_cmd.zig and workflow_skills.zig.

## Verification
- zig 405/405 (renderSessionStartHook asserts the rule/workflow scan path)
- cargo lib 99