### PR TITLE
macos: make sidebar filters direct menus

### DIFF
--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		1A22D0A11BA0ADB767369B75 /* IssueBoardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F9A16C0257F846C6850394 /* IssueBoardModel.swift */; };
 		1C911F77525AB5ABB6D585FE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D481B8C9371F57B60C8462AB /* Assets.xcassets */; };
 		20EA89238D29B3C111E36F01 /* MemoryWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18CAC580523AC687B94FA4C9 /* MemoryWorkspaceView.swift */; };
+		262EEDD3B2709E6F304D1FAA /* ToolbarFilterMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CFBC5DEC7607B6F7B8096B7 /* ToolbarFilterMenu.swift */; };
 		27D27351210746ADB09517AD /* AuthenticationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660A9B545B2648D12AC3FF32 /* AuthenticationClient.swift */; };
 		3101CF20F9CD873C50F3A0E3 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2E412C2A50FFE0CD817D24CB /* MarkdownUI */; };
 		3FF35919DB8D5792C67B00A1 /* FileSymbolCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F3E7B661CE27FE5A6A3C43 /* FileSymbolCatalogTests.swift */; };
@@ -86,6 +87,7 @@
 		8417B8F08E5E969A2EE13063 /* IssueBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueBoardView.swift; sourceTree = "<group>"; };
 		84C800F553C36980E0ABDCF2 /* ProjectManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectManagementTests.swift; sourceTree = "<group>"; };
 		8B1C08B35EEC492EB9705051 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		8CFBC5DEC7607B6F7B8096B7 /* ToolbarFilterMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarFilterMenu.swift; sourceTree = "<group>"; };
 		907531FC0F69F10F4EC7FC8E /* ProjectOrgSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectOrgSelectionTests.swift; sourceTree = "<group>"; };
 		940BD7C82DC144B067648080 /* NativeTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTextEditor.swift; sourceTree = "<group>"; };
 		9A94470634048BE21398273F /* FileSymbols */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FileSymbols; path = Resources/FileSymbols; sourceTree = SOURCE_ROOT; };
@@ -151,6 +153,7 @@
 				54AA571BE4F7DBAC7439EB6D /* PointingHandCursor.swift */,
 				D5E2F9ADC924309D0DF748F2 /* SharedUpdateIndicator.swift */,
 				325B2E0E0E56B671C925B71F /* SplitDiffView.swift */,
+				8CFBC5DEC7607B6F7B8096B7 /* ToolbarFilterMenu.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -428,6 +431,7 @@
 				6DCCFBA6BA084361DAACE1B9 /* SharedUpdateIndicator.swift in Sources */,
 				47AC97FF423BEDDD532DE639 /* SoftwareUpdateController.swift in Sources */,
 				EEF5E92DEA84381918527F18 /* SplitDiffView.swift in Sources */,
+				262EEDD3B2709E6F304D1FAA /* ToolbarFilterMenu.swift in Sources */,
 				A53F0E8912030AA286A4A285 /* WorkspaceStore.swift in Sources */,
 				DC1B191092F8585B353496E6 /* WorkspaceView.swift in Sources */,
 				D673EA34613D807AEEAE78AD /* main.swift in Sources */,

--- a/apps/macos/Sources/Components/ToolbarFilterMenu.swift
+++ b/apps/macos/Sources/Components/ToolbarFilterMenu.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ToolbarFilterMenu<MenuContent: View>: View {
+    let selectionTitle: String
+    let isLoading: Bool
+
+    private let menuContent: () -> MenuContent
+
+    init(
+        selectionTitle: String,
+        isLoading: Bool = false,
+        @ViewBuilder menuContent: @escaping () -> MenuContent
+    ) {
+        self.selectionTitle = selectionTitle
+        self.isLoading = isLoading
+        self.menuContent = menuContent
+    }
+
+    var body: some View {
+        Menu {
+            menuContent()
+        } label: {
+            HStack(spacing: 6) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+
+                Text(selectionTitle)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .frame(maxWidth: 180, alignment: .leading)
+            }
+        }
+        .frame(maxWidth: 220, alignment: .leading)
+    }
+}

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -1,5 +1,73 @@
 import SwiftUI
 
