### PR TITLE
daemon: preserve project idempotency headers

### DIFF
--- a/crates/daemon/src/server_client.rs
+++ b/crates/daemon/src/server_client.rs
@@ -248,6 +248,7 @@ pub(crate) fn filter_proxy_request_headers(
     const ALLOWED: &[&str] = &[
         "accept",
         "content-type",
+        "idempotency-key",
         "if-match",
         "if-none-match",
         "x-clumsies-request-id",
@@ -345,4 +346,36 @@ pub(crate) async fn clear_server_response_cache(pool: &SqlitePool) -> Result<(),
         .execute(pool)
         .await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_request_headers_preserve_contract_headers_and_filter_credentials() {
+        let filtered = filter_proxy_request_headers(BTreeMap::from([
+            ("Accept".to_owned(), "application/json".to_owned()),
+            ("Content-Type".to_owned(), "application/json".to_owned()),
+            ("IdEmPoTeNcY-Key".to_owned(), "project-create-1".to_owned()),
+            ("If-Match".to_owned(), "17".to_owned()),
+            ("If-None-Match".to_owned(), "\"etag\"".to_owned()),
+            ("X-Clumsies-Request-ID".to_owned(), "request-1".to_owned()),
+            ("Authorization".to_owned(), "Bearer caller-token".to_owned()),
+            ("Cookie".to_owned(), "session=caller".to_owned()),
+            ("X-Untrusted".to_owned(), "value".to_owned()),
+        ]));
+
+        assert_eq!(
+            filtered,
+            BTreeMap::from([
+                ("accept".to_owned(), "application/json".to_owned()),
+                ("content-type".to_owned(), "application/json".to_owned()),
+                ("idempotency-key".to_owned(), "project-create-1".to_owned(),),
+                ("if-match".to_owned(), "17".to_owned()),
+                ("if-none-match".to_owned(), "\"etag\"".to_owned()),
+                ("x-clumsies-request-id".to_owned(), "request-1".to_owned(),),
+            ])
+        );
+    }
 }

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -4189,6 +4189,49 @@ async fn daemon_restart_requeues_an_interrupted_operation() {
 }
 
 #[tokio::test]
+async fn server_proxy_preserves_contract_headers_and_rejects_caller_credentials() {
+    let app = Router::new().route("/api/v1/header-probe", post(proxy_header_probe));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{address}");
+    config.project.project_id = Some("prj_headers".to_owned());
+    let (state, _) = common::initialize_authenticated_daemon(config, "test-token", None).await;
+
+    let response = state
+        .server_request(DaemonServerRequest {
+            method: "POST".to_owned(),
+            path: "/api/v1/header-probe".to_owned(),
+            headers: BTreeMap::from([
+                ("IdEmPoTeNcY-Key".to_owned(), "project-create-1".to_owned()),
+                ("If-Match".to_owned(), "17".to_owned()),
+                ("IF-NONE-MATCH".to_owned(), "\"etag\"".to_owned()),
+                ("Authorization".to_owned(), "Bearer caller-token".to_owned()),
+                ("Cookie".to_owned(), "session=caller".to_owned()),
+                ("X-Untrusted".to_owned(), "value".to_owned()),
+            ]),
+            body: Some("{}".to_owned()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(response.status, 200);
+    let probe: ProxyHeaderProbe = serde_json::from_str(&response.body).unwrap();
+    assert_eq!(probe.idempotency_key.as_deref(), Some("project-create-1"));
+    assert_eq!(probe.if_match.as_deref(), Some("17"));
+    assert_eq!(probe.if_none_match.as_deref(), Some("\"etag\""));
+    assert_eq!(probe.authorization, vec!["Bearer test-token"]);
+    assert_eq!(probe.cookie, None);
+    assert_eq!(probe.untrusted, None);
+
+    server.abort();
+}
+
+#[tokio::test]
 async fn server_proxy_uses_stale_cache_only_for_read_failures() {
     let proxy_state = CachedProxyState {
         unavailable: Arc::new(AtomicBool::new(false)),
@@ -4695,6 +4738,39 @@ async fn empty_draft_events() -> Json<serde_json::Value> {
 #[derive(Clone)]
 struct CachedProxyState {
     unavailable: Arc<AtomicBool>,
+}
+
+#[derive(Deserialize)]
+struct ProxyHeaderProbe {
+    idempotency_key: Option<String>,
+    if_match: Option<String>,
+    if_none_match: Option<String>,
+    authorization: Vec<String>,
+    cookie: Option<String>,
+    untrusted: Option<String>,
+}
+
+async fn proxy_header_probe(headers: axum::http::HeaderMap) -> Json<serde_json::Value> {
+    let authorization = headers
+        .get_all("authorization")
+        .iter()
+        .filter_map(|value| value.to_str().ok().map(str::to_owned))
+        .collect::<Vec<_>>();
+    Json(json!({
+        "idempotency_key": proxy_header_value(&headers, "idempotency-key"),
+        "if_match": proxy_header_value(&headers, "if-match"),
+        "if_none_match": proxy_header_value(&headers, "if-none-match"),
+        "authorization": authorization,
+        "cookie": proxy_header_value(&headers, "cookie"),
+        "untrusted": proxy_header_value(&headers, "x-untrusted"),
+    }))
+}
+
+fn proxy_header_value(headers: &axum::http::HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned)
 }
 
 async fn cached_proxy_get(

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::collections::BTreeMap;
+
 use daemon::{
     DaemonConfig, DaemonContentDraftUpdate, DaemonCreateDraftOperation, DaemonDeleteDraftOperation,
     DaemonDraftContent, DaemonDraftListQuery, DaemonDraftOperation,
@@ -8,15 +10,15 @@ use daemon::{
     DaemonMemoryCacheRequest, DaemonMemoryCacheState, DaemonProjectCheckoutRequest,
     DaemonProjectSelectionRequest, DaemonProjectStorageMoveState,
     DaemonProjectStorageReplaceRequest, DaemonProjectStorageRequest, DaemonRenameDraftOperation,
-    DaemonSyncRetryRequest, DaemonUpdateDraftOperation, DraftOperationSyncStatus,
-    LoadMemoryRequest, SyncRetryChannel, SyncState,
+    DaemonServerRequest, DaemonSyncRetryRequest, DaemonUpdateDraftOperation,
+    DraftOperationSyncStatus, LoadMemoryRequest, SyncRetryChannel, SyncState,
 };
 use server::api::{
-    CreateDraftRebaseRequest, CreateDraftRequest, CreateReviewDecisionRequest,
-    CreateReviewMergeRequest, CreateReviewRequest, CreateReviewSubmissionRequest,
-    DraftOperationAction, DraftOperationInput, DraftResourceContent, DraftResourceKind,
-    DraftResourceRef, ReconciliationCandidateStatus, ReplaceProjectOrgSelectionRequest,
-    ResourceScope, ReviewDecision, ReviewMergeResult,
+    CreateDraftRebaseRequest, CreateDraftRequest, CreateProjectRequest,
+    CreateReviewDecisionRequest, CreateReviewMergeRequest, CreateReviewRequest,
+    CreateReviewSubmissionRequest, DraftOperationAction, DraftOperationInput, DraftResourceContent,
+    DraftResourceKind, DraftResourceRef, Project, ReconciliationCandidateStatus,
+    ReplaceProjectOrgSelectionRequest, ResourceScope, ReviewDecision, ReviewMergeResult,
 };
 use server::repository::ServerRepository;
 use sha2::{Digest, Sha256};
@@ -323,6 +325,92 @@ async fn cache_root_for_commit(
         .unwrap();
     assert_eq!(cache.commit_id.as_deref(), Some(commit_id));
     std::path::PathBuf::from(cache.active_generation_path.unwrap())
+}
+
+#[tokio::test]
+async fn project_creation_proxy_preserves_idempotency_and_replays_the_result() {
+    let postgres = common::start_postgres().await;
+    let port = postgres.port;
+    let database_url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+    let pool = sqlx::PgPool::connect(&database_url).await.unwrap();
+    server::db::run_migrations(&pool).await.unwrap();
+    let bootstrap = common::initialize_installation(pool.clone(), "Project Proxy").await;
+
+    let access_token = "daemon-project-create-access-token";
+    let token_hash = hex::encode(Sha256::digest(access_token.as_bytes()));
+    sqlx::query(
+        "INSERT INTO auth_sessions (session_id, user_id, org_id)
+         VALUES ('ses_daemon_project_create', $1, $2)",
+    )
+    .bind(&bootstrap.user_id)
+    .bind(&bootstrap.org_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO access_tokens (
+            token_id, session_id, user_id, kind, token_hash, expires_at
+         ) VALUES (
+            'tok_daemon_project_create', 'ses_daemon_project_create', $1,
+            'access', $2, now() + interval '30 minutes'
+         )",
+    )
+    .bind(&bootstrap.user_id)
+    .bind(token_hash)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let server_address = listener.local_addr().unwrap();
+    let server_pool = pool.clone();
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, server::http::router(server_pool))
+            .await
+            .unwrap();
+    });
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{server_address}");
+    config.project.project_id = Some(bootstrap.project_id);
+    let (state, _) = common::initialize_authenticated_daemon(config, access_token, None).await;
+    let request = DaemonServerRequest {
+        method: "POST".to_owned(),
+        path: "/api/v1/projects".to_owned(),
+        headers: BTreeMap::from([
+            ("Content-Type".to_owned(), "application/json".to_owned()),
+            (
+                "Idempotency-Key".to_owned(),
+                "daemon-project-create-1".to_owned(),
+            ),
+        ]),
+        body: Some(
+            serde_json::to_string(&CreateProjectRequest {
+                name: "Created Through Daemon".to_owned(),
+                description: Some("Proxy contract verification".to_owned()),
+            })
+            .unwrap(),
+        ),
+    };
+
+    let first = state.server_request(request.clone()).await.unwrap();
+    assert_eq!(first.status, 201);
+    let first_project: Project = serde_json::from_str(&first.body).unwrap();
+
+    let replay = state.server_request(request).await.unwrap();
+    assert_eq!(replay.status, 201);
+    let replayed_project: Project = serde_json::from_str(&replay.body).unwrap();
+    assert_eq!(replayed_project.project_id, first_project.project_id);
+
+    let project_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM projects WHERE lower(name) = lower($1)")
+            .bind("Created Through Daemon")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(project_count, 1);
+
+    server_task.abort();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Project creation from macOS failed with HTTP 400 because the daemon
proxy dropped the required Idempotency-Key header. Preserve that header
case-insensitively while retaining credential filtering and the explicit
request-header allowlist.

## Test plan

- [x] `cargo test --workspace`
- [x] `bun run api:check`
- [x] `bun run test:macos`
- [x] `zig fmt --check src/`
- [x] `zig build`
- [x] `zig build test`
- [x] Create a Project in the built macOS app and verify initialization completes without the missing-header error.