### PR TITLE
macos: decode unknown AgentRun hosts and add dsh

### DIFF
--- a/apps/macos/Sources/Features/IssueBoardView.swift
+++ b/apps/macos/Sources/Features/IssueBoardView.swift
@@ -1215,6 +1215,8 @@ private extension AgentRunHost {
         case .manual: "Manual"
         case .zed: "Zed"
         case .opencode: "opencode"
+        case .dsh: "dsh"
+        case .unknown: "Unknown"
         }
     }
 }

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -651,6 +651,16 @@ enum AgentRunHost: String, Codable, Hashable, Sendable {
     case manual
     case zed
     case opencode
+    /// DeepSeek Harness web sessions (hook-issued runs).
+    case dsh
+    /// Host added by a newer daemon than this app build; the board must keep
+    /// decoding instead of failing the whole payload.
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let raw = try decoder.singleValueContainer().decode(String.self)
+        self = AgentRunHost(rawValue: raw) ?? .unknown
+    }
 }
 
 enum AgentRunKind: String, Codable, Hashable, Sendable {


### PR DESCRIPTION
## Summary

The daemon now issues runs for the dsh host (DeepSeek Harness), but the
macos app's `AgentRunHost` enum only knew codex / claude-code / manual /
zed / opencode. Any board response carrying a dsh run failed to decode and
the whole Kanban pane errored out.

Add `case dsh` and an `unknown` fallback via a custom `init(from:)`, so a
host introduced by a newer daemon degrades to "Unknown" instead of breaking
the board. The run-host title extension gains both cases.

## Test plan

- [x] Decode check: `"dsh"` → `.dsh`, `"opencode"` → `.opencode`, an unrecognized value → `.unknown`
- [x] `xcodebuild -configuration Debug` build succeeds; board renders with dsh runs present