### PR TITLE
macos: add Org entry to the Memory project filter

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -649,6 +649,15 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    func showOrgMemory() {
+        guard activeProjectId != nil else { return }
+        activeProjectId = nil
+        showsProjectSettings = false
+        selectedItemId = nil
+        let tab = visibleTabs.last
+        activeTabId = tab?.id
+    }
+
     func selectProject(_ projectId: String) async {
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
         guard projectId != activeProjectId || !project.isLoaded else { return }
@@ -931,7 +940,11 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func createMemory(kind: MemoryKind, scope: MemoryScope) async {
-        guard let projectId = activeProjectId else { return }
+        // Org-scope drafts are carried by a project in the daemon; when the
+        // user is browsing the Org view without an active project, fall back
+        // to the first project as the carrying project.
+        let projectId = activeProjectId ?? (scope == .org ? projects.first?.id : nil)
+        guard let projectId else { return }
         guard canCreateMemory(kind: kind, scope: scope) else { return }
         let path = uniqueDefaultPath(for: kind, scope: scope)
         let document = defaultDocument(kind: kind, path: path)

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -1233,9 +1233,23 @@ private struct MemoryProjectFilter: View {
 
     var body: some View {
         ToolbarFilterMenu(
-            selectionTitle: store.activeProject?.name ?? "Hub",
+            selectionTitle: store.activeProject?.name ?? "Org",
             isLoading: store.loadingProjectId != nil
         ) {
+            Button {
+                store.showOrgMemory()
+            } label: {
+                if store.activeProjectId == nil {
+                    Label("Org", systemImage: "checkmark")
+                } else {
+                    Label("Org", systemImage: "building.2")
+                }
+            }
+
+            if !store.projects.isEmpty {
+                Divider()
+            }
+
             if store.projects.isEmpty {
                 Button("No Projects") {}
                     .disabled(true)
@@ -1257,7 +1271,7 @@ private struct MemoryProjectFilter: View {
         }
         .help("Filter Memory by Project")
         .accessibilityLabel("Project Filter")
-        .accessibilityValue(store.activeProject?.name ?? "Hub")
+        .accessibilityValue(store.activeProject?.name ?? "Org")
     }
 }
 


### PR DESCRIPTION
## Summary

Restores the Org entry in the Memory project filter that was left out of
the unified Memory section merge: the filter now lists Org (org-scope
memories) as the default entry above the projects, with a checkmark when
active. The store gains `showOrgMemory()` to clear the active project, and
org-scope memory creation falls back to the first project as the daemon's
carrying project when no project is active.

## Test plan

- [x] `bun run test:macos` (macOS contract and navigation tests)
- [x] Manual: with no project selected the filter shows "Org" checked and
      the org-scope memory list; creating an org memory works without an
      active project
