### PR TITLE
macos app: redesign Reviews as push-navigated pages with anchored comments

### DIFF
--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		78EC181F0D61FD1DB4F569FF /* ServerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A6A05AA73B94A0DE921C31 /* ServerClient.swift */; };
 		7D0F2CD9BF92EEB2815DB0DA /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AA571BE4F7DBAC7439EB6D /* PointingHandCursor.swift */; };
 		809EEDD058885C7E9A478691 /* ReviewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4576DAE2527AF11B222921B /* ReviewsView.swift */; };
+		86314001D65EF5C49B62B269 /* UnifiedDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C06AA7E1AE68E8A4DD9239 /* UnifiedDiffView.swift */; };
 		8EEDC302E3D01C71C36A4250 /* ClumsiesIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB3E1C996D7A718AE933D03 /* ClumsiesIdentifiers.swift */; };
 		978C3F8A44E156309CAA21DC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4C4B6CD38A41A323309597 /* SettingsView.swift */; };
 		A53F0E8912030AA286A4A285 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108C769F026D02B9C4326B3 /* WorkspaceStore.swift */; };
@@ -74,6 +75,7 @@
 		0D653D21BD58E9D24450141A /* DocumentTabStripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTabStripTests.swift; sourceTree = "<group>"; };
 		18CAC580523AC687B94FA4C9 /* MemoryWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWorkspaceView.swift; sourceTree = "<group>"; };
 		1B4C4B6CD38A41A323309597 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		20C06AA7E1AE68E8A4DD9239 /* UnifiedDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedDiffView.swift; sourceTree = "<group>"; };
 		22F9A16C0257F846C6850394 /* IssueBoardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueBoardModel.swift; sourceTree = "<group>"; };
 		2698CA8F3BB84E3519C3D54B /* DaemonBootstrapController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonBootstrapController.swift; sourceTree = "<group>"; };
 		325B2E0E0E56B671C925B71F /* SplitDiffView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitDiffView.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 				D5E2F9ADC924309D0DF748F2 /* SharedUpdateIndicator.swift */,
 				325B2E0E0E56B671C925B71F /* SplitDiffView.swift */,
 				8CFBC5DEC7607B6F7B8096B7 /* ToolbarFilterMenu.swift */,
+				20C06AA7E1AE68E8A4DD9239 /* UnifiedDiffView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 				47AC97FF423BEDDD532DE639 /* SoftwareUpdateController.swift in Sources */,
 				EEF5E92DEA84381918527F18 /* SplitDiffView.swift in Sources */,
 				262EEDD3B2709E6F304D1FAA /* ToolbarFilterMenu.swift in Sources */,
+				86314001D65EF5C49B62B269 /* UnifiedDiffView.swift in Sources */,
 				A53F0E8912030AA286A4A285 /* WorkspaceStore.swift in Sources */,
 				DC1B191092F8585B353496E6 /* WorkspaceView.swift in Sources */,
 				D673EA34613D807AEEAE78AD /* main.swift in Sources */,

--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		7D0F2CD9BF92EEB2815DB0DA /* PointingHandCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54AA571BE4F7DBAC7439EB6D /* PointingHandCursor.swift */; };
 		809EEDD058885C7E9A478691 /* ReviewsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4576DAE2527AF11B222921B /* ReviewsView.swift */; };
 		86314001D65EF5C49B62B269 /* UnifiedDiffView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C06AA7E1AE68E8A4DD9239 /* UnifiedDiffView.swift */; };
+		8699233D29BC393B465FC1CA /* PathTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20D470F6A061A60DF76EBD5 /* PathTreeView.swift */; };
 		8EEDC302E3D01C71C36A4250 /* ClumsiesIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB3E1C996D7A718AE933D03 /* ClumsiesIdentifiers.swift */; };
 		978C3F8A44E156309CAA21DC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4C4B6CD38A41A323309597 /* SettingsView.swift */; };
 		A53F0E8912030AA286A4A285 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A108C769F026D02B9C4326B3 /* WorkspaceStore.swift */; };
@@ -107,6 +108,7 @@
 		C6ABC405480198DD68F37918 /* JSONCoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONCoding.swift; sourceTree = "<group>"; };
 		CAB3E1C996D7A718AE933D03 /* ClumsiesIdentifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClumsiesIdentifiers.swift; sourceTree = "<group>"; };
 		D0D4802A9777F53C78323C0E /* DaemonXPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonXPCClient.swift; sourceTree = "<group>"; };
+		D20D470F6A061A60DF76EBD5 /* PathTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTreeView.swift; sourceTree = "<group>"; };
 		D28D1FCAAD46366BE5157162 /* AppBundleRuntimeLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBundleRuntimeLocation.swift; sourceTree = "<group>"; };
 		D42BE12B94090440642362FC /* Clumsies.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Clumsies.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D481B8C9371F57B60C8462AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				C2065CEBF21A0AD6D7D70259 /* MarkdownPreview.swift */,
 				A071EB67D684BAD0157C5700 /* NativeAccountMenu.swift */,
 				940BD7C82DC144B067648080 /* NativeTextEditor.swift */,
+				D20D470F6A061A60DF76EBD5 /* PathTreeView.swift */,
 				54AA571BE4F7DBAC7439EB6D /* PointingHandCursor.swift */,
 				D5E2F9ADC924309D0DF748F2 /* SharedUpdateIndicator.swift */,
 				325B2E0E0E56B671C925B71F /* SplitDiffView.swift */,
@@ -407,6 +410,7 @@
 				20EA89238D29B3C111E36F01 /* MemoryWorkspaceView.swift in Sources */,
 				A76D61667A65C740029F0F2D /* NativeAccountMenu.swift in Sources */,
 				C7687CDE4DE94017775B7F06 /* NativeTextEditor.swift in Sources */,
+				8699233D29BC393B465FC1CA /* PathTreeView.swift in Sources */,
 				7D0F2CD9BF92EEB2815DB0DA /* PointingHandCursor.swift in Sources */,
 				BB98BF86F178D4A9B41AF2FF /* ProjectManagementView.swift in Sources */,
 				6F469EBC740AE8B3E817F9FF /* RetrievalDiagnosticsModel.swift in Sources */,

--- a/apps/macos/Scripts/test.sh
+++ b/apps/macos/Scripts/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eu
+
+result_root=$(mktemp -d "${TMPDIR:-/private/tmp}/clumsies-macos-test-results.XXXXXX")
+result_bundle="$result_root/Clumsies.xcresult"
+
+trap 'rm -rf -- "$result_root"' EXIT
+
+xcodegen generate --spec apps/macos/project.yml
+
+set +e
+CLUMSIES_SKIP_DAEMON_BUILD=1 xcodebuild -quiet \
+    -project apps/macos/Clumsies.xcodeproj \
+    -scheme Clumsies \
+    -configuration Debug \
+    -derivedDataPath /private/tmp/clumsies-macos-tests \
+    -resultBundlePath "$result_bundle" \
+    test
+status=$?
+set -e
+
+if [ "$status" -ne 0 ]; then
+    xcrun xcresulttool get test-results summary --path "$result_bundle" || true
+fi
+
+exit "$status"

--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -117,6 +117,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         if menuItem.action == #selector(toggleSidebar(_:)) {
             menuItem.title = store.sidebarExpanded ? "Hide Sidebar" : "Show Sidebar"
         }
+        if menuItem.action == #selector(approveReview(_:)) {
+            return store.canPerformReviewMenuAction(.approve)
+        }
+        if menuItem.action == #selector(rejectReview(_:)) {
+            return store.canPerformReviewMenuAction(.reject)
+        }
+        if menuItem.action == #selector(mergeReview(_:)) {
+            return store.canPerformReviewMenuAction(.merge)
+        }
+        if menuItem.action == #selector(resubmitReview(_:)) {
+            return store.canPerformReviewMenuAction(.resubmit)
+        }
         return true
     }
 
@@ -467,6 +479,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         sidebar.target = self
         viewItem.submenu = viewMenu
 
+        let reviewItem = NSMenuItem()
+        mainMenu.addItem(reviewItem)
+        let reviewMenu = NSMenu(title: "Review")
+        let approve = reviewMenu.addItem(
+            withTitle: "Approve",
+            action: #selector(approveReview(_:)),
+            keyEquivalent: "a"
+        )
+        approve.keyEquivalentModifierMask = [.command, .option]
+        approve.target = self
+        let reject = reviewMenu.addItem(
+            withTitle: "Reject",
+            action: #selector(rejectReview(_:)),
+            keyEquivalent: "r"
+        )
+        reject.keyEquivalentModifierMask = [.command, .option]
+        reject.target = self
+        reviewMenu.addItem(.separator())
+        let merge = reviewMenu.addItem(
+            withTitle: "Merge",
+            action: #selector(mergeReview(_:)),
+            keyEquivalent: "m"
+        )
+        merge.keyEquivalentModifierMask = [.command, .option]
+        merge.target = self
+        let resubmit = reviewMenu.addItem(
+            withTitle: "Resubmit",
+            action: #selector(resubmitReview(_:)),
+            keyEquivalent: "u"
+        )
+        resubmit.keyEquivalentModifierMask = [.command, .option]
+        resubmit.target = self
+        reviewItem.submenu = reviewMenu
+
         let windowItem = NSMenuItem()
         mainMenu.addItem(windowItem)
         let windowMenu = NSMenu(title: "Window")
@@ -516,6 +562,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     @objc private func toggleSidebar(_ sender: Any?) {
         store.sidebarExpanded.toggle()
         mainWindow?.makeKeyAndOrderFront(nil)
+    }
+
+    @objc private func approveReview(_ sender: Any?) {
+        Task { await store.performReviewMenuAction(.approve) }
+    }
+
+    @objc private func rejectReview(_ sender: Any?) {
+        Task { await store.performReviewMenuAction(.reject) }
+    }
+
+    @objc private func mergeReview(_ sender: Any?) {
+        Task { await store.performReviewMenuAction(.merge) }
+    }
+
+    @objc private func resubmitReview(_ sender: Any?) {
+        Task { await store.performReviewMenuAction(.resubmit) }
     }
 }
 

