### PR TITLE
macos: make error and status text selectable

### DIFF
--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -1001,6 +1001,7 @@ struct DraftReconciliationView: View {
             Button("OK") { errorMessage = nil }
         } message: {
             Text(errorMessage ?? "")
+                .textSelection(.enabled)
         }
     }
 
@@ -1229,6 +1230,7 @@ private struct ReviewRequestSheet: View {
             Button("OK") { errorMessage = nil }
         } message: {
             Text(errorMessage ?? "")
+                .textSelection(.enabled)
         }
     }
 

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -118,6 +118,7 @@ struct ProjectCreationSheet: View {
                 if let errorMessage {
                     Section {
                         Text(errorMessage)
+                            .textSelection(.enabled)
                             .foregroundStyle(.red)
                             .fixedSize(horizontal: false, vertical: true)
                     }
@@ -276,6 +277,7 @@ struct ProjectSettingsView: View {
 
                 if let errorMessage {
                     Text(errorMessage)
+                        .textSelection(.enabled)
                         .foregroundStyle(.red)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -423,6 +425,7 @@ private struct ProjectLocalSetupSettings: View {
 
             if let errorMessage {
                 Text(errorMessage)
+                    .textSelection(.enabled)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/apps/macos/Sources/Features/SettingsView.swift
+++ b/apps/macos/Sources/Features/SettingsView.swift
@@ -74,6 +74,7 @@ struct ProjectMemoryCacheSettings: View {
                     }
                     if let errorMessage {
                         Text(errorMessage)
+                            .textSelection(.enabled)
                             .foregroundStyle(.red)
                     }
 
@@ -90,6 +91,7 @@ struct ProjectMemoryCacheSettings: View {
                     ProgressView()
                 } else {
                     Text(errorMessage ?? "Storage status is unavailable.")
+                        .textSelection(.enabled)
                         .foregroundStyle(.secondary)
                 }
             } else {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -407,6 +407,7 @@ struct WorkspaceView: View {
             Button("OK") { store.errorMessage = nil }
         } message: {
             Text(store.errorMessage ?? "")
+                .textSelection(.enabled)
         }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)
@@ -596,6 +597,7 @@ struct WorkspaceView: View {
             Button("OK") { store.errorMessage = nil }
         } message: {
             Text(store.errorMessage ?? "")
+                .textSelection(.enabled)
         }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)


### PR DESCRIPTION
## Summary

Error/status text was not copyable in several views, blocking users from pasting failures into reports. Apply .textSelection(.enabled) to error and status messages across ProjectManagement, Settings, Workspace, and MemoryWorkspace views. Static UI text stays non-selectable.

## Verification
- xcodebuild 121 tests
- GUI-only change