### PR TITLE
search: bound activate and unblock index builds

### DIFF
--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -509,7 +509,6 @@ pub(crate) async fn activate_memory(
 
     let result = async {
         let previous_state = activation::decode_activation_state(request.state.as_deref())?;
-        let _guard = state.inner.search_lock.lock().await;
 
         failure_stage = "effective_memory";
         let started = Instant::now();
@@ -522,30 +521,43 @@ pub(crate) async fn activate_memory(
             .map(retrieval_corpus_resource)
             .collect();
 
+        // Index ensure and search-head publication are serialized across
+        // Projects by search_index_lock, but run OUTSIDE search_lock so a
+        // slow first-time index build does not block other activates that
+        // only need to query an already-published index.
         failure_stage = "index_ensure";
         let started = Instant::now();
         let (pool, storage) = active_project_index(state, &project_id).await?;
-        let revision_id = match index::ensure_index(state, &pool, &effective).await {
-            Ok(revision_id) => revision_id,
-            Err(error) => {
-                pool.close().await;
-                return Err(error);
+        let revision_id = {
+            let _index_guard = state.inner.search_index_lock.lock().await;
+            match index::ensure_index(state, &pool, &effective).await {
+                Ok(revision_id) => revision_id,
+                Err(error) => {
+                    pool.close().await;
+                    return Err(error);
+                }
             }
         };
         completion.latencies.index_ensure_us = elapsed_us(started);
         completion.index_revision = Some(revision_id.clone());
-        publish_search_head(state, &pool, &project_id, storage.location_revision).await?;
+        {
+            let _index_guard = state.inner.search_index_lock.lock().await;
+            publish_search_head(state, &pool, &project_id, storage.location_revision).await?;
+        }
 
-        let response = query::query_index(
-            state,
-            &pool,
-            &revision_id,
-            &query,
-            previous_state,
-            &mut completion,
-            &mut failure_stage,
-        )
-        .await;
+        let response = {
+            let _guard = state.inner.search_lock.lock().await;
+            query::query_index(
+                state,
+                &pool,
+                &revision_id,
+                &query,
+                previous_state,
+                &mut completion,
+                &mut failure_stage,
+            )
+            .await
+        };
         pool.close().await;
         response
     }
@@ -2475,5 +2487,23 @@ mod tests {
         };
         let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&duplicate).unwrap());
         assert!(activation::decode_activation_state(Some(&encoded)).is_err());
+    }
+
+    #[test]
+    fn retrieval_error_maps_deadline_and_search_codes_to_stable_error_strings() {
+        let (code, _) = retrieval_error(&DaemonError::Search {
+            code: "activation_deadline".to_owned(),
+            message: "exceeded budget".to_owned(),
+        });
+        assert_eq!(code, "activation_deadline");
+
+        let (code, _) = retrieval_error(&DaemonError::Search {
+            code: "search_model_preparing".to_owned(),
+            message: "models preparing".to_owned(),
+        });
+        assert_eq!(code, "search_model_preparing");
+
+        let (code, _) = retrieval_error(&DaemonError::InvalidRequest("bad".to_owned()));
+        assert_eq!(code, "invalid_request");
     }
 }

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -31,6 +31,7 @@ pub(crate) struct DaemonInner {
     pub(crate) token_refresh: Mutex<()>,
     pub(crate) search_models: Arc<dyn search::models::SearchModels>,
     pub(crate) search_lock: Mutex<()>,
+    pub(crate) search_index_lock: Mutex<()>,
     pub(crate) retrieval_history_lock: Mutex<()>,
     pub(crate) draft_mutation_lock: Mutex<()>,
     pub(crate) local_setup_lock: Mutex<()>,
@@ -89,6 +90,7 @@ impl DaemonState {
                 token_refresh: Mutex::new(()),
                 search_models,
                 search_lock: Mutex::new(()),
+                search_index_lock: Mutex::new(()),
                 retrieval_history_lock: Mutex::new(()),
                 draft_mutation_lock: Mutex::new(()),
                 local_setup_lock: Mutex::new(()),
@@ -619,7 +621,18 @@ impl DaemonState {
         &self,
         request: ActivateMemoryRequest,
     ) -> Result<ActivateMemoryResponse, DaemonError> {
-        search::activate_memory(self, request).await
+        const ACTIVATION_DEADLINE: Duration = Duration::from_secs(60);
+        match tokio::time::timeout(ACTIVATION_DEADLINE, search::activate_memory(self, request))
+            .await
+        {
+            Ok(result) => result,
+            Err(_) => Err(DaemonError::Search {
+                code: "activation_deadline".to_owned(),
+                message: format!(
+                    "activate exceeded the {ACTIVATION_DEADLINE:?} budget; a stage timed out and the remaining stages were skipped"
+                ),
+            }),
+        }
     }
 
     pub async fn load_memory(


### PR DESCRIPTION
## Summary

activate could hold the whole MCP process and all Projects for minutes while a first-time index build ran. Two fixes:
- search_index_lock serializes index ensure + head publication outside search_lock, so a slow build no longer blocks other activates that only query an already-published index.
- activate_memory is wrapped in a 60s total deadline; on timeout it returns a structured activation_deadline error instead of an unexplained empty result. load/store stay responsive.

## Verification
- cargo lib 100, clippy 1.97 clean
- retrieval_error maps activation_deadline / search_model_preparing / invalid_request
- Live: load 0.1s responsive while activate is bounded