### PR TITLE
server: enforce versioned Review collaboration

### DIFF
--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -125,6 +125,7 @@ async fn approve_and_merge(
     let approved = repository
         .create_review_decision(
             &review.review.review_id,
+            &review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: review.review.version,
@@ -480,6 +481,7 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
     let rejected = repository
         .create_review_decision(
             &review.review.review_id,
+            &review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Rejected,
                 expected_review_version: review.review.version,
@@ -1379,6 +1381,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
     let approved = repository
         .create_review_decision(
             &review.review.review_id,
+            &review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: review.review.version,
@@ -2477,6 +2480,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
     let approved = repository
         .create_review_decision(
             &review.review.review_id,
+            &review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: review.review.version,

--- a/crates/server/migrations/20260809000100_add_review_comment_anchors.sql
+++ b/crates/server/migrations/20260809000100_add_review_comment_anchors.sql
@@ -1,0 +1,3 @@
+ALTER TABLE review_comments
+    ADD COLUMN anchor_path TEXT,
+    ADD COLUMN anchor_line BIGINT;

--- a/crates/server/migrations/20260810000100_add_review_versions_and_decisions.sql
+++ b/crates/server/migrations/20260810000100_add_review_versions_and_decisions.sql
@@ -1,0 +1,30 @@
+ALTER TABLE review_comments
+    ADD COLUMN review_version BIGINT;
+
+UPDATE review_comments
+SET anchor_path = NULL, anchor_line = NULL
+WHERE (anchor_path IS NULL) <> (anchor_line IS NULL)
+   OR anchor_line < 1;
+
+UPDATE review_comments AS comment
+SET review_version = review.version
+FROM reviews AS review
+WHERE review.review_id = comment.review_id;
+
+ALTER TABLE review_comments
+    ALTER COLUMN review_version SET NOT NULL,
+    ADD CONSTRAINT review_comments_review_version_positive CHECK (review_version > 0),
+    ADD CONSTRAINT review_comments_anchor_pair
+        CHECK ((anchor_path IS NULL) = (anchor_line IS NULL)),
+    ADD CONSTRAINT review_comments_anchor_line_positive
+        CHECK (anchor_line IS NULL OR anchor_line > 0);
+
+-- Decision actors are audit data. Users are disabled rather than hard-deleted, so
+-- RESTRICT keeps the human attribution intact instead of silently orphaning it.
+ALTER TABLE reviews
+    ADD COLUMN decided_by_user_id TEXT REFERENCES users(user_id) ON DELETE RESTRICT,
+    ADD COLUMN decided_at TIMESTAMPTZ;
+
+ALTER TABLE reviews
+    ADD CONSTRAINT reviews_decision_metadata_pair
+    CHECK ((decided_by_user_id IS NULL) = (decided_at IS NULL));

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -794,6 +794,9 @@ pub struct Review {
     pub version: i64,
     pub decision_body: Option<String>,
     pub approved_result_hash: Option<String>,
+    pub decided_by: Option<UserRef>,
+    #[serde(with = "time::serde::rfc3339::option")]
+    pub decided_at: Option<OffsetDateTime>,
     pub coordination: DraftCoordination,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
@@ -827,6 +830,11 @@ pub struct ReviewComment {
     pub review_id: String,
     pub author: UserRef,
     pub body: String,
+    #[serde(default)]
+    pub anchor_path: Option<String>,
+    #[serde(default)]
+    pub anchor_line: Option<i64>,
+    pub review_version: i64,
     #[serde(with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
 }
@@ -834,6 +842,11 @@ pub struct ReviewComment {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateReviewCommentRequest {
     pub body: String,
+    pub expected_review_version: i64,
+    #[serde(default)]
+    pub anchor_path: Option<String>,
+    #[serde(default)]
+    pub anchor_line: Option<i64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1536,7 +1536,7 @@ async fn delete_draft(
     Ok(Json(
         state
             .repository
-            .discard_draft(&draft_id, expected_version)
+            .discard_draft(&draft_id, &principal.user_id, expected_version)
             .await?,
     ))
 }
@@ -1757,7 +1757,7 @@ async fn create_review_decision(
     Ok(Json(
         state
             .repository
-            .create_review_decision(&review_id, request)
+            .create_review_decision(&review_id, &principal.user_id, request)
             .await?,
     ))
 }

--- a/crates/server/src/repository.rs
+++ b/crates/server/src/repository.rs
@@ -1818,6 +1818,7 @@ impl ServerRepository {
     pub async fn discard_draft(
         &self,
         draft_id: &str,
+        actor_user_id: &str,
         expected_draft_version: i64,
     ) -> Result<DeleteResult, ServerError> {
         let mut tx = self.pool.begin().await?;
@@ -1856,10 +1857,12 @@ impl ServerRepository {
             "UPDATE reviews
              SET status = 'rejected', version = version + 1,
                  decision_body = 'Draft discarded.', approved_result_hash = NULL,
+                 decided_by_user_id = $2, decided_at = now(),
                  updated_at = now()
              WHERE draft_id = $1 AND status IN ('open', 'approved')",
         )
         .bind(draft_id)
+        .bind(actor_user_id)
         .execute(&mut *tx)
         .await?;
         insert_draft_event(
@@ -2229,18 +2232,78 @@ impl ServerRepository {
                 "review comment body must not be empty".to_owned(),
             ));
         }
+        let anchor = match (request.anchor_path.as_deref(), request.anchor_line) {
+            (None, None) => None,
+            (Some(path), Some(line)) if !path.is_empty() && line > 0 => Some((path, line)),
+            (Some(_), Some(_)) => {
+                return Err(ServerError::InvalidRequest(
+                    "review comment anchor_path must not be empty and anchor_line must be positive"
+                        .to_owned(),
+                ));
+            }
+            _ => {
+                return Err(ServerError::InvalidRequest(
+                    "review comment anchor_path and anchor_line must be provided together"
+                        .to_owned(),
+                ));
+            }
+        };
         let mut tx = self.pool.begin().await?;
-        load_review(&mut tx, review_id).await?;
+        let review_row = sqlx::query(
+            "SELECT draft_id, version
+             FROM reviews
+             WHERE review_id = $1
+             FOR UPDATE",
+        )
+        .bind(review_id)
+        .fetch_optional(&mut *tx)
+        .await?
+        .ok_or_else(|| ServerError::not_found("review", review_id))?;
+        let review_version: i64 = review_row.try_get("version")?;
+        if review_version != request.expected_review_version {
+            return Err(ServerError::version_conflict(
+                "review",
+                request.expected_review_version,
+                review_version,
+            ));
+        }
+        if let Some((anchor_path, anchor_line)) = anchor {
+            let draft_id: String = review_row.try_get("draft_id")?;
+            let final_state = draft_result_state(&mut tx, &draft_id).await?;
+            let final_path = final_state.resource.path.as_deref();
+            if !final_state.exists || final_path != Some(anchor_path) {
+                return Err(ServerError::InvalidRequest(format!(
+                    "review comment anchor_path must match the final review path ({})",
+                    final_path.unwrap_or("deleted resource")
+                )));
+            }
+            let line_count = final_state
+                .content
+                .as_ref()
+                .map(|content| review_comment_line_count(content_text(content)))
+                .unwrap_or(0);
+            if anchor_line > line_count {
+                return Err(ServerError::InvalidRequest(format!(
+                    "review comment anchor_line {anchor_line} is outside the final review line range 1..={line_count}"
+                )));
+            }
+        }
         user_ref(&mut tx, author_user_id).await?;
         let comment_id = prefixed_id("cmt");
         sqlx::query(
-            "INSERT INTO review_comments (comment_id, review_id, author_user_id, body)
-             VALUES ($1, $2, $3, $4)",
+            "INSERT INTO review_comments (
+                comment_id, review_id, author_user_id, body, anchor_path, anchor_line,
+                review_version
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(&comment_id)
         .bind(review_id)
         .bind(author_user_id)
-        .bind(request.body)
+        .bind(&request.body)
+        .bind(request.anchor_path.as_deref())
+        .bind(request.anchor_line)
+        .bind(review_version)
         .execute(&mut *tx)
         .await?;
         let comments = load_review_comments(&mut tx, review_id).await?;
@@ -2255,6 +2318,7 @@ impl ServerRepository {
     pub async fn create_review_decision(
         &self,
         review_id: &str,
+        decided_by_user_id: &str,
         request: CreateReviewDecisionRequest,
     ) -> Result<ReviewDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
@@ -2329,13 +2393,15 @@ impl ServerRepository {
         sqlx::query(
             "UPDATE reviews
              SET status = $2, version = version + 1, decision_body = $3,
-                 approved_result_hash = $4, updated_at = now()
+                 approved_result_hash = $4, decided_by_user_id = $5,
+                 decided_at = now(), updated_at = now()
              WHERE review_id = $1",
         )
         .bind(review_id)
         .bind(next_status)
         .bind(&request.body)
         .bind(&approved_result_hash)
+        .bind(decided_by_user_id)
         .execute(&mut *tx)
         .await?;
 
@@ -2467,6 +2533,7 @@ impl ServerRepository {
             "UPDATE reviews
              SET status = 'open', version = version + 1, decision_body = NULL,
                  approved_result_hash = NULL,
+                 decided_by_user_id = NULL, decided_at = NULL,
                  title = COALESCE($2, title), description = COALESCE($3, description),
                  updated_at = now()
              WHERE review_id = $1",
@@ -3157,6 +3224,8 @@ async fn refresh_review_after_draft_content_change(
          SET status = CASE WHEN status = 'approved' AND NOT $2 THEN 'open' ELSE status END,
              approved_result_hash = CASE WHEN status = 'approved' AND $2 THEN approved_result_hash ELSE NULL END,
              decision_body = CASE WHEN status = 'approved' AND $2 THEN decision_body ELSE NULL END,
+             decided_by_user_id = CASE WHEN status = 'approved' AND $2 THEN decided_by_user_id ELSE NULL END,
+             decided_at = CASE WHEN status = 'approved' AND $2 THEN decided_at ELSE NULL END,
              version = version + 1,
              updated_at = now()
          WHERE draft_id = $1 AND status IN ('open', 'approved')",
@@ -4226,10 +4295,10 @@ fn diff_resource_states(
     }
 }
 
-async fn draft_result_hash(
+async fn draft_result_state(
     tx: &mut Transaction<'_, Postgres>,
     draft_id: &str,
-) -> Result<String, ServerError> {
+) -> Result<ReconciliationResourceState, ServerError> {
     let row = sqlx::query(
         "SELECT base_commit_id, resource_scope, resource_kind, target_id, path
          FROM drafts WHERE draft_id = $1",
@@ -4252,7 +4321,14 @@ async fn draft_result_hash(
     let base =
         resource_state_at_commit(tx, base_commit_id.as_deref(), &resource, allow_path_lookup)
             .await?;
-    state_hash(&apply_operations_to_state(base, &operations)?)
+    apply_operations_to_state(base, &operations)
+}
+
+async fn draft_result_hash(
+    tx: &mut Transaction<'_, Postgres>,
+    draft_id: &str,
+) -> Result<String, ServerError> {
+    state_hash(&draft_result_state(tx, draft_id).await?)
 }
 
 async fn target_ref_for_draft(
@@ -4633,6 +4709,8 @@ async fn apply_draft_rebase_in_tx(
              SET status = CASE WHEN status = 'approved' AND NOT $2 THEN 'open' ELSE status END,
                  approved_result_hash = CASE WHEN status = 'approved' AND $2 THEN approved_result_hash ELSE NULL END,
                  decision_body = CASE WHEN status = 'approved' AND $2 THEN decision_body ELSE NULL END,
+                 decided_by_user_id = CASE WHEN status = 'approved' AND $2 THEN decided_by_user_id ELSE NULL END,
+                 decided_at = CASE WHEN status = 'approved' AND $2 THEN decided_at ELSE NULL END,
                  version = version + 1, updated_at = now()
              WHERE review_id = $1",
         )
@@ -4693,10 +4771,15 @@ async fn load_review(
         "SELECT
             r.review_id, r.project_id, r.draft_id, r.title, r.description,
             r.status, r.version, r.decision_body, r.approved_result_hash,
+            r.decided_by_user_id, r.decided_at,
             r.created_at, r.updated_at,
-            u.user_id, u.email, u.display_name, u.avatar_url, u.role
+            u.user_id, u.email, u.display_name, u.avatar_url, u.role,
+            du.user_id AS decision_user_id, du.email AS decision_user_email,
+            du.display_name AS decision_user_display_name,
+            du.avatar_url AS decision_user_avatar_url, du.role AS decision_user_role
          FROM reviews r
          JOIN users u ON u.user_id = r.author_user_id
+         LEFT JOIN users du ON du.user_id = r.decided_by_user_id
          WHERE r.review_id = $1",
     )
     .bind(review_id)
@@ -4739,6 +4822,19 @@ fn review_from_row(
         version: row.try_get("version")?,
         decision_body: row.try_get("decision_body")?,
         approved_result_hash: row.try_get("approved_result_hash")?,
+        decided_by: row
+            .try_get::<Option<String>, _>("decision_user_id")?
+            .map(|user_id| {
+                Ok::<UserRef, sqlx::Error>(UserRef {
+                    user_id,
+                    email: row.try_get("decision_user_email")?,
+                    display_name: row.try_get("decision_user_display_name")?,
+                    avatar_url: row.try_get("decision_user_avatar_url")?,
+                    role: row.try_get("decision_user_role")?,
+                })
+            })
+            .transpose()?,
+        decided_at: row.try_get("decided_at")?,
         coordination,
         created_at: row.try_get("created_at")?,
         updated_at: row.try_get("updated_at")?,
@@ -4751,7 +4847,8 @@ async fn load_review_comments(
 ) -> Result<Vec<ReviewComment>, ServerError> {
     let rows = sqlx::query(
         "SELECT
-            c.comment_id, c.review_id, c.body, c.created_at,
+            c.comment_id, c.review_id, c.body, c.anchor_path, c.anchor_line,
+            c.review_version, c.created_at,
             u.user_id, u.email, u.display_name, u.avatar_url, u.role
          FROM review_comments c
          JOIN users u ON u.user_id = c.author_user_id
@@ -4770,10 +4867,21 @@ async fn load_review_comments(
                 review_id: row.try_get("review_id")?,
                 author: user_ref_from_row(row)?,
                 body: row.try_get("body")?,
+                anchor_path: row.try_get("anchor_path")?,
+                anchor_line: row.try_get("anchor_line")?,
+                review_version: row.try_get("review_version")?,
                 created_at: row.try_get("created_at")?,
             })
         })
         .collect()
+}
+
+fn review_comment_line_count(content: &str) -> i64 {
+    if content.is_empty() {
+        0
+    } else {
+        content.split('\n').count() as i64
+    }
 }
 
 async fn apply_operation(
@@ -6534,6 +6642,15 @@ mod tests {
         assert!(validate_rule_content("").is_err());
         assert!(validate_rule_content("  \n").is_err());
         assert!(validate_rule_content("# Testing\n\nRun focused tests.").is_ok());
+    }
+
+    #[test]
+    fn review_comment_line_count_matches_client_line_numbering() {
+        assert_eq!(review_comment_line_count(""), 0);
+        assert_eq!(review_comment_line_count("one"), 1);
+        assert_eq!(review_comment_line_count("one\ntwo"), 2);
+        assert_eq!(review_comment_line_count("one\n"), 2);
+        assert_eq!(review_comment_line_count("one\n\n"), 3);
     }
 
     #[test]

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -102,9 +102,13 @@ async fn draft_created_resource_must_be_discarded_instead_of_deleted() {
             .contains("must be discarded instead of deleted")
     );
 
-    repo.discard_draft(&draft.draft.draft_id, draft.draft.version)
-        .await
-        .unwrap();
+    repo.discard_draft(
+        &draft.draft.draft_id,
+        &bootstrap.user_id,
+        draft.draft.version,
+    )
+    .await
+    .unwrap();
     let discarded = repo.get_draft(&draft.draft.draft_id).await.unwrap();
     assert_eq!(discarded.draft.status, DraftStatus::Discarded);
 }
@@ -431,6 +435,8 @@ async fn draft_review_merge_produces_project_commit() {
     let review_detail = create_review_for_draft(app.clone(), &draft).await;
     let review = review_detail.review;
     assert_eq!(review.status, ReviewStatus::Open);
+    assert_eq!(review.decided_by, None);
+    assert_eq!(review.decided_at, None);
     assert_eq!(review_detail.draft.status, DraftStatus::Submitted);
 
     let review_page: ReviewListResponse = get_json(
@@ -444,12 +450,16 @@ async fn draft_review_merge_produces_project_commit() {
     let created_comment: ReviewComment = post_json(
         app.clone(),
         &format!("/api/v1/reviews/{}/comments", review.review_id),
-        &CreateReviewCommentRequest {
-            body: "Ready to merge".to_owned(),
-        },
+        &serde_json::json!({
+            "body": "Ready to merge",
+            "expected_review_version": review.version
+        }),
     )
     .await;
     assert_eq!(created_comment.author.user_id, user_id);
+    assert_eq!(created_comment.anchor_path, None);
+    assert_eq!(created_comment.anchor_line, None);
+    assert_eq!(created_comment.review_version, review.version);
 
     let comments: ReviewCommentListResponse = get_json(
         app.clone(),
@@ -478,6 +488,24 @@ async fn draft_review_merge_produces_project_commit() {
     .await;
     let review = review_detail.review;
     assert_eq!(review.status, ReviewStatus::Approved);
+    assert_eq!(
+        review.decided_by.as_ref().map(|user| user.user_id.as_str()),
+        Some(user_id.as_str())
+    );
+    assert_eq!(
+        review
+            .decided_by
+            .as_ref()
+            .and_then(|user| user.display_name.as_deref()),
+        Some("Owner")
+    );
+    let approved_at = review.decided_at.expect("approval time should be recorded");
+    let incomplete_decision_metadata =
+        sqlx::query("UPDATE reviews SET decided_by_user_id = NULL WHERE review_id = $1")
+            .bind(&review.review_id)
+            .execute(&postgres.pool)
+            .await;
+    assert!(incomplete_decision_metadata.is_err());
 
     let merge: ReviewMergeResult = post_json_with_etag(
         app.clone(),
@@ -489,6 +517,8 @@ async fn draft_review_merge_produces_project_commit() {
     )
     .await;
     assert_eq!(merge.review.status, ReviewStatus::Merged);
+    assert_eq!(merge.review.decided_by, review.decided_by);
+    assert_eq!(merge.review.decided_at, Some(approved_at));
     assert_eq!(merge.applied_operation_count, 1);
     let commit_id = merge.commit_id.expect("merge should create a commit");
     let merged_draft: DraftDetail = get_json(
@@ -1120,6 +1150,7 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
     let project_review = repo
         .create_review_decision(
             &project_review.review.review_id,
+            &project_review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: project_review.review.version,
@@ -1198,6 +1229,7 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
     let org_review = repo
         .create_review_decision(
             &org_review.review.review_id,
+            &org_review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: org_review.review.version,
@@ -1323,6 +1355,8 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
     let submitted = create_review_for_draft(owner_app.clone(), &draft).await;
     assert_eq!(submitted.review.status, ReviewStatus::Open);
     assert_eq!(submitted.review.decision_body, None);
+    assert_eq!(submitted.review.decided_by, None);
+    assert_eq!(submitted.review.decided_at, None);
     assert_eq!(submitted.draft.status, DraftStatus::Submitted);
     assert_eq!(submitted.draft.version, 2);
     let visible_to_reviewer: ReviewDetail = get_json(
@@ -1368,6 +1402,23 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
     .await;
     assert_eq!(rejected.review.status, ReviewStatus::Rejected);
     assert_eq!(rejected.review.version, 2);
+    assert_eq!(
+        rejected
+            .review
+            .decided_by
+            .as_ref()
+            .map(|user| user.user_id.as_str()),
+        Some(member_id.as_str())
+    );
+    assert_eq!(
+        rejected
+            .review
+            .decided_by
+            .as_ref()
+            .and_then(|user| user.display_name.as_deref()),
+        Some("Member")
+    );
+    assert!(rejected.review.decided_at.is_some());
     assert_eq!(
         rejected.review.decision_body.as_deref(),
         Some("Add the operational constraint.")
@@ -1553,6 +1604,8 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
     assert_eq!(resubmitted.review.version, 4);
     assert_eq!(resubmitted.review.title, "Revised review lifecycle context");
     assert_eq!(resubmitted.review.decision_body, None);
+    assert_eq!(resubmitted.review.decided_by, None);
+    assert_eq!(resubmitted.review.decided_at, None);
     assert_eq!(resubmitted.draft.status, DraftStatus::Submitted);
     assert_eq!(
         resubmitted.draft.base_commit_id.as_deref(),
@@ -1697,6 +1750,19 @@ async fn stale_draft_cannot_overwrite_a_new_project_ref() {
     )
     .await;
     assert_eq!(discarded.review.status, ReviewStatus::Rejected);
+    assert_eq!(
+        discarded.review.decision_body.as_deref(),
+        Some("Draft discarded.")
+    );
+    assert_eq!(
+        discarded
+            .review
+            .decided_by
+            .as_ref()
+            .map(|user| user.user_id.as_str()),
+        Some(bootstrap.user_id.as_str())
+    );
+    assert!(discarded.review.decided_at.is_some());
     assert_eq!(discarded.draft.status, DraftStatus::Discarded);
 
     let current = create_approved_context_review(
@@ -1961,6 +2027,8 @@ async fn stale_draft_cannot_overwrite_a_new_project_ref() {
         rebased_review.approved_result_hash,
         behind.review.approved_result_hash
     );
+    assert_eq!(rebased_review.decided_by, behind.review.decided_by);
+    assert_eq!(rebased_review.decided_at, behind.review.decided_at);
 
     let merge: ReviewMergeResult = post_json_with_etag(
         app.clone(),
@@ -2037,6 +2105,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     let seed_review = repo
         .create_review_decision(
             &seed_review.review.review_id,
+            &seed_review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: seed_review.review.version,
@@ -2113,6 +2182,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     let local_review = repo
         .create_review_decision(
             &local_review.review.review_id,
+            &local_review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: local_review.review.version,
@@ -2183,6 +2253,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     let remote_review = repo
         .create_review_decision(
             &remote_review.review.review_id,
+            &remote_review.review.author.user_id,
             CreateReviewDecisionRequest {
                 decision: ReviewDecision::Approved,
                 expected_review_version: remote_review.review.version,
@@ -2258,7 +2329,12 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
         resolved.draft.draft.base_commit_id.as_deref(),
         Some(current_commit_id.as_str())
     );
-    assert_eq!(resolved.review.as_ref().unwrap().status, ReviewStatus::Open);
+    let invalidated_review = resolved.review.as_ref().unwrap();
+    assert_eq!(invalidated_review.status, ReviewStatus::Open);
+    assert_eq!(invalidated_review.decision_body, None);
+    assert_eq!(invalidated_review.approved_result_hash, None);
+    assert_eq!(invalidated_review.decided_by, None);
+    assert_eq!(invalidated_review.decided_at, None);
     let revision_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM draft_revisions WHERE draft_id = $1")
             .bind(&local_update.draft.draft_id)
@@ -3202,4 +3278,214 @@ where
 {
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     serde_json::from_slice(&body).unwrap()
+}
+
+#[tokio::test]
+async fn review_comments_support_line_anchors() {
+    let postgres = common::migrated_postgres().await;
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Anchored comments",
+    )
+    .await;
+    let (app, _) = common::authenticated_router(postgres.pool.clone()).await;
+    let seed = create_approved_context_review(
+        app.clone(),
+        &bootstrap.project_id,
+        None,
+        "context/anchored.md",
+        "# Anchored\n\nBody.\n",
+    )
+    .await;
+    let seed_merge: ReviewMergeResult = post_json_with_etag(
+        app.clone(),
+        &format!("/api/v1/reviews/{}/merges", seed.review_id),
+        "\"ref-none\"",
+        &CreateReviewMergeRequest {
+            expected_review_version: seed.version,
+        },
+    )
+    .await;
+    let base_commit_id = seed_merge
+        .commit_id
+        .expect("seeding the anchored resource should create a commit");
+    let base_payload: CommitPayload =
+        get_json(app.clone(), &format!("/api/v1/commits/{base_commit_id}")).await;
+    let resource_id = base_payload
+        .tree
+        .entries
+        .iter()
+        .find(|entry| entry.path.as_deref() == Some("context/anchored.md"))
+        .expect("seeded anchored resource should be present in the base commit")
+        .id
+        .clone();
+    let draft: DraftDetail = post_json(
+        app.clone(),
+        "/api/v1/drafts",
+        &CreateDraftRequest {
+            daemon_installation_id: "daemon_anchors".to_owned(),
+            project_id: bootstrap.project_id.clone(),
+            base_commit_id: Some(base_commit_id),
+            title: "Anchored comment draft".to_owned(),
+            description: None,
+            resource: DraftResourceRef {
+                scope: ResourceScope::Project,
+                kind: DraftResourceKind::Context,
+                id: Some(resource_id.clone()),
+                path: None,
+            },
+            operations: vec![DraftOperationInput {
+                action: DraftOperationAction::Rename,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Project,
+                    kind: DraftResourceKind::Context,
+                    id: Some(resource_id),
+                    path: None,
+                },
+                content: None,
+                new_path: Some("context/anchored-final.md".to_owned()),
+            }],
+        },
+    )
+    .await;
+    let review = create_review_for_draft(app.clone(), &draft).await;
+    let review_id = review.review.review_id.clone();
+
+    let unpaired_storage_anchor = sqlx::query(
+        "INSERT INTO review_comments (
+            comment_id, review_id, author_user_id, body, anchor_path, anchor_line,
+            review_version
+         ) VALUES ('cmt_unpaired_storage', $1, $2, 'invalid', $3, NULL, $4)",
+    )
+    .bind(&review_id)
+    .bind(&bootstrap.user_id)
+    .bind("context/anchored.md")
+    .bind(review.review.version)
+    .execute(&postgres.pool)
+    .await;
+    assert!(unpaired_storage_anchor.is_err());
+
+    let non_positive_storage_anchor = sqlx::query(
+        "INSERT INTO review_comments (
+            comment_id, review_id, author_user_id, body, anchor_path, anchor_line,
+            review_version
+         ) VALUES ('cmt_non_positive_storage', $1, $2, 'invalid', $3, 0, $4)",
+    )
+    .bind(&review_id)
+    .bind(&bootstrap.user_id)
+    .bind("context/anchored.md")
+    .bind(review.review.version)
+    .execute(&postgres.pool)
+    .await;
+    assert!(non_positive_storage_anchor.is_err());
+
+    let anchored: ReviewComment = post_json(
+        app.clone(),
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Trailing line looks off".to_owned(),
+            expected_review_version: review.review.version,
+            anchor_path: Some("context/anchored-final.md".to_owned()),
+            anchor_line: Some(4),
+        },
+    )
+    .await;
+    assert_eq!(
+        anchored.anchor_path.as_deref(),
+        Some("context/anchored-final.md")
+    );
+    assert_eq!(anchored.anchor_line, Some(4));
+    assert_eq!(anchored.review_version, review.review.version);
+
+    let general: ReviewComment = post_json(
+        app.clone(),
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Overall direction is fine".to_owned(),
+            expected_review_version: review.review.version,
+            anchor_path: None,
+            anchor_line: None,
+        },
+    )
+    .await;
+    assert_eq!(general.anchor_path, None);
+    assert_eq!(general.anchor_line, None);
+    assert_eq!(general.review_version, review.review.version);
+
+    let detail: ReviewDetail = get_json(app.clone(), &format!("/api/v1/reviews/{review_id}")).await;
+    assert_eq!(detail.comments.len(), 2);
+    let anchored_in_detail = detail
+        .comments
+        .iter()
+        .find(|comment| comment.comment_id == anchored.comment_id)
+        .expect("anchored comment should appear in review detail");
+    assert_eq!(
+        anchored_in_detail.anchor_path.as_deref(),
+        Some("context/anchored-final.md")
+    );
+    assert_eq!(anchored_in_detail.anchor_line, Some(4));
+    assert_eq!(anchored_in_detail.review_version, review.review.version);
+    let general_in_detail = detail
+        .comments
+        .iter()
+        .find(|comment| comment.comment_id == general.comment_id)
+        .expect("general comment should appear in review detail");
+    assert_eq!(general_in_detail.anchor_line, None);
+    assert_eq!(general_in_detail.anchor_path, None);
+
+    let unpaired = post_response(
+        app.clone(),
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Bad anchor".to_owned(),
+            expected_review_version: review.review.version,
+            anchor_path: None,
+            anchor_line: Some(3),
+        },
+    )
+    .await;
+    assert_eq!(unpaired.status(), StatusCode::BAD_REQUEST);
+
+    let wrong_path = post_response(
+        app.clone(),
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Wrong file".to_owned(),
+            expected_review_version: review.review.version,
+            anchor_path: Some("context/anchored.md".to_owned()),
+            anchor_line: Some(1),
+        },
+    )
+    .await;
+    assert_eq!(wrong_path.status(), StatusCode::BAD_REQUEST);
+
+    let out_of_range = post_response(
+        app.clone(),
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Past the end".to_owned(),
+            expected_review_version: review.review.version,
+            anchor_path: Some("context/anchored-final.md".to_owned()),
+            anchor_line: Some(5),
+        },
+    )
+    .await;
+    assert_eq!(out_of_range.status(), StatusCode::BAD_REQUEST);
+
+    let stale = post_response(
+        app,
+        &format!("/api/v1/reviews/{review_id}/comments"),
+        &CreateReviewCommentRequest {
+            body: "Stale context".to_owned(),
+            expected_review_version: review.review.version - 1,
+            anchor_path: None,
+            anchor_line: None,
+        },
+    )
+    .await;
+    assert_eq!(stale.status(), StatusCode::CONFLICT);
 }

--- a/packages/api-client/tests/public-api.test.ts
+++ b/packages/api-client/tests/public-api.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createPublicApiClient,
   ClumsiesApi,
+  type PublicSchema,
 } from "../src/index";
 
 describe("Clumsies API", () => {
@@ -10,6 +11,7 @@ describe("Clumsies API", () => {
     let mergeIfMatch: string | null = null;
     let submissionIfMatch: string | null = null;
     let projectIdempotencyKey: string | null = null;
+    let reviewCommentBody: Record<string, unknown> | null = null;
     const fetch: typeof globalThis.fetch = async (input, init) => {
       const request = new Request(input, init);
       const url = new URL(request.url);
@@ -26,6 +28,12 @@ describe("Clumsies API", () => {
       }
       if (url.pathname.endsWith("/submissions")) {
         submissionIfMatch = request.headers.get("if-match");
+      }
+      if (
+        request.method === "POST" &&
+        url.pathname === "/api/v1/reviews/review/comments"
+      ) {
+        reviewCommentBody = await request.json() as Record<string, unknown>;
       }
       return new Response("{}", {
         status: 200,
@@ -104,7 +112,12 @@ describe("Clumsies API", () => {
     });
     await api.review("review");
     await api.listReviewComments("review");
-    await api.createReviewComment("review", { body: "Comment" });
+    await api.createReviewComment("review", {
+      body: "Comment",
+      expected_review_version: 3,
+      anchor_path: "notes/a.md",
+      anchor_line: 12,
+    });
     await api.createReviewDecision("review", {
       decision: "approved",
       expected_review_version: 1,
@@ -178,5 +191,40 @@ describe("Clumsies API", () => {
     expect(mergeIfMatch).toBe('"ref-none"');
     expect(submissionIfMatch).toBe('"commit"');
     expect(projectIdempotencyKey).toBe("project-create-test");
+    expect(reviewCommentBody).toEqual({
+      body: "Comment",
+      expected_review_version: 3,
+      anchor_path: "notes/a.md",
+      anchor_line: 12,
+    });
+  });
+
+  test("exposes versioned comments and optional decision audit metadata", () => {
+    const request: PublicSchema<"CreateReviewCommentRequest"> = {
+      body: "Comment",
+      expected_review_version: 3,
+      anchor_path: "notes/a.md",
+      anchor_line: 12,
+    };
+    const commentVersion: Pick<PublicSchema<"ReviewComment">, "review_version"> = {
+      review_version: 4,
+    };
+    const decisionAudit: Pick<
+      PublicSchema<"Review">,
+      "decided_by" | "decided_at"
+    > = {
+      decided_by: {
+        user_id: "reviewer-1",
+        email: "reviewer@example.com",
+        display_name: "Reviewer",
+        avatar_url: null,
+        role: "member",
+      },
+      decided_at: "2026-08-06T01:00:00Z",
+    };
+
+    expect(request.expected_review_version).toBe(3);
+    expect(commentVersion.review_version).toBe(4);
+    expect(decisionAudit.decided_by?.user_id).toBe("reviewer-1");
   });
 });

--- a/packages/api-contract/generated/public.d.ts
+++ b/packages/api-contract/generated/public.d.ts
@@ -1111,6 +1111,9 @@ export interface components {
             version: number;
             decision_body: string | null;
             approved_result_hash: string | null;
+            decided_by?: components["schemas"]["UserRef"] | null;
+            /** Format: date-time */
+            decided_at?: string | null;
             coordination: components["schemas"]["DraftCoordination"];
             /** Format: date-time */
             created_at: string;
@@ -1123,12 +1126,18 @@ export interface components {
         };
         CreateReviewCommentRequest: {
             body: string;
+            expected_review_version: number;
+            anchor_path?: string | null;
+            anchor_line?: number | null;
         };
         ReviewComment: {
             comment_id: string;
             review_id: string;
             author: components["schemas"]["UserRef"];
             body: string;
+            anchor_path: string | null;
+            anchor_line: number | null;
+            review_version: number;
             /** Format: date-time */
             created_at: string;
         };

--- a/packages/api-contract/openapi/clumsies.public.v1.yaml
+++ b/packages/api-contract/openapi/clumsies.public.v1.yaml
@@ -1958,6 +1958,13 @@ components:
           type: [string, "null"]
         approved_result_hash:
           type: [string, "null"]
+        decided_by:
+          oneOf:
+            - $ref: "#/components/schemas/UserRef"
+            - type: "null"
+        decided_at:
+          type: [string, "null"]
+          format: date-time
         coordination:
           $ref: "#/components/schemas/DraftCoordination"
         created_at:
@@ -1978,13 +1985,20 @@ components:
           $ref: "#/components/schemas/PageInfo"
     CreateReviewCommentRequest:
       type: object
-      required: [body]
+      required: [body, expected_review_version]
       properties:
         body:
           type: string
+        expected_review_version:
+          type: integer
+        anchor_path:
+          type: [string, "null"]
+        anchor_line:
+          type: [integer, "null"]
     ReviewComment:
       type: object
-      required: [comment_id, review_id, author, body, created_at]
+      required:
+        [comment_id, review_id, author, body, anchor_path, anchor_line, review_version, created_at]
       properties:
         comment_id:
           type: string
@@ -1994,6 +2008,12 @@ components:
           $ref: "#/components/schemas/UserRef"
         body:
           type: string
+        anchor_path:
+          type: [string, "null"]
+        anchor_line:
+          type: [integer, "null"]
+        review_version:
+          type: integer
         created_at:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary

Review comments could be committed successfully and then fail to load in
the macOS client because the Server response omitted the Review version.
This PR locks and validates Review versions for every comment, validates
final-side line anchors, persists the version, and returns the complete
comment contract.

It also records the decision actor and timestamp and preserves that audit
metadata across merge or a retained approval. The request contract now
requires `expected_review_version`; clients that omit it can no longer
create comments and must be upgraded.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (227 passed, 2 ignored)
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `zig fmt --check src/`
- [x] `zig build`
- [x] `zig build test`
- [x] `bun run api:check`
- [x] `bun run build`
- [x] `bun run test:macos` (121 passed, 2 skipped)
- [x] `shellcheck deploy/server/*.sh`
- [x] `bash deploy/server/server-release-test.sh`
- [x] Production preflight restores a current backup and applies all migrations
- [x] Production health reports migration `20260810000100`
