### PR TITLE
macos: restore funnel icon in shared toolbar filter menu

### DIFF
--- a/apps/macos/Sources/Components/ToolbarFilterMenu.swift
+++ b/apps/macos/Sources/Components/ToolbarFilterMenu.swift
@@ -24,6 +24,8 @@ struct ToolbarFilterMenu<MenuContent: View>: View {
                 if isLoading {
                     ProgressView()
                         .controlSize(.mini)
+                } else {
+                    Image(systemName: "line.3.horizontal.decrease")
                 }
 
                 Text(selectionTitle)


### PR DESCRIPTION
## Summary

The sidebar filter unification (PR #165) replaced the Kanban and Local
toolbar filters with the shared `ToolbarFilterMenu` shell, whose label
renders only the selection text and a loading spinner. Kanban and
Local previously led the label with the filter icon
(`line.3.horizontal.decrease`), and that icon is now gone from all
three filters. Restore the icon inside the shared shell label so
Kanban, Local, and Reviews all show it again; the loading spinner
still replaces it while a project load is in flight.

## Test plan

- [ ] `bun run test:macos` passes on this branch (148 executed, 2
      skipped, 0 failures; verified locally and on GitHub CI)
- [ ] The Kanban, Local, and Reviews toolbar filters show the funnel
      icon before the selection label, and the Kanban project filter
      still swaps it for a spinner while loading
