### PR TITLE
daemon: normalize empty adapter binding aliases

### DIFF
--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -560,7 +560,13 @@ private struct ProjectLocalSetupSettings: View {
                             workspaceRoot: repository.workspaceRoot,
                             current: current
                         )
-                        adapters = try await store.projectAgentAdapters(repository.projectId)
+                        // Installing the first Adapter can normalize a historical
+                        // symlink-based binding to its canonical filesystem path.
+                        // Refresh both collections so the toggle compares the two
+                        // daemon-owned records using the same workspace identity.
+                        async let refreshedBindings = store.projectBindings(repository.projectId)
+                        async let refreshedAdapters = store.projectAgentAdapters(repository.projectId)
+                        (bindings, adapters) = try await (refreshedBindings, refreshedAdapters)
                         errorMessage = nil
                     } catch {
                         errorMessage = error.localizedDescription

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -13,8 +13,8 @@ use toml_edit::{Array, DocumentMut, Item, Table, value};
 use uuid::Uuid;
 
 use crate::{
-    DaemonError, DaemonState, canonical_server_url, canonical_workspace_directory,
-    project_binding_from_row,
+    DaemonError, DaemonState, canonical_binding_root, canonical_server_url,
+    canonical_workspace_directory, project_binding_from_row,
 };
 
 #[cfg(target_os = "macos")]
@@ -1798,6 +1798,8 @@ pub(crate) async fn install(
     let project_id = required_value("project_id", request.project_id)?;
     let workspace_root = canonical_workspace_directory(&request.workspace_root)?;
     let server_url = canonical_server_url(&state.project_config().server_url)?;
+    normalize_empty_binding_alias(&state.inner.pool, &server_url, &workspace_root, &project_id)
+        .await?;
     recover_pending_fs_op_for_adapter(
         &state.inner.pool,
         &server_url,
@@ -1982,6 +1984,128 @@ async fn ensure_binding(
             "This repository is bound to a different Project.",
         ));
     }
+    Ok(())
+}
+
+/// Rekeys a historical binding whose stored lexical path now resolves to the
+/// canonical workspace path used by adapter filesystem transactions.
+///
+/// Adapter journals and their foreign key deliberately use one exact workspace
+/// key. Moving an occupied binding would also require rebasing its manifests
+/// and absolute hook commands, so this narrow repair is allowed only before the
+/// first daemon-owned adapter (and before any pending filesystem transaction).
+async fn normalize_empty_binding_alias(
+    pool: &SqlitePool,
+    server_url: &str,
+    workspace_root: &Path,
+    project_id: &str,
+) -> Result<(), DaemonError> {
+    let canonical_workspace = workspace_root.display().to_string();
+    let mut tx = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let rows = sqlx::query(
+        "SELECT server_url, workspace_root, project_id, revision, created_at, updated_at
+         FROM project_bindings
+         WHERE server_url = $1",
+    )
+    .bind(server_url)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    let mut equivalents = rows
+        .iter()
+        .map(project_binding_from_row)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|binding| canonical_binding_root(&binding.workspace_root) == workspace_root)
+        .collect::<Vec<_>>();
+    equivalents.sort_by(|left, right| left.workspace_root.cmp(&right.workspace_root));
+
+    if equivalents.len() > 1 {
+        return Err(state_error(
+            "project_binding_changed",
+            "More than one stored Project binding resolves to this repository. Remove the duplicate binding before installing a Coding Agent integration.",
+        ));
+    }
+    let Some(binding) = equivalents.pop() else {
+        tx.commit().await?;
+        return Ok(());
+    };
+    if binding.project_id != project_id {
+        return Err(state_error(
+            "project_binding_changed",
+            "This repository is bound to a different Project.",
+        ));
+    }
+    if binding.workspace_root == canonical_workspace {
+        tx.commit().await?;
+        return Ok(());
+    }
+
+    let adapter_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM project_agent_adapters
+         WHERE server_url = $1 AND workspace_root = $2",
+    )
+    .bind(server_url)
+    .bind(&binding.workspace_root)
+    .fetch_one(&mut *tx)
+    .await?;
+    let pending_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM adapter_fs_ops
+         WHERE server_url = $1 AND workspace_root = $2",
+    )
+    .bind(server_url)
+    .bind(&binding.workspace_root)
+    .fetch_one(&mut *tx)
+    .await?;
+    if adapter_count != 0 || pending_count != 0 {
+        return Err(state_error(
+            "project_agent_adapter_recovery_required",
+            "This repository moved after a Coding Agent integration was installed. Remove or recover the existing integration before changing its stored path.",
+        ));
+    }
+
+    let inserted = sqlx::query(
+        "INSERT INTO project_bindings (
+             server_url, workspace_root, project_id, revision, created_at, updated_at
+         )
+         SELECT server_url, $3, project_id, revision, created_at, updated_at
+         FROM project_bindings
+         WHERE server_url = $1 AND workspace_root = $2
+           AND project_id = $4 AND revision = $5",
+    )
+    .bind(server_url)
+    .bind(&binding.workspace_root)
+    .bind(&canonical_workspace)
+    .bind(project_id)
+    .bind(binding.revision)
+    .execute(&mut *tx)
+    .await?;
+    if inserted.rows_affected() != 1 {
+        return Err(state_error(
+            "project_binding_changed",
+            "The Project binding changed while its repository path was being normalized.",
+        ));
+    }
+    let deleted = sqlx::query(
+        "DELETE FROM project_bindings
+         WHERE server_url = $1 AND workspace_root = $2
+           AND project_id = $3 AND revision = $4",
+    )
+    .bind(server_url)
+    .bind(&binding.workspace_root)
+    .bind(project_id)
+    .bind(binding.revision)
+    .execute(&mut *tx)
+    .await?;
+    if deleted.rows_affected() != 1 {
+        return Err(state_error(
+            "project_binding_changed",
+            "The Project binding changed while its repository path was being normalized.",
+        ));
+    }
+    tx.commit().await?;
     Ok(())
 }
 

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -3110,6 +3110,93 @@ async fn project_bindings_resolve_when_the_workspace_root_is_replaced_by_a_symli
     assert_eq!(resolved.project_id, "prj_moved");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn adapter_install_normalizes_an_empty_binding_after_a_workspace_symlink_move() {
+    let app = Router::new().route("/api/v1/projects/{project_id}", get(accessible_project));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let daemon_root = tempfile::tempdir().unwrap();
+    let workspaces = tempfile::tempdir().unwrap();
+    let moved_volume = workspaces.path().join("volume");
+    let canonical_root = moved_volume.join("repository");
+    std::fs::create_dir_all(&canonical_root).unwrap();
+    let alias_parent = workspaces.path().join("workspace");
+    let bound_root = alias_parent.join("repository");
+    std::fs::create_dir_all(&bound_root).unwrap();
+
+    let mut config = DaemonConfig::for_root(daemon_root.path());
+    config.project.server_url = format!("http://{address}/");
+    let credential_store = common::TestCredentialStore::new(Some(ServerCredentials {
+        server_url: config.project.server_url.clone(),
+        access_token: "test-token".to_owned(),
+        refresh_token: None,
+    }));
+    let state = common::initialize_daemon(config, credential_store).await;
+    let service = DaemonIpcService::new(state);
+    service
+        .replace_project_binding(DaemonProjectBindingReplaceRequest {
+            workspace_root: bound_root.display().to_string(),
+            project_id: "prj_moved_adapter".to_owned(),
+            expected_revision: None,
+        })
+        .await
+        .unwrap();
+
+    std::fs::remove_dir_all(&alias_parent).unwrap();
+    std::os::unix::fs::symlink(&moved_volume, &alias_parent).unwrap();
+
+    let helper = signed_runtime_binary(daemon_root.path());
+    let installed = service
+        .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
+            project_id: "prj_moved_adapter".to_owned(),
+            workspace_root: bound_root.display().to_string(),
+            adapter: ProjectAgentAdapterKind::Codex,
+            runtime_binary_path: helper.display().to_string(),
+            expected_revision: None,
+        })
+        .await
+        .unwrap();
+    let canonical_root = std::fs::canonicalize(&canonical_root).unwrap();
+    assert_eq!(
+        installed.workspace_root,
+        canonical_root.display().to_string()
+    );
+
+    let bindings = service
+        .list_project_bindings(DaemonProjectBindingListRequest {
+            project_id: "prj_moved_adapter".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(bindings.items.len(), 1);
+    assert_eq!(
+        bindings.items[0].workspace_root,
+        canonical_root.display().to_string()
+    );
+
+    service
+        .remove_project_agent_adapter(DaemonProjectAgentAdapterRemoveRequest {
+            workspace_root: bound_root.display().to_string(),
+            adapter: ProjectAgentAdapterKind::Codex,
+            expected_revision: installed.revision,
+        })
+        .await
+        .unwrap();
+    let removed = service
+        .remove_project_binding(DaemonProjectBindingRemoveRequest {
+            workspace_root: bound_root.display().to_string(),
+            expected_revision: bindings.items[0].revision,
+        })
+        .await
+        .unwrap();
+    assert!(removed.removed);
+}
+
 #[tokio::test]
 async fn project_agent_adapter_install_is_reversible_and_repository_binding_can_then_be_removed() {
     let app = Router::new().route("/api/v1/projects/{project_id}", get(accessible_project));


### PR DESCRIPTION
## Summary

Repository integrations could report that a project was not bound after the
workspace path was replaced by a symlink, because read-only lookup accepted the
alias while adapter transactions required an exact database key. Normalize an
unoccupied equivalent binding transactionally before installation, preserve
fail-closed behavior for existing adapter or recovery state, and refresh the
App's binding and adapter snapshots together.

## Test plan

- [x] Run the daemon unit, integration, XPC, and workspace test suites.
- [x] Run API contract, docs, macOS XCTest, and runtime packaging gates.
- [x] Install Codex and Claude integrations for a repository whose stored `/Users/...` path now resolves through a symlink to `/Volumes/...`; verify one canonical binding remains and the App toggles stay enabled.
