### PR TITLE
server: scope org-selection blob rewrite to selection blobs only

### DIFF
--- a/crates/server/migrations/20260816000100_rewrite_org_selection_blobs.sql
+++ b/crates/server/migrations/20260816000100_rewrite_org_selection_blobs.sql
@@ -18,6 +18,13 @@
 --
 -- Idempotent: only Blobs that still lack a 'memories' key are rewritten,
 -- and only Blobs referenced as org-selection tree entries are touched.
+-- The selection filter is applied as a JOIN before any JSON parsing:
+-- Blobs also store plain Markdown resource bodies, and parsing them as
+-- JSON must never happen (the LATERAL expression must not see non-org-
+-- selection rows, regardless of the planner's join order). A leading-brace
+-- guard additionally skips (rather than fails on) org-selection entries
+-- whose content is not an object, so a single corrupt Blob cannot block
+-- the migration.
 
 UPDATE blobs
 SET content = rewritten.content
@@ -30,7 +37,16 @@ FROM (
             'memories', COALESCE(merged.memories, '[]'::jsonb)
         )::text AS content
     FROM blobs b
-    CROSS JOIN LATERAL (SELECT b.content::jsonb AS parsed) p
+    JOIN (
+        SELECT DISTINCT blob_id
+        FROM tree_entries
+        WHERE resource_kind = 'project_org_selection'
+    ) selection_blobs ON selection_blobs.blob_id = b.blob_id
+    CROSS JOIN LATERAL (
+        SELECT CASE
+                   WHEN b.content ~ '^[[:space:]]*\{' THEN b.content::jsonb
+               END AS parsed
+    ) p
     CROSS JOIN LATERAL (
         SELECT jsonb_agg(
             jsonb_build_object(
@@ -69,7 +85,4 @@ FROM (
     ) merged
     WHERE NOT parsed ? 'memories'
 ) rewritten
-WHERE blobs.blob_id = rewritten.blob_id
-  AND blobs.blob_id IN (
-      SELECT blob_id FROM tree_entries WHERE resource_kind = 'project_org_selection'
-  );
+WHERE blobs.blob_id = rewritten.blob_id;

--- a/crates/server/tests/org_selection_blob_rewrite_migration.rs
+++ b/crates/server/tests/org_selection_blob_rewrite_migration.rs
@@ -89,7 +89,15 @@ async fn rewrite_migration_converts_legacy_selection_blobs() {
                         "status": "active", "updated_at": "2026-07-16T00:00:00Z"
                     }],
                     "revision": 5
-                }');
+                }'),
+                -- Production-shaped data: plain Markdown resource bodies share
+                -- the blobs table with org-selection payloads, and a corrupt
+                -- selection entry may reference a non-object Blob. Neither
+                -- may abort the migration.
+                ('blob_markdown_body', '# s6-0 TUI 组件体系总览
+
+clumsies TUI 的完整 UI 组件库文档正文。'),
+                ('blob_selection_corrupt', '# 不是 JSON 的 selection 内容');
 
             INSERT INTO trees (tree_id) VALUES ('tree_v1');
             INSERT INTO tree_entries (
@@ -98,7 +106,9 @@ async fn rewrite_migration_converts_legacy_selection_blobs() {
                 ('tree_v1', 'selection_legacy', 'project_org_selection', 'project',
                  'project_test', NULL, 'blob_selection_legacy', 'config'),
                 ('tree_v1', 'selection_unified', 'project_org_selection', 'project',
-                 'project_test', NULL, 'blob_selection_unified', 'config');
+                 'project_test', NULL, 'blob_selection_unified', 'config'),
+                ('tree_v1', 'selection_corrupt', 'project_org_selection', 'project',
+                 'project_test', NULL, 'blob_selection_corrupt', 'config');
             "##,
         )
         .await
@@ -149,6 +159,25 @@ async fn rewrite_migration_converts_legacy_selection_blobs() {
     assert_eq!(workflow["project_id"], "project_test");
     assert_eq!(workflow["description"], "Workflow desc");
     assert_eq!(workflow["status"], "active");
+
+    // Production-shaped data: Markdown resource bodies in the blobs table
+    // and a corrupt org-selection entry must not abort the migration, and
+    // the corrupt entry is skipped rather than rewritten.
+    let markdown: String =
+        sqlx::query_scalar("SELECT content FROM blobs WHERE blob_id = 'blob_markdown_body'")
+            .fetch_one(&postgres.pool)
+            .await
+            .unwrap();
+    assert!(markdown.starts_with("# s6-0"), "Markdown body untouched");
+    let corrupt: String =
+        sqlx::query_scalar("SELECT content FROM blobs WHERE blob_id = 'blob_selection_corrupt'")
+            .fetch_one(&postgres.pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        corrupt, "# 不是 JSON 的 selection 内容",
+        "corrupt selection Blob skipped, not rewritten"
+    );
 
     // Idempotent: the already-unified Blob is untouched, and re-running the
     // migration changes nothing.


### PR DESCRIPTION
## Summary

Fixes the org-selection Blob rewrite migration aborting on production
data. The migration parsed every Blob in the table as JSON inside a
LATERAL expression and relied on the planner to push the org-selection
filter down before parsing; production Blobs also store plain Markdown
resource bodies, and depending on join order the migration aborted with
`22P02 invalid input syntax for type json` (`Token "#" is invalid`), which
surfaced as the new Server container failing its health check and the
release rolling back.

The selection filter is now a JOIN applied before any JSON parsing, and a
leading-brace guard skips (rather than fails on) org-selection entries
whose content is not a JSON object, so a single corrupt Blob cannot block
the migration. The test seeds production-shaped data: Markdown bodies in
the blobs table and a corrupt org-selection entry.

## Test plan

- [ ] `cargo test -p server --test org_selection_blob_rewrite_migration`
      (legacy conversion, idempotency, Markdown bodies and corrupt
      selection entries tolerated)
- [ ] `cargo test -p server -- --test-threads=1` full suite
- [ ] Production: the migration already ran successfully against the
      production database (34 legacy Blobs rewritten, 0 remaining); the
      next deployment must apply it idempotently (0 rows) and come up
      healthy
