### PR TITLE
macos: unify toolbar search fields as classic search bars

### DIFF
--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		43BA80CE66E7645FE1289DAD /* MemoryModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFD932255E9B3EF5C7BCF35 /* MemoryModels.swift */; };
 		47AC97FF423BEDDD532DE639 /* SoftwareUpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C5934380C2CA476EA20D42 /* SoftwareUpdateController.swift */; };
 		4D0F2A84C1396679AB6D9601 /* DaemonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1752C4FFEB4FF7D4E8C14C /* DaemonModels.swift */; };
+		50B2905F57000E5DE123D668 /* ClassicSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B2DE143CAD3774B8548689 /* ClassicSearchField.swift */; };
 		5A82C529BBA6689E300760FF /* FileTreeSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65F12B107D78DBB96A122599 /* FileTreeSelectionTests.swift */; };
 		603640F6B13F940ACD8445BD /* JSONCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6ABC405480198DD68F37918 /* JSONCoding.swift */; };
 		6242A4726CA51495F419DEDA /* DocumentTabStripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D653D21BD58E9D24450141A /* DocumentTabStripTests.swift */; };
@@ -72,6 +73,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05B2DE143CAD3774B8548689 /* ClassicSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicSearchField.swift; sourceTree = "<group>"; };
 		0D1A76BE67F6B85156A3330C /* WorkspaceNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceNavigationTests.swift; sourceTree = "<group>"; };
 		0D653D21BD58E9D24450141A /* DocumentTabStripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTabStripTests.swift; sourceTree = "<group>"; };
 		18CAC580523AC687B94FA4C9 /* MemoryWorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryWorkspaceView.swift; sourceTree = "<group>"; };
@@ -150,6 +152,7 @@
 		070EFA753C7735CD6F13AB05 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				05B2DE143CAD3774B8548689 /* ClassicSearchField.swift */,
 				ED8B574ED4DAF0CF09DEE6C6 /* DocumentTabStrip.swift */,
 				9E825BC0050556CC6498B7B6 /* ExternalLinkText.swift */,
 				E3B9632C578719E6E8E78DDD /* FileSymbolCatalog.swift */,
@@ -394,6 +397,7 @@
 				06CBBD4CFE8160627E3DAEAE /* AppDelegate.swift in Sources */,
 				27D27351210746ADB09517AD /* AuthenticationClient.swift in Sources */,
 				F12498C396FD62EFD4716267 /* BundlesView.swift in Sources */,
+				50B2905F57000E5DE123D668 /* ClassicSearchField.swift in Sources */,
 				8EEDC302E3D01C71C36A4250 /* ClumsiesIdentifiers.swift in Sources */,
 				6FC1A304E65B976D0DBF22E9 /* DaemonBootstrapController.swift in Sources */,
 				4D0F2A84C1396679AB6D9601 /* DaemonModels.swift in Sources */,

