### PR TITLE
fix: daemon org-scope draft updates + issue board scroll height

### DIFF
--- a/apps/macos/Sources/Features/IssueBoardView.swift
+++ b/apps/macos/Sources/Features/IssueBoardView.swift
@@ -426,7 +426,7 @@ struct IssueBoardView: View {
     private func board(_ response: IssueBoardResponse) -> some View {
         GeometryReader { proxy in
             ScrollView([.horizontal, .vertical]) {
-                LazyHStack(alignment: .top, spacing: IssueBoardLayout.columnSpacing) {
+                HStack(alignment: .top, spacing: IssueBoardLayout.columnSpacing) {
                     ForEach(IssueBoardState.allCases, id: \.self) { state in
                         IssueBoardColumn(
                             state: state,

--- a/crates/daemon/src/draft.rs
+++ b/crates/daemon/src/draft.rs
@@ -59,13 +59,9 @@ pub(crate) async fn resolve_local_draft(
         .ok_or_else(|| DaemonError::NotFound(format!("local draft not found: {draft_id}")))?;
         let stored_kind: String = row.try_get("resource_kind")?;
         let stored_project_id: String = row.try_get("project_id")?;
-        let stored_scope: String = row.try_get("resource_scope")?;
-        if stored_project_id != project_id
-            || stored_scope != scope.as_str()
-            || stored_kind != resource.as_str()
-        {
+        if stored_project_id != project_id || stored_kind != resource.as_str() {
             return Err(DaemonError::InvalidRequest(format!(
-                "local draft {draft_id} belongs to a different project, scope, or resource kind"
+                "local draft {draft_id} belongs to a different project or resource kind"
             )));
         }
         let stored_base_commit_id: Option<String> = row.try_get("base_commit_id")?;
@@ -133,14 +129,10 @@ pub(crate) async fn resolve_local_draft(
     {
         let draft_id: String = existing.try_get("draft_id")?;
         let stored_project_id: String = existing.try_get("project_id")?;
-        let stored_scope: String = existing.try_get("resource_scope")?;
         let stored_kind: String = existing.try_get("resource_kind")?;
-        if stored_project_id != project_id
-            || stored_scope != scope.as_str()
-            || stored_kind != resource.as_str()
-        {
+        if stored_project_id != project_id || stored_kind != resource.as_str() {
             return Err(DaemonError::InvalidRequest(format!(
-                "local draft {draft_id} belongs to a different project, scope, or resource kind"
+                "local draft {draft_id} belongs to a different project or resource kind"
             )));
         }
         let stored_base_commit_id: Option<String> = existing.try_get("base_commit_id")?;

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -2027,6 +2027,79 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn mcp_text_update_of_org_resource_resolves_its_real_scope() {
+        let (_temp, state) = test_state().await;
+        sqlx::query(
+            "INSERT INTO cached_refs (
+                ref_key, name, scope, org_id, project_id, commit_id, etag, server_updated_at
+             ) VALUES ('org:org_test', 'refs/heads/main', 'org', 'org_test', NULL,
+                       'commit_test', '\"commit_test\"', '2026-07-21T00:00:00Z')",
+        )
+        .execute(&state.inner.pool)
+        .await
+        .unwrap();
+        let service = DaemonIpcService::new(state);
+        let original = service
+            .load_memory(LoadMemoryRequest {
+                project_id: "prj_test".to_owned(),
+                ids: vec!["rule_testing".to_owned()],
+                known_hashes: BTreeMap::new(),
+            })
+            .await
+            .unwrap()
+            .resources
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let response = service
+            .dispatch(DaemonIpcRequest::new(
+                "store_draft_operation",
+                json!({
+                    "project_id": "prj_test",
+                    "scope": "project",
+                    "resource": "rule",
+                    "op": {
+                        "update": {
+                            "id": "rule_testing",
+                            "expected_hash": original.content_hash,
+                            "replacements": [{
+                                "old_text": "Run integration tests.",
+                                "new_text": "Run integration and regression tests."
+                            }]
+                        }
+                    },
+                    "source": "mcp_store"
+                }),
+            ))
+            .await;
+        assert!(
+            response.ok,
+            "daemon rejected org text replacement envelope: {:?}",
+            response.error
+        );
+        let stored: DaemonDraftOperationResponse = serde_json::from_value(response.payload).unwrap();
+
+        let detail = service.get_draft(&stored.draft_id).await.unwrap();
+        assert_eq!(detail.draft.scope, crate::DaemonDraftScope::Org);
+
+        let loaded = service
+            .load_memory(LoadMemoryRequest {
+                project_id: "prj_test".to_owned(),
+                ids: vec!["rule_testing".to_owned()],
+                known_hashes: BTreeMap::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            loaded.resources[0].content.as_deref(),
+            Some(
+                "# Testing\n\nApply when changing retrieval.\n\nRun integration and regression tests.\n\nTags: testing"
+            )
+        );
+    }
+
     #[test]
     fn draft_overlay_uses_the_complete_base_result_for_every_crud_action() {
         fn context_resource(path: &str, content: &str, commit_id: &str) -> EffectiveResource {

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -2079,7 +2079,8 @@ mod tests {
             "daemon rejected org text replacement envelope: {:?}",
             response.error
         );
-        let stored: DaemonDraftOperationResponse = serde_json::from_value(response.payload).unwrap();
+        let stored: DaemonDraftOperationResponse =
+            serde_json::from_value(response.payload).unwrap();
 
         let detail = service.get_draft(&stored.draft_id).await.unwrap();
         assert_eq!(detail.draft.scope, crate::DaemonDraftScope::Org);
@@ -2121,7 +2122,10 @@ mod tests {
             discarded.error
         );
         let detail = service.get_draft(&stored.draft_id).await.unwrap();
-        assert_eq!(detail.draft.status, crate::DaemonLocalDraftStatus::Discarded);
+        assert_eq!(
+            detail.draft.status,
+            crate::DaemonLocalDraftStatus::Discarded
+        );
 
         let reverted = service
             .load_memory(LoadMemoryRequest {
@@ -2131,7 +2135,10 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(reverted.resources[0].content.as_deref(), original.content.as_deref());
+        assert_eq!(
+            reverted.resources[0].content.as_deref(),
+            original.content.as_deref()
+        );
     }
 
     #[test]

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -2098,6 +2098,40 @@ mod tests {
                 "# Testing\n\nApply when changing retrieval.\n\nRun integration and regression tests.\n\nTags: testing"
             )
         );
+
+        let discarded = service
+            .dispatch(DaemonIpcRequest::new(
+                "store_draft_operation",
+                json!({
+                    "project_id": "prj_test",
+                    "scope": "project",
+                    "resource": "rule",
+                    "op": {
+                        "discard": {
+                            "id": "rule_testing"
+                        }
+                    },
+                    "source": "mcp_store"
+                }),
+            ))
+            .await;
+        assert!(
+            discarded.ok,
+            "daemon rejected discarding an org draft with project scope: {:?}",
+            discarded.error
+        );
+        let detail = service.get_draft(&stored.draft_id).await.unwrap();
+        assert_eq!(detail.draft.status, crate::DaemonLocalDraftStatus::Discarded);
+
+        let reverted = service
+            .load_memory(LoadMemoryRequest {
+                project_id: "prj_test".to_owned(),
+                ids: vec!["rule_testing".to_owned()],
+                known_hashes: BTreeMap::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(reverted.resources[0].content.as_deref(), original.content.as_deref());
     }
 
     #[test]

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -1135,6 +1135,13 @@ impl DaemonState {
                 ),
             });
         }
+        let resolved_scope = match resource.scope {
+            SourceScope::Org => DaemonDraftScope::Org,
+            SourceScope::Project => DaemonDraftScope::Project,
+        };
+        if request.scope != resolved_scope {
+            request.scope = resolved_scope;
+        }
         let content = resource.content.ok_or_else(|| DaemonError::State {
             code: "memory_content_unavailable",
             message: format!(

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -1871,17 +1871,17 @@ pub(crate) async fn apply_issue_gate(
             return Err(DaemonError::InvalidRequest(format!(
                 "cannot approve ISSUE-{:03}: verification {} still incomplete: {list}",
                 request.issue_number,
-                if pending.len() == 1 { "step is" } else { "steps are" }
+                if pending.len() == 1 {
+                    "step is"
+                } else {
+                    "steps are"
+                }
             )));
         }
     }
     let target = match (request.action, current.board_state) {
-        (IssueGateAction::ApproveClosure, IssueBoardState::InReview) => {
-            IssueBoardState::Done
-        }
-        (IssueGateAction::RequestChanges, IssueBoardState::InReview) => {
-            IssueBoardState::InProgress
-        }
+        (IssueGateAction::ApproveClosure, IssueBoardState::InReview) => IssueBoardState::Done,
+        (IssueGateAction::RequestChanges, IssueBoardState::InReview) => IssueBoardState::InProgress,
         (IssueGateAction::Reopen, IssueBoardState::Done) => IssueBoardState::Todo,
         (action, state) => {
             return Err(run_conflict(format!(
@@ -2460,12 +2460,15 @@ async fn load_project_state_events(
         let issue_number: i64 = row.try_get("issue_number")?;
         let from_state: String = row.try_get("from_state")?;
         let to_state: String = row.try_get("to_state")?;
-        events.entry(issue_number).or_default().push(IssueStateEvent {
-            from_state: IssueBoardState::from_db(&from_state)?,
-            to_state: IssueBoardState::from_db(&to_state)?,
-            changed_by_run_id: row.try_get("changed_by_run_id")?,
-            occurred_at: row.try_get("occurred_at")?,
-        });
+        events
+            .entry(issue_number)
+            .or_default()
+            .push(IssueStateEvent {
+                from_state: IssueBoardState::from_db(&from_state)?,
+                to_state: IssueBoardState::from_db(&to_state)?,
+                changed_by_run_id: row.try_get("changed_by_run_id")?,
+                occurred_at: row.try_get("occurred_at")?,
+            });
     }
     Ok(events)
 }


### PR DESCRIPTION
## Summary

Two fixes on one branch (per request, both verified in the macOS app):

### 1. daemon: org-scope Draft updates fail with "absent from its Base Commit"
MCP store hardcodes `scope=project` when persisting a Draft operation, so updating an org-scope resource stored `resource_scope='project'`. The search overlay then cannot find the target in the base commit tree.

- `materialize_text_update` now corrects `request.scope` from the loaded target resource (`crates/daemon/src/state.rs`)
- `resolve_local_draft` keeps project/kind validation but follows the stored scope for existing drafts, so discard/delete on org drafts work too (`crates/daemon/src/draft.rs`)
- New test: `search::tests::mcp_text_update_of_org_resource_resolves_its_real_scope` (update → load overlay → discard → revert)

### 2. macos: board vertical scroll extent computed from the visible column
`LazyHStack` only lays out columns near the viewport, so vertical scroll extent followed the visible (e.g. Todo) column; taller columns such as In Review could not be scrolled to the bottom. Replaced with a plain `HStack` — the five-column board is small, and content now sizes to the tallest column (`apps/macos/Sources/Features/IssueBoardView.swift`).

## Verification
- daemon: 101 lib tests + 55 daemon_lifecycle tests pass (7 server_integration failures are pre-existing environment issues, same on main)
- macOS: full test suite passes, including IssueBoardLayoutTests
- Deployed via `apps/macos/Scripts/run.sh`; org-scope workflow/CODING.md was updated end-to-end through the fixed daemon