--- a/apps/macos/Sources/Components/PathTreeView.swift
+++ b/apps/macos/Sources/Components/PathTreeView.swift
@@ -1,0 +1,288 @@
+import SwiftUI
+
+struct PathTreeItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let path: String
+    let fallbackName: String?
+
+    init(id: String, path: String, fallbackName: String? = nil) {
+        self.id = id
+        self.path = path
+        self.fallbackName = fallbackName
+    }
+}
+
+struct VisiblePathTreeNode: Identifiable, Sendable {
+    let node: PathTreeNode
+    let depth: Int
+
+    var id: String { node.id }
+}
+
+struct PathTreeNode: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let item: PathTreeItem?
+    let children: [PathTreeNode]?
+
+    private struct Entry {
+        let item: PathTreeItem
+        let components: ArraySlice<String>
+    }
+
+    static func build(_ items: [PathTreeItem]) -> [PathTreeNode] {
+        let entries = items.map { item in
+            let pathComponents = item.path.split(separator: "/").map(String.init)
+            let components = pathComponents.isEmpty
+                ? [item.fallbackName ?? "Untitled"]
+                : pathComponents
+            return Entry(item: item, components: components[...])
+        }
+        return build(entries, prefix: "")
+    }
+
+    private static func build(_ entries: [Entry], prefix: String) -> [PathTreeNode] {
+        let groups = Dictionary(grouping: entries) { $0.components.first ?? "Untitled" }
+        return groups.keys.sorted {
+            $0.localizedStandardCompare($1) == .orderedAscending
+        }.map { name in
+            let group = groups[name] ?? []
+            if let file = group.first(where: { $0.components.count <= 1 }) {
+                return .init(
+                    id: file.item.id,
+                    name: name,
+                    item: file.item,
+                    children: nil
+                )
+            }
+
+            let path = prefix.isEmpty ? name : "\(prefix)/\(name)"
+            let descendants = group.map {
+                Entry(item: $0.item, components: $0.components.dropFirst())
+            }
+            return .init(
+                id: "directory:\(path)",
+                name: name,
+                item: nil,
+                children: build(descendants, prefix: path)
+            )
+        }
+    }
+
+    static func directoryIds(in nodes: [PathTreeNode]) -> Set<String> {
+        nodes.reduce(into: Set<String>()) { result, node in
+            guard let children = node.children else { return }
+            result.insert(node.id)
+            result.formUnion(directoryIds(in: children))
+        }
+    }
+
+    static func allIds(in nodes: [PathTreeNode]) -> [String] {
+        nodes.flatMap { node in
+            [node.id] + (node.children.map { allIds(in: $0) } ?? [])
+        }
+    }
+
+    static func node(withId id: String, in nodes: [PathTreeNode]) -> PathTreeNode? {
+        for node in nodes {
+            if node.id == id { return node }
+            if let children = node.children,
+               let match = self.node(withId: id, in: children) {
+                return match
+            }
+        }
+        return nil
+    }
+
+    static func firstItemId(in nodes: [PathTreeNode]) -> String? {
+        for node in nodes {
+            if let item = node.item { return item.id }
+            if let children = node.children,
+               let itemId = firstItemId(in: children) {
+                return itemId
+            }
+        }
+        return nil
+    }
+
+    static func visibleNodes(
+        _ nodes: [PathTreeNode],
+        expandedDirectoryIds: Set<String>,
+        depth: Int = 0
+    ) -> [VisiblePathTreeNode] {
+        nodes.flatMap { node in
+            var result = [VisiblePathTreeNode(node: node, depth: depth)]
+            if expandedDirectoryIds.contains(node.id), let children = node.children {
+                result.append(contentsOf: visibleNodes(
+                    children,
+                    expandedDirectoryIds: expandedDirectoryIds,
+                    depth: depth + 1
+                ))
+            }
+            return result
+        }
+    }
+}
+
+struct PathTreeView: View {
+    let items: [PathTreeItem]
+    @Binding var selection: String?
+
+    @State private var expandedDirectoryIds: Set<String> = []
+    @State private var initialized = false
+
+    private var roots: [PathTreeNode] {
+        PathTreeNode.build(items)
+    }
+
+    private var visibleNodes: [VisiblePathTreeNode] {
+        PathTreeNode.visibleNodes(roots, expandedDirectoryIds: expandedDirectoryIds)
+    }
+
+    var body: some View {
+        List(selection: $selection) {
+            ForEach(visibleNodes) { entry in
+                if let item = entry.node.item {
+                    PathTreeRowLabel(
+                        name: entry.node.name,
+                        path: item.path,
+                        depth: entry.depth,
+                        isDirectory: false,
+                        isExpanded: false
+                    )
+                    .tag(item.id)
+                    .accessibilityIdentifier("path-tree-item-\(item.id)")
+                    .listRowInsets(.init(top: 0, leading: 5, bottom: 0, trailing: 5))
+                    .listRowSeparator(.hidden)
+                } else {
+                    Button {
+                        toggleDirectory(entry.id)
+                    } label: {
+                        PathTreeRowLabel(
+                            name: entry.node.name,
+                            path: nil,
+                            depth: entry.depth,
+                            isDirectory: true,
+                            isExpanded: expandedDirectoryIds.contains(entry.id)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("path-tree-directory-\(entry.id)")
+                    .listRowInsets(.init(top: 0, leading: 5, bottom: 0, trailing: 5))
+                    .listRowSeparator(.hidden)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .onAppear(perform: initialize)
+        .onChange(of: items) { _, _ in synchronizeWithItems() }
+    }
+
+    private func initialize() {
+        guard !initialized else { return }
+        initialized = true
+        expandedDirectoryIds = PathTreeNode.directoryIds(in: roots)
+        ensureSelection()
+    }
+
+    private func synchronizeWithItems() {
+        expandedDirectoryIds.formUnion(PathTreeNode.directoryIds(in: roots))
+        ensureSelection()
+    }
+
+    private func ensureSelection() {
+        let itemIds = Set(items.map(\.id))
+        if selection == nil || !itemIds.contains(selection ?? "") {
+            selection = PathTreeNode.firstItemId(in: roots)
+        }
+    }
+
+    private func toggleDirectory(_ id: String) {
+        withAnimation(.snappy(duration: 0.14)) {
+            if expandedDirectoryIds.contains(id) {
+                expandedDirectoryIds.remove(id)
+            } else {
+                expandedDirectoryIds.insert(id)
+            }
+        }
+    }
+}
+
+struct PathTreeRowLabel<Accessory: View>: View {
+    let name: String
+    let path: String?
+    let depth: Int
+    let isDirectory: Bool
+    let isExpanded: Bool
+    let titleColor: Color
+    private let accessory: Accessory
+
+    init(
+        name: String,
+        path: String?,
+        depth: Int,
+        isDirectory: Bool,
+        isExpanded: Bool,
+        titleColor: Color = .primary,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        self.name = name
+        self.path = path
+        self.depth = depth
+        self.isDirectory = isDirectory
+        self.isExpanded = isExpanded
+        self.titleColor = titleColor
+        self.accessory = accessory()
+    }
+
+    var body: some View {
+        HStack(spacing: 6) {
+            if isDirectory {
+                Image(systemName: isExpanded ? "folder.fill" : "folder")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+            } else {
+                FileSymbolView(path: path ?? name)
+            }
+
+            Text(name)
+                .font(.system(size: 12.5, weight: .regular))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .foregroundStyle(titleColor)
+
+            Spacer(minLength: 4)
+            accessory
+        }
+        .padding(.leading, CGFloat(depth) * 13 + 5)
+        .padding(.trailing, 7)
+        .frame(maxWidth: .infinity, minHeight: 25, maxHeight: 25, alignment: .leading)
+        .contentShape(Rectangle())
+        .help(path ?? name)
+    }
+}
+
+extension PathTreeRowLabel where Accessory == EmptyView {
+    init(
+        name: String,
+        path: String?,
+        depth: Int,
+        isDirectory: Bool,
+        isExpanded: Bool,
+        titleColor: Color = .primary
+    ) {
+        self.init(
+            name: name,
+            path: path,
+            depth: depth,
+            isDirectory: isDirectory,
+            isExpanded: isExpanded,
+            titleColor: titleColor
+        ) {
+            EmptyView()
+        }
+    }
+}

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+struct UnifiedDiffView: View {
+    let model: SplitDiffModel
+    let commentsByLine: [Int: [ReviewComment]]
+    let composingLine: Int?
+    let commentDraft: String
+    let isSubmittingComment: Bool
+    let onCommentDraftChange: (String) -> Void
+    let onRequestComment: (Int) -> Void
+    let onCancelComment: () -> Void
+    let onSubmitComment: (Int) -> Void
+    let onReply: (Int) -> Void
+
+    @State private var hoveredLine: Int?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: true) {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(model.blocks) { block in
+                    blockHeader(block)
+                    ForEach(block.rows) { row in
+                        diffRow(row)
+                        if let line = newLineNumber(of: row),
+                           let thread = commentsByLine[line] {
+                            commentThread(thread, line: line)
+                        }
+                        if composingLine == newLineNumber(of: row) {
+                            composer(for: newLineNumber(of: row) ?? 0)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private func blockHeader(_ block: SplitDiffBlock) -> some View {
+        Group {
+            switch block.kind {
+            case .hunk(let label):
+                Text(label)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(.quaternary.opacity(0.5))
+            case .omission:
+                Text("…")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+            }
+        }
+    }
+
+    private func diffRow(_ row: SplitDiffRow) -> some View {
+        let cell: (kind: SplitDiffCellKind, text: String, line: Int)? = diffCell(of: row)
+        guard let cell else { return AnyView(EmptyView()) }
+        let line = newLineNumber(of: row)
+        let isHovered = line != nil && hoveredLine == line
+        return AnyView(
+            HStack(spacing: 0) {
+                Text(cell.kind == .removal ? "-" : (cell.kind == .insertion ? "+" : " "))
+                    .font(.caption.monospaced())
+                    .foregroundStyle(
+                        cell.kind == .removal ? Color.red : (cell.kind == .insertion ? Color.green : Color.secondary)
+                    )
+                    .frame(width: 14)
+                Text("\(cell.line)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 40, alignment: .trailing)
+                Text(cell.text)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(cell.kind == .removal ? Color.red : (cell.kind == .insertion ? Color.green : Color.primary))
+                    .textSelection(.enabled)
+                    .padding(.leading, 10)
+                Spacer(minLength: 0)
+                if isHovered {
+                    Button {
+                        if let line { onRequestComment(line) }
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+                    .help("Comment on this line")
+                    .accessibilityLabel("Comment on line \(cell.line)")
+                    .padding(.trailing, 6)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 1)
+            .background(cell.kind == .removal ? Color.red.opacity(0.07) : (cell.kind == .insertion ? Color.green.opacity(0.07) : .clear))
+            .onHover { hovering in
+                hoveredLine = hovering ? (line ?? hoveredLine) : nil
+            }
+        )
+    }
+
+    private func commentThread(_ comments: [ReviewComment], line: Int) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(comments) { comment in
+                ReviewCommentRow(comment: comment) {
+                    onReply(line)
+                }
+            }
+        }
+        .padding(.leading, 76)
+        .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func composer(for line: Int) -> some View {
+        ReviewCommentComposer(
+            text: commentDraft,
+            isSubmitting: isSubmittingComment,
+            onTextChange: onCommentDraftChange,
+            onCancel: onCancelComment,
+            onSubmit: { onSubmitComment(line) }
+        )
+        .padding(.leading, 76)
+        .padding(.vertical, 6)
+    }
+
+    private func diffCell(of row: SplitDiffRow) -> (kind: SplitDiffCellKind, text: String, line: Int)? {
+        if let original = row.original, original.kind == .removal {
+            return (kind: .removal, text: original.text, line: original.lineNumber)
+        }
+        if let modified = row.modified, modified.kind == .insertion {
+            return (kind: .insertion, text: modified.text, line: modified.lineNumber)
+        }
+        if let modified = row.modified {
+            return (kind: .context, text: modified.text, line: modified.lineNumber)
+        }
+        return nil
+    }
+
+    private func newLineNumber(of row: SplitDiffRow) -> Int? {
+        row.modified?.lineNumber
+    }
+}

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -1,103 +1,435 @@
 import SwiftUI
 
+enum UnifiedDiffLineKind: Equatable, Sendable {
+    case context
+    case insertion
+    case removal
+}
+
+struct UnifiedDiffLine: Identifiable, Equatable, Sendable {
+    let id: String
+    let kind: UnifiedDiffLineKind
+    let text: String
+    let oldLineNumber: Int?
+    let newLineNumber: Int?
+
+    var commentAnchorLine: Int? {
+        kind == .removal ? nil : newLineNumber
+    }
+}
+
+struct UnifiedDiffBlockPresentation: Identifiable, Equatable, Sendable {
+    let id: Int
+    let kind: SplitDiffBlockKind
+    let lines: [UnifiedDiffLine]
+}
+
+struct UnifiedDiffPresentation: Equatable, Sendable {
+    let blocks: [UnifiedDiffBlockPresentation]
+
+    init(model: SplitDiffModel, anchoredLines: Set<Int> = []) {
+        if model.blocks.isEmpty, !anchoredLines.isEmpty {
+            blocks = Self.anchoredContextBlocks(
+                rows: model.rows,
+                anchoredLines: anchoredLines,
+                startingBlockId: 0
+            )
+            return
+        }
+
+        var presentations: [UnifiedDiffBlockPresentation] = []
+        for block in model.blocks {
+            if case .omission = block.kind,
+               block.rows.contains(where: { row in
+                   guard let line = row.modified?.lineNumber else { return false }
+                   return anchoredLines.contains(line)
+               }) {
+                presentations.append(contentsOf: Self.anchoredContextBlocks(
+                    rows: block.rows,
+                    anchoredLines: anchoredLines,
+                    startingBlockId: presentations.count
+                ))
+                continue
+            }
+
+            let id = presentations.count
+            presentations.append(UnifiedDiffBlockPresentation(
+                id: id,
+                kind: block.kind,
+                lines: Self.lines(for: block.rows, blockId: id)
+            ))
+        }
+        blocks = presentations
+    }
+
+    var changedLineCount: Int {
+        blocks.reduce(into: 0) { count, block in
+            guard case .hunk = block.kind else { return }
+            count += block.lines.count
+        }
+    }
+
+    private static func lines(
+        for rows: [SplitDiffRow],
+        blockId: Int
+    ) -> [UnifiedDiffLine] {
+        rows.flatMap { row in
+            var lines: [UnifiedDiffLine] = []
+
+            if let original = row.original, original.kind == .removal {
+                lines.append(UnifiedDiffLine(
+                    id: "\(blockId)-\(row.id)-removal",
+                    kind: .removal,
+                    text: original.text,
+                    oldLineNumber: original.lineNumber,
+                    newLineNumber: nil
+                ))
+            }
+
+            if let modified = row.modified, modified.kind == .insertion {
+                lines.append(UnifiedDiffLine(
+                    id: "\(blockId)-\(row.id)-insertion",
+                    kind: .insertion,
+                    text: modified.text,
+                    oldLineNumber: nil,
+                    newLineNumber: modified.lineNumber
+                ))
+            } else if let modified = row.modified {
+                lines.append(UnifiedDiffLine(
+                    id: "\(blockId)-\(row.id)-context",
+                    kind: .context,
+                    text: modified.text,
+                    oldLineNumber: row.original?.lineNumber,
+                    newLineNumber: modified.lineNumber
+                ))
+            }
+
+            return lines
+        }
+    }
+
+    private static func anchoredContextBlocks(
+        rows: [SplitDiffRow],
+        anchoredLines: Set<Int>,
+        startingBlockId: Int,
+        contextLineCount: Int = 3
+    ) -> [UnifiedDiffBlockPresentation] {
+        let anchorIndices = rows.indices.filter { index in
+            guard let line = rows[index].modified?.lineNumber else { return false }
+            return anchoredLines.contains(line)
+        }
+        guard !anchorIndices.isEmpty else { return [] }
+
+        var ranges: [ClosedRange<Int>] = []
+        for index in anchorIndices {
+            let candidate = max(0, index - contextLineCount)
+                ... min(rows.count - 1, index + contextLineCount)
+            if let previous = ranges.last,
+               candidate.lowerBound <= previous.upperBound + 1 {
+                ranges[ranges.count - 1] = previous.lowerBound
+                    ... max(previous.upperBound, candidate.upperBound)
+            } else {
+                ranges.append(candidate)
+            }
+        }
+
+        var result: [UnifiedDiffBlockPresentation] = []
+        var cursor = 0
+        for range in ranges {
+            if cursor < range.lowerBound {
+                appendBlock(
+                    kind: .omission,
+                    rows: Array(rows[cursor..<range.lowerBound]),
+                    startingBlockId: startingBlockId,
+                    to: &result
+                )
+            }
+
+            let hunkRows = Array(rows[range])
+            appendBlock(
+                kind: .hunk(hunkLabel(for: hunkRows)),
+                rows: hunkRows,
+                startingBlockId: startingBlockId,
+                to: &result
+            )
+            cursor = range.upperBound + 1
+        }
+
+        if cursor < rows.count {
+            appendBlock(
+                kind: .omission,
+                rows: Array(rows[cursor...]),
+                startingBlockId: startingBlockId,
+                to: &result
+            )
+        }
+        return result
+    }
+
+    private static func appendBlock(
+        kind: SplitDiffBlockKind,
+        rows: [SplitDiffRow],
+        startingBlockId: Int,
+        to blocks: inout [UnifiedDiffBlockPresentation]
+    ) {
+        let id = startingBlockId + blocks.count
+        blocks.append(.init(
+            id: id,
+            kind: kind,
+            lines: lines(for: rows, blockId: id)
+        ))
+    }
+
+    private static func hunkLabel(for rows: [SplitDiffRow]) -> String {
+        let oldStart = rows.first?.original?.lineNumber ?? rows.first?.modified?.lineNumber ?? 1
+        let newStart = rows.first?.modified?.lineNumber ?? rows.first?.original?.lineNumber ?? 1
+        let oldCount = rows.filter { $0.original != nil }.count
+        let newCount = rows.filter { $0.modified != nil }.count
+        return "@@ -\(oldStart),\(oldCount) +\(newStart),\(newCount) @@"
+    }
+}
+
+private enum UnifiedDiffMetrics {
+    static let oldLineGutterWidth: CGFloat = 42
+    static let newLineGutterWidth: CGFloat = 42
+    static let markerWidth: CGFloat = 18
+    static let commentButtonWidth: CGFloat = 26
+}
+
+private struct UnifiedDiffViewportWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 struct UnifiedDiffView: View {
-    let model: SplitDiffModel
+    let presentation: UnifiedDiffPresentation
     let commentsByLine: [Int: [ReviewComment]]
     let composingLine: Int?
-    let commentDraft: String
+    @Binding var commentDraft: String
     let isSubmittingComment: Bool
-    let onCommentDraftChange: (String) -> Void
     let onRequestComment: (Int) -> Void
     let onCancelComment: () -> Void
     let onSubmitComment: (Int) -> Void
     let onReply: (Int) -> Void
 
-    @State private var hoveredLine: Int?
+    @State private var hoveredLineId: String?
+    @State private var expandedOmissionIds: Set<Int> = []
+    @State private var viewportWidth: CGFloat = 0
+
+    init(
+        model: SplitDiffModel,
+        commentsByLine: [Int: [ReviewComment]],
+        composingLine: Int?,
+        commentDraft: Binding<String>,
+        isSubmittingComment: Bool,
+        onRequestComment: @escaping (Int) -> Void,
+        onCancelComment: @escaping () -> Void,
+        onSubmitComment: @escaping (Int) -> Void,
+        onReply: @escaping (Int) -> Void
+    ) {
+        var anchoredLines = Set(commentsByLine.keys)
+        if let composingLine {
+            anchoredLines.insert(composingLine)
+        }
+        presentation = UnifiedDiffPresentation(
+            model: model,
+            anchoredLines: anchoredLines
+        )
+        self.commentsByLine = commentsByLine
+        self.composingLine = composingLine
+        _commentDraft = commentDraft
+        self.isSubmittingComment = isSubmittingComment
+        self.onRequestComment = onRequestComment
+        self.onCancelComment = onCancelComment
+        self.onSubmitComment = onSubmitComment
+        self.onReply = onReply
+    }
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: true) {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(model.blocks) { block in
-                    blockHeader(block)
-                    ForEach(block.rows) { row in
-                        diffRow(row)
-                        if let line = newLineNumber(of: row),
-                           let thread = commentsByLine[line] {
-                            commentThread(thread, line: line)
-                        }
-                        if composingLine == newLineNumber(of: row) {
-                            composer(for: newLineNumber(of: row) ?? 0)
-                        }
-                    }
-                }
-            }
-            .padding(.vertical, 4)
-        }
-    }
-
-    private func blockHeader(_ block: SplitDiffBlock) -> some View {
         Group {
-            switch block.kind {
-            case .hunk(let label):
-                Text(label)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.tertiary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(.quaternary.opacity(0.5))
-            case .omission:
-                Text("…")
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.tertiary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 2)
+            if presentation.changedLineCount == 0 {
+                Text("No content changes")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 96)
+            } else {
+                ScrollView(.horizontal, showsIndicators: true) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(presentation.blocks) { block in
+                            blockView(block)
+                        }
+                    }
+                    .frame(minWidth: minimumContentWidth, alignment: .leading)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .textBackgroundColor))
+        .background {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: UnifiedDiffViewportWidthKey.self,
+                    value: proxy.size.width
+                )
+            }
+        }
+        .onPreferenceChange(UnifiedDiffViewportWidthKey.self) { viewportWidth = $0 }
+    }
+
+    private var minimumContentWidth: CGFloat {
+        max(viewportWidth, 1)
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: UnifiedDiffBlockPresentation) -> some View {
+        switch block.kind {
+        case .hunk(let label):
+            hunkHeader(label)
+            ForEach(block.lines) { line in
+                lineView(line)
+            }
+        case .omission:
+            omissionControl(block)
+            if omissionIsExpanded(block) {
+                ForEach(block.lines) { line in
+                    lineView(line)
+                }
             }
         }
     }
 
-    private func diffRow(_ row: SplitDiffRow) -> some View {
-        let cell: (kind: SplitDiffCellKind, text: String, line: Int)? = diffCell(of: row)
-        guard let cell else { return AnyView(EmptyView()) }
-        let line = newLineNumber(of: row)
-        let isHovered = line != nil && hoveredLine == line
-        return AnyView(
-            HStack(spacing: 0) {
-                Text(cell.kind == .removal ? "-" : (cell.kind == .insertion ? "+" : " "))
-                    .font(.caption.monospaced())
-                    .foregroundStyle(
-                        cell.kind == .removal ? Color.red : (cell.kind == .insertion ? Color.green : Color.secondary)
-                    )
-                    .frame(width: 14)
-                Text("\(cell.line)")
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.tertiary)
-                    .frame(width: 40, alignment: .trailing)
-                Text(cell.text)
-                    .font(.caption.monospaced())
-                    .foregroundStyle(cell.kind == .removal ? Color.red : (cell.kind == .insertion ? Color.green : Color.primary))
-                    .textSelection(.enabled)
-                    .padding(.leading, 10)
-                Spacer(minLength: 0)
-                if isHovered {
-                    Button {
-                        if let line { onRequestComment(line) }
-                    } label: {
-                        Image(systemName: "plus.circle.fill")
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(Color.accentColor)
-                    .help("Comment on this line")
-                    .accessibilityLabel("Comment on line \(cell.line)")
-                    .padding(.trailing, 6)
-                }
+    private func hunkHeader(_ label: String) -> some View {
+        Text(label)
+            .font(.caption.monospaced())
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .frame(
+                minWidth: minimumContentWidth,
+                maxWidth: .infinity,
+                minHeight: 26,
+                alignment: .leading
+            )
+            .background(Color.accentColor.opacity(0.06))
+    }
+
+    private func omissionControl(_ block: UnifiedDiffBlockPresentation) -> some View {
+        Button {
+            if expandedOmissionIds.contains(block.id) {
+                expandedOmissionIds.remove(block.id)
+            } else {
+                expandedOmissionIds.insert(block.id)
             }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 1)
-            .background(cell.kind == .removal ? Color.red.opacity(0.07) : (cell.kind == .insertion ? Color.green.opacity(0.07) : .clear))
-            .onHover { hovering in
-                hoveredLine = hovering ? (line ?? hoveredLine) : nil
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: omissionIsExpanded(block) ? "chevron.up" : "chevron.down")
+                Text("\(block.lines.count) unchanged lines")
             }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .frame(
+                minWidth: minimumContentWidth,
+                maxWidth: .infinity,
+                minHeight: 26,
+                alignment: .leading
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .focusEffectDisabled()
+        .accessibilityLabel(
+            omissionIsExpanded(block)
+                ? "Collapse \(block.lines.count) unchanged lines"
+                : "Expand \(block.lines.count) unchanged lines"
         )
+    }
+
+    private func omissionIsExpanded(_ block: UnifiedDiffBlockPresentation) -> Bool {
+        if expandedOmissionIds.contains(block.id) {
+            return true
+        }
+        return block.lines.contains { line in
+            guard let anchor = line.commentAnchorLine else { return false }
+            return commentsByLine[anchor] != nil || composingLine == anchor
+        }
+    }
+
+    @ViewBuilder
+    private func lineView(_ line: UnifiedDiffLine) -> some View {
+        diffRow(line)
+        if let anchor = line.commentAnchorLine,
+           let thread = commentsByLine[anchor] {
+            commentThread(thread, line: anchor)
+        }
+        if composingLine == line.commentAnchorLine,
+           let anchor = line.commentAnchorLine {
+            composer(for: anchor)
+        }
+    }
+
+    private func diffRow(_ line: UnifiedDiffLine) -> some View {
+        HStack(alignment: .top, spacing: 0) {
+            lineNumber(line.oldLineNumber, width: UnifiedDiffMetrics.oldLineGutterWidth)
+            lineNumber(line.newLineNumber, width: UnifiedDiffMetrics.newLineGutterWidth)
+
+            Text(marker(for: line.kind))
+                .foregroundStyle(markerColor(for: line.kind))
+                .frame(width: UnifiedDiffMetrics.markerWidth)
+
+            commentControl(for: line)
+
+            Text(line.text.isEmpty ? " " : line.text)
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.trailing, 12)
+        }
+        .font(.system(size: 12, design: .monospaced))
+        .padding(.vertical, 3)
+        .frame(
+            minWidth: minimumContentWidth,
+            maxWidth: .infinity,
+            minHeight: 24,
+            alignment: .topLeading
+        )
+        .background(rowBackground(for: line.kind))
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            hoveredLineId = hovering ? line.id : (hoveredLineId == line.id ? nil : hoveredLineId)
+        }
+    }
+
+    private func lineNumber(_ value: Int?, width: CGFloat) -> some View {
+        Text(value.map(String.init) ?? "")
+            .foregroundStyle(.tertiary)
+            .frame(width: width, alignment: .trailing)
+            .padding(.trailing, 7)
+            .frame(maxHeight: .infinity, alignment: .topTrailing)
+            .background(Color(nsColor: .controlBackgroundColor).opacity(0.48))
+    }
+
+    @ViewBuilder
+    private func commentControl(for line: UnifiedDiffLine) -> some View {
+        if let anchor = line.commentAnchorLine {
+            Button {
+                onRequestComment(anchor)
+            } label: {
+                Image(systemName: "plus")
+            }
+            .buttonStyle(.borderless)
+            .foregroundStyle(.secondary)
+            .opacity(hoveredLineId == line.id ? 1 : 0)
+            .frame(width: UnifiedDiffMetrics.commentButtonWidth)
+            .help("Comment on new line \(anchor)")
+            .accessibilityLabel("Comment on new line \(anchor)")
+        } else {
+            Color.clear
+                .frame(width: UnifiedDiffMetrics.commentButtonWidth, height: 1)
+                .accessibilityHidden(true)
+        }
     }
 
     private func commentThread(_ comments: [ReviewComment], line: Int) -> some View {
@@ -108,37 +440,56 @@ struct UnifiedDiffView: View {
                 }
             }
         }
-        .padding(.leading, 76)
-        .padding(.vertical, 6)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.leading, 112)
+        .padding(.trailing, 12)
+        .padding(.vertical, 8)
+        .frame(
+            minWidth: minimumContentWidth,
+            maxWidth: .infinity,
+            alignment: .leading
+        )
+        .background(Color.accentColor.opacity(0.035))
     }
 
     private func composer(for line: Int) -> some View {
         ReviewCommentComposer(
-            text: commentDraft,
+            text: $commentDraft,
             isSubmitting: isSubmittingComment,
-            onTextChange: onCommentDraftChange,
             onCancel: onCancelComment,
             onSubmit: { onSubmitComment(line) }
         )
-        .padding(.leading, 76)
-        .padding(.vertical, 6)
+        .padding(.leading, 112)
+        .padding(.trailing, 12)
+        .padding(.vertical, 8)
+        .frame(
+            minWidth: minimumContentWidth,
+            maxWidth: .infinity,
+            alignment: .leading
+        )
+        .background(Color.accentColor.opacity(0.035))
     }
 
-    private func diffCell(of row: SplitDiffRow) -> (kind: SplitDiffCellKind, text: String, line: Int)? {
-        if let original = row.original, original.kind == .removal {
-            return (kind: .removal, text: original.text, line: original.lineNumber)
+    private func marker(for kind: UnifiedDiffLineKind) -> String {
+        switch kind {
+        case .context: " "
+        case .insertion: "+"
+        case .removal: "−"
         }
-        if let modified = row.modified, modified.kind == .insertion {
-            return (kind: .insertion, text: modified.text, line: modified.lineNumber)
-        }
-        if let modified = row.modified {
-            return (kind: .context, text: modified.text, line: modified.lineNumber)
-        }
-        return nil
     }
 
-    private func newLineNumber(of row: SplitDiffRow) -> Int? {
-        row.modified?.lineNumber
+    private func markerColor(for kind: UnifiedDiffLineKind) -> Color {
+        switch kind {
+        case .context: .secondary
+        case .insertion: .green
+        case .removal: .red
+        }
+    }
+
+    private func rowBackground(for kind: UnifiedDiffLineKind) -> Color {
+        switch kind {
+        case .context: .clear
+        case .insertion: .green.opacity(0.08)
+        case .removal: .red.opacity(0.08)
+        }
     }
 }

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -178,6 +178,8 @@ struct ReviewRecord: Identifiable, Hashable, Sendable {
     let version: Int
     let decisionBody: String?
     let approvedResultHash: String?
+    let decidedBy: UserReference?
+    let decidedAt: String?
     let freshness: DraftFreshness
     let reconciliation: DraftReconciliationStatus
     let reconciliationCandidateId: String?
@@ -190,6 +192,7 @@ struct ReviewChangeSources: Sendable {
     let currentContent: String?
     let draftContent: String?
     let resolutionContent: String?
+    let proposedPath: String?
     let operationLabels: [String]
 }
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -1426,11 +1426,20 @@ final class WorkspaceStore: ObservableObject {
         try await server.get("/api/v1/reviews/\(reviewId)")
     }
 
-    func addComment(_ body: String, to review: ReviewRecord) async throws {
+    func addComment(
+        _ body: String,
+        to review: ReviewRecord,
+        anchorPath: String? = nil,
+        anchorLine: Int? = nil
+    ) async throws {
         let _: ReviewComment = try await server.send(
             method: "POST",
             path: "/api/v1/reviews/\(review.id)/comments",
-            body: CreateReviewCommentRequest(body: body)
+            body: CreateReviewCommentRequest(
+                body: body,
+                anchorPath: anchorPath,
+                anchorLine: anchorLine
+            )
         )
         try await refreshReview(review.id)
     }

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -97,6 +97,54 @@ enum ReviewRequestError: LocalizedError, Sendable {
     }
 }
 
+enum ReviewMenuAction: Sendable, Equatable {
+    case approve
+    case reject
+    case merge
+    case resubmit
+
+    func isAvailable(
+        for review: ReviewRecord,
+        canMergeReviews: Bool,
+        isAuthor: Bool
+    ) -> Bool {
+        switch self {
+        case .approve, .reject:
+            return review.status == "open"
+        case .merge:
+            return review.status == "approved"
+                && review.approvedResultHash?.isEmpty == false
+                && canMergeReviews
+        case .resubmit:
+            return review.status == "rejected" && isAuthor
+        }
+    }
+}
+
+struct ReviewDecisionReadiness: Equatable, Sendable {
+    let reviewId: String
+    let reviewVersion: Int
+    let status: String
+    let approvedResultHash: String?
+    let freshness: DraftFreshness
+    let reconciliation: DraftReconciliationStatus
+    let currentCommitId: String?
+
+    init(review: ReviewRecord) {
+        reviewId = review.id
+        reviewVersion = review.version
+        status = review.status
+        approvedResultHash = review.approvedResultHash
+        freshness = review.freshness
+        reconciliation = review.reconciliation
+        currentCommitId = review.currentCommitId
+    }
+
+    func matches(_ review: ReviewRecord) -> Bool {
+        self == ReviewDecisionReadiness(review: review)
+    }
+}
+
 enum ProjectSetupError: LocalizedError, Sendable {
     case noRepositories
     case bundledAgentRuntimeMissing
@@ -188,6 +236,7 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var navigationForwardStack: [String] = []
     @Published var pendingDocumentCommand: DocumentSessionCommand?
     @Published var pendingReviewReconciliationId: String?
+    @Published var reviewDecisionReadiness: ReviewDecisionReadiness?
     @Published var documentReconciliationToolbarState: DocumentReconciliationToolbarState?
     @Published private(set) var loadingResourceIds: Set<String> = []
     @Published private(set) var loadingProjectId: String?
@@ -276,6 +325,55 @@ final class WorkspaceStore: ObservableObject {
 
     var selectedReview: ReviewRecord? {
         reviews.first { $0.id == selectedReviewId } ?? reviews.first
+    }
+
+    func canPerformReviewMenuAction(_ action: ReviewMenuAction) -> Bool {
+        guard phase == .ready,
+              selectedSection == .reviews,
+              let selectedReviewId,
+              let review = reviews.first(where: { $0.id == selectedReviewId }),
+              reviewDecisionReadiness?.matches(review) == true,
+              review.freshness == .current else {
+            return false
+        }
+        return action.isAvailable(
+            for: review,
+            canMergeReviews: canMergeReviews,
+            isAuthor: isReviewAuthor(review)
+        )
+    }
+
+    func performReviewMenuAction(_ action: ReviewMenuAction) async {
+        guard canPerformReviewMenuAction(action),
+              let selectedReviewId,
+              let review = reviews.first(where: { $0.id == selectedReviewId }),
+              let readiness = reviewDecisionReadiness else { return }
+        reviewDecisionReadiness = nil
+        do {
+            switch action {
+            case .approve:
+                try await decide(review, decision: "approved", note: "")
+            case .reject:
+                try await decide(review, decision: "rejected", note: "")
+            case .merge:
+                try await merge(review)
+            case .resubmit:
+                let detail = try await reviewDetail(review.id)
+                if detail.draft.coordination.freshness == .behind {
+                    pendingReviewReconciliationId = review.id
+                } else {
+                    try await resubmit(review, detail: detail)
+                }
+            }
+        } catch {
+            if self.selectedReviewId == selectedReviewId,
+               selectedSection == .reviews,
+               let currentReview = reviews.first(where: { $0.id == selectedReviewId }),
+               readiness.matches(currentReview) {
+                reviewDecisionReadiness = readiness
+            }
+            errorMessage = error.localizedDescription
+        }
     }
 
     var visibleMemoryItems: [MemoryListItem] {
@@ -1437,6 +1535,7 @@ final class WorkspaceStore: ObservableObject {
             path: "/api/v1/reviews/\(review.id)/comments",
             body: CreateReviewCommentRequest(
                 body: body,
+                expectedReviewVersion: review.version,
                 anchorPath: anchorPath,
                 anchorLine: anchorLine
             )
@@ -1588,7 +1687,10 @@ final class WorkspaceStore: ObservableObject {
         ))
         syncStatusAvailable = true
         selectedBundleId = selectedBundleId ?? bundles.first?.id
-        selectedReviewId = selectedReviewId ?? reviews.first?.id
+        if let selectedReviewId,
+           !reviews.contains(where: { $0.id == selectedReviewId }) {
+            self.selectedReviewId = nil
+        }
         if projects.isEmpty {
             selectedSection = .local
             showsProjectSettings = false
@@ -1782,7 +1884,7 @@ final class WorkspaceStore: ObservableObject {
         replaceReview(with: WorkspaceLoader.mapReview(detail))
     }
 
-    private func replaceReview(with review: ReviewRecord) {
+    func replaceReview(with review: ReviewRecord) {
         if let index = reviews.firstIndex(where: { $0.id == review.id }) {
             reviews[index] = review
         } else {
@@ -2402,6 +2504,8 @@ struct WorkspaceLoader: Sendable {
             version: metadata.version,
             decisionBody: metadata.decisionBody,
             approvedResultHash: metadata.approvedResultHash,
+            decidedBy: metadata.decidedBy,
+            decidedAt: metadata.decidedAt,
             freshness: metadata.coordination.freshness,
             reconciliation: metadata.coordination.reconciliation,
             reconciliationCandidateId: metadata.coordination.candidateId,
@@ -2449,6 +2553,7 @@ struct WorkspaceLoader: Sendable {
             currentContent: commitResourceText(current, resource: detail.draft.resource),
             draftContent: draftContent,
             resolutionContent: resolutionContent,
+            proposedPath: finalPath,
             operationLabels: operationLabels
         )
     }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -451,34 +451,20 @@ private struct FileTreeRow: View {
     }
 
     private var rowContent: some View {
-        HStack(spacing: 6) {
-            if let item {
-                FileSymbolView(path: item.document.path)
-            } else {
-                Image(systemName: isExpanded ? "folder.fill" : "folder")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 14)
-            }
-
-            Text(entry.node.name)
-                .font(.system(size: 12.5, weight: .regular))
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .foregroundStyle(titleColor)
-
-            Spacer(minLength: 4)
-
+        PathTreeRowLabel(
+            name: entry.node.name,
+            path: item?.document.path,
+            depth: entry.depth,
+            isDirectory: item == nil,
+            isExpanded: isExpanded,
+            titleColor: titleColor
+        ) {
             SharedUpdateIndicator(
                 freshness: item?.draft?.freshness,
                 hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
                 reconciliation: item?.draft?.reconciliation
             )
         }
-        .padding(.leading, CGFloat(entry.depth) * 13 + 5)
-        .padding(.trailing, 7)
-        .frame(maxWidth: .infinity, minHeight: 25, maxHeight: 25, alignment: .leading)
-        .contentShape(Rectangle())
         .help(item?.inherited == true ? "Inherited from Hub" : entry.node.name)
     }
 
@@ -569,38 +555,31 @@ struct FileTreeNode: Identifiable {
     let item: MemoryListItem?
     let children: [FileTreeNode]?
 
-    private struct Entry {
-        let item: MemoryListItem
-        let components: ArraySlice<String>
-    }
-
     static func build(_ items: [MemoryListItem]) -> [FileTreeNode] {
-        let entries = items.map { item in
+        var itemsById: [String: MemoryListItem] = [:]
+        let pathItems = items.map { item in
+            itemsById[item.id] = item
             var components = item.document.path.split(separator: "/").map(String.init)
             if item.kind == .workflows, components.first == "workflow", components.count > 1 {
                 components.removeFirst()
             }
-            return Entry(item: item, components: components[...])
+            return PathTreeItem(
+                id: item.id,
+                path: components.joined(separator: "/"),
+                fallbackName: item.document.title
+            )
         }
-        return build(entries, prefix: "")
-    }
 
-    private static func build(_ entries: [Entry], prefix: String) -> [FileTreeNode] {
-        let groups = Dictionary(grouping: entries) { $0.components.first ?? $0.item.document.title }
-        return groups.keys.sorted { $0.localizedStandardCompare($1) == .orderedAscending }.map { name in
-            let group = groups[name] ?? []
-            if let file = group.first(where: { $0.components.count <= 1 }) {
-                return .init(
-                    id: file.item.id,
-                    name: name,
-                    item: file.item,
-                    children: nil
-                )
-            }
-            let path = prefix.isEmpty ? name : "\(prefix)/\(name)"
-            let descendants = group.map { Entry(item: $0.item, components: $0.components.dropFirst()) }
-            return .init(id: "directory:\(path)", name: name, item: nil, children: build(descendants, prefix: path))
+        func convert(_ node: PathTreeNode) -> FileTreeNode {
+            FileTreeNode(
+                id: node.id,
+                name: node.name,
+                item: node.item.flatMap { itemsById[$0.id] },
+                children: node.children.map { $0.map(convert) }
+            )
         }
+
+        return PathTreeNode.build(pathItems).map(convert)
     }
 
     static func directoryIds(in nodes: [FileTreeNode]) -> Set<String> {

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 enum ReviewStatusFilter: String, CaseIterable, Identifiable {
@@ -38,6 +39,10 @@ enum ReviewStatusFilter: String, CaseIterable, Identifiable {
     }
 }
 
+struct ReviewRoute: Hashable {
+    let reviewId: String
+}
+
 struct ReviewStatusFilterControl: View {
     let reviews: [ReviewRecord]
     @Binding var selection: ReviewStatusFilter
@@ -68,84 +73,159 @@ struct ReviewStatusFilterControl: View {
     }
 }
 
+struct ReviewListPage: View {
+    @ObservedObject var store: WorkspaceStore
+    let reviews: [ReviewRecord]
+    @Binding var statusFilter: ReviewStatusFilter
+    let onOpen: (ReviewRecord) -> Void
+
+    var body: some View {
+        Group {
+            if store.reviews.isEmpty {
+                ContentUnavailableView(
+                    "No Reviews",
+                    systemImage: "checkmark.bubble",
+                    description: Text("Reviews created from synchronized drafts appear here.")
+                )
+            } else if reviews.isEmpty {
+                ContentUnavailableView(
+                    "No \(statusFilter.title) Reviews",
+                    systemImage: "checkmark.bubble",
+                    description: Text("Reviews with status \(statusFilter.title) will appear here.")
+                )
+            } else {
+                List(reviews) { review in
+                    ReviewRow(review: review, projectName: projectName(for: review))
+                        .contentShape(Rectangle())
+                        .onTapGesture { onOpen(review) }
+                }
+                .listStyle(.inset)
+            }
+        }
+        .navigationTitle("Reviews")
+    }
+
+    private func projectName(for review: ReviewRecord) -> String? {
+        store.projects.first { $0.id == review.projectId }?.name
+    }
+}
+
+struct ReviewRow: View {
+    let review: ReviewRecord
+    let projectName: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(review.title)
+                    .fontWeight(.medium)
+                    .lineLimit(1)
+                ReviewStatusBadge(status: review.status)
+                if review.freshness == .behind {
+                    DraftBaseBehindIndicator(reconciliation: review.reconciliation)
+                }
+                Spacer(minLength: 4)
+            }
+            Text(review.description.isEmpty ? "No description" : review.description)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            Text(meta)
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private var meta: String {
+        let author = review.author.displayName ?? review.author.email
+        let project = projectName ?? "—"
+        let relative = IssueTiming.relativeText(review.updatedAt, relativeTo: .now) ?? "unknown"
+        return "\(author) · \(project) · \(relative)"
+    }
+}
+
+struct ReviewStatusBadge: View {
+    let status: String
+
+    var body: some View {
+        Label {
+            Text(status.capitalized)
+        } icon: {
+            Image(systemName: symbol)
+        }
+        .font(.caption)
+        .foregroundStyle(color)
+        .labelStyle(.titleAndIcon)
+        .help("Status: \(status.capitalized)")
+        .accessibilityLabel("Status: \(status.capitalized)")
+    }
+
+    private var symbol: String {
+        switch status {
+        case "open": "clock"
+        case "approved": "checkmark.circle"
+        case "rejected": "xmark.circle"
+        case "merged": "arrow.triangle.merge"
+        default: "circle"
+        }
+    }
+
+    private var color: Color {
+        switch status {
+        case "open": .accentColor
+        case "approved": .green
+        case "rejected": .red
+        case "merged": .secondary
+        default: .secondary
+        }
+    }
+}
+
+private enum ReviewCommentTarget: Hashable {
+    case general
+    case line(Int)
+}
+
 private enum ReviewReconciliationPurpose {
     case updateDraft
     case resubmit
 }
 
-struct ReviewNavigator: View {
+struct ReviewDetailPage: View {
     @ObservedObject var store: WorkspaceStore
-    @Binding var statusFilter: ReviewStatusFilter
-
-    private var filteredReviews: [ReviewRecord] {
-        store.reviews.filter(statusFilter.matches)
-    }
-
-    var body: some View {
-        List(selection: $store.selectedReviewId) {
-            ForEach(filteredReviews) { review in
-                HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(review.title)
-                            .lineLimit(1)
-                        HStack(spacing: 5) {
-                            Text(review.status.capitalized)
-                            Text("·")
-                            Text(review.author.displayName ?? review.author.email)
-                        }
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    }
-                    Spacer(minLength: 4)
-                    if review.freshness == .behind {
-                        DraftBaseBehindIndicator(reconciliation: review.reconciliation)
-                    }
-                }
-                .tag(review.id)
-                .contextMenu {
-                    if review.freshness == .behind {
-                        Button("Review Changes") {
-                            store.selectedReviewId = review.id
-                            store.pendingReviewReconciliationId = review.id
-                        }
-                    }
-                }
-            }
-        }
-        .listStyle(.inset)
-    }
-}
-
-struct ReviewDetailPane: View {
-    @ObservedObject var store: WorkspaceStore
-    let review: ReviewRecord?
-
-    var body: some View {
-        if let review {
-            ReviewEditor(store: store, review: review)
-                .id("\(review.id):\(review.version)")
-        } else {
-            ContentUnavailableView(
-                "No Reviews",
-                systemImage: "checkmark.bubble",
-                description: Text("Reviews created from synchronized drafts appear here.")
-            )
-        }
-    }
-}
-
-private struct ReviewEditor: View {
-    @ObservedObject var store: WorkspaceStore
-    let review: ReviewRecord
+    let reviewId: String
+    let orderedReviews: [ReviewRecord]
+    let onNavigateToReview: (String) -> Void
 
     @State private var detail: ReviewDetail?
-    @State private var comment = ""
-    @State private var decisionNote = ""
-    @State private var loading = true
     @State private var changeSources: ReviewChangeSources?
+    @State private var loading = true
+    @State private var pendingAction: String?
+    @State private var composing: ReviewCommentTarget?
+    @State private var commentDraft = ""
+    @State private var isSubmittingComment = false
     @State private var reconciliationCandidate: DraftReconciliationCandidate?
     @State private var loadsReconciliation = false
     @State private var reconciliationPurpose = ReviewReconciliationPurpose.updateDraft
+
+    private var review: ReviewRecord? {
+        store.reviews.first { $0.id == reviewId }
+    }
+
+    private var generalComments: [ReviewComment] {
+        detail?.comments.filter { $0.anchorLine == nil } ?? []
+    }
+
+    private var commentsByLine: [Int: [ReviewComment]] {
+        var result: [Int: [ReviewComment]] = [:]
+        for comment in detail?.comments ?? [] {
+            guard let line = comment.anchorLine else { continue }
+            result[line, default: []].append(comment)
+        }
+        return result
+    }
 
     var body: some View {
         Group {
@@ -156,6 +236,9 @@ private struct ReviewEditor: View {
                 ) { resolvedState in
                     guard let detail else {
                         throw ServerClientError.invalidResponse("Review detail is unavailable.")
+                    }
+                    guard let review else {
+                        throw ServerClientError.invalidResponse("Review is unavailable.")
                     }
                     switch reconciliationPurpose {
                     case .updateDraft:
@@ -177,134 +260,298 @@ private struct ReviewEditor: View {
             } else if loading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let review {
+                content(review)
             } else {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
-                        HStack(alignment: .firstTextBaseline, spacing: 12) {
-                            Text(review.title)
-                                .font(.title2.weight(.semibold))
-                                .lineLimit(2)
-                            Spacer(minLength: 16)
-                            Text(review.status.capitalized)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(review.description.isEmpty ? "No description" : review.description)
-                            Text("Requested by \(review.author.displayName ?? review.author.email)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Changes")
-                                .font(.headline)
-                            ForEach(changeSources?.operationLabels ?? [], id: \.self) { label in
-                                Text(label)
-                                    .foregroundStyle(.secondary)
-                            }
-                            if let proposed = changeSources?.draftContent {
-                                SplitDiffView(
-                                    original: changeSources?.baseContent ?? "",
-                                    modified: proposed,
-                                    originalTitle: "Base",
-                                    modifiedTitle: "Proposed"
-                                )
-                                .frame(minHeight: 260)
-                            } else if changeSources?.operationLabels.isEmpty != false {
-                                Text("No content change")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-
-                        if let detail {
-                            GroupBox("Discussion") {
-                                VStack(alignment: .leading, spacing: 12) {
-                                    ForEach(detail.comments) { comment in
-                                        VStack(alignment: .leading, spacing: 3) {
-                                            Text(comment.author.displayName ?? comment.author.email)
-                                                .font(.caption.weight(.semibold))
-                                            Text(comment.body)
-                                        }
-                                    }
-                                    HStack(alignment: .bottom) {
-                                        TextField("Add a comment", text: $comment, axis: .vertical)
-                                        Button("Comment") { submitComment() }
-                                            .disabled(comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                                    }
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(6)
-                            }
-                        }
-
-                        if review.status == "open" {
-                            GroupBox("Decision") {
-                                VStack(alignment: .leading, spacing: 10) {
-                                    TextField("Optional note", text: $decisionNote, axis: .vertical)
-                                    HStack {
-                                        Button("Reject") { decide("rejected") }
-                                        Button("Approve") { decide("approved") }
-                                            .buttonStyle(.borderedProminent)
-                                    }
-                                }
-                                .padding(6)
-                            }
-                        } else if review.status == "rejected", let detail, store.isReviewAuthor(review) {
-                            Button("Resubmit") { resubmit(detail) }
-                                .buttonStyle(.borderedProminent)
-                        } else if review.status == "approved" && review.freshness == .current && store.canMergeReviews {
-                            Button("Merge") { merge() }
-                                .buttonStyle(.borderedProminent)
-                        }
-                    }
-                    .frame(maxWidth: 760, alignment: .leading)
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .padding(24)
-                }
+                ContentUnavailableView(
+                    "Review Unavailable",
+                    systemImage: "checkmark.bubble",
+                    description: Text("This Review is no longer in the workspace.")
+                )
             }
-        }
-        .onChange(of: store.pendingReviewReconciliationId) { _, reviewId in
-            handlePendingReconciliation(reviewId)
         }
         .task {
             await load()
-            handlePendingReconciliation(store.pendingReviewReconciliationId)
+        }
+        .navigationTitle(review?.title ?? "Review")
+        .onChange(of: store.pendingReviewReconciliationId) { _, reviewId in
+            handlePendingReconciliation(reviewId)
+        }
+        .toolbar {
+            if let review {
+                decisionToolbar(review)
+            }
+        }
+        .background {
+            Button("Previous Review") { navigate(offset: -1) }
+                .keyboardShortcut(.upArrow, modifiers: .command)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+            Button("Next Review") { navigate(offset: 1) }
+                .keyboardShortcut(.downArrow, modifiers: .command)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+        }
+    }
+
+    private func content(_ review: ReviewRecord) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                header(review)
+                metaLine(review)
+                Text(review.title)
+                    .font(.title2.weight(.semibold))
+                    .lineLimit(3)
+                if !review.description.isEmpty {
+                    Text(review.description)
+                        .textSelection(.enabled)
+                }
+                Divider()
+                changesSection(review)
+            }
+            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .padding(24)
+        }
+    }
+
+    private func header(_ review: ReviewRecord) -> some View {
+        HStack(spacing: 10) {
+            ReviewStatusBadge(status: review.status)
+            Text("Version \(review.version)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let updated = IssueTiming.relativeText(review.updatedAt, relativeTo: .now) {
+                Text("Updated \(updated)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+    }
+
+    private func metaLine(_ review: ReviewRecord) -> some View {
+        HStack(spacing: 8) {
+            Text(metaText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+            if review.freshness == .behind {
+                staleChip
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var metaText: String {
+        let kind = detail.map { kindTitle($0.draft.resource.kind) } ?? ""
+        let path = detail?.draft.resource.path ?? ""
+        let author = review?.author.displayName ?? review?.author.email ?? ""
+        let project = store.projects.first { $0.id == review?.projectId }?.name ?? "—"
+        return "\(kind) · \(path) · by \(author) · \(project)"
+    }
+
+    private var staleChip: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
+                .foregroundStyle(review?.reconciliation == .conflicts ? Color.orange : Color.secondary)
+            Text(review?.reconciliation == .conflicts ? "Needs conflict resolution" : "Base is stale")
+            Button("View Changes") {
+                loadReconciliation(detail: detail, purpose: .updateDraft)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .help(
+            review?.reconciliation == .conflicts
+                ? "Draft conflicts with the shared version; resolve before deciding"
+                : "Review base is behind the shared version; review changes before deciding"
+        )
+    }
+
+    private func changesSection(_ review: ReviewRecord) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Changes")
+                .font(.headline)
+            ForEach(changeSources?.operationLabels ?? [], id: \.self) { label in
+                Text(label)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let proposed = changeSources?.draftContent {
+                generalSlot
+                UnifiedDiffView(
+                    model: SplitDiffModel.make(
+                        original: changeSources?.baseContent ?? "",
+                        modified: proposed
+                    ),
+                    commentsByLine: commentsByLine,
+                    composingLine: composingLine,
+                    commentDraft: commentDraft,
+                    isSubmittingComment: isSubmittingComment,
+                    onCommentDraftChange: { commentDraft = $0 },
+                    onRequestComment: { composing = .line($0) },
+                    onCancelComment: { composing = nil; commentDraft = "" },
+                    onSubmitComment: { line in Task { await submitComment(line: line) } },
+                    onReply: { line in composing = .line(line) }
+                )
+                .frame(minHeight: 200)
+            } else if changeSources?.operationLabels.isEmpty != false {
+                Text("No content change")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var generalSlot: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if composing == .general {
+                ReviewCommentComposer(
+                    text: commentDraft,
+                    isSubmitting: isSubmittingComment,
+                    onTextChange: { commentDraft = $0 },
+                    onCancel: { composing = nil; commentDraft = "" },
+                    onSubmit: { Task { await submitComment(line: nil) } }
+                )
+            } else {
+                Button {
+                    composing = .general
+                    commentDraft = ""
+                } label: {
+                    Label("Add a general comment", systemImage: "plus.circle")
+                }
+                .buttonStyle(.plain)
+                .font(.callout)
+                .foregroundStyle(Color.accentColor)
+                .help("Comment on the review as a whole")
+                .accessibilityLabel("Add a general comment")
+            }
+            ForEach(generalComments) { comment in
+                ReviewCommentRow(comment: comment) {
+                    composing = .general
+                    commentDraft = ""
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var composingLine: Int? {
+        if case .line(let line) = composing { return line }
+        return nil
+    }
+
+    private func decisionToolbar(_ review: ReviewRecord) -> some ToolbarContent {
+        ToolbarItemGroup(placement: .primaryAction) {
+            switch review.status {
+            case "open":
+                Button {
+                    decide("rejected")
+                } label: {
+                    if pendingAction == "rejected" {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Reject")
+                    }
+                }
+                .keyboardShortcut("r", modifiers: [.command, .option])
+                .disabled(pendingAction != nil)
+                .help("Reject this Review")
+                .accessibilityLabel("Reject Review")
+                Button {
+                    decide("approved")
+                } label: {
+                    if pendingAction == "approved" {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Approve")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut("a", modifiers: [.command, .option])
+                .disabled(pendingAction != nil)
+                .help("Approve this Review")
+                .accessibilityLabel("Approve Review")
+            case "approved":
+                if review.freshness == .current, store.canMergeReviews {
+                    Button {
+                        merge()
+                    } label: {
+                        if pendingAction == "merge" {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text("Merge")
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.return, modifiers: [.command])
+                    .disabled(pendingAction != nil)
+                    .help("Merge the approved changes")
+                    .accessibilityLabel("Merge Review")
+                }
+            case "rejected":
+                if store.isReviewAuthor(review) {
+                    Button {
+                        resubmit()
+                    } label: {
+                        if pendingAction == "resubmit" {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text("Resubmit")
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.return, modifiers: [.command])
+                    .disabled(pendingAction != nil)
+                    .help("Resubmit this Review")
+                    .accessibilityLabel("Resubmit Review")
+                }
+            default:
+                EmptyView()
+            }
+            Menu {
+                Button("Copy Review ID") { copyReviewID() }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+            }
+            .menuIndicator(.hidden)
+            .help("More Actions")
+            .accessibilityLabel("More Actions")
         }
     }
 
     private func load() async {
         loading = true
+        defer { loading = false }
         do {
-            let loadedDetail = try await store.reviewDetail(review.id)
+            let loadedDetail = try await store.reviewDetail(reviewId)
             detail = loadedDetail
-            let sources = try await store.reviewChangeSources(for: loadedDetail)
-            changeSources = sources
+            changeSources = try await store.reviewChangeSources(for: loadedDetail)
         } catch {
             store.errorMessage = error.localizedDescription
         }
-        loading = false
     }
 
-    private func submitComment() {
-        let body = comment.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty else { return }
-        Task {
-            do {
-                try await store.addComment(body, to: review)
-                comment = ""
-                await load()
-            } catch {
-                store.errorMessage = error.localizedDescription
-            }
+    private func refreshDetail() async {
+        do {
+            let loadedDetail = try await store.reviewDetail(reviewId)
+            detail = loadedDetail
+            changeSources = try await store.reviewChangeSources(for: loadedDetail)
+        } catch {
+            store.errorMessage = error.localizedDescription
         }
     }
 
     private func decide(_ decision: String) {
+        guard let review else { return }
+        pendingAction = decision
         Task {
+            defer { pendingAction = nil }
             do {
-                try await store.decide(review, decision: decision, note: decisionNote)
+                try await store.decide(review, decision: decision, note: "")
+                await refreshDetail()
             } catch {
                 store.errorMessage = error.localizedDescription
             }
@@ -312,7 +559,10 @@ private struct ReviewEditor: View {
     }
 
     private func merge() {
+        guard let review else { return }
+        pendingAction = "merge"
         Task {
+            defer { pendingAction = nil }
             do {
                 try await store.merge(review)
             } catch {
@@ -321,12 +571,16 @@ private struct ReviewEditor: View {
         }
     }
 
-    private func resubmit(_ detail: ReviewDetail) {
+    private func resubmit() {
+        guard let detail else { return }
+        guard let review else { return }
         if detail.draft.coordination.freshness == .behind {
-            loadReconciliation(detail, purpose: .resubmit)
+            loadReconciliation(detail: detail, purpose: .resubmit)
             return
         }
+        pendingAction = "resubmit"
         Task {
+            defer { pendingAction = nil }
             do {
                 try await store.resubmit(review, detail: detail)
             } catch {
@@ -335,11 +589,29 @@ private struct ReviewEditor: View {
         }
     }
 
-    private func loadReconciliation(
-        _ detail: ReviewDetail,
-        purpose: ReviewReconciliationPurpose = .updateDraft
-    ) {
-        guard !loadsReconciliation else { return }
+    private func submitComment(line: Int?) async {
+        guard let review, !commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        isSubmittingComment = true
+        defer { isSubmittingComment = false }
+        do {
+            try await store.addComment(
+                commentDraft,
+                to: review,
+                anchorPath: detail?.draft.resource.path,
+                anchorLine: line
+            )
+            composing = nil
+            commentDraft = ""
+            await refreshDetail()
+        } catch {
+            store.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func loadReconciliation(detail: ReviewDetail?, purpose: ReviewReconciliationPurpose) {
+        guard let detail, !loadsReconciliation else { return }
         loadsReconciliation = true
         reconciliationPurpose = purpose
         Task {
@@ -353,8 +625,96 @@ private struct ReviewEditor: View {
     }
 
     private func handlePendingReconciliation(_ reviewId: String?) {
-        guard reviewId == review.id, let detail else { return }
+        guard reviewId == self.reviewId, let detail else { return }
         store.pendingReviewReconciliationId = nil
-        loadReconciliation(detail)
+        loadReconciliation(detail: detail, purpose: .updateDraft)
+    }
+
+    private func navigate(offset: Int) {
+        guard let index = orderedReviews.firstIndex(where: { $0.id == reviewId }) else { return }
+        let target = index + offset
+        guard orderedReviews.indices.contains(target) else { return }
+        let next = orderedReviews[target]
+        store.selectedReviewId = next.id
+        onNavigateToReview(next.id)
+    }
+
+    private func copyReviewID() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(reviewId, forType: .string)
+    }
+
+    private func kindTitle(_ kind: DaemonResourceKind) -> String {
+        switch kind {
+        case .context: "Context"
+        case .rule: "Rule"
+        case .workflow: "Workflow"
+        }
+    }
+}
+
+struct ReviewCommentRow: View {
+    let comment: ReviewComment
+    let onReply: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(comment.author.displayName ?? comment.author.email)
+                    .font(.caption.weight(.semibold))
+                Text(IssueTiming.relativeText(comment.createdAt, relativeTo: .now) ?? comment.createdAt)
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+            Text(comment.body)
+                .font(.callout)
+                .textSelection(.enabled)
+            Button("Reply", action: onReply)
+                .font(.caption)
+                .buttonStyle(.plain)
+                .foregroundStyle(Color.accentColor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct ReviewCommentComposer: View {
+    let text: String
+    let isSubmitting: Bool
+    let onTextChange: (String) -> Void
+    let onCancel: () -> Void
+    let onSubmit: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextField(
+                "Write a comment…",
+                text: Binding(get: { text }, set: onTextChange),
+                axis: .vertical
+            )
+            .lineLimit(2...6)
+            .textFieldStyle(.roundedBorder)
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                    .disabled(isSubmitting)
+                Button {
+                    onSubmit()
+                } label: {
+                    if isSubmitting {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Comment")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(
+                    text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -43,6 +43,64 @@ struct ReviewRoute: Hashable {
     let reviewId: String
 }
 
+struct ReviewToolbarOwnership: Equatable {
+    enum Surface: Equatable {
+        case list
+        case detail
+    }
+
+    enum Item: Equatable {
+        case filter
+        case decision(ReviewMenuAction)
+        case search
+    }
+
+    let surface: Surface
+    let items: [Item]
+
+    static func resolve(
+        surface: Surface,
+        review: ReviewRecord?,
+        canMergeReviews: Bool,
+        isAuthor: Bool
+    ) -> Self {
+        guard surface == .detail else {
+            return .init(surface: .list, items: [.filter, .search])
+        }
+
+        let actions = review.map { review in
+            [
+                ReviewMenuAction.reject,
+                .approve,
+                .merge,
+                .resubmit,
+            ].filter {
+                $0.isAvailable(
+                    for: review,
+                    canMergeReviews: canMergeReviews,
+                    isAuthor: isAuthor
+                )
+            }
+        } ?? []
+
+        return .init(
+            surface: .detail,
+            items: actions.map(Item.decision) + [.search]
+        )
+    }
+
+    func contains(_ item: Item) -> Bool {
+        items.contains(item)
+    }
+
+    var hasDecisionActions: Bool {
+        items.contains {
+            if case .decision = $0 { return true }
+            return false
+        }
+    }
+}
+
 struct ReviewStatusFilterControl: View {
     let reviews: [ReviewRecord]
     @Binding var selection: ReviewStatusFilter
@@ -77,6 +135,7 @@ struct ReviewListPage: View {
     @ObservedObject var store: WorkspaceStore
     let reviews: [ReviewRecord]
     @Binding var statusFilter: ReviewStatusFilter
+    let toolbarOwnership: ReviewToolbarOwnership
 
     var body: some View {
         Group {
@@ -129,11 +188,13 @@ struct ReviewListPage: View {
         }
         .navigationTitle("Reviews")
         .toolbar {
-            ToolbarItem(id: "review.filter", placement: .navigation) {
-                ReviewStatusFilterControl(
-                    reviews: store.reviews,
-                    selection: $statusFilter
-                )
+            if toolbarOwnership.contains(.filter) {
+                ToolbarItem(id: "review.filter", placement: .navigation) {
+                    ReviewStatusFilterControl(
+                        reviews: store.reviews,
+                        selection: $statusFilter
+                    )
+                }
             }
         }
     }

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -77,87 +77,284 @@ struct ReviewListPage: View {
     @ObservedObject var store: WorkspaceStore
     let reviews: [ReviewRecord]
     @Binding var statusFilter: ReviewStatusFilter
-    let onOpen: (ReviewRecord) -> Void
 
     var body: some View {
         Group {
-            if store.reviews.isEmpty {
+            switch ReviewListContentState.resolve(
+                phase: store.phase,
+                totalCount: store.reviews.count,
+                visibleCount: reviews.count
+            ) {
+            case .loading:
+                ProgressView("Loading Reviews…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .empty:
                 ContentUnavailableView(
                     "No Reviews",
                     systemImage: "checkmark.bubble",
                     description: Text("Reviews created from synchronized drafts appear here.")
                 )
-            } else if reviews.isEmpty {
-                ContentUnavailableView(
-                    "No \(statusFilter.title) Reviews",
-                    systemImage: "checkmark.bubble",
-                    description: Text("Reviews with status \(statusFilter.title) will appear here.")
-                )
-            } else {
-                List(reviews) { review in
-                    ReviewRow(review: review, projectName: projectName(for: review))
-                        .contentShape(Rectangle())
-                        .onTapGesture { onOpen(review) }
+            case .filteredEmpty:
+                ContentUnavailableView {
+                    Label("No \(statusFilter.title) Reviews", systemImage: statusFilter.symbolName)
+                } description: {
+                    Text("No Reviews match the current status filter.")
+                } actions: {
+                    Button("Show All Reviews") {
+                        statusFilter = .all
+                    }
+                }
+            case .content:
+                List {
+                    ForEach(reviews) { review in
+                        let route = ReviewRoute(reviewId: review.id)
+                        let state = ReviewQueueStatePresentation.resolve(
+                            review: review,
+                            isAuthor: store.isReviewAuthor(review),
+                            canMerge: store.canMergeReviews
+                        )
+                        NavigationLink(value: route) {
+                            ReviewRow(
+                                review: review,
+                                projectName: projectName(for: review),
+                                state: state,
+                                showsState: statusFilter == .all || state.isQueueSignal
+                            )
+                        }
+                        .accessibilityIdentifier("review-row-\(review.id)")
+                    }
                 }
                 .listStyle(.inset)
             }
         }
         .navigationTitle("Reviews")
+        .toolbar {
+            ToolbarItem(id: "review.filter", placement: .navigation) {
+                ReviewStatusFilterControl(
+                    reviews: store.reviews,
+                    selection: $statusFilter
+                )
+            }
+        }
     }
 
     private func projectName(for review: ReviewRecord) -> String? {
         store.projects.first { $0.id == review.projectId }?.name
+    }
+
+}
+
+enum ReviewListContentState: Equatable {
+    case loading
+    case empty
+    case filteredEmpty
+    case content
+
+    static func resolve(
+        phase: ApplicationPhase,
+        totalCount: Int,
+        visibleCount: Int
+    ) -> ReviewListContentState {
+        if totalCount == 0 {
+            return phase == .loading || phase == .launching ? .loading : .empty
+        }
+        return visibleCount == 0 ? .filteredEmpty : .content
+    }
+}
+
+struct ReviewQueueStatePresentation: Equatable {
+    enum Tone: Equatable {
+        case neutral
+        case positive
+        case warning
+        case negative
+
+        var color: Color {
+            switch self {
+            case .neutral: .secondary
+            case .positive: .green
+            case .warning: .orange
+            case .negative: .red
+            }
+        }
+    }
+
+    let title: String
+    let symbolName: String
+    let tone: Tone
+    let isQueueSignal: Bool
+
+    static func resolve(
+        review: ReviewRecord,
+        isAuthor: Bool,
+        canMerge: Bool
+    ) -> ReviewQueueStatePresentation {
+        if review.status == "merged" {
+            return .init(
+                title: "Merged",
+                symbolName: "arrow.triangle.merge",
+                tone: .neutral,
+                isQueueSignal: false
+            )
+        }
+        if review.freshness == .behind, review.reconciliation == .conflicts {
+            return .init(
+                title: "Conflicts",
+                symbolName: "exclamationmark.triangle",
+                tone: .warning,
+                isQueueSignal: true
+            )
+        }
+        if review.freshness == .behind {
+            return .init(
+                title: isAuthor ? "Update Required" : "Out of Date",
+                symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
+                tone: .warning,
+                isQueueSignal: true
+            )
+        }
+
+        switch review.status {
+        case "open":
+            return .init(
+                title: "Needs Review",
+                symbolName: "clock",
+                tone: .neutral,
+                isQueueSignal: false
+            )
+        case "approved"
+            where canMerge && review.approvedResultHash?.isEmpty == false:
+            return .init(
+                title: "Ready to Merge",
+                symbolName: "arrow.triangle.merge",
+                tone: .positive,
+                isQueueSignal: true
+            )
+        case "approved":
+            return .init(
+                title: "Approved",
+                symbolName: "checkmark.circle",
+                tone: .positive,
+                isQueueSignal: false
+            )
+        case "rejected" where isAuthor:
+            return .init(
+                title: "Resubmit",
+                symbolName: "arrow.clockwise.circle",
+                tone: .negative,
+                isQueueSignal: true
+            )
+        case "rejected":
+            return .init(
+                title: "Awaiting Author",
+                symbolName: "clock",
+                tone: .neutral,
+                isQueueSignal: true
+            )
+        default:
+            return .init(
+                title: review.status.capitalized,
+                symbolName: "circle",
+                tone: .neutral,
+                isQueueSignal: false
+            )
+        }
     }
 }
 
 struct ReviewRow: View {
     let review: ReviewRecord
     let projectName: String?
+    let state: ReviewQueueStatePresentation
+    let showsState: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Text(review.title)
-                    .fontWeight(.medium)
+                    .font(.body)
                     .lineLimit(1)
-                ReviewStatusBadge(status: review.status)
-                if review.freshness == .behind {
-                    DraftBaseBehindIndicator(reconciliation: review.reconciliation)
+                    .layoutPriority(1)
+
+                Spacer(minLength: 8)
+
+                if showsState {
+                    ViewThatFits(in: .horizontal) {
+                        Label(state.title, systemImage: state.symbolName)
+                            .lineLimit(1)
+                            .fixedSize(horizontal: true, vertical: false)
+
+                        Image(systemName: state.symbolName)
+                    }
+                    .font(.caption)
+                    .foregroundStyle(state.tone.color)
+                    .help(state.title)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(state.title)
                 }
-                Spacer(minLength: 4)
             }
-            Text(review.description.isEmpty ? "No description" : review.description)
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            Text(meta)
-                .font(.caption)
-                .foregroundStyle(.tertiary)
-                .lineLimit(1)
+
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(context)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                if let updatedAt = IssueTiming.date(from: review.updatedAt) {
+                    Text(updatedAt, style: .relative)
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .help(IssueTiming.absoluteText(review.updatedAt) ?? "")
+                }
+            }
         }
         .padding(.vertical, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
     }
 
-    private var meta: String {
+    private var context: String {
         let author = review.author.displayName ?? review.author.email
-        let project = projectName ?? "—"
-        let relative = IssueTiming.relativeText(review.updatedAt, relativeTo: .now) ?? "unknown"
-        return "\(author) · \(project) · \(relative)"
+        guard let projectName, !projectName.isEmpty else { return author }
+        return "\(projectName) · \(author)"
+    }
+
+    private var accessibilityText: String {
+        let relative = IssueTiming.relativeText(review.updatedAt, relativeTo: .now)
+        let time = relative.map { ", updated \($0)" } ?? ""
+        return "\(review.title), \(state.title), \(context)\(time)"
     }
 }
 
-struct ReviewStatusBadge: View {
+struct ReviewStatusIndicator: View {
     let status: String
+    var iconOnly = false
 
+    @ViewBuilder
     var body: some View {
+        if iconOnly {
+            label
+                .labelStyle(.iconOnly)
+        } else {
+            label
+        }
+    }
+
+    private var label: some View {
         Label {
             Text(status.capitalized)
+                .foregroundStyle(.secondary)
         } icon: {
             Image(systemName: symbol)
+                .foregroundStyle(color)
         }
         .font(.caption)
-        .foregroundStyle(color)
-        .labelStyle(.titleAndIcon)
         .help("Status: \(status.capitalized)")
         .accessibilityLabel("Status: \(status.capitalized)")
     }
@@ -174,7 +371,7 @@ struct ReviewStatusBadge: View {
 
     private var color: Color {
         switch status {
-        case "open": .accentColor
+        case "open": .secondary
         case "approved": .green
         case "rejected": .red
         case "merged": .secondary
@@ -188,43 +385,127 @@ private enum ReviewCommentTarget: Hashable {
     case line(Int)
 }
 
-private enum ReviewReconciliationPurpose {
-    case updateDraft
-    case resubmit
+struct ReviewCommentPlacement: Equatable {
+    let general: [ReviewComment]
+    let byLine: [Int: [ReviewComment]]
+    let unplaced: [ReviewComment]
+
+    static func resolve(
+        comments: [ReviewComment],
+        activePath: String?,
+        renderableLines: Set<Int>,
+        minimumInlineVersion: Int
+    ) -> ReviewCommentPlacement {
+        var general: [ReviewComment] = []
+        var byLine: [Int: [ReviewComment]] = [:]
+        var unplaced: [ReviewComment] = []
+
+        for comment in comments {
+            switch (comment.anchorPath, comment.anchorLine) {
+            case (nil, nil):
+                general.append(comment)
+            case let (path?, line?)
+                where path == activePath
+                    && renderableLines.contains(line)
+                    && comment.reviewVersion >= minimumInlineVersion:
+                byLine[line, default: []].append(comment)
+            default:
+                unplaced.append(comment)
+            }
+        }
+
+        return .init(general: general, byLine: byLine, unplaced: unplaced)
+    }
+
+    static func minimumInlineVersion(reviewVersion: Int, status: String) -> Int {
+        let lifecycleVersionsAfterContent: Int
+        switch status {
+        case "approved", "rejected":
+            lifecycleVersionsAfterContent = 1
+        case "merged":
+            lifecycleVersionsAfterContent = 2
+        default:
+            lifecycleVersionsAfterContent = 0
+        }
+        return max(1, reviewVersion - lifecycleVersionsAfterContent)
+    }
+}
+
+struct ReviewFileDescriptor: Identifiable, Hashable, Sendable {
+    let id: String
+    let path: String
+
+    static func resolve(
+        reviewId: String,
+        detail: ReviewDetail,
+        sources: ReviewChangeSources
+    ) -> ReviewFileDescriptor {
+        let path = sources.proposedPath ?? detail.draft.resource.path ?? "Untitled"
+        let id = detail.draft.resource.id ?? "review-file:\(reviewId):\(path)"
+        return .init(id: id, path: path)
+    }
 }
 
 struct ReviewDetailPage: View {
     @ObservedObject var store: WorkspaceStore
     let reviewId: String
-    let orderedReviews: [ReviewRecord]
-    let onNavigateToReview: (String) -> Void
+    let loadsRemoteContent: Bool
 
     @State private var detail: ReviewDetail?
     @State private var changeSources: ReviewChangeSources?
+    @State private var diffModel: SplitDiffModel?
     @State private var loading = true
-    @State private var pendingAction: String?
+    @State private var loadError: String?
     @State private var composing: ReviewCommentTarget?
     @State private var commentDraft = ""
     @State private var isSubmittingComment = false
     @State private var reconciliationCandidate: DraftReconciliationCandidate?
     @State private var loadsReconciliation = false
-    @State private var reconciliationPurpose = ReviewReconciliationPurpose.updateDraft
+    @State private var selectedFileId: String?
+    @State private var showsGeneralComments = false
+    @State private var detailRequestGeneration = UUID()
+
+    private struct DetailRequest {
+        let generation: UUID
+        let baseline: ReviewDecisionReadiness?
+    }
 
     private var review: ReviewRecord? {
-        store.reviews.first { $0.id == reviewId }
+        let loadedReview = detail.map { WorkspaceLoader.mapReview($0.review) }
+        let storedReview = store.reviews.first { $0.id == reviewId }
+        if let loadedReview, let storedReview {
+            return storedReview.version >= loadedReview.version ? storedReview : loadedReview
+        }
+        return storedReview ?? loadedReview
+    }
+
+    private var storedReviewDecisionSignature: ReviewDecisionReadiness? {
+        store.reviews.first { $0.id == reviewId }.map(ReviewDecisionReadiness.init)
+    }
+
+    private var commentPlacement: ReviewCommentPlacement {
+        let loadedReview = detail?.review
+        return ReviewCommentPlacement.resolve(
+            comments: detail?.comments ?? [],
+            activePath: changeSources?.proposedPath,
+            renderableLines: Set(diffModel?.rows.compactMap { $0.modified?.lineNumber } ?? []),
+            minimumInlineVersion: ReviewCommentPlacement.minimumInlineVersion(
+                reviewVersion: loadedReview?.version ?? 1,
+                status: loadedReview?.status ?? "open"
+            )
+        )
     }
 
     private var generalComments: [ReviewComment] {
-        detail?.comments.filter { $0.anchorLine == nil } ?? []
+        commentPlacement.general
     }
 
     private var commentsByLine: [Int: [ReviewComment]] {
-        var result: [Int: [ReviewComment]] = [:]
-        for comment in detail?.comments ?? [] {
-            guard let line = comment.anchorLine else { continue }
-            result[line, default: []].append(comment)
-        }
-        return result
+        commentPlacement.byLine
+    }
+
+    private var unplacedComments: [ReviewComment] {
+        commentPlacement.unplaced
     }
 
     var body: some View {
@@ -232,36 +513,40 @@ struct ReviewDetailPage: View {
             if let candidate = reconciliationCandidate {
                 DraftReconciliationView(
                     candidate: candidate,
-                    onCancel: { reconciliationCandidate = nil }
+                    onCancel: {
+                        reconciliationCandidate = nil
+                        markCurrentDetailDecisionReady()
+                    },
+                    onApplied: {
+                        reconciliationCandidate = nil
+                        Task { await refreshDetail() }
+                    }
                 ) { resolvedState in
                     guard let detail else {
                         throw ServerClientError.invalidResponse("Review detail is unavailable.")
                     }
-                    guard let review else {
-                        throw ServerClientError.invalidResponse("Review is unavailable.")
-                    }
-                    switch reconciliationPurpose {
-                    case .updateDraft:
-                        try await store.applyReconciliation(
-                            draftId: detail.draft.draftId,
-                            draftVersion: detail.draft.version,
-                            candidate: candidate,
-                            resolvedState: resolvedState
-                        )
-                    case .resubmit:
-                        try await store.resubmit(
-                            review,
-                            detail: detail,
-                            candidate: candidate,
-                            resolvedState: resolvedState
-                        )
-                    }
+                    try await store.applyReconciliation(
+                        draftId: detail.draft.draftId,
+                        draftVersion: detail.draft.version,
+                        candidate: candidate,
+                        resolvedState: resolvedState
+                    )
                 }
             } else if loading {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let review {
-                content(review)
+            } else if let loadError {
+                ContentUnavailableView {
+                    Label("Unable to Load Review", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(loadError)
+                } actions: {
+                    Button("Try Again") {
+                        Task { await load() }
+                    }
+                }
+            } else if let review, let detail, let changeSources {
+                content(review, detail: detail, sources: changeSources)
             } else {
                 ContentUnavailableView(
                     "Review Unavailable",
@@ -270,172 +555,333 @@ struct ReviewDetailPage: View {
                 )
             }
         }
-        .task {
+        .task(id: reviewId) {
+            guard loadsRemoteContent else {
+                loading = false
+                return
+            }
             await load()
+        }
+        .onDisappear {
+            invalidateDetailRequests()
         }
         .navigationTitle(review?.title ?? "Review")
         .onChange(of: store.pendingReviewReconciliationId) { _, reviewId in
             handlePendingReconciliation(reviewId)
         }
-        .toolbar {
-            if let review {
-                decisionToolbar(review)
-            }
-        }
-        .background {
-            Button("Previous Review") { navigate(offset: -1) }
-                .keyboardShortcut(.upArrow, modifiers: .command)
-                .frame(width: 0, height: 0)
-                .opacity(0)
-            Button("Next Review") { navigate(offset: 1) }
-                .keyboardShortcut(.downArrow, modifiers: .command)
-                .frame(width: 0, height: 0)
-                .opacity(0)
+        .onChange(of: storedReviewDecisionSignature) { _, signature in
+            guard let signature,
+                  detail.map({ ReviewDecisionReadiness(review: WorkspaceLoader.mapReview($0.review)) })
+                    != signature else { return }
+            invalidateDetailRequests()
+            Task { await refreshDetail() }
         }
     }
 
-    private func content(_ review: ReviewRecord) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                header(review)
-                metaLine(review)
+    private func content(
+        _ review: ReviewRecord,
+        detail: ReviewDetail,
+        sources: ReviewChangeSources
+    ) -> some View {
+        let file = ReviewFileDescriptor.resolve(
+            reviewId: reviewId,
+            detail: detail,
+            sources: sources
+        )
+        return HSplitView {
+            ReviewFileNavigator(
+                files: [file],
+                selection: $selectedFileId
+            )
+            .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
+
+            Group {
+                if selectedFileId == nil || selectedFileId == file.id {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 20) {
+                            reviewHeader(review)
+
+                            if review.freshness == .behind {
+                                readinessChip(review, detail: detail)
+                            }
+
+                            if showsGeneralComments {
+                                generalCommentsPanel
+                            }
+
+                            diffPanel(detail: detail)
+                        }
+                        .frame(maxWidth: 1180, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .top)
+                        .padding(.horizontal, 24)
+                        .padding(.top, 24)
+                        .padding(.bottom, 48)
+                    }
+                } else {
+                    ContentUnavailableView(
+                        "Select a File",
+                        systemImage: "doc.text",
+                        description: Text("Choose a changed file from the file navigator.")
+                    )
+                }
+            }
+            .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(nsColor: .windowBackgroundColor))
+        }
+        .onAppear {
+            if selectedFileId == nil {
+                selectedFileId = file.id
+            }
+        }
+    }
+
+    private func reviewHeader(_ review: ReviewRecord) -> some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
                 Text(review.title)
                     .font(.title2.weight(.semibold))
-                    .lineLimit(3)
-                if !review.description.isEmpty {
-                    Text(review.description)
-                        .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+
+                Spacer(minLength: 16)
+
+                ReviewStatusIndicator(status: review.status)
+
+                Button(action: toggleGeneralComments) {
+                    Image(systemName: reviewWideCommentCount == 0 ? "bubble.badge.plus" : "bubble")
                 }
-                Divider()
-                changesSection(review)
+                .buttonStyle(.borderless)
+                .help(reviewWideCommentCount == 0
+                    ? "Add a review-wide comment"
+                    : "Show \(reviewWideCommentCount) review-wide comments")
+                .accessibilityLabel(reviewWideCommentCount == 0
+                    ? "Add a review-wide comment"
+                    : "Show \(reviewWideCommentCount) review-wide comments")
             }
-            .frame(maxWidth: 760, alignment: .leading)
-            .frame(maxWidth: .infinity, alignment: .topLeading)
-            .padding(24)
-        }
-    }
 
-    private func header(_ review: ReviewRecord) -> some View {
-        HStack(spacing: 10) {
-            ReviewStatusBadge(status: review.status)
-            Text("Version \(review.version)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            if let updated = IssueTiming.relativeText(review.updatedAt, relativeTo: .now) {
-                Text("Updated \(updated)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+            metadata(review)
+
+            let description = review.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !description.isEmpty {
+                Text(description)
+                    .foregroundStyle(.primary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
             }
-            Spacer()
-        }
-    }
 
-    private func metaLine(_ review: ReviewRecord) -> some View {
-        HStack(spacing: 8) {
-            Text(metaText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            if review.freshness == .behind {
-                staleChip
-            }
-            Spacer(minLength: 0)
-        }
-    }
-
-    private var metaText: String {
-        let kind = detail.map { kindTitle($0.draft.resource.kind) } ?? ""
-        let path = detail?.draft.resource.path ?? ""
-        let author = review?.author.displayName ?? review?.author.email ?? ""
-        let project = store.projects.first { $0.id == review?.projectId }?.name ?? "—"
-        return "\(kind) · \(path) · by \(author) · \(project)"
-    }
-
-    private var staleChip: some View {
-        HStack(spacing: 4) {
-            Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
-                .foregroundStyle(review?.reconciliation == .conflicts ? Color.orange : Color.secondary)
-            Text(review?.reconciliation == .conflicts ? "Needs conflict resolution" : "Base is stale")
-            Button("View Changes") {
-                loadReconciliation(detail: detail, purpose: .updateDraft)
-            }
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .help(
-            review?.reconciliation == .conflicts
-                ? "Draft conflicts with the shared version; resolve before deciding"
-                : "Review base is behind the shared version; review changes before deciding"
-        )
-    }
-
-    private func changesSection(_ review: ReviewRecord) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Changes")
-                .font(.headline)
-            ForEach(changeSources?.operationLabels ?? [], id: \.self) { label in
-                Text(label)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-            if let proposed = changeSources?.draftContent {
-                generalSlot
-                UnifiedDiffView(
-                    model: SplitDiffModel.make(
-                        original: changeSources?.baseContent ?? "",
-                        modified: proposed
-                    ),
-                    commentsByLine: commentsByLine,
-                    composingLine: composingLine,
-                    commentDraft: commentDraft,
-                    isSubmittingComment: isSubmittingComment,
-                    onCommentDraftChange: { commentDraft = $0 },
-                    onRequestComment: { composing = .line($0) },
-                    onCancelComment: { composing = nil; commentDraft = "" },
-                    onSubmitComment: { line in Task { await submitComment(line: line) } },
-                    onReply: { line in composing = .line(line) }
-                )
-                .frame(minHeight: 200)
-            } else if changeSources?.operationLabels.isEmpty != false {
-                Text("No content change")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+            if review.status != "open" {
+                decisionSummary(review)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var generalSlot: some View {
-        VStack(alignment: .leading, spacing: 8) {
+    private func metadata(_ review: ReviewRecord) -> some View {
+        let author = review.author.displayName ?? review.author.email
+        let project = store.projects.first { $0.id == review.projectId }?.name
+        let context = [author, project]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+        let updated = IssueTiming.relativeText(review.updatedAt, relativeTo: .now)
+            .map { " · Updated \($0)" } ?? ""
+        return Text("\(context)\(updated)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func readinessChip(_ review: ReviewRecord, detail: ReviewDetail) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Label(
+                review.reconciliation == .conflicts
+                    ? "Resolve conflicts before deciding"
+                    : "The shared version changed",
+                systemImage: review.reconciliation == .conflicts
+                    ? "exclamationmark.triangle"
+                    : "arrow.trianglehead.2.clockwise.rotate.90"
+            )
+            .foregroundStyle(review.reconciliation == .conflicts ? Color.orange : Color.secondary)
+
+            Spacer(minLength: 8)
+
+            Button("Review Changes…") {
+                loadReconciliation(detail: detail)
+            }
+            .controlSize(.small)
+        }
+        .font(.caption)
+        .fixedSize(horizontal: false, vertical: true)
+        .help(
+            review.reconciliation == .conflicts
+                ? "Draft conflicts with the shared version; resolve before deciding"
+                : "Review base is behind the shared version; review changes before deciding"
+        )
+    }
+
+    private func decisionSummary(_ review: ReviewRecord) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 7) {
+                Image(systemName: decisionSymbol(review.status))
+                    .foregroundStyle(decisionColor(review.status))
+                Text(decisionTitle(review.status))
+                    .font(.callout.weight(.semibold))
+                if let decider = review.decidedBy {
+                    Text("· Decision by \(decider.displayName ?? decider.email)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if let decidedAt = review.decidedAt,
+                   let relativeDecisionTime = IssueTiming.relativeText(decidedAt, relativeTo: .now) {
+                    Text("· \(relativeDecisionTime)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .help(IssueTiming.absoluteText(decidedAt).map {
+                            "Decision recorded at \($0)"
+                        } ?? "Decision time")
+                }
+            }
+
+            if let body = review.decisionBody?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !body.isEmpty {
+                Text(body)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+
+            if let hash = review.approvedResultHash, !hash.isEmpty {
+                HStack(spacing: 6) {
+                    Text("Result")
+                        .foregroundStyle(.secondary)
+                    Text(hash)
+                        .font(.caption.monospaced())
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .textSelection(.enabled)
+                    Button {
+                        copy(hash)
+                    } label: {
+                        Image(systemName: "doc.on.doc")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Copy result hash")
+                    .accessibilityLabel("Copy result hash")
+                }
+                .font(.caption)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var generalCommentsPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Review comments")
+                    .font(.headline)
+
+                Spacer()
+
+                if composing != .general {
+                    Button {
+                        composing = .general
+                        commentDraft = ""
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Add a review-wide comment")
+                    .accessibilityLabel("Add a review-wide comment")
+                }
+            }
+
             if composing == .general {
                 ReviewCommentComposer(
-                    text: commentDraft,
+                    text: $commentDraft,
                     isSubmitting: isSubmittingComment,
-                    onTextChange: { commentDraft = $0 },
                     onCancel: { composing = nil; commentDraft = "" },
                     onSubmit: { Task { await submitComment(line: nil) } }
                 )
-            } else {
-                Button {
-                    composing = .general
-                    commentDraft = ""
-                } label: {
-                    Label("Add a general comment", systemImage: "plus.circle")
-                }
-                .buttonStyle(.plain)
-                .font(.callout)
-                .foregroundStyle(Color.accentColor)
-                .help("Comment on the review as a whole")
-                .accessibilityLabel("Add a general comment")
             }
+
             ForEach(generalComments) { comment in
                 ReviewCommentRow(comment: comment) {
                     composing = .general
                     commentDraft = ""
                 }
             }
+
+            if !unplacedComments.isEmpty {
+                Text("Comments from an earlier revision or file path")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                ForEach(unplacedComments) { comment in
+                    VStack(alignment: .leading, spacing: 4) {
+                        if let path = comment.anchorPath, let line = comment.anchorLine {
+                            Text("\(path):\(line)")
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        ReviewCommentRow(comment: comment) {
+                            composing = .general
+                            commentDraft = ""
+                        }
+                    }
+                }
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func diffPanel(detail: ReviewDetail) -> some View {
+        if detail.operations.last?.action == "delete" {
+            Label {
+                Text("This Review deletes the selected memory. There is no proposed file to render.")
+            } icon: {
+                Image(systemName: "trash")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 20)
+        } else if let diffModel {
+            UnifiedDiffView(
+                model: diffModel,
+                commentsByLine: commentsByLine,
+                composingLine: composingLine,
+                commentDraft: $commentDraft,
+                isSubmittingComment: isSubmittingComment,
+                onRequestComment: { composing = .line($0) },
+                onCancelComment: { composing = nil; commentDraft = "" },
+                onSubmitComment: { line in Task { await submitComment(line: line) } },
+                onReply: { line in composing = .line(line) }
+            )
+        } else {
+            Text("This Review changes metadata without changing text content.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 20)
+        }
+    }
+
+    private var reviewWideCommentCount: Int {
+        generalComments.count + unplacedComments.count
+    }
+
+    private func toggleGeneralComments() {
+        if showsGeneralComments {
+            showsGeneralComments = false
+            return
+        }
+
+        showsGeneralComments = true
+        if reviewWideCommentCount == 0 {
+            composing = .general
+            commentDraft = ""
+        }
     }
 
     private var composingLine: Int? {
@@ -443,154 +889,135 @@ struct ReviewDetailPage: View {
         return nil
     }
 
-    private func decisionToolbar(_ review: ReviewRecord) -> some ToolbarContent {
-        ToolbarItemGroup(placement: .primaryAction) {
-            switch review.status {
-            case "open":
-                Button {
-                    decide("rejected")
-                } label: {
-                    if pendingAction == "rejected" {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Reject")
-                    }
-                }
-                .keyboardShortcut("r", modifiers: [.command, .option])
-                .disabled(pendingAction != nil)
-                .help("Reject this Review")
-                .accessibilityLabel("Reject Review")
-                Button {
-                    decide("approved")
-                } label: {
-                    if pendingAction == "approved" {
-                        ProgressView().controlSize(.small)
-                    } else {
-                        Text("Approve")
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .keyboardShortcut("a", modifiers: [.command, .option])
-                .disabled(pendingAction != nil)
-                .help("Approve this Review")
-                .accessibilityLabel("Approve Review")
-            case "approved":
-                if review.freshness == .current, store.canMergeReviews {
-                    Button {
-                        merge()
-                    } label: {
-                        if pendingAction == "merge" {
-                            ProgressView().controlSize(.small)
-                        } else {
-                            Text("Merge")
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.return, modifiers: [.command])
-                    .disabled(pendingAction != nil)
-                    .help("Merge the approved changes")
-                    .accessibilityLabel("Merge Review")
-                }
-            case "rejected":
-                if store.isReviewAuthor(review) {
-                    Button {
-                        resubmit()
-                    } label: {
-                        if pendingAction == "resubmit" {
-                            ProgressView().controlSize(.small)
-                        } else {
-                            Text("Resubmit")
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .keyboardShortcut(.return, modifiers: [.command])
-                    .disabled(pendingAction != nil)
-                    .help("Resubmit this Review")
-                    .accessibilityLabel("Resubmit Review")
-                }
-            default:
-                EmptyView()
-            }
-            Menu {
-                Button("Copy Review ID") { copyReviewID() }
-            } label: {
-                Image(systemName: "ellipsis.circle")
-            }
-            .menuIndicator(.hidden)
-            .help("More Actions")
-            .accessibilityLabel("More Actions")
-        }
-    }
-
     private func load() async {
+        let request = beginDetailRequest()
         loading = true
-        defer { loading = false }
+        loadError = nil
+        detail = nil
+        changeSources = nil
+        diffModel = nil
+        composing = nil
+        commentDraft = ""
+        selectedFileId = nil
+        showsGeneralComments = false
+        defer {
+            if detailRequestGeneration == request.generation {
+                loading = false
+            }
+        }
         do {
             let loadedDetail = try await store.reviewDetail(reviewId)
-            detail = loadedDetail
-            changeSources = try await store.reviewChangeSources(for: loadedDetail)
+            let loadedSources = try await store.reviewChangeSources(for: loadedDetail)
+            applyLoadedDetail(
+                loadedDetail,
+                sources: loadedSources,
+                request: request
+            )
         } catch {
+            guard !Task.isCancelled,
+                  detailRequestGeneration == request.generation else { return }
+            clearDecisionReadiness()
+            loadError = error.localizedDescription
             store.errorMessage = error.localizedDescription
         }
     }
 
     private func refreshDetail() async {
+        let request = beginDetailRequest()
         do {
             let loadedDetail = try await store.reviewDetail(reviewId)
-            detail = loadedDetail
-            changeSources = try await store.reviewChangeSources(for: loadedDetail)
+            let loadedSources = try await store.reviewChangeSources(for: loadedDetail)
+            applyLoadedDetail(
+                loadedDetail,
+                sources: loadedSources,
+                request: request
+            )
         } catch {
+            guard !Task.isCancelled,
+                  detailRequestGeneration == request.generation else { return }
+            clearDecisionReadiness()
+            if detail == nil {
+                loading = false
+                loadError = error.localizedDescription
+            }
             store.errorMessage = error.localizedDescription
         }
     }
 
-    private func decide(_ decision: String) {
-        guard let review else { return }
-        pendingAction = decision
-        Task {
-            defer { pendingAction = nil }
-            do {
-                try await store.decide(review, decision: decision, note: "")
-                await refreshDetail()
-            } catch {
-                store.errorMessage = error.localizedDescription
-            }
+    private func beginDetailRequest() -> DetailRequest {
+        clearDecisionReadiness()
+        let generation = UUID()
+        detailRequestGeneration = generation
+        return DetailRequest(
+            generation: generation,
+            baseline: storedReviewDecisionSignature
+        )
+    }
+
+    private func invalidateDetailRequests() {
+        detailRequestGeneration = UUID()
+        clearDecisionReadiness()
+    }
+
+    private func clearDecisionReadiness() {
+        if store.reviewDecisionReadiness?.reviewId == reviewId {
+            store.reviewDecisionReadiness = nil
         }
     }
 
-    private func merge() {
-        guard let review else { return }
-        pendingAction = "merge"
-        Task {
-            defer { pendingAction = nil }
-            do {
-                try await store.merge(review)
-            } catch {
-                store.errorMessage = error.localizedDescription
-            }
-        }
-    }
-
-    private func resubmit() {
-        guard let detail else { return }
-        guard let review else { return }
-        if detail.draft.coordination.freshness == .behind {
-            loadReconciliation(detail: detail, purpose: .resubmit)
+    private func applyLoadedDetail(
+        _ loadedDetail: ReviewDetail,
+        sources loadedSources: ReviewChangeSources,
+        request: DetailRequest
+    ) {
+        guard !Task.isCancelled,
+              detailRequestGeneration == request.generation,
+              storedReviewDecisionSignature == request.baseline else { return }
+        let loadedReview = WorkspaceLoader.mapReview(loadedDetail.review)
+        let loadedSignature = ReviewDecisionReadiness(review: loadedReview)
+        if let baseline = request.baseline,
+           loadedReview.version < baseline.reviewVersion {
+            loading = false
+            loadError = "The Review changed while its detail was loading. Try again."
             return
         }
-        pendingAction = "resubmit"
-        Task {
-            defer { pendingAction = nil }
-            do {
-                try await store.resubmit(review, detail: detail)
-            } catch {
-                store.errorMessage = error.localizedDescription
-            }
+
+        detail = loadedDetail
+        changeSources = loadedSources
+        diffModel = makeDiffModel(from: loadedSources)
+        loading = false
+        loadError = nil
+        selectedFileId = ReviewFileDescriptor.resolve(
+            reviewId: reviewId,
+            detail: loadedDetail,
+            sources: loadedSources
+        ).id
+        store.replaceReview(with: loadedReview)
+        store.reviewDecisionReadiness = loadedSignature
+    }
+
+    private func markCurrentDetailDecisionReady() {
+        guard let detail else {
+            clearDecisionReadiness()
+            return
         }
+        let loadedReview = WorkspaceLoader.mapReview(detail.review)
+        guard storedReviewDecisionSignature == ReviewDecisionReadiness(review: loadedReview) else {
+            clearDecisionReadiness()
+            return
+        }
+        store.reviewDecisionReadiness = ReviewDecisionReadiness(review: loadedReview)
     }
 
     private func submitComment(line: Int?) async {
-        guard let review, !commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let detail,
+              !commentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+        let renderedReview = WorkspaceLoader.mapReview(detail.review)
+        let anchorPath = line == nil ? nil : changeSources?.proposedPath
+        guard line == nil || anchorPath != nil else {
+            store.errorMessage = "The proposed file path is unavailable for this line comment."
             return
         }
         isSubmittingComment = true
@@ -598,8 +1025,8 @@ struct ReviewDetailPage: View {
         do {
             try await store.addComment(
                 commentDraft,
-                to: review,
-                anchorPath: detail?.draft.resource.path,
+                to: renderedReview,
+                anchorPath: anchorPath,
                 anchorLine: line
             )
             composing = nil
@@ -607,18 +1034,24 @@ struct ReviewDetailPage: View {
             await refreshDetail()
         } catch {
             store.errorMessage = error.localizedDescription
+            if let serverError = error as? ServerClientError,
+               case .response(let status, _) = serverError,
+               status == 409 {
+                await refreshDetail()
+            }
         }
     }
 
-    private func loadReconciliation(detail: ReviewDetail?, purpose: ReviewReconciliationPurpose) {
+    private func loadReconciliation(detail: ReviewDetail?) {
         guard let detail, !loadsReconciliation else { return }
+        clearDecisionReadiness()
         loadsReconciliation = true
-        reconciliationPurpose = purpose
         Task {
             defer { loadsReconciliation = false }
             do {
                 reconciliationCandidate = try await store.reconciliationCandidate(for: detail)
             } catch {
+                markCurrentDetailDecisionReady()
                 store.errorMessage = error.localizedDescription
             }
         }
@@ -627,29 +1060,60 @@ struct ReviewDetailPage: View {
     private func handlePendingReconciliation(_ reviewId: String?) {
         guard reviewId == self.reviewId, let detail else { return }
         store.pendingReviewReconciliationId = nil
-        loadReconciliation(detail: detail, purpose: .updateDraft)
+        loadReconciliation(detail: detail)
     }
 
-    private func navigate(offset: Int) {
-        guard let index = orderedReviews.firstIndex(where: { $0.id == reviewId }) else { return }
-        let target = index + offset
-        guard orderedReviews.indices.contains(target) else { return }
-        let next = orderedReviews[target]
-        store.selectedReviewId = next.id
-        onNavigateToReview(next.id)
+    private func makeDiffModel(from sources: ReviewChangeSources) -> SplitDiffModel? {
+        guard let proposed = sources.draftContent else { return nil }
+        return SplitDiffModel.make(
+            original: sources.baseContent ?? "",
+            modified: proposed
+        )
     }
 
-    private func copyReviewID() {
+    private func copy(_ value: String) {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(reviewId, forType: .string)
+        NSPasteboard.general.setString(value, forType: .string)
     }
 
-    private func kindTitle(_ kind: DaemonResourceKind) -> String {
-        switch kind {
-        case .context: "Context"
-        case .rule: "Rule"
-        case .workflow: "Workflow"
+    private func decisionTitle(_ status: String) -> String {
+        switch status {
+        case "approved": "Approved"
+        case "rejected": "Changes requested"
+        case "merged": "Merged"
+        default: status.capitalized
         }
+    }
+
+    private func decisionSymbol(_ status: String) -> String {
+        switch status {
+        case "approved": "checkmark.circle.fill"
+        case "rejected": "xmark.circle.fill"
+        case "merged": "arrow.triangle.merge"
+        default: "circle.fill"
+        }
+    }
+
+    private func decisionColor(_ status: String) -> Color {
+        switch status {
+        case "approved": .green
+        case "rejected": .red
+        default: .secondary
+        }
+    }
+
+}
+
+private struct ReviewFileNavigator: View {
+    let files: [ReviewFileDescriptor]
+    @Binding var selection: String?
+
+    var body: some View {
+        PathTreeView(
+            items: files.map { PathTreeItem(id: $0.id, path: $0.path) },
+            selection: $selection
+        )
+        .accessibilityIdentifier("review-file-tree")
     }
 }
 
@@ -658,30 +1122,42 @@ struct ReviewCommentRow: View {
     let onReply: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 6) {
-                Text(comment.author.displayName ?? comment.author.email)
-                    .font(.caption.weight(.semibold))
-                Text(IssueTiming.relativeText(comment.createdAt, relativeTo: .now) ?? comment.createdAt)
+        HStack(alignment: .top, spacing: 9) {
+            AvatarView(account: comment.author)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Text(comment.author.displayName ?? comment.author.email)
+                        .font(.caption.weight(.semibold))
+                    Text(
+                        IssueTiming.relativeText(comment.createdAt, relativeTo: .now)
+                            ?? comment.createdAt
+                    )
                     .font(.caption)
                     .foregroundStyle(.tertiary)
+
+                    Spacer(minLength: 8)
+
+                    Button(action: onReply) {
+                        Image(systemName: "arrowshape.turn.up.left")
+                    }
+                    .buttonStyle(.borderless)
+                    .help("Reply")
+                    .accessibilityLabel("Reply")
+                }
+                Text(comment.body)
+                    .font(.callout)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
             }
-            Text(comment.body)
-                .font(.callout)
-                .textSelection(.enabled)
-            Button("Reply", action: onReply)
-                .font(.caption)
-                .buttonStyle(.plain)
-                .foregroundStyle(Color.accentColor)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
 struct ReviewCommentComposer: View {
-    let text: String
+    @Binding var text: String
     let isSubmitting: Bool
-    let onTextChange: (String) -> Void
     let onCancel: () -> Void
     let onSubmit: () -> Void
 
@@ -689,7 +1165,7 @@ struct ReviewCommentComposer: View {
         VStack(alignment: .leading, spacing: 6) {
             TextField(
                 "Write a comment…",
-                text: Binding(get: { text }, set: onTextChange),
+                text: $text,
                 axis: .vertical
             )
             .lineLimit(2...6)
@@ -709,7 +1185,7 @@ struct ReviewCommentComposer: View {
                     }
                 }
                 .buttonStyle(.borderedProminent)
-                .keyboardShortcut(.defaultAction)
+                .keyboardShortcut(.return, modifiers: .command)
                 .disabled(
                     text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSubmitting
                 )

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -89,7 +89,7 @@ enum WorkspaceColumnLayout: Equatable {
     case sidebarContentDetail
 
     init(section: WorkspaceSection) {
-        self = section == .issues ? .sidebarDetail : .sidebarContentDetail
+        self = (section == .issues || section == .reviews) ? .sidebarDetail : .sidebarContentDetail
     }
 }
 
@@ -103,7 +103,6 @@ struct WorkspaceView: View {
     let onOpenDiagnostics: (DiagnosticsDestination) -> Void
     let onShowLogs: () -> Void
     @StateObject private var issueBoardModel: IssueBoardModel
-    @State private var reviewStatusFilter: ReviewStatusFilter = .open
     @State private var splitVisibility: NavigationSplitViewVisibility = .all
     @State private var issueSplitVisibility: NavigationSplitViewVisibility = .all
     @State private var showsBundleResourcePicker = false
@@ -113,6 +112,8 @@ struct WorkspaceView: View {
     @State private var showsIssueWorkflowHelp = false
     @State private var issueNavigationPath: [IssueBoardRoute] = []
     @FocusState private var issueSearchFocused: Bool
+    @State private var reviewNavigationPath: [ReviewRoute] = []
+    @State private var reviewStatusFilter: ReviewStatusFilter = .open
 
     init(
         store: WorkspaceStore,
@@ -140,9 +141,12 @@ struct WorkspaceView: View {
     }
 
     var body: some View {
-        if WorkspaceColumnLayout(section: store.selectedSection) == .sidebarDetail {
+        switch store.selectedSection {
+        case .issues:
             issuesWorkspace
-        } else {
+        case .reviews:
+            reviewsWorkspace
+        default:
             regularWorkspace
         }
     }
@@ -456,6 +460,60 @@ struct WorkspaceView: View {
         )
     }
 
+    private var reviewsWorkspace: some View {
+        NavigationSplitView(columnVisibility: $issueSplitVisibility) {
+            GlobalSidebar(
+                store: store,
+                onOpenSettings: onOpenSettings,
+                onOpenDiagnostics: onOpenDiagnostics,
+                onShowLogs: onShowLogs
+            )
+            .navigationSplitViewColumnWidth(min: 190, ideal: 220, max: 280)
+        } detail: {
+            NavigationStack(path: $reviewNavigationPath) {
+                ReviewListPage(
+                    store: store,
+                    reviews: filteredReviews,
+                    statusFilter: $reviewStatusFilter,
+                    onOpen: { review in
+                        reviewNavigationPath = [ReviewRoute(reviewId: review.id)]
+                    }
+                )
+                .navigationDestination(for: ReviewRoute.self) { route in
+                    ReviewDetailPage(
+                        store: store,
+                        reviewId: route.reviewId,
+                        orderedReviews: filteredReviews,
+                        onNavigateToReview: { reviewId in
+                            reviewNavigationPath = [ReviewRoute(reviewId: reviewId)]
+                        }
+                    )
+                }
+            }
+            .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
+            .toolbar {
+                if reviewNavigationPath.isEmpty {
+                    ToolbarItem(placement: .primaryAction) {
+                        ReviewStatusFilterControl(
+                            reviews: store.reviews,
+                            selection: $reviewStatusFilter
+                        )
+                    }
+                }
+            }
+        }
+        .onChange(of: store.selectedReviewId) { _, reviewId in
+            guard store.selectedSection == .reviews, let reviewId else { return }
+            guard reviewNavigationPath.last?.reviewId != reviewId else { return }
+            guard store.reviews.contains(where: { $0.id == reviewId }) else { return }
+            reviewNavigationPath = [ReviewRoute(reviewId: reviewId)]
+        }
+    }
+
+    private var filteredReviews: [ReviewRecord] {
+        store.reviews.filter { reviewStatusFilter.matches($0) }
+    }
+
     private var issuesWorkspace: some View {
         NavigationSplitView(columnVisibility: $issueSplitVisibility) {
             GlobalSidebar(
@@ -692,11 +750,8 @@ struct WorkspaceView: View {
                 EmptyView()
             }
         case .reviews:
-            ToolbarItem(placement: .navigation) {
-                ReviewStatusFilterControl(
-                    reviews: store.reviews,
-                    selection: $reviewStatusFilter
-                )
+            ToolbarItem {
+                EmptyView()
             }
         }
     }
@@ -711,7 +766,7 @@ struct WorkspaceView: View {
         case .issues:
             EmptyView()
         case .reviews:
-            ReviewNavigator(store: store, statusFilter: $reviewStatusFilter)
+            EmptyView()
         }
     }
 
@@ -735,12 +790,8 @@ struct WorkspaceView: View {
         case .issues:
             EmptyView()
         case .reviews:
-            ReviewDetailPane(store: store, review: selectedReview)
+            EmptyView()
         }
-    }
-
-    private var selectedReview: ReviewRecord? {
-        filteredReviews.first { $0.id == store.selectedReviewId } ?? filteredReviews.first
     }
 
     @ViewBuilder
@@ -750,10 +801,6 @@ struct WorkspaceView: View {
                 .frame(minWidth: 120, maxWidth: 360, alignment: .leading)
                 .accessibilityLabel("Path: \(path)")
         }
-    }
-
-    private var filteredReviews: [ReviewRecord] {
-        store.reviews.filter(reviewStatusFilter.matches)
     }
 
     private var searchResults: [SearchEntry] {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -89,7 +89,9 @@ enum WorkspaceColumnLayout: Equatable {
     case sidebarContentDetail
 
     init(section: WorkspaceSection) {
-        self = (section == .issues || section == .reviews) ? .sidebarDetail : .sidebarContentDetail
+        self = section == .issues || section == .reviews
+            ? .sidebarDetail
+            : .sidebarContentDetail
     }
 }
 
@@ -102,29 +104,34 @@ struct WorkspaceView: View {
     let onOpenSettings: () -> Void
     let onOpenDiagnostics: (DiagnosticsDestination) -> Void
     let onShowLogs: () -> Void
+    let loadsReviewDetail: Bool
     @StateObject private var issueBoardModel: IssueBoardModel
     @State private var splitVisibility: NavigationSplitViewVisibility = .all
     @State private var issueSplitVisibility: NavigationSplitViewVisibility = .all
+    @State private var reviewSplitVisibility: NavigationSplitViewVisibility = .all
     @State private var showsBundleResourcePicker = false
     @State private var confirmsBundleDeletion = false
     @State private var showsSyncIssuePopover = false
     @State private var showsUnlinkedActivity = false
     @State private var showsIssueWorkflowHelp = false
     @State private var issueNavigationPath: [IssueBoardRoute] = []
-    @FocusState private var issueSearchFocused: Bool
     @State private var reviewNavigationPath: [ReviewRoute] = []
+    @FocusState private var issueSearchFocused: Bool
     @State private var reviewStatusFilter: ReviewStatusFilter = .open
+    @State private var pendingReviewToolbarAction: ReviewMenuAction?
 
     init(
         store: WorkspaceStore,
         onOpenSettings: @escaping () -> Void,
         onOpenDiagnostics: @escaping (DiagnosticsDestination) -> Void,
-        onShowLogs: @escaping () -> Void
+        onShowLogs: @escaping () -> Void,
+        loadsReviewDetail: Bool = true
     ) {
         self.store = store
         self.onOpenSettings = onOpenSettings
         self.onOpenDiagnostics = onOpenDiagnostics
         self.onShowLogs = onShowLogs
+        self.loadsReviewDetail = loadsReviewDetail
         _issueBoardModel = StateObject(wrappedValue: IssueBoardModel(daemon: store.daemon))
     }
 
@@ -461,7 +468,7 @@ struct WorkspaceView: View {
     }
 
     private var reviewsWorkspace: some View {
-        NavigationSplitView(columnVisibility: $issueSplitVisibility) {
+        NavigationSplitView(columnVisibility: $reviewSplitVisibility) {
             GlobalSidebar(
                 store: store,
                 onOpenSettings: onOpenSettings,
@@ -474,44 +481,319 @@ struct WorkspaceView: View {
                 ReviewListPage(
                     store: store,
                     reviews: filteredReviews,
-                    statusFilter: $reviewStatusFilter,
-                    onOpen: { review in
-                        reviewNavigationPath = [ReviewRoute(reviewId: review.id)]
-                    }
+                    statusFilter: $reviewStatusFilter
                 )
                 .navigationDestination(for: ReviewRoute.self) { route in
                     ReviewDetailPage(
                         store: store,
                         reviewId: route.reviewId,
-                        orderedReviews: filteredReviews,
-                        onNavigateToReview: { reviewId in
-                            reviewNavigationPath = [ReviewRoute(reviewId: reviewId)]
-                        }
+                        loadsRemoteContent: loadsReviewDetail
                     )
+                    .toolbar {
+                        reviewDetailToolbarContent
+                    }
                 }
             }
             .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
             .toolbar {
                 if reviewNavigationPath.isEmpty {
-                    ToolbarItem(placement: .primaryAction) {
-                        ReviewStatusFilterControl(
-                            reviews: store.reviews,
-                            selection: $reviewStatusFilter
-                        )
+                    if #available(macOS 26.0, *) {
+                        ToolbarSpacer(.flexible, placement: .automatic)
                     }
+
+                    reviewUtilityToolbarContent(hasLeadingActions: false)
                 }
             }
         }
+        .onAppear {
+            store.showsProjectSettings = false
+            let target: NavigationSplitViewVisibility = store.sidebarExpanded ? .all : .detailOnly
+            if reviewSplitVisibility != target {
+                reviewSplitVisibility = target
+            }
+
+            if let routedReviewId = reviewNavigationPath.last?.reviewId,
+               !store.reviews.contains(where: { $0.id == routedReviewId }) {
+                reviewNavigationPath.removeAll()
+            }
+            if reviewNavigationPath.isEmpty,
+               let reviewId = store.selectedReviewId,
+               store.reviews.contains(where: { $0.id == reviewId }) {
+                reviewNavigationPath = [ReviewRoute(reviewId: reviewId)]
+            }
+        }
+        .onChange(of: reviewSplitVisibility) { _, visibility in
+            let expanded = visibility != .detailOnly
+            if store.sidebarExpanded != expanded {
+                store.sidebarExpanded = expanded
+            }
+        }
+        .onChange(of: store.sidebarExpanded) { _, expanded in
+            let target: NavigationSplitViewVisibility = expanded ? .all : .detailOnly
+            if reviewSplitVisibility != target {
+                reviewSplitVisibility = target
+            }
+        }
+        .onChange(of: reviewNavigationPath) { _, path in
+            let reviewId = path.last?.reviewId
+            if store.selectedReviewId != reviewId {
+                store.selectedReviewId = reviewId
+            }
+            if reviewId == nil {
+                store.reviewDecisionReadiness = nil
+                pendingReviewToolbarAction = nil
+            }
+        }
         .onChange(of: store.selectedReviewId) { _, reviewId in
-            guard store.selectedSection == .reviews, let reviewId else { return }
+            guard store.selectedSection == .reviews else { return }
+            guard let reviewId else {
+                if !reviewNavigationPath.isEmpty {
+                    reviewNavigationPath.removeAll()
+                }
+                return
+            }
             guard reviewNavigationPath.last?.reviewId != reviewId else { return }
             guard store.reviews.contains(where: { $0.id == reviewId }) else { return }
             reviewNavigationPath = [ReviewRoute(reviewId: reviewId)]
+        }
+        .onChange(of: syncToolbarPresentation) { _, presentation in
+            if presentation == nil || presentation?.isSyncing == true {
+                showsSyncIssuePopover = false
+            }
+        }
+        .task {
+            while !Task.isCancelled {
+                await store.refreshSyncStatus()
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+            }
+        }
+        .alert(
+            "Clumsies",
+            isPresented: Binding(
+                get: { store.errorMessage != nil },
+                set: { if !$0 { store.errorMessage = nil } }
+            )
+        ) {
+            Button("OK") { store.errorMessage = nil }
+        } message: {
+            Text(store.errorMessage ?? "")
+                .textSelection(.enabled)
+        }
+        .sheet(isPresented: $store.showsProjectCreation) {
+            ProjectCreationSheet(store: store)
         }
     }
 
     private var filteredReviews: [ReviewRecord] {
         store.reviews.filter { reviewStatusFilter.matches($0) }
+    }
+
+    private var selectedReviewForToolbar: ReviewRecord? {
+        guard let reviewId = store.selectedReviewId else { return nil }
+        return store.reviews.first { $0.id == reviewId }
+    }
+
+    private var hasReviewDecisionToolbarAction: Bool {
+        guard let review = selectedReviewForToolbar else { return false }
+        switch review.status {
+        case "open":
+            return true
+        case "approved":
+            return ReviewMenuAction.merge.isAvailable(
+                for: review,
+                canMergeReviews: store.canMergeReviews,
+                isAuthor: store.isReviewAuthor(review)
+            )
+        case "rejected":
+            return store.isReviewAuthor(review)
+        default:
+            return false
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var reviewDetailToolbarContent: some ToolbarContent {
+        if #available(macOS 26.0, *) {
+            ToolbarSpacer(.flexible, placement: .automatic)
+        }
+
+        if let review = selectedReviewForToolbar,
+           hasReviewDecisionToolbarAction {
+            if review.status == "open" {
+                ToolbarItem(id: "review.reject", placement: .automatic) {
+                    Button {
+                        performReviewToolbarAction(.reject)
+                    } label: {
+                        reviewToolbarActionLabel(
+                            systemImage: "xmark",
+                            isPending: pendingReviewToolbarAction == .reject
+                        )
+                    }
+                    .disabled(
+                        pendingReviewToolbarAction != nil
+                            || !store.canPerformReviewMenuAction(.reject)
+                    )
+                    .help(review.freshness == .behind
+                        ? "Review the latest shared changes before deciding"
+                        : "Reject this Review")
+                    .accessibilityLabel("Reject Review")
+                    .accessibilityIdentifier("review-toolbar-reject")
+                }
+
+                ToolbarItem(id: "review.approve", placement: .automatic) {
+                    Button {
+                        performReviewToolbarAction(.approve)
+                    } label: {
+                        reviewToolbarActionLabel(
+                            systemImage: "checkmark",
+                            isPending: pendingReviewToolbarAction == .approve
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(
+                        pendingReviewToolbarAction != nil
+                            || !store.canPerformReviewMenuAction(.approve)
+                    )
+                    .help(review.freshness == .behind
+                        ? "Review the latest shared changes before deciding"
+                        : "Approve this Review")
+                    .accessibilityLabel("Approve Review")
+                    .accessibilityIdentifier("review-toolbar-approve")
+                }
+            } else if ReviewMenuAction.merge.isAvailable(
+                for: review,
+                canMergeReviews: store.canMergeReviews,
+                isAuthor: store.isReviewAuthor(review)
+            ) {
+                ToolbarItem(id: "review.merge", placement: .automatic) {
+                    Button {
+                        performReviewToolbarAction(.merge)
+                    } label: {
+                        reviewToolbarActionLabel(
+                            systemImage: "arrow.triangle.merge",
+                            isPending: pendingReviewToolbarAction == .merge
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(
+                        pendingReviewToolbarAction != nil
+                            || !store.canPerformReviewMenuAction(.merge)
+                    )
+                    .help("Merge the approved changes")
+                    .accessibilityLabel("Merge Review")
+                    .accessibilityIdentifier("review-toolbar-merge")
+                }
+            } else if review.status == "rejected", store.isReviewAuthor(review) {
+                ToolbarItem(id: "review.resubmit", placement: .automatic) {
+                    Button {
+                        performReviewToolbarAction(.resubmit)
+                    } label: {
+                        reviewToolbarActionLabel(
+                            systemImage: "arrow.clockwise",
+                            isPending: pendingReviewToolbarAction == .resubmit
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(
+                        pendingReviewToolbarAction != nil
+                            || !store.canPerformReviewMenuAction(.resubmit)
+                    )
+                    .help("Resubmit this Review")
+                    .accessibilityLabel("Resubmit Review")
+                    .accessibilityIdentifier("review-toolbar-resubmit")
+                }
+            }
+        }
+
+        reviewUtilityToolbarContent(hasLeadingActions: hasReviewDecisionToolbarAction)
+    }
+
+    @ToolbarContentBuilder
+    private func reviewUtilityToolbarContent(hasLeadingActions: Bool) -> some ToolbarContent {
+        if #available(macOS 26.0, *),
+           syncToolbarPresentation != nil,
+           hasLeadingActions {
+            ToolbarSpacer(.fixed, placement: .automatic)
+        }
+
+        if let syncToolbarPresentation {
+            ToolbarItem(id: "review.sync", placement: .automatic) {
+                switch syncToolbarPresentation {
+                case .syncing:
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 24, height: 24)
+                        .help(syncToolbarPresentation.label)
+                        .accessibilityLabel(syncToolbarPresentation.label)
+                        .accessibilityIdentifier("review-toolbar-sync")
+                case .failed, .unavailable, .stale:
+                    Button {
+                        showsSyncIssuePopover.toggle()
+                    } label: {
+                        Image(systemName: syncToolbarPresentation.symbolName)
+                            .foregroundStyle(syncToolbarPresentation.tint)
+                    }
+                    .help(syncToolbarPresentation.label)
+                    .accessibilityLabel(syncToolbarPresentation.label)
+                    .accessibilityIdentifier("review-toolbar-sync")
+                    .popover(isPresented: $showsSyncIssuePopover, arrowEdge: .top) {
+                        SyncIssuePopover(
+                            presentation: syncToolbarPresentation,
+                            store: store,
+                            isPresented: $showsSyncIssuePopover
+                        )
+                    }
+                }
+            }
+        }
+
+        if #available(macOS 26.0, *),
+           syncToolbarPresentation != nil || hasLeadingActions {
+            ToolbarSpacer(.fixed, placement: .automatic)
+        }
+
+        ToolbarItem(id: "review.search", placement: .automatic) {
+            Button {
+                store.showsGlobalSearch.toggle()
+            } label: {
+                Image(systemName: "magnifyingglass")
+            }
+            .help("Search Reviews")
+            .accessibilityLabel("Search Reviews")
+            .accessibilityIdentifier("review-toolbar-search")
+            .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
+                WorkspaceSearchPopover(
+                    store: store,
+                    results: searchResults,
+                    onOpen: open
+                )
+            }
+        }
+    }
+
+    private func performReviewToolbarAction(_ action: ReviewMenuAction) {
+        guard pendingReviewToolbarAction == nil else { return }
+        pendingReviewToolbarAction = action
+        Task {
+            defer { pendingReviewToolbarAction = nil }
+            await store.performReviewMenuAction(action)
+        }
+    }
+
+    private func reviewToolbarActionLabel(systemImage: String, isPending: Bool) -> some View {
+        ZStack {
+            Image(systemName: systemImage)
+                .opacity(isPending ? 0 : 1)
+            if isPending {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .frame(width: 16, height: 16)
     }
 
     private var issuesWorkspace: some View {
@@ -868,6 +1150,7 @@ struct WorkspaceView: View {
             store.selectedBundleId = bundle.id
         case .review(let review):
             store.selectedSection = .reviews
+            reviewStatusFilter = ReviewStatusFilter(rawValue: review.status) ?? .all
             store.selectedReviewId = review.id
         }
         store.searchQuery = ""

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -481,7 +481,8 @@ struct WorkspaceView: View {
                 ReviewListPage(
                     store: store,
                     reviews: filteredReviews,
-                    statusFilter: $reviewStatusFilter
+                    statusFilter: $reviewStatusFilter,
+                    toolbarOwnership: reviewToolbarOwnership
                 )
                 .navigationDestination(for: ReviewRoute.self) { route in
                     ReviewDetailPage(
@@ -490,13 +491,15 @@ struct WorkspaceView: View {
                         loadsRemoteContent: loadsReviewDetail
                     )
                     .toolbar {
-                        reviewDetailToolbarContent
+                        if reviewToolbarOwnership.surface == .detail {
+                            reviewDetailToolbarContent
+                        }
                     }
                 }
             }
             .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
             .toolbar {
-                if reviewNavigationPath.isEmpty {
+                if reviewToolbarOwnership.surface == .list {
                     if #available(macOS 26.0, *) {
                         ToolbarSpacer(.flexible, placement: .automatic)
                     }
@@ -592,27 +595,19 @@ struct WorkspaceView: View {
         store.reviews.filter { reviewStatusFilter.matches($0) }
     }
 
+    private var reviewToolbarOwnership: ReviewToolbarOwnership {
+        let review = selectedReviewForToolbar
+        return .resolve(
+            surface: reviewNavigationPath.isEmpty ? .list : .detail,
+            review: review,
+            canMergeReviews: store.canMergeReviews,
+            isAuthor: review.map(store.isReviewAuthor) ?? false
+        )
+    }
+
     private var selectedReviewForToolbar: ReviewRecord? {
         guard let reviewId = store.selectedReviewId else { return nil }
         return store.reviews.first { $0.id == reviewId }
-    }
-
-    private var hasReviewDecisionToolbarAction: Bool {
-        guard let review = selectedReviewForToolbar else { return false }
-        switch review.status {
-        case "open":
-            return true
-        case "approved":
-            return ReviewMenuAction.merge.isAvailable(
-                for: review,
-                canMergeReviews: store.canMergeReviews,
-                isAuthor: store.isReviewAuthor(review)
-            )
-        case "rejected":
-            return store.isReviewAuthor(review)
-        default:
-            return false
-        }
     }
 
     @ToolbarContentBuilder
@@ -621,9 +616,8 @@ struct WorkspaceView: View {
             ToolbarSpacer(.flexible, placement: .automatic)
         }
 
-        if let review = selectedReviewForToolbar,
-           hasReviewDecisionToolbarAction {
-            if review.status == "open" {
+        if let review = selectedReviewForToolbar {
+            if reviewToolbarOwnership.contains(.decision(.reject)) {
                 ToolbarItem(id: "review.reject", placement: .automatic) {
                     Button {
                         performReviewToolbarAction(.reject)
@@ -643,7 +637,9 @@ struct WorkspaceView: View {
                     .accessibilityLabel("Reject Review")
                     .accessibilityIdentifier("review-toolbar-reject")
                 }
+            }
 
+            if reviewToolbarOwnership.contains(.decision(.approve)) {
                 ToolbarItem(id: "review.approve", placement: .automatic) {
                     Button {
                         performReviewToolbarAction(.approve)
@@ -664,11 +660,9 @@ struct WorkspaceView: View {
                     .accessibilityLabel("Approve Review")
                     .accessibilityIdentifier("review-toolbar-approve")
                 }
-            } else if ReviewMenuAction.merge.isAvailable(
-                for: review,
-                canMergeReviews: store.canMergeReviews,
-                isAuthor: store.isReviewAuthor(review)
-            ) {
+            }
+
+            if reviewToolbarOwnership.contains(.decision(.merge)) {
                 ToolbarItem(id: "review.merge", placement: .automatic) {
                     Button {
                         performReviewToolbarAction(.merge)
@@ -687,7 +681,9 @@ struct WorkspaceView: View {
                     .accessibilityLabel("Merge Review")
                     .accessibilityIdentifier("review-toolbar-merge")
                 }
-            } else if review.status == "rejected", store.isReviewAuthor(review) {
+            }
+
+            if reviewToolbarOwnership.contains(.decision(.resubmit)) {
                 ToolbarItem(id: "review.resubmit", placement: .automatic) {
                     Button {
                         performReviewToolbarAction(.resubmit)
@@ -709,7 +705,7 @@ struct WorkspaceView: View {
             }
         }
 
-        reviewUtilityToolbarContent(hasLeadingActions: hasReviewDecisionToolbarAction)
+        reviewUtilityToolbarContent(hasLeadingActions: reviewToolbarOwnership.hasDecisionActions)
     }
 
     @ToolbarContentBuilder
@@ -756,21 +752,23 @@ struct WorkspaceView: View {
             ToolbarSpacer(.fixed, placement: .automatic)
         }
 
-        ToolbarItem(id: "review.search", placement: .automatic) {
-            Button {
-                store.showsGlobalSearch.toggle()
-            } label: {
-                Image(systemName: "magnifyingglass")
-            }
-            .help("Search Reviews")
-            .accessibilityLabel("Search Reviews")
-            .accessibilityIdentifier("review-toolbar-search")
-            .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
-                WorkspaceSearchPopover(
-                    store: store,
-                    results: searchResults,
-                    onOpen: open
-                )
+        if reviewToolbarOwnership.contains(.search) {
+            ToolbarItem(id: "review.search", placement: .automatic) {
+                Button {
+                    store.showsGlobalSearch.toggle()
+                } label: {
+                    Image(systemName: "magnifyingglass")
+                }
+                .help("Search Reviews")
+                .accessibilityLabel("Search Reviews")
+                .accessibilityIdentifier("review-toolbar-search")
+                .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
+                    WorkspaceSearchPopover(
+                        store: store,
+                        results: searchResults,
+                        onOpen: open
+                    )
+                }
             }
         }
     }

--- a/apps/macos/Sources/Infrastructure/ServerModels.swift
+++ b/apps/macos/Sources/Infrastructure/ServerModels.swift
@@ -237,6 +237,8 @@ struct ReviewMetadata: Codable, Identifiable, Hashable, Sendable {
     let version: Int
     let decisionBody: String?
     let approvedResultHash: String?
+    let decidedBy: UserReference?
+    let decidedAt: String?
     let coordination: DraftCoordination
     let createdAt: String
     let updatedAt: String
@@ -252,6 +254,7 @@ struct ReviewComment: Codable, Identifiable, Hashable, Sendable {
     let createdAt: String
     let anchorPath: String?
     let anchorLine: Int?
+    let reviewVersion: Int
 }
 
 struct ServerDraftResourceReference: Codable, Hashable, Sendable {
@@ -390,11 +393,18 @@ struct CreateReviewSubmissionRequest: Codable, Sendable {
 
 struct CreateReviewCommentRequest: Codable, Sendable {
     let body: String
+    let expectedReviewVersion: Int
     let anchorPath: String?
     let anchorLine: Int?
 
-    init(body: String, anchorPath: String? = nil, anchorLine: Int? = nil) {
+    init(
+        body: String,
+        expectedReviewVersion: Int,
+        anchorPath: String? = nil,
+        anchorLine: Int? = nil
+    ) {
         self.body = body
+        self.expectedReviewVersion = expectedReviewVersion
         self.anchorPath = anchorPath
         self.anchorLine = anchorLine
     }

--- a/apps/macos/Sources/Infrastructure/ServerModels.swift
+++ b/apps/macos/Sources/Infrastructure/ServerModels.swift
@@ -250,6 +250,8 @@ struct ReviewComment: Codable, Identifiable, Hashable, Sendable {
     let author: UserReference
     let body: String
     let createdAt: String
+    let anchorPath: String?
+    let anchorLine: Int?
 }
 
 struct ServerDraftResourceReference: Codable, Hashable, Sendable {
@@ -388,6 +390,14 @@ struct CreateReviewSubmissionRequest: Codable, Sendable {
 
 struct CreateReviewCommentRequest: Codable, Sendable {
     let body: String
+    let anchorPath: String?
+    let anchorLine: Int?
+
+    init(body: String, anchorPath: String? = nil, anchorLine: Int? = nil) {
+        self.body = body
+        self.anchorPath = anchorPath
+        self.anchorLine = anchorLine
+    }
 }
 
 struct CreateReviewDecisionRequest: Codable, Sendable {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -893,6 +893,94 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertTrue(loaded.resources[0].contentLoaded)
     }
 
+    func testReviewCommentContractCarriesVersionAndAnchor() throws {
+        let request = CreateReviewCommentRequest(
+            body: "Please tighten this sentence.",
+            expectedReviewVersion: 7,
+            anchorPath: "notes/a.md",
+            anchorLine: 12
+        )
+        let requestData = try JSONCoding.encoder().encode(request)
+        let requestObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requestData) as? [String: Any]
+        )
+
+        XCTAssertEqual(requestObject["body"] as? String, "Please tighten this sentence.")
+        XCTAssertEqual(requestObject["expected_review_version"] as? Int, 7)
+        XCTAssertEqual(requestObject["anchor_path"] as? String, "notes/a.md")
+        XCTAssertEqual(requestObject["anchor_line"] as? Int, 12)
+
+        let response = """
+        {
+          "comment_id": "comment-1",
+          "review_id": "review-1",
+          "author": {
+            "user_id": "reviewer-1",
+            "email": "reviewer@example.com",
+            "display_name": "Reviewer",
+            "avatar_url": null,
+            "role": "member"
+          },
+          "body": "Please tighten this sentence.",
+          "anchor_path": "notes/a.md",
+          "anchor_line": 12,
+          "review_version": 8,
+          "created_at": "2026-08-06T01:00:00Z"
+        }
+        """
+        let comment = try JSONCoding.decoder().decode(
+            ReviewComment.self,
+            from: Data(response.utf8)
+        )
+
+        XCTAssertEqual(comment.anchorPath, "notes/a.md")
+        XCTAssertEqual(comment.anchorLine, 12)
+        XCTAssertEqual(comment.reviewVersion, 8)
+    }
+
+    func testReviewMetadataDecodesLegacyPayloadWithoutDecisionAuditFields() throws {
+        let json = """
+        {
+          "review_id": "review-legacy",
+          "project_id": "project-1",
+          "draft_id": "draft-1",
+          "author": {
+            "user_id": "author-1",
+            "email": "author@example.com",
+            "display_name": null,
+            "avatar_url": null,
+            "role": "member"
+          },
+          "title": "Legacy review",
+          "description": "Created before decision audit metadata.",
+          "status": "approved",
+          "version": 2,
+          "decision_body": "Looks good.",
+          "approved_result_hash": "sha256:approved",
+          "coordination": {
+            "freshness": "current",
+            "current_commit_id": "commit-1",
+            "has_upstream_resource_changes": false,
+            "reconciliation": "clean",
+            "candidate_id": null
+          },
+          "created_at": "2026-08-05T00:00:00Z",
+          "updated_at": "2026-08-05T01:00:00Z"
+        }
+        """
+
+        let metadata = try JSONCoding.decoder().decode(
+            ReviewMetadata.self,
+            from: Data(json.utf8)
+        )
+        let record = WorkspaceLoader.mapReview(metadata)
+
+        XCTAssertNil(metadata.decidedBy)
+        XCTAssertNil(metadata.decidedAt)
+        XCTAssertNil(record.decidedBy)
+        XCTAssertNil(record.decidedAt)
+    }
+
     func testReviewChangeSourcesUseCommitTreeAndDraftOperation() throws {
         let resource = ServerDraftResourceReference(scope: "project", kind: .context, id: "context-1", path: "notes/a.md")
         let detail = ReviewDetail(
@@ -907,6 +995,8 @@ final class DaemonContractTests: XCTestCase {
                 version: 3,
                 decisionBody: nil,
                 approvedResultHash: nil,
+                decidedBy: nil,
+                decidedAt: nil,
                 coordination: coordination(
                     freshness: .behind,
                     currentCommitId: "commit-current",
@@ -956,6 +1046,7 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(sources.currentContent, "Current body")
         XCTAssertEqual(sources.draftContent, "Draft body")
         XCTAssertEqual(sources.resolutionContent, "Draft body")
+        XCTAssertEqual(sources.proposedPath, "notes/a.md")
         XCTAssertTrue(sources.operationLabels.isEmpty)
         let mapped = WorkspaceLoader.mapReview(detail)
         XCTAssertEqual(mapped.freshness, .behind)
@@ -1000,6 +1091,7 @@ final class DaemonContractTests: XCTestCase {
 
         XCTAssertEqual(sources.operationLabels, ["Rename to notes/b.md"])
         XCTAssertEqual(sources.draftContent, "Draft body")
+        XCTAssertEqual(sources.proposedPath, "notes/b.md")
     }
 
     func testRuleDraftRenderingPreservesMarkdown() {
@@ -1013,7 +1105,7 @@ final class DaemonContractTests: XCTestCase {
         )
     }
 
-    func testReviewListMetadataMapsWithoutLoadingReviewDetail() {
+    func testReviewListMetadataMapsWithoutLoadingReviewDetail() throws {
         let metadata = ReviewMetadata(
             reviewId: "review-1",
             projectId: "project-1",
@@ -1031,6 +1123,14 @@ final class DaemonContractTests: XCTestCase {
             version: 1,
             decisionBody: nil,
             approvedResultHash: nil,
+            decidedBy: UserReference(
+                userId: "reviewer-1",
+                email: "reviewer@example.com",
+                displayName: "Reviewer",
+                avatarUrl: nil,
+                role: "member"
+            ),
+            decidedAt: "2026-08-06T01:00:00Z",
             coordination: DraftCoordination(
                 freshness: .current,
                 currentCommitId: "commit-1",
@@ -1048,6 +1148,21 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(review.title, "Split diff UI example")
         XCTAssertEqual(review.freshness, .current)
         XCTAssertEqual(review.currentCommitId, "commit-1")
+        XCTAssertEqual(review.decidedBy?.userId, "reviewer-1")
+        XCTAssertEqual(review.decidedBy?.displayName, "Reviewer")
+        XCTAssertEqual(review.decidedAt, "2026-08-06T01:00:00Z")
+
+        let encoded = try JSONCoding.encoder().encode(metadata)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        let decidedBy = try XCTUnwrap(object["decided_by"] as? [String: Any])
+        XCTAssertEqual(decidedBy["user_id"] as? String, "reviewer-1")
+        XCTAssertEqual(object["decided_at"] as? String, "2026-08-06T01:00:00Z")
+
+        let decoded = try JSONCoding.decoder().decode(ReviewMetadata.self, from: encoded)
+        XCTAssertEqual(decoded.decidedBy?.displayName, "Reviewer")
+        XCTAssertEqual(decoded.decidedAt, "2026-08-06T01:00:00Z")
     }
 
     func testCommitPayloadDecodesInternalProjectSelectionTreeEntry() throws {
@@ -1108,6 +1223,123 @@ final class DaemonContractTests: XCTestCase {
         }
     }
 
+    func testReviewCommentPlacementKeepsCurrentFileThreadsOnTheirExactLine() {
+        let author = UserReference(
+            userId: "reviewer-1",
+            email: "reviewer@example.com",
+            displayName: "Reviewer",
+            avatarUrl: nil,
+            role: "member"
+        )
+        func comment(
+            _ id: String,
+            path: String?,
+            line: Int?,
+            version: Int = 3
+        ) -> ReviewComment {
+            ReviewComment(
+                commentId: id,
+                reviewId: "review-1",
+                author: author,
+                body: id,
+                createdAt: "2026-08-11T00:00:00Z",
+                anchorPath: path,
+                anchorLine: line,
+                reviewVersion: version
+            )
+        }
+        let general = comment("general", path: nil, line: nil)
+        let inline = comment("inline", path: "context/review.md", line: 7)
+        let priorPath = comment("prior", path: "context/old-review.md", line: 7)
+        let priorVersion = comment(
+            "prior-version",
+            path: "context/review.md",
+            line: 7,
+            version: 2
+        )
+        let missingLine = comment("missing-line", path: "context/review.md", line: 99)
+
+        let placement = ReviewCommentPlacement.resolve(
+            comments: [general, inline, priorPath, priorVersion, missingLine],
+            activePath: "context/review.md",
+            renderableLines: [7, 8],
+            minimumInlineVersion: 3
+        )
+
+        XCTAssertEqual(placement.general.map(\.id), ["general"])
+        XCTAssertEqual(placement.byLine[7]?.map(\.id), ["inline"])
+        XCTAssertEqual(
+            placement.unplaced.map(\.id),
+            ["prior", "prior-version", "missing-line"]
+        )
+        XCTAssertNil(placement.byLine[1])
+    }
+
+    func testReviewCommentPlacementAccountsForDecisionOnlyVersionChanges() {
+        XCTAssertEqual(
+            ReviewCommentPlacement.minimumInlineVersion(reviewVersion: 4, status: "open"),
+            4
+        )
+        XCTAssertEqual(
+            ReviewCommentPlacement.minimumInlineVersion(reviewVersion: 4, status: "approved"),
+            3
+        )
+        XCTAssertEqual(
+            ReviewCommentPlacement.minimumInlineVersion(reviewVersion: 4, status: "rejected"),
+            3
+        )
+        XCTAssertEqual(
+            ReviewCommentPlacement.minimumInlineVersion(reviewVersion: 5, status: "merged"),
+            3
+        )
+    }
+
+    func testUnifiedDiffRevealsUnchangedContextContainingAnchoredComments() {
+        let content = (1...12).map { "line \($0)" }.joined(separator: "\n")
+        let model = SplitDiffModel.make(original: content, modified: content)
+
+        XCTAssertTrue(UnifiedDiffPresentation(model: model).blocks.isEmpty)
+
+        let presentation = UnifiedDiffPresentation(
+            model: model,
+            anchoredLines: [8]
+        )
+        let anchoredLine = presentation.blocks
+            .flatMap(\.lines)
+            .first { $0.commentAnchorLine == 8 }
+
+        XCTAssertNotNil(anchoredLine)
+        XCTAssertTrue(presentation.blocks.contains { block in
+            guard case .hunk = block.kind else { return false }
+            return block.lines.contains { $0.commentAnchorLine == 8 }
+        })
+    }
+
+    func testUnifiedDiffSplitsLargeOmissionAroundAnchoredComment() throws {
+        let originalLines = (1...50).map { "line \($0)" }
+        var modifiedLines = originalLines
+        modifiedLines[1] = "changed line 2"
+        let model = SplitDiffModel.make(
+            original: originalLines.joined(separator: "\n"),
+            modified: modifiedLines.joined(separator: "\n")
+        )
+
+        let presentation = UnifiedDiffPresentation(
+            model: model,
+            anchoredLines: [40]
+        )
+        let commentHunk = try XCTUnwrap(presentation.blocks.first { block in
+            guard case .hunk = block.kind else { return false }
+            return block.lines.contains { $0.commentAnchorLine == 40 }
+        })
+
+        XCTAssertLessThanOrEqual(commentHunk.lines.count, 7)
+        XCTAssertFalse(presentation.blocks.contains { block in
+            guard case .omission = block.kind else { return false }
+            return block.lines.contains { $0.commentAnchorLine == 40 }
+        })
+    }
+
     func testSplitDiffAlignsReplacementRows() {
         let model = SplitDiffModel.make(original: "one\ntwo", modified: "one\nthree")
 
@@ -1120,6 +1352,37 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(model.rows[1].modified?.text, "three")
         XCTAssertEqual(model.rows[1].original?.lineNumber, 2)
         XCTAssertEqual(model.rows[1].modified?.lineNumber, 2)
+    }
+
+    func testUnifiedDiffExpandsReplacementIntoRemovalAndInsertion() {
+        let model = SplitDiffModel.make(original: "one\ntwo", modified: "one\nthree")
+        let presentation = UnifiedDiffPresentation(model: model)
+        let changed = presentation.blocks
+            .flatMap(\.lines)
+            .filter { $0.kind != .context }
+
+        XCTAssertEqual(changed.map(\.kind), [.removal, .insertion])
+        XCTAssertEqual(changed.map(\.text), ["two", "three"])
+        XCTAssertEqual(changed[0].oldLineNumber, 2)
+        XCTAssertNil(changed[0].commentAnchorLine)
+        XCTAssertEqual(changed[1].newLineNumber, 2)
+        XCTAssertEqual(changed[1].commentAnchorLine, 2)
+    }
+
+    func testUnifiedDiffKeepsDistantContextInCollapsedOmissionBlock() {
+        let original = (1...20).map { "line \($0)" }.joined(separator: "\n")
+        var modifiedLines = (1...20).map { "line \($0)" }
+        modifiedLines[1] = "changed 2"
+        modifiedLines[18] = "changed 19"
+
+        let presentation = UnifiedDiffPresentation(model: SplitDiffModel.make(
+            original: original,
+            modified: modifiedLines.joined(separator: "\n")
+        ))
+
+        XCTAssertEqual(presentation.blocks.count, 3)
+        XCTAssertEqual(presentation.blocks[1].kind, .omission)
+        XCTAssertGreaterThan(presentation.blocks[1].lines.count, 0)
     }
 
     func testSplitDiffTreatsEmptyContentAsNoLines() {
@@ -1485,6 +1748,8 @@ final class DaemonContractTests: XCTestCase {
                 version: 1,
                 decisionBody: nil,
                 approvedResultHash: nil,
+                decidedBy: nil,
+                decidedAt: nil,
                 coordination: coordination(),
                 createdAt: timestamp,
                 updatedAt: timestamp

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -3,6 +3,23 @@ import XCTest
 @testable import Clumsies
 
 final class FileTreeSelectionTests: XCTestCase {
+    func testSharedPathTreeBuildsDirectoriesForReviewAndMemoryNavigators() throws {
+        let roots = PathTreeNode.build([
+            PathTreeItem(id: "review-file", path: "context/guides/review.md"),
+            PathTreeItem(id: "memory-file", path: "context/notes.md"),
+        ])
+
+        let context = try XCTUnwrap(roots.first)
+        XCTAssertEqual(context.id, "directory:context")
+        XCTAssertEqual(context.name, "context")
+        XCTAssertEqual(PathTreeNode.firstItemId(in: roots), "review-file")
+        XCTAssertEqual(
+            PathTreeNode.directoryIds(in: roots),
+            ["directory:context", "directory:context/guides"]
+        )
+        XCTAssertNotNil(PathTreeNode.node(withId: "review-file", in: roots)?.item)
+    }
+
     func testPlainDirectoryClickSelectsAndTogglesDirectory() {
         let result = FileTreeSelectionInteraction.directoryClick(
             nodeId: "directory:design",

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -1,5 +1,3 @@
-import AppKit
-import SwiftUI
 import XCTest
 @testable import Clumsies
 
@@ -194,75 +192,26 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
-    @available(macOS 26.0, *)
-    func testReviewToolbarOwnershipAcrossListAndOpenDetail() throws {
-        let store = WorkspaceStore()
+    func testReviewToolbarOwnershipAcrossListAndOpenDetail() {
         let review = reviewRecord(status: "open")
-        store.replaceReview(with: review)
-        store.selectedSection = .reviews
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 920, height: 700),
-            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
-            backing: .buffered,
-            defer: false
+        XCTAssertEqual(
+            ReviewToolbarOwnership.resolve(
+                surface: .list,
+                review: review,
+                canMergeReviews: false,
+                isAuthor: false
+            ).items,
+            [.filter, .search]
         )
-        window.titleVisibility = .hidden
-        window.titlebarAppearsTransparent = true
-        window.toolbarStyle = .unified
-
-        let hostingView = NSHostingView(rootView: WorkspaceView(
-            store: store,
-            onOpenSettings: {},
-            onOpenDiagnostics: { _ in },
-            onShowLogs: {},
-            loadsReviewDetail: false
-        ))
-        hostingView.sceneBridgingOptions = .all
-        window.contentView = hostingView
-        let previousKeyWindow = NSApp.keyWindow
-        window.makeKeyAndOrderFront(nil)
-        defer {
-            window.close()
-            previousKeyWindow?.makeKeyAndOrderFront(nil)
-        }
-
-        let filterIdentifier = NSToolbarItem.Identifier("review.filter")
-        let searchIdentifier = NSToolbarItem.Identifier("review.search")
-        let deadline = Date().addingTimeInterval(5)
-        var items: [NSToolbarItem] = []
-        var foundReviewItems = false
-        repeat {
-            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
-            items = window.toolbar?.items ?? []
-            foundReviewItems = items.contains { $0.itemIdentifier == filterIdentifier }
-                && items.contains { $0.itemIdentifier == searchIdentifier }
-        } while Date() < deadline && !foundReviewItems
-
-        let identifiers = items.map(\.itemIdentifier)
-        _ = try XCTUnwrap(identifiers.firstIndex(of: filterIdentifier))
-        _ = try XCTUnwrap(identifiers.firstIndex(of: searchIdentifier))
-
-        store.selectedReviewId = review.id
-
-        let approveIdentifier = NSToolbarItem.Identifier("review.approve")
-        let rejectIdentifier = NSToolbarItem.Identifier("review.reject")
-        let detailDeadline = Date().addingTimeInterval(5)
-        var detailIdentifiers: [NSToolbarItem.Identifier] = []
-        var foundDetailItems = false
-        repeat {
-            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
-            detailIdentifiers = window.toolbar?.items.map(\.itemIdentifier) ?? []
-            foundDetailItems = detailIdentifiers.contains(approveIdentifier)
-                && detailIdentifiers.contains(rejectIdentifier)
-                && detailIdentifiers.contains(searchIdentifier)
-                && !detailIdentifiers.contains(filterIdentifier)
-        } while Date() < detailDeadline && !foundDetailItems
-
-        XCTAssertTrue(detailIdentifiers.contains(approveIdentifier), toolbarDiagnostics(window))
-        XCTAssertTrue(detailIdentifiers.contains(rejectIdentifier), toolbarDiagnostics(window))
-        XCTAssertTrue(detailIdentifiers.contains(searchIdentifier), toolbarDiagnostics(window))
-        XCTAssertFalse(detailIdentifiers.contains(filterIdentifier), toolbarDiagnostics(window))
+        XCTAssertEqual(
+            ReviewToolbarOwnership.resolve(
+                surface: .detail,
+                review: review,
+                canMergeReviews: false,
+                isAuthor: false
+            ).items,
+            [.decision(.reject), .decision(.approve), .search]
+        )
     }
 
     func testReviewDetailRouteCarriesOnlyTheStableReviewId() {
@@ -443,13 +392,6 @@ final class WorkspaceNavigationTests: XCTestCase {
             currentCommitId: currentCommitId,
             updatedAt: "2026-08-09T00:00:00Z"
         )
-    }
-
-    private func toolbarDiagnostics(_ window: NSWindow) -> String {
-        (window.toolbar?.items ?? []).map { item -> String in
-            let frame = item.view.map { $0.convert($0.bounds, to: nil) }
-            return "\(item.itemIdentifier.rawValue)=\(String(describing: frame))"
-        }.joined(separator: ", ")
     }
 
 }

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -229,7 +229,7 @@ final class WorkspaceNavigationTests: XCTestCase {
 
         let filterIdentifier = NSToolbarItem.Identifier("review.filter")
         let searchIdentifier = NSToolbarItem.Identifier("review.search")
-        let deadline = Date().addingTimeInterval(1)
+        let deadline = Date().addingTimeInterval(5)
         var items: [NSToolbarItem] = []
         var foundReviewItems = false
         repeat {
@@ -242,26 +242,12 @@ final class WorkspaceNavigationTests: XCTestCase {
         let identifiers = items.map(\.itemIdentifier)
         _ = try XCTUnwrap(identifiers.firstIndex(of: filterIdentifier))
         _ = try XCTUnwrap(identifiers.firstIndex(of: searchIdentifier))
-        let listToolbarDiagnostics = items.map { item -> String in
-            let frame = item.view.map { $0.convert($0.bounds, to: nil) }
-            return "\(item.itemIdentifier.rawValue)=\(String(describing: frame))"
-        }.joined(separator: ", ")
-
-        let filterItem = try XCTUnwrap(items.first { $0.itemIdentifier == filterIdentifier })
-        let searchItem = try XCTUnwrap(items.first { $0.itemIdentifier == searchIdentifier })
-        let filterView = try XCTUnwrap(filterItem.view)
-        let searchView = try XCTUnwrap(searchItem.view)
-        let filterFrame = filterView.convert(filterView.bounds, to: nil)
-        let searchFrame = searchView.convert(searchView.bounds, to: nil)
-        XCTAssertLessThan(filterFrame.maxX, searchFrame.minX, listToolbarDiagnostics)
-        XCTAssertLessThan(filterFrame.midX, window.frame.width / 2, listToolbarDiagnostics)
-        XCTAssertGreaterThan(searchFrame.midX, window.frame.width / 2, listToolbarDiagnostics)
 
         store.selectedReviewId = review.id
 
         let approveIdentifier = NSToolbarItem.Identifier("review.approve")
         let rejectIdentifier = NSToolbarItem.Identifier("review.reject")
-        let detailDeadline = Date().addingTimeInterval(1)
+        let detailDeadline = Date().addingTimeInterval(5)
         var detailIdentifiers: [NSToolbarItem.Identifier] = []
         var foundDetailItems = false
         repeat {

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -7,20 +7,55 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(WorkspaceSection.issues.title, "Kanban")
     }
 
-    func testIssuesUseSidebarAndDetailWhileOtherSectionsKeepThreeColumns() {
+    func testIssuesAndReviewsUseSidebarAndDetailWhileOtherSectionsKeepThreeColumns() {
         XCTAssertEqual(WorkspaceColumnLayout(section: .issues), .sidebarDetail)
+        XCTAssertEqual(WorkspaceColumnLayout(section: .reviews), .sidebarDetail)
 
         for section in [
             WorkspaceSection.hub,
             .local,
             .bundles,
-            .reviews,
         ] {
             XCTAssertEqual(
                 WorkspaceColumnLayout(section: section),
                 .sidebarContentDetail
             )
         }
+    }
+
+    func testReviewStatusFilterMatchesByStatus() {
+        func record(status: String) -> ReviewRecord {
+            ReviewRecord(
+                id: UUID().uuidString,
+                projectId: "prj",
+                draftId: "draft",
+                title: "T",
+                description: "",
+                author: UserReference(
+                    userId: "u",
+                    email: "u@example.com",
+                    displayName: nil,
+                    avatarUrl: nil,
+                    role: "member"
+                ),
+                status: status,
+                version: 1,
+                decisionBody: nil,
+                approvedResultHash: nil,
+                freshness: .current,
+                reconciliation: .clean,
+                reconciliationCandidateId: nil,
+                currentCommitId: nil,
+                updatedAt: "2026-08-09T00:00:00Z"
+            )
+        }
+
+        let all = ReviewStatusFilter.allCases
+        let open = record(status: "open")
+        XCTAssertTrue(ReviewStatusFilter.open.matches(open))
+        XCTAssertFalse(ReviewStatusFilter.approved.matches(open))
+        XCTAssertTrue(ReviewStatusFilter.all.matches(open))
+        XCTAssertEqual(all.count, 5)
     }
 
     func testIssueDetailRouteCarriesOnlyTheGlobalIssueId() {

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import XCTest
 @testable import Clumsies
 
@@ -7,7 +9,7 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(WorkspaceSection.issues.title, "Kanban")
     }
 
-    func testIssuesAndReviewsUseSidebarAndDetailWhileOtherSectionsKeepThreeColumns() {
+    func testReviewsAndKanbanUseSidebarWithPushNavigatedDetail() {
         XCTAssertEqual(WorkspaceColumnLayout(section: .issues), .sidebarDetail)
         XCTAssertEqual(WorkspaceColumnLayout(section: .reviews), .sidebarDetail)
 
@@ -24,38 +26,263 @@ final class WorkspaceNavigationTests: XCTestCase {
     }
 
     func testReviewStatusFilterMatchesByStatus() {
-        func record(status: String) -> ReviewRecord {
-            ReviewRecord(
-                id: UUID().uuidString,
-                projectId: "prj",
-                draftId: "draft",
-                title: "T",
-                description: "",
-                author: UserReference(
-                    userId: "u",
-                    email: "u@example.com",
-                    displayName: nil,
-                    avatarUrl: nil,
-                    role: "member"
-                ),
-                status: status,
-                version: 1,
-                decisionBody: nil,
-                approvedResultHash: nil,
-                freshness: .current,
-                reconciliation: .clean,
-                reconciliationCandidateId: nil,
-                currentCommitId: nil,
-                updatedAt: "2026-08-09T00:00:00Z"
-            )
-        }
-
         let all = ReviewStatusFilter.allCases
-        let open = record(status: "open")
+        let open = reviewRecord(status: "open")
         XCTAssertTrue(ReviewStatusFilter.open.matches(open))
         XCTAssertFalse(ReviewStatusFilter.approved.matches(open))
         XCTAssertTrue(ReviewStatusFilter.all.matches(open))
+        XCTAssertEqual(ReviewStatusFilter.open.count(in: [open]), 1)
+        XCTAssertEqual(ReviewStatusFilter.approved.count(in: [open]), 0)
+        XCTAssertEqual(ReviewStatusFilter.all.count(in: [open]), 1)
         XCTAssertEqual(all.count, 5)
+    }
+
+    func testReviewQueueStatePrioritizesDecisionBlockersAndViewerAction() {
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(
+                    status: "merged",
+                    freshness: .behind,
+                    reconciliation: .conflicts
+                ),
+                isAuthor: false,
+                canMerge: true
+            ),
+            .init(
+                title: "Merged",
+                symbolName: "arrow.triangle.merge",
+                tone: .neutral,
+                isQueueSignal: false
+            )
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(
+                    status: "open",
+                    freshness: .behind,
+                    reconciliation: .conflicts
+                ),
+                isAuthor: false,
+                canMerge: false
+            ).title,
+            "Conflicts"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "open", reconciliation: .conflicts),
+                isAuthor: false,
+                canMerge: false
+            ).title,
+            "Needs Review"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "approved", freshness: .behind),
+                isAuthor: false,
+                canMerge: true
+            ).title,
+            "Out of Date"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "approved", freshness: .behind),
+                isAuthor: true,
+                canMerge: true
+            ).title,
+            "Update Required"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "open"),
+                isAuthor: false,
+                canMerge: false
+            ).title,
+            "Needs Review"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "approved", approvedResultHash: "result"),
+                isAuthor: false,
+                canMerge: true
+            ).title,
+            "Ready to Merge"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "approved"),
+                isAuthor: false,
+                canMerge: true
+            ).title,
+            "Approved"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "rejected"),
+                isAuthor: true,
+                canMerge: false
+            ).title,
+            "Resubmit"
+        )
+        XCTAssertEqual(
+            ReviewQueueStatePresentation.resolve(
+                review: reviewRecord(status: "rejected"),
+                isAuthor: false,
+                canMerge: false
+            ).title,
+            "Awaiting Author"
+        )
+    }
+
+    func testReviewDecisionReadinessIsBoundToTheRenderedVersion() {
+        let reviewId = "review-versioned"
+        let rendered = reviewRecord(status: "open", id: reviewId, version: 7)
+        let readiness = ReviewDecisionReadiness(review: rendered)
+
+        XCTAssertTrue(readiness.matches(rendered))
+        XCTAssertFalse(readiness.matches(reviewRecord(
+            status: "open",
+            id: reviewId,
+            version: 8
+        )))
+        XCTAssertFalse(readiness.matches(reviewRecord(
+            status: "open",
+            freshness: .behind,
+            id: reviewId,
+            version: 7,
+            currentCommitId: "commit-new"
+        )))
+    }
+
+    func testMergeActionRequiresAnImmutableApprovedResult() {
+        XCTAssertFalse(ReviewMenuAction.merge.isAvailable(
+            for: reviewRecord(status: "approved"),
+            canMergeReviews: true,
+            isAuthor: false
+        ))
+        XCTAssertFalse(ReviewMenuAction.merge.isAvailable(
+            for: reviewRecord(status: "approved", approvedResultHash: ""),
+            canMergeReviews: true,
+            isAuthor: false
+        ))
+        XCTAssertTrue(ReviewMenuAction.merge.isAvailable(
+            for: reviewRecord(status: "approved", approvedResultHash: "sha256:result"),
+            canMergeReviews: true,
+            isAuthor: false
+        ))
+    }
+
+    func testReviewListContentStateDistinguishesLoadingAndEmptyQueues() {
+        XCTAssertEqual(
+            ReviewListContentState.resolve(phase: .launching, totalCount: 0, visibleCount: 0),
+            .loading
+        )
+        XCTAssertEqual(
+            ReviewListContentState.resolve(phase: .loading, totalCount: 0, visibleCount: 0),
+            .loading
+        )
+        XCTAssertEqual(
+            ReviewListContentState.resolve(phase: .ready, totalCount: 0, visibleCount: 0),
+            .empty
+        )
+        XCTAssertEqual(
+            ReviewListContentState.resolve(phase: .ready, totalCount: 2, visibleCount: 0),
+            .filteredEmpty
+        )
+        XCTAssertEqual(
+            ReviewListContentState.resolve(phase: .loading, totalCount: 2, visibleCount: 1),
+            .content
+        )
+    }
+
+    @available(macOS 26.0, *)
+    func testReviewToolbarOwnershipAcrossListAndOpenDetail() throws {
+        let store = WorkspaceStore()
+        let review = reviewRecord(status: "open")
+        store.replaceReview(with: review)
+        store.selectedSection = .reviews
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 920, height: 700),
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.toolbarStyle = .unified
+
+        let hostingView = NSHostingView(rootView: WorkspaceView(
+            store: store,
+            onOpenSettings: {},
+            onOpenDiagnostics: { _ in },
+            onShowLogs: {},
+            loadsReviewDetail: false
+        ))
+        hostingView.sceneBridgingOptions = .all
+        window.contentView = hostingView
+        let previousKeyWindow = NSApp.keyWindow
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.close()
+            previousKeyWindow?.makeKeyAndOrderFront(nil)
+        }
+
+        let filterIdentifier = NSToolbarItem.Identifier("review.filter")
+        let searchIdentifier = NSToolbarItem.Identifier("review.search")
+        let deadline = Date().addingTimeInterval(1)
+        var items: [NSToolbarItem] = []
+        var foundReviewItems = false
+        repeat {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            items = window.toolbar?.items ?? []
+            foundReviewItems = items.contains { $0.itemIdentifier == filterIdentifier }
+                && items.contains { $0.itemIdentifier == searchIdentifier }
+        } while Date() < deadline && !foundReviewItems
+
+        let identifiers = items.map(\.itemIdentifier)
+        _ = try XCTUnwrap(identifiers.firstIndex(of: filterIdentifier))
+        _ = try XCTUnwrap(identifiers.firstIndex(of: searchIdentifier))
+        let listToolbarDiagnostics = items.map { item -> String in
+            let frame = item.view.map { $0.convert($0.bounds, to: nil) }
+            return "\(item.itemIdentifier.rawValue)=\(String(describing: frame))"
+        }.joined(separator: ", ")
+
+        let filterItem = try XCTUnwrap(items.first { $0.itemIdentifier == filterIdentifier })
+        let searchItem = try XCTUnwrap(items.first { $0.itemIdentifier == searchIdentifier })
+        let filterView = try XCTUnwrap(filterItem.view)
+        let searchView = try XCTUnwrap(searchItem.view)
+        let filterFrame = filterView.convert(filterView.bounds, to: nil)
+        let searchFrame = searchView.convert(searchView.bounds, to: nil)
+        XCTAssertLessThan(filterFrame.maxX, searchFrame.minX, listToolbarDiagnostics)
+        XCTAssertLessThan(filterFrame.midX, window.frame.width / 2, listToolbarDiagnostics)
+        XCTAssertGreaterThan(searchFrame.midX, window.frame.width / 2, listToolbarDiagnostics)
+
+        store.selectedReviewId = review.id
+
+        let approveIdentifier = NSToolbarItem.Identifier("review.approve")
+        let rejectIdentifier = NSToolbarItem.Identifier("review.reject")
+        let detailDeadline = Date().addingTimeInterval(1)
+        var detailIdentifiers: [NSToolbarItem.Identifier] = []
+        var foundDetailItems = false
+        repeat {
+            RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+            detailIdentifiers = window.toolbar?.items.map(\.itemIdentifier) ?? []
+            foundDetailItems = detailIdentifiers.contains(approveIdentifier)
+                && detailIdentifiers.contains(rejectIdentifier)
+                && detailIdentifiers.contains(searchIdentifier)
+                && !detailIdentifiers.contains(filterIdentifier)
+        } while Date() < detailDeadline && !foundDetailItems
+
+        XCTAssertTrue(detailIdentifiers.contains(approveIdentifier), toolbarDiagnostics(window))
+        XCTAssertTrue(detailIdentifiers.contains(rejectIdentifier), toolbarDiagnostics(window))
+        XCTAssertTrue(detailIdentifiers.contains(searchIdentifier), toolbarDiagnostics(window))
+        XCTAssertFalse(detailIdentifiers.contains(filterIdentifier), toolbarDiagnostics(window))
+    }
+
+    func testReviewDetailRouteCarriesOnlyTheStableReviewId() {
+        let route = ReviewRoute(reviewId: "review-0123456789abcdef")
+
+        XCTAssertEqual(route.reviewId, "review-0123456789abcdef")
     }
 
     func testIssueDetailRouteCarriesOnlyTheGlobalIssueId() {
@@ -195,4 +422,48 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
         return MemoryListItem(id: resource.id, resource: resource, draft: nil, inherited: false)
     }
+
+    private func reviewRecord(
+        status: String,
+        freshness: DraftFreshness = .current,
+        reconciliation: DraftReconciliationStatus = .clean,
+        approvedResultHash: String? = nil,
+        id: String = UUID().uuidString,
+        version: Int = 1,
+        currentCommitId: String? = nil
+    ) -> ReviewRecord {
+        ReviewRecord(
+            id: id,
+            projectId: "prj",
+            draftId: "draft",
+            title: "Review title",
+            description: "",
+            author: UserReference(
+                userId: "u",
+                email: "u@example.com",
+                displayName: "Reviewer",
+                avatarUrl: nil,
+                role: "member"
+            ),
+            status: status,
+            version: version,
+            decisionBody: nil,
+            approvedResultHash: approvedResultHash,
+            decidedBy: nil,
+            decidedAt: nil,
+            freshness: freshness,
+            reconciliation: reconciliation,
+            reconciliationCandidateId: nil,
+            currentCommitId: currentCommitId,
+            updatedAt: "2026-08-09T00:00:00Z"
+        )
+    }
+
+    private func toolbarDiagnostics(_ window: NSWindow) -> String {
+        (window.toolbar?.items ?? []).map { item -> String in
+            let frame = item.view.map { $0.convert($0.bounds, to: nil) }
+            return "\(item.itemIdentifier.rawValue)=\(String(describing: frame))"
+        }.joined(separator: ", ")
+    }
+
 }

--- a/docs/reviews-ui-design.md
+++ b/docs/reviews-ui-design.md
@@ -1,122 +1,173 @@
 # Reviews UI Design (macOS App)
 
-Design for the Reviews section of the macOS app, following Apple HIG and
-GitHub's page-navigation model. Supersedes the previous master-detail split
-and the bundled decision/discussion sections.
+The Reviews section follows the same native navigation hierarchy as Kanban:
+the global app sidebar stays in place, the Review list is the root page, and a
+selected Review is pushed onto a `NavigationStack`. The detail is a file-review
+workspace rather than a permanently visible third app column.
+
+This document replaces both the earlier web-style Review page and the temporary
+three-column master-detail variant.
 
 ## 1. Navigation model
 
-Two pages, push navigation (GitHub issues style). The app sidebar (section
-navigation) stays visible on both pages; the review list is replaced by the
-detail page on selection.
+The outer shell has two stable roles:
 
 ```
-page 1 列表页  (sidebar + review list)
-   │  click a row
-   ▼
-page 2 详情页  (sidebar + full detail, no list)
+global sidebar | NavigationStack (Review list -> Review detail)
 ```
 
-- Back: toolbar Back button, ⌘[, window gestures.
-- ⌘↑ / ⌘↓ jump to previous/next review in place (no return to list).
-- Mirrors the existing Issues pattern in `WorkspaceView`
-  (`issueNavigationPath` + `NavigationStack`).
+- Entering Reviews opens the list, not an automatically selected Review.
+- A native `NavigationLink` opens a Review. The system owns pointer, keyboard,
+  VoiceOver activation, Back, and navigation transition behavior.
+- Returning from a detail restores the list and its filter context.
+- Search and newly created Reviews may deep-link to a stable `reviewId`.
+- The global sidebar remains visible according to the user's existing sidebar
+  preference and is not replaced by Review navigation.
 
-## 2. Page 1 - Review list
+## 2. Review list
 
-Toolbar: sidebar toggle, window title "Reviews", status filter with counts
-(`Open(n) Approved(n) Rejected(n) Merged(n) All(n)`) as a segmented control
-that collapses to a menu on narrow windows.
+Use a native inset `List`. Do not draw card borders, custom selection stripes,
+or web-style status pills.
 
-List rows (GitHub issues style, ~64pt, `.inset`):
-
-```
-title (1 line)                     [status badge] [freshness ⟳]
-description or resource path (1 line, secondary)
-author · project · relative time (caption, secondary)
-```
-
-- Status badge: shared component, symbol + tint per status:
-  open = clock (accent), approved = checkmark.circle (green),
-  rejected = xmark.circle (red), merged = arrow.triangle.merge (secondary).
-  `.help()` and accessibility labels on all indicators.
-- Freshness indicator reuses `DraftBaseBehindIndicator` (behind/conflicts only).
-- project name is resolved client-side from the projects list
-  (`ReviewRecord` only carries `projectId`).
-
-Empty states: no reviews at all / no results for the current filter
-("No Open Reviews") / no selection is no longer possible (push model).
-
-## 3. Page 2 - Review detail
-
-Toolbar: Back button, review title, trailing decision buttons
-(`Reject` / `Approve` prominent / `Merge` prominent / `Resubmit` prominent,
-one prominent per state) and a More menu. Every toolbar action also exists
-in the menu bar with shortcuts (⌘⌥A approve, ⌘⌥R reject, ⌘↩ merge).
-
-Detail body, top to bottom:
+The list is a review queue, not a summary card. Each row answers five scan
+questions: what changed, where it belongs, who submitted it, when its Review
+record last changed, and what the current viewer can do next. It has at most
+two useful lines:
 
 ```
-Header     status badge · version · updated time
-Meta line  resource path · author · project   ↻ stale [view changes]   (condition)
-Title      review title
-Description full text
-Changes    General slot [＋ add general comment]
-           unified diff (no card, full width)
-              hunk headers @@, line numbers, - red / + green
-              hover line → [＋] inline comment composer under the line
-              anchored comment threads rendered under their line
+review title                     symbol + one semantic workflow state
+project · author                              relative update time
 ```
 
-- Stale/conflict state renders as a compact status chip in the meta line
-  (`↻ base stale · [view changes]` / `⚠ needs conflict resolution`),
-  not a full-width banner and not a context-menu-only entry.
-- Decided states render the decision result (decisionBody, result hash,
-  decision author/time) inside the header area - controls only, no separate
-  Decision section.
-- Changes: unified diff rendered directly, no container card. Operation
-  summary as a symbol line (`＋ update rules/search.md · 15 lines changed`).
-  Delete-only reviews render a deletion note, no empty diff.
+- Keep descriptions in the detail page.
+- Keep the relative time in its own trailing column so a long Project or author
+  cannot remove it. If a Project name or timestamp cannot be resolved, omit the
+  value; never expose an opaque Project ID or raw protocol timestamp.
+- Resolve one workflow state for the row. Precedence is `Merged`, `Conflicts`,
+  `Update Required`/`Out of Date`, then the viewer-aware lifecycle state:
+  `Needs Review`, `Ready to Merge`/`Approved`, or `Resubmit`/`Awaiting Author`.
+  A merged Review never displays stale merely because the merge advanced the
+  current Project ref. `Ready to Merge` also requires a nonempty approved result
+  hash; capability alone does not make a legacy approval mergeable.
+- The workflow state is a plain system `Label` with an SF Symbol and semantic
+  foreground color. It is neither a button nor a capsule. Never stack a status
+  icon and freshness icon that require hover to distinguish. In `All`, show the
+  lifecycle label. In a single-status scope, omit the repetitive baseline label
+  and show only queue signals that change the next step. At narrow widths, the
+  label may reduce to its symbol so the primary Review title retains priority.
+- Let macOS draw focus, hover/press feedback, separators, and inactive-window
+  state. In this push-navigation list, `NavigationLink` and the stack path are
+  the only navigation state; do not add a parallel `List(selection:)` binding
+  that can push the same route twice during a programmatic deep-link.
+- The status Filter menu belongs to the list page's leading/navigation toolbar
+  area. Its collapsed label communicates the selected scope; counts remain in
+  the menu, help, and accessibility value. The menu contains Open, Approved,
+  Rejected, Merged, and All with counts.
+- Search is an independent window-level action and remains the trailing-most
+  Review tool. Sync and decision actions are not grouped with Filter.
+- Loading without cached Reviews uses a labeled `ProgressView`. Existing cached
+  rows remain visible during refresh. Empty and filtered-empty states use
+  `ContentUnavailableView`; filtered-empty includes `Show All Reviews`.
 
-## 4. Comments
+The GitHub pull-request list informs the information order — title first,
+scope/author/time second, and a small number of workflow signals — but not the
+visual chrome. Do not copy its bordered Web container, row rules, blue links,
+colored pills, PR numbers, avatar stacks, comment counters, or pagination. The
+Server does not currently provide unread counts, unresolved-thread counts, or a
+true last-activity timestamp, and the macOS client must not invent them from
+`updatedAt`.
 
-One comment mechanism only: anchored comments on the diff.
+## 3. Review detail
 
-- Anchor targets: a diff line, or the synthetic "General" slot above the
-  diff (for whole-review feedback).
-- Composer opens inline under the anchor ([＋] on hover / in General slot),
-  submit inserts the thread under the anchor; threads support replies.
-- No bottom composer, no standalone discussion section, no decision-in-
-  comment flow.
-- Server: comments gain an optional anchor (`path` + line) - schema change
-  in `reviews` comments table, `POST /api/v1/reviews/{id}/comments` accepts
-  the anchor, `GET /api/v1/reviews/{id}` returns anchored comments.
-  Line numbers refer to the new file side; review version is the expected
-  optimistic-concurrency token.
+The pushed detail contains an independent split:
 
-## 5. Decisions
+```
+changed-file navigator | review metadata + unified diff
+```
 
-Header buttons are the only decision surface:
+The file navigator reuses the path hierarchy, folder expansion, file symbols,
+and native row styling extracted from the Memory file tree. It owns only Review
+file selection; it must not inherit Memory rename, delete, or open side effects.
 
-- open: Reject / Approve (prominent)
-- approved: Merge (prominent) - only for authors with merge capability
-- rejected: Resubmit (prominent) - only for the draft author
+The current Server contract models one Draft resource per Review, so the tree
+currently contains one real terminal file path. Do not turn operation history
+into fake files. The tree accepts stable file IDs and paths so a future
+materialized multi-file API can extend it without changing the interaction.
 
-Decisions carry no note by default; `decisionBody` stays for server
-compatibility and may be left empty. Keyboard shortcuts cover the quick path.
+The main pane contains only information needed to make the decision:
 
-## 6. States
+1. title and plain status;
+2. author, project, and update time;
+3. description when present;
+4. actionable stale/conflict state when present;
+5. decision result and audit metadata after a decision;
+6. unified diff.
 
-| State | Handling |
-|-------|----------|
-| Loading | detail ProgressView; list keeps cached data, silent refresh on entry |
-| No reviews | ContentUnavailableView with explanation |
-| Filter empty | per-filter ContentUnavailableView |
-| Narrow window | filter collapses to menu; decision buttons stay visible |
-| Stale/conflict | meta-line status chip + view changes entry |
+Do not show a `Changes` heading or summaries such as `Create path · 20 changed
+lines`. The file navigator already communicates the path and the diff directly
+communicates insertions/removals. Delete-only and metadata-only Reviews retain a
+short explicit empty state because the diff cannot communicate those outcomes.
 
-## 7. Data gaps
+## 4. Diff and comments
 
-- project name: client-side mapping from projects list (no server change).
-- anchored comments: server schema + API change (section 4).
-- relative time formatting for createdAt/updatedAt strings.
+- Replacement rows render both the removal and insertion.
+- Long lines scroll horizontally. Unchanged regions remain collapsed unless
+  expanded or required to reveal an anchored comment.
+- A line anchor is the final/new-side `(path, line)` pair. Removal rows are not
+  comment targets until the API gains an explicit side field.
+- A line thread renders immediately after its exact diff row. It is never moved
+  to the top of the diff.
+- Review-wide comments have no path or line. They live in an explicitly labeled,
+  user-opened `Review comments` area and must never look like line feedback.
+- Anchored comments for an earlier path remain discoverable in that area with
+  their original `path:line` label instead of silently disappearing.
+- Comment creation uses the version of the Review detail that produced the
+  visible diff. If that version is stale, the strict Server contract rejects it
+  and the detail reloads rather than anchoring a comment to unrelated content.
+
+Historical comments created before the strict Server anchor deployment may be
+General because the old Server discarded unknown path/line fields before the
+client failed to decode its response. The client cannot infer the lost line;
+the UI labels these honestly rather than pretending they are inline comments.
+
+## 5. Toolbar decisions
+
+Decision actions remain native symbol toolbar items with menu-command parity:
+
+- Open: Reject (`xmark`) and the single prominent Approve (`checkmark`).
+- Approved: Merge (`arrow.triangle.merge`) when permitted and the Server
+  supplied a nonempty approved result hash. Legacy approvals without that
+  immutable result identity remain visible but cannot be merged.
+- Rejected: Resubmit (`arrow.clockwise`) for the Draft author.
+
+Filter belongs only to the list page. Decision tools belong only to an active
+detail. Sync remains its own utility slot. Search remains independent and
+trailing-most. Cross-section toolbar grouping and macOS 14-26 placement are
+tracked as a separate workspace-wide design issue; Reviews must not reintroduce
+one catch-all action group while that work is pending.
+
+## 6. State and accessibility
+
+| State | Native handling |
+| --- | --- |
+| Loading | `ProgressView` |
+| No Reviews/filter matches | Contextual `ContentUnavailableView` |
+| Detail load failure | Explicit error and Retry; decisions stay unavailable |
+| Stale/conflict | Concise semantic label and nearby action |
+| Delete/metadata-only | Explicit main-pane result instead of an empty diff |
+| Narrow window | Native outer sidebar behavior and toolbar overflow |
+
+- Preserve system focus and link activation feedback; do not encode state by
+  color alone.
+- Every symbol-only control has `.help()` and an accessibility label.
+- Verify list -> detail -> Back with mouse, keyboard, and Full Keyboard Access.
+- Verify nested paths, long paths, CJK text, long diff lines, comments inside
+  omissions, rename-only comments, stale details, and loading/error states.
+
+## 7. Data boundary
+
+The current domain is intentionally honest: one Review is one Draft resource
+with operation history. A true multi-file Review requires a Server-provided
+materialized list of file changes with stable change IDs, per-file source
+states, reconciliation, and comment anchors. That contract expansion must be a
+separate backend change; the macOS client must not infer it from operations.

--- a/docs/reviews-ui-design.md
+++ b/docs/reviews-ui-design.md
@@ -1,0 +1,122 @@
+# Reviews UI Design (macOS App)
+
+Design for the Reviews section of the macOS app, following Apple HIG and
+GitHub's page-navigation model. Supersedes the previous master-detail split
+and the bundled decision/discussion sections.
+
+## 1. Navigation model
+
+Two pages, push navigation (GitHub issues style). The app sidebar (section
+navigation) stays visible on both pages; the review list is replaced by the
+detail page on selection.
+
+```
+page 1 列表页  (sidebar + review list)
+   │  click a row
+   ▼
+page 2 详情页  (sidebar + full detail, no list)
+```
+
+- Back: toolbar Back button, ⌘[, window gestures.
+- ⌘↑ / ⌘↓ jump to previous/next review in place (no return to list).
+- Mirrors the existing Issues pattern in `WorkspaceView`
+  (`issueNavigationPath` + `NavigationStack`).
+
+## 2. Page 1 - Review list
+
+Toolbar: sidebar toggle, window title "Reviews", status filter with counts
+(`Open(n) Approved(n) Rejected(n) Merged(n) All(n)`) as a segmented control
+that collapses to a menu on narrow windows.
+
+List rows (GitHub issues style, ~64pt, `.inset`):
+
+```
+title (1 line)                     [status badge] [freshness ⟳]
+description or resource path (1 line, secondary)
+author · project · relative time (caption, secondary)
+```
+
+- Status badge: shared component, symbol + tint per status:
+  open = clock (accent), approved = checkmark.circle (green),
+  rejected = xmark.circle (red), merged = arrow.triangle.merge (secondary).
+  `.help()` and accessibility labels on all indicators.
+- Freshness indicator reuses `DraftBaseBehindIndicator` (behind/conflicts only).
+- project name is resolved client-side from the projects list
+  (`ReviewRecord` only carries `projectId`).
+
+Empty states: no reviews at all / no results for the current filter
+("No Open Reviews") / no selection is no longer possible (push model).
+
+## 3. Page 2 - Review detail
+
+Toolbar: Back button, review title, trailing decision buttons
+(`Reject` / `Approve` prominent / `Merge` prominent / `Resubmit` prominent,
+one prominent per state) and a More menu. Every toolbar action also exists
+in the menu bar with shortcuts (⌘⌥A approve, ⌘⌥R reject, ⌘↩ merge).
+
+Detail body, top to bottom:
+
+```
+Header     status badge · version · updated time
+Meta line  resource path · author · project   ↻ stale [view changes]   (condition)
+Title      review title
+Description full text
+Changes    General slot [＋ add general comment]
+           unified diff (no card, full width)
+              hunk headers @@, line numbers, - red / + green
+              hover line → [＋] inline comment composer under the line
+              anchored comment threads rendered under their line
+```
+
+- Stale/conflict state renders as a compact status chip in the meta line
+  (`↻ base stale · [view changes]` / `⚠ needs conflict resolution`),
+  not a full-width banner and not a context-menu-only entry.
+- Decided states render the decision result (decisionBody, result hash,
+  decision author/time) inside the header area - controls only, no separate
+  Decision section.
+- Changes: unified diff rendered directly, no container card. Operation
+  summary as a symbol line (`＋ update rules/search.md · 15 lines changed`).
+  Delete-only reviews render a deletion note, no empty diff.
+
+## 4. Comments
+
+One comment mechanism only: anchored comments on the diff.
+
+- Anchor targets: a diff line, or the synthetic "General" slot above the
+  diff (for whole-review feedback).
+- Composer opens inline under the anchor ([＋] on hover / in General slot),
+  submit inserts the thread under the anchor; threads support replies.
+- No bottom composer, no standalone discussion section, no decision-in-
+  comment flow.
+- Server: comments gain an optional anchor (`path` + line) - schema change
+  in `reviews` comments table, `POST /api/v1/reviews/{id}/comments` accepts
+  the anchor, `GET /api/v1/reviews/{id}` returns anchored comments.
+  Line numbers refer to the new file side; review version is the expected
+  optimistic-concurrency token.
+
+## 5. Decisions
+
+Header buttons are the only decision surface:
+
+- open: Reject / Approve (prominent)
+- approved: Merge (prominent) - only for authors with merge capability
+- rejected: Resubmit (prominent) - only for the draft author
+
+Decisions carry no note by default; `decisionBody` stays for server
+compatibility and may be left empty. Keyboard shortcuts cover the quick path.
+
+## 6. States
+
+| State | Handling |
+|-------|----------|
+| Loading | detail ProgressView; list keeps cached data, silent refresh on entry |
+| No reviews | ContentUnavailableView with explanation |
+| Filter empty | per-filter ContentUnavailableView |
+| Narrow window | filter collapses to menu; decision buttons stay visible |
+| Stale/conflict | meta-line status chip + view changes entry |
+
+## 7. Data gaps
+
+- project name: client-side mapping from projects list (no server change).
+- anchored comments: server schema + API change (section 4).
+- relative time formatting for createdAt/updatedAt strings.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:web-admin": "bun run --cwd apps/web-admin build",
     "build:macos": "sh apps/macos/Scripts/build.sh",
     "test:macos:package": "sh apps/macos/Scripts/test-runtime-package.sh",
-    "test:macos": "xcodegen generate --spec apps/macos/project.yml && CLUMSIES_SKIP_DAEMON_BUILD=1 xcodebuild -quiet -project apps/macos/Clumsies.xcodeproj -scheme Clumsies -configuration Debug -derivedDataPath /private/tmp/clumsies-macos-tests test",
+    "test:macos": "sh apps/macos/Scripts/test.sh",
     "test:macos:live": "xcodegen generate --spec apps/macos/project.yml && CLUMSIES_SKIP_DAEMON_BUILD=1 xcodebuild -quiet -project apps/macos/Clumsies.xcodeproj -scheme ClumsiesLiveTests -configuration Debug -derivedDataPath /private/tmp/clumsies-macos-live-tests test",
     "preview": "vitepress preview docs",
     "api:generate": "bun run --cwd packages/api-contract generate",


### PR DESCRIPTION
## Summary

Reviews now uses page-style push navigation while retaining the App sidebar. The list is optimized for triage; selecting a Review replaces the list with a full detail workspace.

- Adds viewer-aware queue states, status counts, native filtering, and focused empty/loading states.
- Adds a reusable path tree and robust unified diff with anchored line comments, general comments, omission expansion, and UTF-8-safe layout behavior.
- Moves Approve, Reject, Merge, and Resubmit into native toolbar and menu actions with capability, freshness, version, coordination, and immutable-result gates.
- Prevents stale detail responses from re-enabling decisions after a collaborative update.
- Preserves the App-bundled `clumsiesd` runtime and offline Adapter reconciliation from #166.
- Updates the Reviews design document and expands macOS navigation, contract, diff, and accessibility coverage.

The versioned Review/comment server contract is already present on `main` through #163; this PR consumes that contract instead of carrying a second server implementation.

## Test plan

- [x] `bun run test:macos`
- [x] `bun run test:macos:package`
- [x] `bun run api:check`
- [x] `bun run build`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `cargo test --workspace` (one PostgreSQL container startup flake was rerun in isolation and passed)
- [x] `sh dev/check-agent-runtime-boundary.sh`
- [x] `git diff --check`

## Manual verification after merge

- Open Reviews, switch status filters, and push from the list into a Review detail.
- Verify path selection, unified diff context expansion, general/inline comments, and back navigation.
- Exercise Approve/Reject/Merge/Resubmit availability across current, behind, conflicted, and legacy approved Reviews.
