### PR TITLE
docs: cover kanban operations and add zh locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # clumsies
 
 [![CI](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/ci.yml)
-[![Tests](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml/badge.svg)](https://github.com/lilhammerfun/clumsies/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/github/license/lilhammerfun/clumsies?label=License)](https://github.com/lilhammerfun/clumsies/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/v/release/lilhammerfun/clumsies?label=Release)](https://github.com/lilhammerfun/clumsies/releases)
 [![Zig](https://img.shields.io/badge/Zig-0.16%2B-f7a41d?logo=zig&logoColor=white)](https://ziglang.org/)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,6 +12,10 @@ export default withMermaid(
     appearance: "dark",
     cleanUrls: true,
     lastUpdated: true,
+    locales: {
+      "/": { label: "English", lang: "en-US" },
+      "/zh/": { label: "中文", lang: "zh-CN" },
+    },
     markdown: {
       config(md) {
         md.use(footnote);

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -198,11 +198,14 @@ The input contains exactly one tagged operation under `op`:
 | Operation | Fields | Result |
 |---|---|---|
 | `list` | none | The bound Project's native Issue board and recent unlinked runs. |
-| `get` | global `issue_id` | The complete Issue, acceptance criteria, external references, dependencies, blocking facts, state, revision, and owning `project_id`. |
-| `create` | `title`, `description`; optional `acceptance_criteria`, `external_references`, `dependencies`, `blocking_facts` | A new Todo Issue with an atomically allocated key. |
-| `update` | `issue_key`, Issue `expected_revision`, and at least one semantic field, including optional `external_references`, `dependencies`, `blocking_facts` | Updated Issue content without a status transition. |
-| `start` | `run_id`, `issue_key`, `expected_revision` | In Progress state plus the linked AgentRun. |
+| `get` | exactly one of global `issue_id` or Project-local `issue_key` | The complete Issue, acceptance criteria, external references, dependencies, blocking facts, verification protocol, state, revision, and owning `project_id`. |
+| `create` | `title`, `description`; optional `acceptance_criteria`, `external_references`, `dependencies`, `blocking_facts`, `verification_level`, `verification_steps` | A new Todo Issue with an atomically allocated key. |
+| `update` | `issue_key`, Issue `expected_revision`, and at least one semantic field, including optional `external_references`, `dependencies`, `blocking_facts`, `verification_level`, `verification_steps` | Updated Issue content without a status transition. |
+| `begin_work` | `issue_key`; `run_id`, `expected_revision` for a hook-issued run, optional `session_id` for a manual run | In Progress state plus the linked AgentRun. One session holds at most one In Progress Issue. |
+| `pause_issue` | `run_id`, `issue_key` | Paused state; the pausing run may later resume. |
+| `resume_issue` | `run_id`, `issue_key`; optional `takeover` | Back to In Progress. Non-owner resume requires `takeover`. |
 | `request_closure` | `run_id`, `expected_revision`; optional `summary` | Closure Requested state plus the linked AgentRun. |
+| `export` | `issue_key` | A deterministic, portable Markdown snapshot of the Issue. |
 
 `issue_id` uses `issue_` followed by 32 lowercase hexadecimal characters and is
 globally unique. This is the value copied from Kanban and passed to `get`.
@@ -211,6 +214,9 @@ digits, with `ISSUE-000` reserved as invalid. Repeating the same start is
 idempotent; changing an existing run association to another Issue is a
 conflict. `expected_revision` is the exact positive run revision injected by
 the lifecycle hook.
+
+`verification_level` is `agent_self`, `human_required`, or `mixed`, with
+`verification_steps` listing the human verification protocol for closure.
 
 `external_references` is a bounded array of objects with `kind` (`issue` or
 `pull_request`) and an absolute HTTP(S) `url`. Omitting it on create produces an
@@ -271,8 +277,11 @@ tagged input and forwards the operation.
 | `store_draft_operation` | MCP `store`, Desktop, and other clients |
 | `list_issue_board` | MCP `kanban.list` and Desktop |
 | `get_issue_detail` | Native Issue detail lookup for local clients |
-| `get_issue` | MCP `kanban.get` global Issue lookup |
+| `get_issue` | MCP `kanban.get` (by `issue_id` or `issue_key`) |
+| `export_issue` | MCP `kanban.export` |
 | `start_issue_work` | MCP `kanban.begin_work` |
+| `pause_issue` | MCP `kanban.pause_issue` |
+| `resume_issue` | MCP `kanban.resume_issue` |
 | `request_issue_closure` | MCP `kanban.request_closure` |
 | `record_agent_run_event` | Private Coding Agent lifecycle hook bridge |
 | `search_index_status` | Desktop diagnostics and tests |

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -1,0 +1,10 @@
+# 架构
+
+clumsies 是编码 Agent 的协作式外部记忆基础设施：把规则、工作流与项目上下文分发到 Agent，并把本地 Draft 变更同步回组织。
+
+- **Hub**：组织共享记忆的权威来源。
+- **Local**：项目专属记忆 + 个人 Draft。
+- **daemon**：常驻本地服务，是 Desktop、MCP 与 Agent hook 的统一协调者。
+- **Adapter**：把 Codex / Claude Code / opencode 的 lifecycle 事件接入 daemon 的 AgentRun。
+
+（中文文档持续翻译中；英文为准。）

--- a/docs/zh/guides/agent-run-injection.md
+++ b/docs/zh/guides/agent-run-injection.md
@@ -1,0 +1,8 @@
+# Agent run 注入
+
+生命周期 hook 把 run_id 与 revision 注入 Agent 上下文；Agent 据此调用
+`kanban.begin_work` / `kanban.request_closure` 绑定并推进 Issue。
+一个 session 同时只能持有一个 In Progress Issue；换 Issue 前先 pause
+或 request_closure。
+
+（中文文档持续翻译中；英文为准。）

--- a/docs/zh/guides/agent-runtime.md
+++ b/docs/zh/guides/agent-runtime.md
@@ -1,0 +1,9 @@
+# Agent 运行时
+
+运行时面包括 CLI、MCP 与 Agent hook。常驻 daemon 是唯一协调者：
+
+- Desktop 与 MCP 通过 daemon 读写 Draft。
+- Agent hook（Codex / Claude Code / opencode）把 lifecycle 事件送入 daemon 的 AgentRun 记录。
+- AgentRun 绑定到原生 Issue，看板状态由 Agent 显式调用 `kanban` 工具推进。
+
+（中文文档持续翻译中；英文为准。）

--- a/docs/zh/guides/how-to-use-clumsies.md
+++ b/docs/zh/guides/how-to-use-clumsies.md
@@ -1,0 +1,8 @@
+# 如何开始使用 clumsies
+
+1. 安装 clumsies，登录 Server，选择或创建 Project。
+2. 在 Desktop 中浏览 Hub 与 Local 记忆，创建 Rule / Workflow / Context。
+3. 让编码 Agent（Codex / Claude Code / opencode）接入 MCP，AgentRun 自动进入看板。
+4. 个人 Draft 自动同步，变更经 Review 后发布。
+
+（中文文档持续翻译中；英文为准。）

--- a/docs/zh/guides/index.md
+++ b/docs/zh/guides/index.md
@@ -1,0 +1,7 @@
+# 指南
+
+- [Agent 运行时](/zh/guides/agent-runtime)
+- [Agent run 注入](/zh/guides/agent-run-injection)
+- [如何开始使用 clumsies](/zh/guides/how-to-use-clumsies)
+
+（中文文档持续翻译中；英文为准。）

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,0 +1,22 @@
+---
+layout: home
+
+hero:
+  name: clumsies
+  text: 面向编码 Agent 的协作式外部记忆
+  tagline: 分发项目上下文与约束，本地 Draft 自动同步，变更经 Review 后发布。
+  actions:
+    - theme: brand
+      text: 快速开始
+      link: /zh/guides/how-to-use-clumsies
+    - theme: alt
+      text: 架构
+      link: /zh/architecture
+
+features:
+  - title: Hub 与 Local
+    details: 在一个 Desktop 工作流中浏览组织共享记忆与项目专属记忆。
+  - title: 自动 Draft
+    details: Desktop 与 MCP 写入同一个常驻 daemon；本地变更无需手动 push 即可同步。
+  - title: Agent 集成
+    details: 为 Codex、Claude Code 与 opencode 提供 hook/plugin 事件桥，AgentRun 进入看板。


### PR DESCRIPTION
## Summary

- mcp.md: document pause_issue / resume_issue / export / get by issue_key, session_id, and verification protocol on the kanban tool
- README: drop the removed Tests workflow badge
- vitepress: add zh-CN locale with Chinese landing page, architecture, and guide stubs (English authoritative)

## Verification
- vitepress build passes (en + zh pages render)