+enum ReviewStatusFilter: String, CaseIterable, Identifiable {
+    case open
+    case approved
+    case rejected
+    case merged
+    case all
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .open: "Open"
+        case .approved: "Approved"
+        case .rejected: "Rejected"
+        case .merged: "Merged"
+        case .all: "All"
+        }
+    }
+
+    var symbolName: String {
+        switch self {
+        case .open: "clock"
+        case .approved: "checkmark.circle"
+        case .rejected: "xmark.circle"
+        case .merged: "arrow.triangle.merge"
+        case .all: "tray.full"
+        }
+    }
+
+    func matches(_ review: ReviewRecord) -> Bool {
+        self == .all || review.status == rawValue
+    }
+
+    func count(in reviews: [ReviewRecord]) -> Int {
+        reviews.lazy.filter(matches).count
+    }
+}
+
+struct ReviewStatusFilterControl: View {
+    let reviews: [ReviewRecord]
+    @Binding var selection: ReviewStatusFilter
+
+    var body: some View {
+        ToolbarFilterMenu(selectionTitle: selection.title) {
+            ForEach(ReviewStatusFilter.allCases) { filter in
+                Toggle(
+                    label(for: filter),
+                    isOn: Binding(
+                        get: { selection == filter },
+                        set: { isSelected in
+                            guard isSelected else { return }
+                            selection = filter
+                        }
+                    )
+                )
+            }
+        }
+        .help("Filter Reviews: \(label(for: selection))")
+        .accessibilityLabel("Filter Reviews")
+        .accessibilityValue(label(for: selection))
+        .accessibilityIdentifier("review-toolbar-filter")
+    }
+
+    private func label(for filter: ReviewStatusFilter) -> String {
+        "\(filter.title) (\(filter.count(in: reviews)))"
+    }
+}
+
 private enum ReviewReconciliationPurpose {
     case updateDraft
     case resubmit
@@ -7,10 +75,10 @@ private enum ReviewReconciliationPurpose {
 
 struct ReviewNavigator: View {
     @ObservedObject var store: WorkspaceStore
-    @Binding var statusFilter: String
+    @Binding var statusFilter: ReviewStatusFilter
 
     private var filteredReviews: [ReviewRecord] {
-        statusFilter == "all" ? store.reviews : store.reviews.filter { $0.status == statusFilter }
+        store.reviews.filter(statusFilter.matches)
     }
 
     var body: some View {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -103,7 +103,7 @@ struct WorkspaceView: View {
     let onOpenDiagnostics: (DiagnosticsDestination) -> Void
     let onShowLogs: () -> Void
     @StateObject private var issueBoardModel: IssueBoardModel
-    @State private var reviewStatusFilter = "open"
+    @State private var reviewStatusFilter: ReviewStatusFilter = .open
     @State private var splitVisibility: NavigationSplitViewVisibility = .all
     @State private var issueSplitVisibility: NavigationSplitViewVisibility = .all
     @State private var showsBundleResourcePicker = false
@@ -644,21 +644,25 @@ struct WorkspaceView: View {
     private var navigationToolbarContent: some ToolbarContent {
         switch store.selectedSection {
         case .hub, .local:
-            ToolbarItem {
-                HStack(spacing: 4) {
-                    Image(systemName: "line.3.horizontal.decrease")
-                        .foregroundStyle(.secondary)
-                    Picker("Memory Type", selection: $store.selectedKind) {
-                        ForEach(MemoryKind.allCases) { kind in
+            ToolbarItem(placement: .navigation) {
+                ToolbarFilterMenu(selectionTitle: store.selectedKind.title) {
+                    ForEach(MemoryKind.allCases) { kind in
+                        Toggle(
+                            isOn: Binding(
+                                get: { store.selectedKind == kind },
+                                set: { isSelected in
+                                    guard isSelected else { return }
+                                    store.selectedKind = kind
+                                }
+                            )
+                        ) {
                             Label(kind.title, systemImage: kind.symbol)
-                                .tag(kind)
                         }
                     }
-                    .pickerStyle(.menu)
-                    .labelsHidden()
-                    .help("Memory Type: \(store.selectedKind.title)")
-                    .accessibilityLabel("Memory Type")
                 }
+                .help("Memory Type: \(store.selectedKind.title)")
+                .accessibilityLabel("Memory Type Filter")
+                .accessibilityValue(store.selectedKind.title)
             }
 
             if store.selectedSection == .local {
@@ -688,17 +692,11 @@ struct WorkspaceView: View {
                 EmptyView()
             }
         case .reviews:
-            ToolbarItem {
-                Picker("Status", selection: $reviewStatusFilter) {
-                    Text("Open").tag("open")
-                    Text("Approved").tag("approved")
-                    Text("Rejected").tag("rejected")
-                    Text("Merged").tag("merged")
-                    Text("All").tag("all")
-                }
-                .labelsHidden()
-                .frame(width: 110)
-                .help("Review Status")
+            ToolbarItem(placement: .navigation) {
+                ReviewStatusFilterControl(
+                    reviews: store.reviews,
+                    selection: $reviewStatusFilter
+                )
             }
         }
     }
@@ -755,9 +753,7 @@ struct WorkspaceView: View {
     }
 
     private var filteredReviews: [ReviewRecord] {
-        reviewStatusFilter == "all"
-            ? store.reviews
-            : store.reviews.filter { $0.status == reviewStatusFilter }
+        store.reviews.filter(reviewStatusFilter.matches)
     }
 
     private var searchResults: [SearchEntry] {
@@ -846,7 +842,10 @@ private struct IssueProjectFilter: View {
     @ObservedObject var store: WorkspaceStore
 
     var body: some View {
-        Menu {
+        ToolbarFilterMenu(
+            selectionTitle: store.activeProject?.name ?? "Select Project",
+            isLoading: store.loadingProjectId != nil
+        ) {
             if store.projects.isEmpty {
                 Button("No Projects") {}
                     .disabled(true)
@@ -865,21 +864,7 @@ private struct IssueProjectFilter: View {
                     .disabled(store.loadingProjectId != nil)
                 }
             }
-        } label: {
-            HStack(spacing: 6) {
-                if store.loadingProjectId == nil {
-                    Image(systemName: "line.3.horizontal.decrease")
-                } else {
-                    ProgressView()
-                        .controlSize(.mini)
-                }
-                Text(store.activeProject?.name ?? "Select Project")
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: 180, alignment: .leading)
-            }
         }
-        .frame(maxWidth: 220, alignment: .leading)
         .help("Filter Kanban by Project")
         .accessibilityLabel("Project Filter")
         .accessibilityValue(store.activeProject?.name ?? "No Project Selected")

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -34,6 +34,17 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
+    func testReviewStatusFiltersKeepServerStatusOrderAndTitles() {
+        XCTAssertEqual(
+            ReviewStatusFilter.allCases.map(\.rawValue),
+            ["open", "approved", "rejected", "merged", "all"]
+        )
+        XCTAssertEqual(
+            ReviewStatusFilter.allCases.map(\.title),
+            ["Open", "Approved", "Rejected", "Merged", "All"]
+        )
+    }
+
     func testBackAndForwardFollowTabSelectionHistory() {
         let store = WorkspaceStore()
         let first = tab(itemId: "first")


### PR DESCRIPTION
## Summary

The Local and Reviews toolbar filters used inconsistent controls, extra
filter imagery, and a nested status picker. This change moves Kanban,
Local, and Reviews onto a shared native toolbar menu: the collapsed
label shows only the current value, Local exposes memory kinds with
their own icons, and Reviews exposes every status directly at the first
menu level while preserving counts, filtering, and accessibility.

## Test plan

- [x] Run `bun run test:macos` (122 passed, 2 skipped, 0 failed)
- [x] Run `bun run api:check`
- [x] Run `zig fmt --check src/`, `zig build`, and `zig build test`
- [x] Run deployment script syntax, shellcheck, and transaction tests
- [x] Run `bun run build`
- [x] Run `cargo fmt --all --check`, `cargo test --workspace`, and `cargo clippy -p daemon -- -D warnings`
- [x] Review the final menu hierarchy and single-selection behavior
- [x] Confirm the Linux CI macOS cross-compile job passes