--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -552,9 +552,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     @objc private func showSearch(_ sender: Any?) {
         mainWindow?.makeKeyAndOrderFront(nil)
-        if store.selectedSection == .issues {
+        switch store.selectedSection {
+        case .issues:
             store.focusIssueSearch()
-        } else {
+        case .reviews:
+            store.focusReviewSearch()
+        default:
             store.showsGlobalSearch = true
         }
     }

--- a/apps/macos/Sources/Components/ClassicSearchField.swift
+++ b/apps/macos/Sources/Components/ClassicSearchField.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+
+/// A unified, always-visible search field for toolbar placement.
+///
+/// Wraps `NSSearchField` so every search surface in the app shares the
+/// classic macOS search box: rounded bezel, system magnifying-glass icon,
+/// clear button, focus ring, and automatic light/dark appearance. The field
+/// is rendered directly in the toolbar — never collapsed behind an icon —
+/// and stays on the trailing (right) edge of every workspace.
+struct ClassicSearchField: NSViewRepresentable {
+    @Binding var text: String
+    var prompt: String
+    var width: CGFloat = 190
+    var accessibilityIdentifier = "toolbar-search"
+    var accessibilityHelp: String?
+    /// Increment to request first responder (e.g. the Cmd+K shortcut).
+    var focusToken = 0
+    /// Called when the field gains or loses editing focus.
+    var onFocusChange: ((Bool) -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            text: $text,
+            onFocusChange: onFocusChange,
+            focusToken: focusToken
+        )
+    }
+
+    func makeNSView(context: Context) -> NSSearchField {
+        let field = NSSearchField()
+        field.placeholderString = prompt
+        field.bezelStyle = .roundedBezel
+        field.sendsSearchStringImmediately = true
+        field.sendsWholeSearchString = false
+        field.delegate = context.coordinator
+        field.translatesAutoresizingMaskIntoConstraints = false
+        field.widthAnchor.constraint(equalToConstant: width).isActive = true
+        field.setAccessibilityIdentifier(accessibilityIdentifier)
+        if let accessibilityHelp {
+            field.setAccessibilityHelp(accessibilityHelp)
+        }
+        return field
+    }
+
+    func updateNSView(_ field: NSSearchField, context: Context) {
+        if field.stringValue != text, field.currentEditor() == nil {
+            field.stringValue = text
+        }
+        if field.placeholderString != prompt {
+            field.placeholderString = prompt
+        }
+        if field.accessibilityIdentifier() != accessibilityIdentifier {
+            field.setAccessibilityIdentifier(accessibilityIdentifier)
+        }
+        if focusToken != context.coordinator.lastFocusToken {
+            context.coordinator.lastFocusToken = focusToken
+            DispatchQueue.main.async {
+                field.window?.makeFirstResponder(field)
+            }
+        }
+    }
+
+    final class Coordinator: NSObject, NSSearchFieldDelegate {
+        @Binding var text: String
+        private let onFocusChange: ((Bool) -> Void)?
+        var lastFocusToken: Int
+
+        init(
+            text: Binding<String>,
+            onFocusChange: ((Bool) -> Void)?,
+            focusToken: Int
+        ) {
+            _text = text
+            self.onFocusChange = onFocusChange
+            // Seed with the initial token so the first render never steals focus;
+            // only explicit increments (e.g. Cmd+K) request first responder.
+            lastFocusToken = focusToken
+        }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard let field = obj.object as? NSSearchField,
+                  text != field.stringValue
+            else { return }
+            text = field.stringValue
+        }
+
+        func controlTextDidBeginEditing(_ obj: Notification) {
+            onFocusChange?(true)
+        }
+
+        func controlTextDidEndEditing(_ obj: Notification) {
+            onFocusChange?(false)
+        }
+    }
+}

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -226,6 +226,7 @@ final class WorkspaceStore: ObservableObject {
     @Published var searchQuery = ""
     @Published var showsGlobalSearch = false
     @Published var issueSearchFocusToken = UUID()
+    @Published var reviewSearchFocusToken = UUID()
     @Published var showsProjectCreation = false
     @Published var showsProjectSettings = false
     @Published var sidebarExpanded = true
@@ -706,6 +707,10 @@ final class WorkspaceStore: ObservableObject {
 
     func focusIssueSearch() {
         issueSearchFocusToken = UUID()
+    }
+
+    func focusReviewSearch() {
+        reviewSearchFocusToken = UUID()
     }
 
     func prepareWorkspaceIndex(includeContent: Bool) async {

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -85,7 +85,7 @@ struct ReviewToolbarOwnership: Equatable {
 
         return .init(
             surface: .detail,
-            items: actions.map(Item.decision) + [.search]
+            items: actions.map(Item.decision)
         )
     }
 

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -351,7 +351,9 @@ struct WorkspaceView: View {
                             .help("Document Actions")
                             .accessibilityLabel("Document Actions")
                         }
+                    }
 
+                    ToolbarItem(id: "workspace.search", placement: .primaryAction) {
                         ClassicSearchField(
                             text: $store.searchQuery,
                             prompt: workspaceSearchPrompt,
@@ -925,7 +927,9 @@ struct WorkspaceView: View {
                                 }
                             }
                         }
+                    }
 
+                    ToolbarItem(id: "issue.search", placement: .primaryAction) {
                         ClassicSearchField(
                             text: $issueBoardModel.searchQuery,
                             prompt: "Search Issues",

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -1,6 +1,17 @@
 import AppKit
 import SwiftUI
 
+extension ToolbarItemPlacement {
+    /// Pins toolbar content to the trailing edge on both macOS 14 (where
+    /// `.primaryAction` is trailing) and macOS 26 Liquid Glass (where
+    /// primary-action items render centered and the trailing edge is reached
+    /// with `.automatic` items pushed by a `ToolbarSpacer(.flexible)`).
+    static var trailingPinned: ToolbarItemPlacement {
+        if #available(macOS 26.0, *) { return .automatic }
+        return .primaryAction
+    }
+}
+
 enum SyncToolbarPresentation: Equatable {
     case syncing(changeCount: Int)
     case failed(changeCount: Int, message: String?)
@@ -234,7 +245,7 @@ struct WorkspaceView: View {
                         ToolbarSpacer(.flexible)
                     }
 
-                    ToolbarItemGroup {
+                    ToolbarItemGroup(placement: .trailingPinned) {
                         if store.selectedSection == .bundles, store.selectedBundle != nil {
                             Button {
                                 showsBundleResourcePicker = true
@@ -353,7 +364,11 @@ struct WorkspaceView: View {
                         }
                     }
 
-                    ToolbarItem(id: "workspace.search", placement: .primaryAction) {
+                    if #available(macOS 26.0, *) {
+                        ToolbarSpacer(.fixed, placement: .automatic)
+                    }
+
+                    ToolbarItem(id: "workspace.search", placement: .trailingPinned) {
                         ClassicSearchField(
                             text: $store.searchQuery,
                             prompt: workspaceSearchPrompt,
@@ -790,7 +805,7 @@ struct WorkspaceView: View {
         }
 
         if reviewToolbarOwnership.contains(.search) {
-            ToolbarItem(id: "review.search", placement: .primaryAction) {
+            ToolbarItem(id: "review.search", placement: .trailingPinned) {
                 ClassicSearchField(
                     text: $reviewSearchQuery,
                     prompt: "Search Reviews",
@@ -853,7 +868,11 @@ struct WorkspaceView: View {
                         IssueProjectFilter(store: store)
                     }
 
-                    ToolbarItemGroup(placement: .primaryAction) {
+                    if #available(macOS 26.0, *) {
+                        ToolbarSpacer(.flexible, placement: .automatic)
+                    }
+
+                    ToolbarItemGroup(placement: .trailingPinned) {
                         Toggle(isOn: $issueBoardModel.showsStaleOnly) {
                             Label("Stale", systemImage: "clock.badge.exclamationmark")
                         }
@@ -929,7 +948,11 @@ struct WorkspaceView: View {
                         }
                     }
 
-                    ToolbarItem(id: "issue.search", placement: .primaryAction) {
+                    if #available(macOS 26.0, *) {
+                        ToolbarSpacer(.fixed, placement: .automatic)
+                    }
+
+                    ToolbarItem(id: "issue.search", placement: .trailingPinned) {
                         ClassicSearchField(
                             text: $issueBoardModel.searchQuery,
                             prompt: "Search Issues",

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -116,7 +116,9 @@ struct WorkspaceView: View {
     @State private var showsIssueWorkflowHelp = false
     @State private var issueNavigationPath: [IssueBoardRoute] = []
     @State private var reviewNavigationPath: [ReviewRoute] = []
-    @FocusState private var issueSearchFocused: Bool
+    @State private var issueSearchFocusRequest = 0
+    @State private var reviewSearchQuery = ""
+    @State private var reviewSearchFocusRequest = 0
     @State private var reviewStatusFilter: ReviewStatusFilter = .open
     @State private var pendingReviewToolbarAction: ReviewMenuAction?
 
@@ -279,21 +281,6 @@ struct WorkspaceView: View {
                             }
                         }
 
-                        Button {
-                            store.showsGlobalSearch.toggle()
-                        } label: {
-                            Image(systemName: "magnifyingglass")
-                        }
-                        .help("Search")
-                        .accessibilityLabel("Search")
-                        .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
-                            WorkspaceSearchPopover(
-                                store: store,
-                                results: searchResults,
-                                onOpen: open
-                            )
-                        }
-
                         if showsDocumentTabs, let item = store.currentItem {
                             if let state = documentReconciliationState {
                                 if state.isLoading || state.isUpdating {
@@ -363,6 +350,25 @@ struct WorkspaceView: View {
                             .menuIndicator(.hidden)
                             .help("Document Actions")
                             .accessibilityLabel("Document Actions")
+                        }
+
+                        ClassicSearchField(
+                            text: $store.searchQuery,
+                            prompt: workspaceSearchPrompt,
+                            accessibilityIdentifier: "workspace-toolbar-search",
+                            accessibilityHelp: "Search across the current workspace",
+                            onFocusChange: { focused in
+                                if focused {
+                                    store.showsGlobalSearch = true
+                                }
+                            }
+                        )
+                        .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
+                            WorkspaceSearchPopover(
+                                store: store,
+                                results: searchResults,
+                                onOpen: open
+                            )
                         }
                     }
                 }
@@ -556,6 +562,10 @@ struct WorkspaceView: View {
                 pendingReviewToolbarAction = nil
             }
         }
+        .onChange(of: store.reviewSearchFocusToken) { _, _ in
+            reviewNavigationPath.removeAll()
+            reviewSearchFocusRequest += 1
+        }
         .onChange(of: store.selectedReviewId) { _, reviewId in
             guard store.selectedSection == .reviews else { return }
             guard let reviewId else {
@@ -600,8 +610,24 @@ struct WorkspaceView: View {
         }
     }
 
+    private var workspaceSearchPrompt: String {
+        switch store.selectedSection {
+        case .hub: "Search Hub"
+        case .local: "Search Local"
+        case .bundles: "Search Bundles"
+        case .reviews: "Search Reviews"
+        case .issues: "Search Issues"
+        }
+    }
+
     private var filteredReviews: [ReviewRecord] {
-        store.reviews.filter { reviewStatusFilter.matches($0) }
+        let byStatus = store.reviews.filter { reviewStatusFilter.matches($0) }
+        let needle = reviewSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines).localizedLowercase
+        guard !needle.isEmpty else { return byStatus }
+        return byStatus.filter {
+            "\($0.title) \($0.description) \($0.author.email) \($0.status)"
+                .localizedLowercase.contains(needle)
+        }
     }
 
     private var reviewToolbarOwnership: ReviewToolbarOwnership {
@@ -762,22 +788,14 @@ struct WorkspaceView: View {
         }
 
         if reviewToolbarOwnership.contains(.search) {
-            ToolbarItem(id: "review.search", placement: .automatic) {
-                Button {
-                    store.showsGlobalSearch.toggle()
-                } label: {
-                    Image(systemName: "magnifyingglass")
-                }
-                .help("Search Reviews")
-                .accessibilityLabel("Search Reviews")
-                .accessibilityIdentifier("review-toolbar-search")
-                .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
-                    WorkspaceSearchPopover(
-                        store: store,
-                        results: searchResults,
-                        onOpen: open
-                    )
-                }
+            ToolbarItem(id: "review.search", placement: .primaryAction) {
+                ClassicSearchField(
+                    text: $reviewSearchQuery,
+                    prompt: "Search Reviews",
+                    accessibilityIdentifier: "review-toolbar-search",
+                    accessibilityHelp: "Search Reviews by title, description or author",
+                    focusToken: reviewSearchFocusRequest
+                )
             }
         }
     }
@@ -834,11 +852,6 @@ struct WorkspaceView: View {
                     }
 
                     ToolbarItemGroup(placement: .primaryAction) {
-                        IssueSearchField(
-                            text: $issueBoardModel.searchQuery,
-                            isFocused: $issueSearchFocused
-                        )
-
                         Toggle(isOn: $issueBoardModel.showsStaleOnly) {
                             Label("Stale", systemImage: "clock.badge.exclamationmark")
                         }
@@ -912,6 +925,14 @@ struct WorkspaceView: View {
                                 }
                             }
                         }
+
+                        ClassicSearchField(
+                            text: $issueBoardModel.searchQuery,
+                            prompt: "Search Issues",
+                            accessibilityIdentifier: "issue-toolbar-search",
+                            accessibilityHelp: "Search only the Issues on this board",
+                            focusToken: issueSearchFocusRequest
+                        )
                     }
                 }
             }
@@ -924,7 +945,7 @@ struct WorkspaceView: View {
             }
         }
         .onChange(of: store.issueSearchFocusToken) { _, _ in
-            issueSearchFocused = true
+            issueSearchFocusRequest += 1
         }
         .onChange(of: issueSplitVisibility) { _, visibility in
             let expanded = visibility != .detailOnly
@@ -1205,46 +1226,6 @@ private struct IssueProjectFilter: View {
         .help("Filter Kanban by Project")
         .accessibilityLabel("Project Filter")
         .accessibilityValue(store.activeProject?.name ?? "No Project Selected")
-    }
-}
-
-private struct IssueSearchField: View {
-    @Binding var text: String
-    @FocusState.Binding var isFocused: Bool
-
-    var body: some View {
-        HStack(spacing: 5) {
-            Image(systemName: "magnifyingglass")
-                .foregroundStyle(.secondary)
-            TextField("Search Issues", text: $text)
-                .textFieldStyle(.plain)
-                .focused($isFocused)
-            if !text.isEmpty {
-                Button {
-                    text = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .focusEffectDisabled()
-                .help("Clear search")
-                .accessibilityLabel("Clear search")
-            }
-        }
-        .padding(.horizontal, 7)
-        .padding(.vertical, 4)
-        .frame(width: 190)
-        .background(
-            Color(nsColor: .textBackgroundColor),
-            in: RoundedRectangle(cornerRadius: 6)
-        )
-        .overlay {
-            RoundedRectangle(cornerRadius: 6)
-                .stroke(Color(nsColor: .separatorColor), lineWidth: 1)
-        }
-        .accessibilityLabel("Search Issues")
-        .accessibilityHint("Search only the Issues on this board")
     }
 }
 

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -210,7 +210,7 @@ final class WorkspaceNavigationTests: XCTestCase {
                 canMergeReviews: false,
                 isAuthor: false
             ).items,
-            [.decision(.reject), .decision(.approve), .search]
+            [.decision(.reject), .decision(.approve)]
         )
     }
 


### PR DESCRIPTION
## Summary

Every workspace now shows the classic macOS search field (NSSearchField)
directly at the toolbar trailing edge instead of hiding search behind an
icon-only button. One shared ClassicSearchField component replaces the
hand-rolled board field and the icon buttons: the Issues board keeps its
field at the trailing-most position, Reviews filters its list inline and
drops the search icon from the detail toolbar, and Hub/Local/Bundles opens
the existing results popover on focus. Cmd+K now focuses the board search,
returns to the review list and focuses its search field, or opens workspace
search elsewhere.

## Test plan

- [x] macOS unit test suite passes (bun run test:macos — build and all
      tests green locally)
- [x] Manual: every workspace (Issues / Reviews / Hub / Local / Bundles)
      shows the classic search field at the trailing toolbar edge
- [x] Manual: Cmd+K focuses the matching search entry on each page, on both
      macOS 14 and macOS 26
