### PR TITLE
macos: merge Hub and Local into a unified Memory section

### DIFF
--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -107,8 +107,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             return store.canManageProjects && store.phase == .ready
         }
         if menuItem.action == #selector(newMemory(_:)) {
-            guard store.selectedSection == .hub || store.selectedSection == .local else { return false }
-            let scope: MemoryScope = store.selectedSection == .hub ? .org : .project
+            guard store.selectedSection == .memory else { return false }
+            let scope: MemoryScope = store.activeProjectId == nil ? .org : .project
             return store.canCreateMemory(kind: store.selectedKind, scope: scope)
         }
         if menuItem.action == #selector(closeActiveTab(_:)) {
@@ -531,8 +531,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     }
 
     @objc private func newMemory(_ sender: Any?) {
-        guard store.selectedSection == .hub || store.selectedSection == .local else { return }
-        let scope: MemoryScope = store.selectedSection == .hub ? .org : .project
+        guard store.selectedSection == .memory else { return }
+        let scope: MemoryScope = store.activeProjectId == nil ? .org : .project
         Task { await store.createMemory(kind: store.selectedKind, scope: scope) }
     }
 

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 enum WorkspaceSection: String, CaseIterable, Identifiable, Sendable {
-    case hub
-    case local
+    case memory
     case issues
     case bundles
     case reviews
@@ -11,8 +10,7 @@ enum WorkspaceSection: String, CaseIterable, Identifiable, Sendable {
 
     var title: String {
         switch self {
-        case .hub: "Hub"
-        case .local: "Local"
+        case .memory: "Memory"
         case .issues: "Kanban"
         case .bundles: "Bundles"
         case .reviews: "Reviews"
@@ -21,8 +19,7 @@ enum WorkspaceSection: String, CaseIterable, Identifiable, Sendable {
 
     var symbol: String {
         switch self {
-        case .hub: "cloud"
-        case .local: "macbook.and.ipod"
+        case .memory: "brain"
         case .issues: "rectangle.3.group"
         case .bundles: "shippingbox"
         case .reviews: "checkmark.bubble"
@@ -231,7 +228,9 @@ struct WorkbenchTab: Identifiable, Hashable, Sendable {
 
     func isVisible(in section: WorkspaceSection, projectId: String?) -> Bool {
         guard self.section == section else { return false }
-        guard section == .local else { return true }
-        return self.projectId == projectId
+        guard section == .memory else { return true }
+        // Org-scope (Hub) tabs stay visible regardless of the active project;
+        // project-scope tabs are only visible while their project is active.
+        return self.projectId == nil || self.projectId == projectId
     }
 }

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -218,7 +218,7 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var legacyAgentAdapterInspectionWarning: String?
 
     @Published var activeProjectId: String?
-    @Published var selectedSection: WorkspaceSection = .hub
+    @Published var selectedSection: WorkspaceSection = .memory
     @Published var selectedKind: MemoryKind = .context
     @Published var selectedItemId: String?
     @Published var selectedBundleId: String?
@@ -380,29 +380,26 @@ final class WorkspaceStore: ObservableObject {
     var visibleMemoryItems: [MemoryListItem] {
         let authoritative: [MemoryResource]
         switch selectedSection {
-        case .hub:
-            authoritative = resources.filter { $0.scope == .org && $0.kind == selectedKind }
-        case .local:
+        case .memory:
+            // Unified Memory: org-scope (Hub) memories are always visible;
+            // the active project's project-scope memories are merged in.
+            let orgResources = resources.filter { $0.scope == .org }
             let projectResources = resources.filter {
-                $0.scope == .project && $0.projectId == activeProjectId && $0.kind == selectedKind
+                $0.scope == .project && $0.projectId == activeProjectId
             }
-            let inheritedIds = activeProject?.selectedOrgResourceIds ?? []
-            let inherited = resources.filter {
-                $0.scope == .org && $0.kind == selectedKind && inheritedIds.contains($0.id)
-            }
-            authoritative = projectResources + inherited
+            authoritative = orgResources + projectResources
         case .issues, .bundles, .reviews:
             return []
         }
 
         let activeDrafts = drafts.filter { draft in
-            guard draft.status != .discarded && draft.status != .merged && draft.kind == selectedKind else {
+            guard draft.status != .discarded && draft.status != .merged else {
                 return false
             }
-            if selectedSection == .hub {
-                return draft.scope == .org
+            if draft.scope == .org {
+                return true
             }
-            return draft.scope == .project && draft.projectId == activeProjectId
+            return draft.projectId == activeProjectId
         }
         let draftByTarget = Dictionary(
             activeDrafts.compactMap { draft in draft.targetId.map { ($0, draft) } },
@@ -413,7 +410,9 @@ final class WorkspaceStore: ObservableObject {
                 id: resource.id,
                 resource: resource,
                 draft: draftByTarget[resource.id],
-                inherited: resource.scope == .org && selectedSection == .local
+                inherited: resource.scope == .org
+                    && activeProjectId != nil
+                    && (activeProject?.selectedOrgResourceIds.contains(resource.id) ?? false)
             )
         }
         items.append(contentsOf: activeDrafts.filter { $0.targetId == nil }.map {
@@ -534,7 +533,7 @@ final class WorkspaceStore: ObservableObject {
                 }
             }
         }
-        selectedSection = .local
+        selectedSection = .memory
         showsProjectSettings = false
         await selectProject(created.id)
     }
@@ -763,7 +762,7 @@ final class WorkspaceStore: ObservableObject {
         let resolvedMode = mode ?? (item.supportsMarkdownPreview ? .preview : .source)
         let tab = WorkbenchTab(
             section: selectedSection,
-            projectId: selectedSection == .local ? (item.projectId ?? activeProjectId) : nil,
+            projectId: item.projectId,
             itemId: item.id,
             mode: resolvedMode,
             title: item.document.title
@@ -781,7 +780,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func reveal(_ item: MemoryListItem) async {
-        selectedSection = item.scope == .org ? .hub : .local
+        selectedSection = .memory
         selectedKind = item.kind
         if let projectId = item.projectId {
             await selectProject(projectId)
@@ -798,7 +797,9 @@ final class WorkspaceStore: ObservableObject {
                 id: resource.id,
                 resource: resource,
                 draft: draft,
-                inherited: tab.section == .local && resource.scope == .org
+                inherited: resource.scope == .org
+                    && activeProjectId != nil
+                    && (activeProject?.selectedOrgResourceIds.contains(resource.id) ?? false)
             )
         }
         if let draft = drafts.first(where: { $0.id == tab.itemId }) {
@@ -1697,7 +1698,7 @@ final class WorkspaceStore: ObservableObject {
             self.selectedReviewId = nil
         }
         if projects.isEmpty {
-            selectedSection = .local
+            selectedSection = .memory
             showsProjectSettings = false
             tabs = []
             activeTabId = nil

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -17,7 +17,7 @@ struct MemoryMainPane: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if store.selectedSection == .local, store.activeProject?.isLoaded == false {
+            if let project = store.activeProject, !project.isLoaded {
                 ProjectPreparationView(store: store)
             } else if !store.visibleTabs.isEmpty {
                 DocumentTabStrip(
@@ -87,26 +87,24 @@ private struct EmptyWorkspaceView: View {
 private struct EmptyMemoryCollectionView: View {
     @ObservedObject var store: WorkspaceStore
 
+    private var scope: MemoryScope {
+        store.activeProjectId == nil ? .org : .project
+    }
+
     var body: some View {
         ContentUnavailableView {
-            Label("No \(store.selectedKind.title)", systemImage: "doc")
+            Label("No Memory", systemImage: "doc")
         } description: {
-            Text("Create the first \(store.selectedKind.singularTitle.lowercased()) here.")
+            Text("Create the first memory here.")
         } actions: {
-            Button("New \(store.selectedKind.singularTitle)") {
+            Button("New Memory") {
                 Task {
-                    await store.createMemory(
-                        kind: store.selectedKind,
-                        scope: store.selectedSection == .hub ? .org : .project
-                    )
+                    await store.createMemory(kind: store.selectedKind, scope: scope)
                 }
             }
             .keyboardShortcut(.defaultAction)
             .disabled(
-                !store.canCreateMemory(
-                    kind: store.selectedKind,
-                    scope: store.selectedSection == .hub ? .org : .project
-                )
+                !store.canCreateMemory(kind: store.selectedKind, scope: scope)
             )
         }
     }
@@ -304,7 +302,7 @@ private struct FileTreeView: View {
     private func fileTreeMenu(for nodeIds: Set<String>) -> some View {
         let targetItems = FileTreeNode.items(in: roots, selectedNodeIds: nodeIds)
         let singleItem = targetItems.count == 1 ? targetItems.first : nil
-        let hubItems = targetItems.filter { $0.scope == .org }
+        let addableItems = targetItems.filter { $0.scope == .org && !$0.inherited }
         let removableItems = targetItems.filter(\.inherited)
 
         if let singleItem {
@@ -320,15 +318,15 @@ private struct FileTreeView: View {
             Divider()
         }
 
-        if store.selectedSection == .hub, !hubItems.isEmpty {
-            Menu(addToLocalTitle(count: hubItems.count)) {
+        if !addableItems.isEmpty {
+            Menu(addToLocalTitle(count: addableItems.count)) {
                 if store.projects.isEmpty {
                     Button("No Projects") {}
                         .disabled(true)
                 } else {
                     ForEach(store.projects) { project in
                         Button(project.name) {
-                            addToLocal(hubItems, projectId: project.id)
+                            addToLocal(addableItems, projectId: project.id)
                         }
                     }
                 }
@@ -336,7 +334,7 @@ private struct FileTreeView: View {
             .disabled(!store.canManageOrgSelection || store.projects.isEmpty)
         }
 
-        if store.selectedSection == .local, !removableItems.isEmpty {
+        if !removableItems.isEmpty {
             Button(removeFromLocalTitle(count: removableItems.count)) {
                 removeFromLocal(removableItems)
             }
@@ -344,15 +342,10 @@ private struct FileTreeView: View {
         }
 
         if let singleItem {
-            if store.selectedSection == .hub && !hubItems.isEmpty
-                || store.selectedSection == .local && !removableItems.isEmpty {
+            if !addableItems.isEmpty || !removableItems.isEmpty {
                 Divider()
             }
-            if singleItem.inherited {
-                Button("Open in Hub") {
-                    Task { await store.reveal(singleItem) }
-                }
-            } else {
+            if !singleItem.inherited {
                 Button("Rename…") { beginRenaming(singleItem) }
             }
             if let draft = singleItem.draft {
@@ -368,18 +361,18 @@ private struct FileTreeView: View {
         }
 
         if targetItems.isEmpty {
-            Button("New \(store.selectedKind.singularTitle)") {
+            Button("New Memory") {
                 Task {
                     await store.createMemory(
                         kind: store.selectedKind,
-                        scope: store.selectedSection == .hub ? .org : .project
+                        scope: store.activeProjectId == nil ? .org : .project
                     )
                 }
             }
             .disabled(
                 !store.canCreateMemory(
                     kind: store.selectedKind,
-                    scope: store.selectedSection == .hub ? .org : .project
+                    scope: store.activeProjectId == nil ? .org : .project
                 )
             )
         }

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -206,33 +206,25 @@ struct ProjectUnavailableView: View {
     @ObservedObject var store: WorkspaceStore
 
     var body: some View {
-        if store.projects.isEmpty {
-            ContentUnavailableView {
-                Label("No Projects", systemImage: "folder")
-            } description: {
-                if store.canManageProjects {
-                    Text("Create a Project to start organizing local memory.")
-                } else {
-                    Text("Ask an organization administrator to grant you access to a Project.")
+        ContentUnavailableView {
+            Label("No Projects", systemImage: "folder")
+        } description: {
+            if store.canManageProjects {
+                Text("Create a Project to start organizing local memory.")
+            } else {
+                Text("Ask an organization administrator to grant you access to a Project.")
+            }
+        } actions: {
+            if store.canManageProjects {
+                Button("New Project…") {
+                    store.presentProjectCreation()
                 }
-            } actions: {
-                if store.canManageProjects {
-                    Button("New Project…") {
-                        store.presentProjectCreation()
-                    }
-                    .keyboardShortcut(.defaultAction)
-                } else {
-                    Button("Refresh") {
-                        Task { await store.reload() }
-                    }
+                .keyboardShortcut(.defaultAction)
+            } else {
+                Button("Refresh") {
+                    Task { await store.reload() }
                 }
             }
-        } else {
-            ContentUnavailableView(
-                "Select a Project",
-                systemImage: "folder",
-                description: Text("Choose a Project from Local.")
-            )
         }
     }
 }

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -149,7 +149,7 @@ struct WorkspaceView: View {
     }
 
     private var showsDocumentTabs: Bool {
-        (store.selectedSection == .hub || store.selectedSection == .local)
+        store.selectedSection == .memory
             && !store.visibleTabs.isEmpty
             && !store.showsProjectSettings
     }
@@ -328,11 +328,6 @@ struct WorkspaceView: View {
                             }
 
                             Menu {
-                                if item.inherited {
-                                    Button("Open in Hub") {
-                                        Task { await store.reveal(item) }
-                                    }
-                                }
                                 if let draft = item.draft, draft.status == .open {
                                     Button("Request Review") {
                                         store.pendingDocumentCommand = .requestReview(
@@ -401,7 +396,7 @@ struct WorkspaceView: View {
             Task { await store.prepareWorkspaceIndex(includeContent: true) }
         }
         .onChange(of: store.selectedSection) { _, section in
-            if section != .local {
+            if section != .memory {
                 store.showsProjectSettings = false
             }
         }
@@ -629,8 +624,7 @@ struct WorkspaceView: View {
 
     private var workspaceSearchPrompt: String {
         switch store.selectedSection {
-        case .hub: "Search Hub"
-        case .local: "Search Local"
+        case .memory: "Search Memory"
         case .bundles: "Search Bundles"
         case .reviews: "Search Reviews"
         case .issues: "Search Issues"
@@ -1038,39 +1032,20 @@ struct WorkspaceView: View {
     @ToolbarContentBuilder
     private var navigationToolbarContent: some ToolbarContent {
         switch store.selectedSection {
-        case .hub, .local:
+        case .memory:
             ToolbarItem(placement: .navigation) {
-                ToolbarFilterMenu(selectionTitle: store.selectedKind.title) {
-                    ForEach(MemoryKind.allCases) { kind in
-                        Toggle(
-                            isOn: Binding(
-                                get: { store.selectedKind == kind },
-                                set: { isSelected in
-                                    guard isSelected else { return }
-                                    store.selectedKind = kind
-                                }
-                            )
-                        ) {
-                            Label(kind.title, systemImage: kind.symbol)
-                        }
-                    }
-                }
-                .help("Memory Type: \(store.selectedKind.title)")
-                .accessibilityLabel("Memory Type Filter")
-                .accessibilityValue(store.selectedKind.title)
+                MemoryProjectFilter(store: store)
             }
 
-            if store.selectedSection == .local {
-                ToolbarItem {
-                    Button {
-                        store.showsProjectSettings.toggle()
-                    } label: {
-                        Image(systemName: "gearshape")
-                    }
-                    .disabled(store.activeProjectId == nil)
-                    .help("Project Settings")
-                    .accessibilityLabel("Project Settings")
+            ToolbarItem {
+                Button {
+                    store.showsProjectSettings.toggle()
+                } label: {
+                    Image(systemName: "gearshape")
                 }
+                .disabled(store.activeProjectId == nil)
+                .help("Project Settings")
+                .accessibilityLabel("Project Settings")
             }
         case .bundles:
             ToolbarItem {
@@ -1096,7 +1071,7 @@ struct WorkspaceView: View {
     @ViewBuilder
     private var navigator: some View {
         switch store.selectedSection {
-        case .hub, .local:
+        case .memory:
             MemoryNavigator(store: store)
         case .bundles:
             BundleNavigator(store: store)
@@ -1110,10 +1085,10 @@ struct WorkspaceView: View {
     @ViewBuilder
     private var detail: some View {
         switch store.selectedSection {
-        case .hub, .local:
-            if store.selectedSection == .local, store.activeProjectId == nil {
+        case .memory:
+            if store.projects.isEmpty, !store.resources.contains(where: { $0.scope == .org }) {
                 ProjectUnavailableView(store: store)
-            } else if store.selectedSection == .local, store.showsProjectSettings {
+            } else if store.showsProjectSettings, store.activeProjectId != nil {
                 ProjectSettingsView(store: store)
             } else {
                 MemoryMainPane(store: store)
@@ -1145,15 +1120,12 @@ struct WorkspaceView: View {
         guard !needle.isEmpty else { return [] }
         var entries: [SearchEntry] = []
         switch store.selectedSection {
-        case .hub:
-            entries = memorySearchEntries(needle: needle) { $0.scope == .org }
-        case .local:
-            let inheritedIds = store.activeProject?.selectedOrgResourceIds ?? []
+        case .memory:
             entries = memorySearchEntries(needle: needle) { item in
-                if item.scope == .project {
-                    return item.projectId == store.activeProjectId
+                if item.scope == .org {
+                    return true
                 }
-                return inheritedIds.contains(item.id)
+                return item.projectId == store.activeProjectId
             }
         case .bundles:
             for bundle in store.bundles
@@ -1256,6 +1228,39 @@ private struct IssueProjectFilter: View {
     }
 }
 
+private struct MemoryProjectFilter: View {
+    @ObservedObject var store: WorkspaceStore
+
+    var body: some View {
+        ToolbarFilterMenu(
+            selectionTitle: store.activeProject?.name ?? "Hub",
+            isLoading: store.loadingProjectId != nil
+        ) {
+            if store.projects.isEmpty {
+                Button("No Projects") {}
+                    .disabled(true)
+            } else {
+                ForEach(store.projects) { project in
+                    Button {
+                        guard project.id != store.activeProjectId else { return }
+                        Task { await store.selectProject(project.id) }
+                    } label: {
+                        if project.id == store.activeProjectId {
+                            Label(project.name, systemImage: "checkmark")
+                        } else {
+                            Text(project.name)
+                        }
+                    }
+                    .disabled(store.loadingProjectId != nil)
+                }
+            }
+        }
+        .help("Filter Memory by Project")
+        .accessibilityLabel("Project Filter")
+        .accessibilityValue(store.activeProject?.name ?? "Hub")
+    }
+}
+
 private extension SyncToolbarPresentation {
     var tint: Color {
         switch self {
@@ -1345,8 +1350,7 @@ private struct WorkspaceSearchPopover: View {
 
     private var searchPrompt: String {
         switch store.selectedSection {
-        case .hub: "Search Hub"
-        case .local: "Search Local"
+        case .memory: "Search Memory"
         case .bundles: "Search Bundles"
         case .reviews: "Search Reviews"
         case .issues: "Search Issues"
@@ -1427,81 +1431,12 @@ private struct GlobalSidebar: View {
     let onOpenSettings: () -> Void
     let onOpenDiagnostics: (DiagnosticsDestination) -> Void
     let onShowLogs: () -> Void
-    @State private var localExpanded = true
 
     var body: some View {
         List(selection: selection) {
             Section {
-                SidebarDestinationLabel(section: .hub)
-                    .tag(GlobalSidebarDestination.section(.hub))
-
-                HStack(spacing: 4) {
-                    Button {
-                        store.selectedSection = .local
-                        store.selectedItemId = nil
-                        withAnimation(.snappy(duration: 0.16)) {
-                            localExpanded.toggle()
-                        }
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: WorkspaceSection.local.symbol)
-                                .frame(width: 16)
-                            Text(WorkspaceSection.local.title)
-                            Spacer(minLength: 8)
-                        }
-                        .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .focusEffectDisabled()
-
-                    if store.canManageProjects {
-                        Button {
-                            store.presentProjectCreation()
-                        } label: {
-                            Image(systemName: "plus")
-                                .frame(width: 16, height: 16, alignment: .center)
-                        }
-                        .buttonStyle(.plain)
-                        .focusEffectDisabled()
-                        .frame(width: 20, height: 20, alignment: .center)
-                        .contentShape(Rectangle())
-                        .help("New Project")
-                        .accessibilityLabel("New Project")
-                    }
-                }
-                .tag(GlobalSidebarDestination.section(.local))
-
-                if localExpanded {
-                    ForEach(store.projects) { project in
-                        HStack {
-                            Text(project.name)
-                                .lineLimit(1)
-                            Spacer()
-                            if store.loadingProjectId == project.id {
-                                ProgressView()
-                                    .controlSize(.mini)
-                            } else if store.drafts.contains(where: {
-                                $0.projectId == project.id
-                                    && $0.status != .discarded
-                                    && $0.status != .merged
-                                    && $0.freshness == .behind
-                            }) {
-                                DraftBaseBehindIndicator()
-                            }
-                        }
-                        .padding(.leading, 24)
-                        .tag(GlobalSidebarDestination.project(project.id))
-                        .accessibilityLabel(project.name)
-                        .contextMenu {
-                            Button("Project Settings…") {
-                                Task {
-                                    await store.selectProject(project.id)
-                                    store.showsProjectSettings = true
-                                }
-                            }
-                        }
-                    }
-                }
+                SidebarDestinationLabel(section: .memory)
+                    .tag(GlobalSidebarDestination.section(.memory))
 
                 SidebarDestinationLabel(section: .issues)
                     .tag(GlobalSidebarDestination.section(.issues))
@@ -1555,22 +1490,12 @@ private struct GlobalSidebar: View {
 
     private var selection: Binding<GlobalSidebarDestination?> {
         Binding(
-            get: {
-                if store.selectedSection == .local, let projectId = store.activeProjectId {
-                    return .project(projectId)
-                }
-                return .section(store.selectedSection)
-            },
+            get: { .section(store.selectedSection) },
             set: { destination in
                 guard let destination else { return }
-                switch destination {
-                case .section(let section):
+                if case .section(let section) = destination {
                     store.selectedSection = section
                     store.selectedItemId = nil
-                case .project(let projectId):
-                    store.selectedSection = .local
-                    store.showsProjectSettings = false
-                    Task { await store.selectProject(projectId) }
                 }
             }
         )
@@ -1594,7 +1519,6 @@ private struct SidebarDestinationLabel: View {
 
 private enum GlobalSidebarDestination: Hashable {
     case section(WorkspaceSection)
-    case project(String)
 }
 
 private struct SearchEntry: Identifiable {
@@ -1619,7 +1543,6 @@ private struct SearchEntry: Identifiable {
             destination: .memory(item)
         )
     }
-
     static func bundle(_ bundle: PersonalBundle) -> Self {
         .init(
             id: "bundle:\(bundle.id)",

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -1430,16 +1430,16 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertTrue(workflow.supportsMarkdownPreview)
     }
 
-    func testLocalWorkbenchTabsAreScopedToTheirProject() {
+    func testProjectWorkbenchTabsAreScopedToTheirProject() {
         let firstProjectTab = WorkbenchTab(
-            section: .local,
+            section: .memory,
             projectId: "project-1",
             itemId: "context-1",
             mode: .source,
             title: "Context"
         )
         let secondProjectTab = WorkbenchTab(
-            section: .local,
+            section: .memory,
             projectId: "project-2",
             itemId: "context-1",
             mode: .source,
@@ -1447,23 +1447,21 @@ final class DaemonContractTests: XCTestCase {
         )
 
         XCTAssertNotEqual(firstProjectTab.id, secondProjectTab.id)
-        XCTAssertTrue(firstProjectTab.isVisible(in: .local, projectId: "project-1"))
-        XCTAssertFalse(firstProjectTab.isVisible(in: .local, projectId: "project-2"))
-        XCTAssertFalse(firstProjectTab.isVisible(in: .hub, projectId: "project-1"))
+        XCTAssertTrue(firstProjectTab.isVisible(in: .memory, projectId: "project-1"))
+        XCTAssertFalse(firstProjectTab.isVisible(in: .memory, projectId: "project-2"))
     }
 
-    func testHubWorkbenchTabsDoNotDependOnTheActiveProject() {
+    func testOrgWorkbenchTabsDoNotDependOnTheActiveProject() {
         let tab = WorkbenchTab(
-            section: .hub,
+            section: .memory,
             projectId: nil,
             itemId: "rule-1",
             mode: .source,
             title: "Rule"
         )
 
-        XCTAssertTrue(tab.isVisible(in: .hub, projectId: "project-1"))
-        XCTAssertTrue(tab.isVisible(in: .hub, projectId: "project-2"))
-        XCTAssertFalse(tab.isVisible(in: .local, projectId: "project-1"))
+        XCTAssertTrue(tab.isVisible(in: .memory, projectId: "project-1"))
+        XCTAssertTrue(tab.isVisible(in: .memory, projectId: "project-2"))
     }
 
     func testReplacingRulePrimaryTextReplacesMarkdown() {

--- a/apps/macos/Tests/DocumentTabStripTests.swift
+++ b/apps/macos/Tests/DocumentTabStripTests.swift
@@ -233,7 +233,7 @@ final class DocumentTabStripTests: XCTestCase {
         mode: WorkbenchTabMode = .source
     ) -> WorkbenchTab {
         WorkbenchTab(
-            section: .local,
+            section: .memory,
             projectId: "project-1",
             itemId: itemId,
             mode: mode,

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -7,13 +7,16 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(WorkspaceSection.issues.title, "Kanban")
     }
 
+    func testMemoryWorkspaceTitleIsMemory() {
+        XCTAssertEqual(WorkspaceSection.memory.title, "Memory")
+    }
+
     func testReviewsAndKanbanUseSidebarWithPushNavigatedDetail() {
         XCTAssertEqual(WorkspaceColumnLayout(section: .issues), .sidebarDetail)
         XCTAssertEqual(WorkspaceColumnLayout(section: .reviews), .sidebarDetail)
 
         for section in [
-            WorkspaceSection.hub,
-            .local,
+            WorkspaceSection.memory,
             .bundles,
         ] {
             XCTAssertEqual(
@@ -270,13 +273,13 @@ final class WorkspaceNavigationTests: XCTestCase {
 
     func testNavigationHistoryUsesTheVisibleTabWhenStoredActiveTabIsFromAnotherScope() {
         let store = WorkspaceStore()
-        let hiddenHubTab = tab(itemId: "hub", section: .hub)
-        let firstLocalTab = tab(itemId: "local-first", section: .local, projectId: "project")
-        let secondLocalTab = tab(itemId: "local-second", section: .local, projectId: "project")
-        store.tabs = [hiddenHubTab, firstLocalTab, secondLocalTab]
-        store.selectedSection = .local
+        let hiddenTab = tab(itemId: "other-project", section: .memory, projectId: "other-project")
+        let firstLocalTab = tab(itemId: "local-first", section: .memory, projectId: "project")
+        let secondLocalTab = tab(itemId: "local-second", section: .memory, projectId: "project")
+        store.tabs = [hiddenTab, firstLocalTab, secondLocalTab]
+        store.selectedSection = .memory
         store.activeProjectId = "project"
-        store.activeTabId = hiddenHubTab.id
+        store.activeTabId = hiddenTab.id
 
         store.selectTab(firstLocalTab)
         store.goBack()
@@ -330,7 +333,7 @@ final class WorkspaceNavigationTests: XCTestCase {
 
     private func tab(
         itemId: String,
-        section: WorkspaceSection = .hub,
+        section: WorkspaceSection = .memory,
         projectId: String? = nil
     ) -> WorkbenchTab {
         WorkbenchTab(


### PR DESCRIPTION
## Summary

The macOS app previously split the workspace sidebar into separate
"Hub" (org-scope) and "Local" (per-project) memory surfaces with a
rules/context/workflow kind filter in the navigator toolbar. As the
first step of the unified Memory model (ISSUE-012), this PR collapses
those two sidebar items into a single "Memory" section.

The sidebar now shows one Memory item; the per-project sub-navigation
moves into a kanban-style project filter in the navigator toolbar, and
the rules/context/workflow kind filter is removed. The Memory list
always shows org-scope memories and merges in the active project's
project-scope memories; org memories the project references keep the
inherited styling and context-menu actions (Add/Remove from Local).

## Test plan

- [x] `bun run test:macos` — 149 tests pass (2 live integration tests skipped as usual)
- [x] Builds cleanly in Debug for the Clumsies scheme
- [x] Manual: sidebar shows one Memory item; project filter switches the merged list; no kind filter remains
