### PR TITLE
daemon: unify memory mcp tool and configure guidelines

### DIFF
--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -8,6 +8,24 @@ struct DaemonProjectConfig: Codable, Equatable, Sendable {
     let hasRefreshToken: Bool
     let ready: Bool
     let missingFields: [String]
+
+    init(
+        serverUrl: String,
+        projectId: String? = nil,
+        memoryGuidelinesPath: String? = nil,
+        hasAccessToken: Bool,
+        hasRefreshToken: Bool,
+        ready: Bool,
+        missingFields: [String] = []
+    ) {
+        self.serverUrl = serverUrl
+        self.projectId = projectId
+        self.memoryGuidelinesPath = memoryGuidelinesPath
+        self.hasAccessToken = hasAccessToken
+        self.hasRefreshToken = hasRefreshToken
+        self.ready = ready
+        self.missingFields = missingFields
+    }
 }
 
 struct DaemonProjectConfigUpdate: Codable, Sendable {
@@ -16,6 +34,20 @@ struct DaemonProjectConfigUpdate: Codable, Sendable {
     let memoryGuidelinesPath: String?
     let accessToken: String?
     let refreshToken: String?
+
+    init(
+        serverUrl: String,
+        projectId: String? = nil,
+        memoryGuidelinesPath: String? = nil,
+        accessToken: String? = nil,
+        refreshToken: String? = nil
+    ) {
+        self.serverUrl = serverUrl
+        self.projectId = projectId
+        self.memoryGuidelinesPath = memoryGuidelinesPath
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
 }
 
 struct DaemonProjectSelection: Codable, Sendable {

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -3,6 +3,7 @@ import Foundation
 struct DaemonProjectConfig: Codable, Equatable, Sendable {
     let serverUrl: String
     let projectId: String?
+    let memoryGuidelinesPath: String?
     let hasAccessToken: Bool
     let hasRefreshToken: Bool
     let ready: Bool
@@ -12,6 +13,7 @@ struct DaemonProjectConfig: Codable, Equatable, Sendable {
 struct DaemonProjectConfigUpdate: Codable, Sendable {
     let serverUrl: String
     let projectId: String?
+    let memoryGuidelinesPath: String?
     let accessToken: String?
     let refreshToken: String?
 }

--- a/assets/adapters/claude-code/runtime/skills/activate/SKILL.md
+++ b/assets/adapters/claude-code/runtime/skills/activate/SKILL.md
@@ -4,7 +4,7 @@ description: Activate available managed agent memory
 argument-hint: "[task or retrieval cue]"
 user-invocable: true
 ---
-Call the `activate` MCP tool once with a natural-language `query` describing
+Call the `memory` MCP tool once with `op: { activate: { query: "..." } }` describing
 the current task or retrieval cue. Use `$ARGUMENTS` when provided; otherwise
 derive the query from the current user task.
 

--- a/assets/adapters/codex/runtime/skills/activate/SKILL.md
+++ b/assets/adapters/codex/runtime/skills/activate/SKILL.md
@@ -4,7 +4,7 @@ description: Activate available managed agent memory
 argument-hint: "[task or retrieval cue]"
 user-invocable: true
 ---
-Call the `activate` MCP tool once with a natural-language `query` describing
+Call the `memory` MCP tool once with `op: { activate: { query: "..." } }` describing
 the current task or retrieval cue. Use `$ARGUMENTS` when provided; otherwise
 derive the query from the current user task.
 

--- a/crates/daemon/src/agent_runtime/mcp.rs
+++ b/crates/daemon/src/agent_runtime/mcp.rs
@@ -5,13 +5,20 @@ use std::io::{self, BufRead, Write};
 use serde_json::{Map, Value, json};
 
 use super::AgentRuntimeBackend;
-use super::mcp_contract::{decode_tool_call_params, parse_tool_call, tool_definitions};
+use super::mcp_contract::{
+    DEFAULT_GUIDELINES_PATH, decode_tool_call_params, parse_tool_call,
+    tool_definitions_with_guidelines,
+};
 
 const JSONRPC_VERSION: &str = "2.0";
 pub const PROTOCOL_VERSION: &str = "2025-06-18";
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 
-pub const SERVER_INSTRUCTIONS: &str = "Call activate once at the start of every substantive user task. It returns ranked memory fragments ready for the current reasoning context. Pass its next_state only while the earlier fragments remain in the model context; omit state after context compaction or when starting fresh. Use load only to read complete resources by known id or path, and store only when the user explicitly asks for memory maintenance. Store queues synchronization and does not publish authority directly. Use kanban for the native Kanban (distinct from remote GitHub Issues). Other agents share this board: before creating or mutating anything, call kanban.list first to check for existing Issues and active runs, so you do not duplicate work or claim an Issue another agent is already working on. A Todo may report blocked=true with blocking_reasons when its dependencies are not Done or an external condition is unsatisfied; treat such an Issue as not yet actionable and do not begin_work on it unless the user explicitly overrides. While you are already working an Issue, a new code-related request from the user does not interrupt the current work: capture it as a new Todo Issue with kanban.create (without begin_work) and continue; only non-code requests such as documentation, memory, or workflow text may be handled immediately. Then call kanban.get when the user supplies a global issue_id, create durable Todo work only after the list check, update semantic content, call kanban.begin_work BEFORE starting work on any Issue (user-assigned or self-created) to claim it and enter In Progress (skip it only if the Issue is already bound to an active run), and call kanban.request_closure only after judging its acceptance criteria satisfied. kanban.get returns the owning project_id; mutations remain scoped to this MCP workspace. Agents cannot approve closure. AgentRun lifecycle events never advance an Issue.";
+pub fn server_instructions(guidelines_path: &str) -> String {
+    format!(
+        "Call memory with op: {{ activate: {{ query: \"...\" }} }} once at the start of every substantive user task. It returns ranked memory fragments ready for the current reasoning context. Pass its next_state only while the earlier fragments remain in the model context; omit state after context compaction or when starting fresh. Use memory with op: {{ load: {{ ids: [...] }} }} to read complete resources by known id or path (including project memory conventions at {guidelines_path}). Use memory with op: {{ store: ... }} only when the user explicitly asks for memory maintenance; adhere to project memory update rules before storing drafts. Store queues synchronization and does not publish authority directly. Use kanban for the native Kanban (distinct from remote GitHub Issues). Other agents share this board: before creating or mutating anything, call kanban.list first to check for existing Issues and active runs, so you do not duplicate work or claim an Issue another agent is already working on. A Todo may report blocked=true with blocking_reasons when its dependencies are not Done or an external condition is unsatisfied; treat such an Issue as not yet actionable and do not begin_work on it unless the user explicitly overrides. While you are already working an Issue, a new code-related request from the user does not interrupt the current work: capture it as a new Todo Issue with kanban.create (without begin_work) and continue; only non-code requests such as documentation, memory, or workflow text may be handled immediately. Then call kanban.get when the user supplies a global issue_id, create durable Todo work only after the list check, update semantic content, call kanban.begin_work BEFORE starting work on any Issue (user-assigned or self-created) to claim it and enter In Progress (skip it only if the Issue is already bound to an active run), and call kanban.request_closure only after judging its acceptance criteria satisfied. kanban.get returns the owning project_id; mutations remain scoped to this MCP workspace. Agents cannot approve closure. AgentRun lifecycle events never advance an Issue."
+    )
+}
 
 #[derive(Clone, Copy)]
 enum ErrorCode {
@@ -26,6 +33,7 @@ enum ErrorCode {
 pub struct McpServer<B> {
     backend: B,
     project_id: String,
+    guidelines_path: String,
     version: String,
     initialize_seen: bool,
     initialized: bool,
@@ -36,13 +44,24 @@ where
     B: AgentRuntimeBackend,
 {
     pub fn new(backend: B, project_id: impl Into<String>, version: impl Into<String>) -> Self {
+        let guidelines_path = backend
+            .guidelines_path()
+            .ok()
+            .flatten()
+            .unwrap_or_else(|| DEFAULT_GUIDELINES_PATH.to_owned());
         Self {
             backend,
             project_id: project_id.into(),
+            guidelines_path,
             version: version.into(),
             initialize_seen: false,
             initialized: false,
         }
+    }
+
+    pub fn with_guidelines_path(mut self, path: impl Into<String>) -> Self {
+        self.guidelines_path = path.into();
+        self
     }
 
     /// Processes one newline-delimited JSON-RPC message. Notifications return
@@ -150,7 +169,7 @@ where
                         "protocolVersion": PROTOCOL_VERSION,
                         "capabilities": {"tools": {"listChanged": false}},
                         "serverInfo": {"name": "clumsies", "version": self.version},
-                        "instructions": SERVER_INSTRUCTIONS
+                        "instructions": server_instructions(&self.guidelines_path)
                     }),
                 ))
             }
@@ -160,7 +179,10 @@ where
                 ErrorCode::ServerNotInitialized,
                 "Server not initialized",
             )),
-            "tools/list" => Some(success_response(id, json!({"tools": tool_definitions()}))),
+            "tools/list" => Some(success_response(
+                id,
+                json!({"tools": tool_definitions_with_guidelines(&self.guidelines_path)}),
+            )),
             "tools/call" => Some(success_response(id, self.call_tool(params))),
             _ => Some(error_response(
                 id,
@@ -374,7 +396,7 @@ mod tests {
         let list = server
             .process_line(br#"{"id":2,"method":"tools/list","params":{}}"#)
             .unwrap();
-        assert_eq!(list["result"]["tools"].as_array().unwrap().len(), 4);
+        assert_eq!(list["result"]["tools"].as_array().unwrap().len(), 2);
     }
 
     #[test]
@@ -383,7 +405,7 @@ mod tests {
         let mut server = initialized_server(backend);
         let response = server
             .process_line(
-                br#"{"id":3,"method":"tools/call","params":{"name":"activate","arguments":{"query":"runtime identity"}}}"#,
+                br#"{"id":3,"method":"tools/call","params":{"name":"memory","arguments":{"op":{"activate":{"query":"runtime identity"}}}}}"#,
             )
             .unwrap();
 
@@ -406,7 +428,7 @@ mod tests {
         let mut server = initialized_server(backend);
         let response = server
             .process_line(
-                br#"{"id":4,"method":"tools/call","params":{"name":"activate","arguments":{"query":"ok","prompt":"secret"}}}"#,
+                br#"{"id":4,"method":"tools/call","params":{"name":"memory","arguments":{"op":{"activate":{"query":"ok","prompt":"secret"}}}}}"#,
             )
             .unwrap();
 
@@ -438,7 +460,7 @@ mod tests {
         let mut server = initialized_server(backend);
         let response = server
             .process_line(
-                br#"{"id":5,"method":"tools/call","params":{"name":"activate","arguments":{"query":"hello"}}}"#,
+                br#"{"id":5,"method":"tools/call","params":{"name":"memory","arguments":{"op":{"activate":{"query":"hello"}}}}}"#,
             )
             .unwrap();
 
@@ -465,5 +487,35 @@ mod tests {
         let ping: Value = serde_json::from_slice(lines[1]).unwrap();
         assert_eq!(too_large["error"]["code"], -32700);
         assert_eq!(ping["result"], json!({}));
+    }
+
+    #[test]
+    fn server_injects_custom_guidelines_path_into_instructions_and_tool_definition() {
+        let backend = RecordingBackend::success(json!({}));
+        let mut server = McpServer::new(backend, "prj_test", "0.16.3")
+            .with_guidelines_path("./docs/MEMORY_RULES.md");
+
+        let init = server
+            .process_line(br#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#)
+            .unwrap();
+        assert!(
+            init["result"]["instructions"]
+                .as_str()
+                .unwrap()
+                .contains("./docs/MEMORY_RULES.md")
+        );
+
+        server.process_line(br#"{"method":"notifications/initialized"}"#);
+        let list = server
+            .process_line(br#"{"id":2,"method":"tools/list","params":{}}"#)
+            .unwrap();
+        let tools = list["result"]["tools"].as_array().unwrap();
+        let memory_tool = tools.iter().find(|t| t["name"] == "memory").unwrap();
+        assert!(
+            memory_tool["description"]
+                .as_str()
+                .unwrap()
+                .contains("./docs/MEMORY_RULES.md")
+        );
     }
 }

--- a/crates/daemon/src/agent_runtime/mcp_contract.rs
+++ b/crates/daemon/src/agent_runtime/mcp_contract.rs
@@ -24,9 +24,7 @@ const MAX_ISSUE_FACT_ID_BYTES: usize = 128;
 const MAX_ISSUE_FACT_DESCRIPTION_BYTES: usize = 1_000;
 const MAX_ISSUE_FACT_VALUE_BYTES: usize = 256;
 
-pub const ACTIVATE_TOOL_NAME: &str = "activate";
-pub const LOAD_TOOL_NAME: &str = "load";
-pub const STORE_TOOL_NAME: &str = "store";
+pub const MEMORY_TOOL_NAME: &str = "memory";
 pub const KANBAN_TOOL_NAME: &str = "kanban";
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -88,16 +86,8 @@ pub fn parse_tool_call(
     reject_null_values(&arguments)?;
 
     match name {
-        ACTIVATE_TOOL_NAME => {
-            let input: ActivateInput = decode_arguments(name, arguments)?;
-            input.into_domain(project_id)
-        }
-        LOAD_TOOL_NAME => {
-            let input: LoadInput = decode_arguments(name, arguments)?;
-            input.into_domain(project_id)
-        }
-        STORE_TOOL_NAME => {
-            let input: StoreInput = decode_arguments(name, arguments)?;
+        MEMORY_TOOL_NAME => {
+            let input: MemoryInput = decode_arguments(name, arguments)?;
             input.into_domain(project_id)
         }
         KANBAN_TOOL_NAME => {
@@ -132,6 +122,30 @@ fn reject_null_values(value: &Value) -> Result<(), ContractError> {
             Ok(())
         }
         _ => Ok(()),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MemoryInput {
+    op: MemoryOperation,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MemoryOperation {
+    Activate(ActivateInput),
+    Load(LoadInput),
+    Store(StoreInput),
+}
+
+impl MemoryInput {
+    fn into_domain(self, project_id: &str) -> Result<AgentRuntimeRequest, ContractError> {
+        match self.op {
+            MemoryOperation::Activate(input) => input.into_domain(project_id),
+            MemoryOperation::Load(input) => input.into_domain(project_id),
+            MemoryOperation::Store(input) => input.into_domain(project_id),
+        }
     }
 }
 
@@ -199,11 +213,27 @@ impl StoreResource {
     }
 }
 
+fn default_store_resource() -> StoreResource {
+    StoreResource::Memory
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct StoreInput {
+    #[serde(default = "default_store_resource")]
     resource: StoreResource,
-    op: StoreOperation,
+    #[serde(default)]
+    create: Option<StoreCreateInput>,
+    #[serde(default)]
+    update: Option<StoreUpdateInput>,
+    #[serde(default)]
+    rename: Option<StoreRenameInput>,
+    #[serde(default)]
+    delete: Option<StoreDeleteInput>,
+    #[serde(default)]
+    discard: Option<StoreDiscardInput>,
+    #[serde(default)]
+    op: Option<StoreOperation>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -263,6 +293,27 @@ struct StoreDiscardInput {
 
 impl StoreInput {
     fn into_domain(self, project_id: &str) -> Result<AgentRuntimeRequest, ContractError> {
+        let op = match (
+            self.op,
+            self.create,
+            self.update,
+            self.rename,
+            self.delete,
+            self.discard,
+        ) {
+            (Some(op), None, None, None, None, None) => op,
+            (None, Some(create), None, None, None, None) => StoreOperation::Create(create),
+            (None, None, Some(update), None, None, None) => StoreOperation::Update(update),
+            (None, None, None, Some(rename), None, None) => StoreOperation::Rename(rename),
+            (None, None, None, None, Some(delete), None) => StoreOperation::Delete(delete),
+            (None, None, None, None, None, Some(discard)) => StoreOperation::Discard(discard),
+            _ => {
+                return Err(ContractError::new(
+                    "store must provide exactly one operation (create, update, rename, delete, or discard)",
+                ));
+            }
+        };
+
         let resource = self.resource.domain();
         let mut operation = DaemonDraftOperation {
             create: None,
@@ -271,7 +322,7 @@ impl StoreInput {
             delete: None,
             discard: None,
         };
-        match self.op {
+        match op {
             StoreOperation::Create(input) => {
                 require_non_empty(&input.path, "path")?;
                 require_non_empty(&input.body, "body")?;
@@ -932,110 +983,118 @@ fn is_issue_id(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
+pub const DEFAULT_GUIDELINES_PATH: &str = "CLUMSIES.md";
+
 /// Tool definitions exposed over MCP. Keep these schemas MCP-specific: daemon
 /// request structs intentionally do not double as public Agent contracts.
 pub fn tool_definitions() -> Vec<Value> {
+    tool_definitions_with_guidelines(DEFAULT_GUIDELINES_PATH)
+}
+
+pub fn tool_definitions_with_guidelines(guidelines_path: &str) -> Vec<Value> {
     vec![
-        json!({
-            "name": ACTIVATE_TOOL_NAME,
-            "title": "Activate",
-            "description": "Activate the memory fragments most useful for the current task. Call once at the start of each substantive task. The daemon performs BM25 and vector recall, RRF fusion, reranking, budget control, and fragment delta calculation. Pass state only while fragments from the preceding activation remain in the model context.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "minLength": 1,
-                        "description": "Natural-language representation of the current task or retrieval cue."
-                    },
-                    "state": {
-                        "type": "string",
-                        "description": "Opaque next_state from a preceding activation whose fragments are still present in the current model context."
-                    }
-                },
-                "required": ["query"],
-                "additionalProperties": false
-            }
-        }),
-        json!({
-            "name": LOAD_TOOL_NAME,
-            "title": "Load",
-            "description": "Load complete current memory resources by stable id or exact path. Use for deep reading or before editing a known resource; activate already returns directly usable fragments and does not require a follow-up load.",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "ids": {
-                        "type": "array",
-                        "minItems": 1,
-                        "uniqueItems": true,
-                        "items": {"type": "string", "minLength": 1},
-                        "description": "Stable resource ids or exact paths."
-                    },
-                    "knownHashes": {
-                        "type": "object",
-                        "description": "Optional known content hashes keyed by requested id or path. Unchanged resources omit content.",
-                        "additionalProperties": {"type": "string"}
-                    }
-                },
-                "required": ["ids"],
-                "additionalProperties": false
-            }
-        }),
-        store_tool_definition(),
+        memory_tool_definition(guidelines_path),
         kanban_tool_definition(),
     ]
 }
 
-fn store_tool_definition() -> Value {
+fn memory_tool_definition(guidelines_path: &str) -> Value {
+    let description = format!(
+        "Manage project memory: activate ranked memory fragments for the current task, load complete memory resources by ID or path, or create/update/rename/delete/discard memory drafts when explicitly requested. Project memory conventions and update rules are documented at {guidelines_path}; call memory with op.load to read them before making substantial memory updates. Pass exactly one tagged operation in op."
+    );
     json!({
-        "name": STORE_TOOL_NAME,
-        "title": "Store",
-        "description": "Create, update, rename, delete, or discard a local Memory Draft when the user explicitly requests memory maintenance. Issues are native objects managed by the issue tool, not Memory documents. Before update, load the complete resource and use its content_hash with exact text replacements; update never accepts a complete document body. A successful call means durable local persistence and queued synchronization, not authoritative publication. Pass exactly one tagged operation.",
+        "name": MEMORY_TOOL_NAME,
+        "title": "Memory",
+        "description": description,
         "inputSchema": {
             "type": "object",
             "properties": {
-                "resource": {
-                    "type": "string",
-                    "enum": ["memory"],
-                    "description": "Memory resource type. Legacy context/rule/workflow values are accepted and treated as memory."
-                },
                 "op": {
                     "type": "object",
                     "minProperties": 1,
                     "maxProperties": 1,
                     "properties": {
-                        "create": {"$ref": "#/$defs/writeCreate"},
-                        "update": {"$ref": "#/$defs/writeUpdate"},
-                        "rename": {
+                        "activate": {
                             "type": "object",
+                            "description": "Activate the memory fragments most useful for the current task. Call once at the start of each substantive task. The daemon performs BM25 and vector recall, RRF fusion, reranking, budget control, and fragment delta calculation. Pass state only while fragments from the preceding activation remain in the model context.",
                             "properties": {
-                                "id": {"type": "string", "minLength": 1},
-                                "new_path": {"type": "string", "minLength": 1},
-                                "description": {"type": "string"}
+                                "query": {
+                                    "type": "string",
+                                    "minLength": 1,
+                                    "description": "Natural-language representation of the current task or retrieval cue."
+                                },
+                                "state": {
+                                    "type": "string",
+                                    "description": "Opaque next_state from a preceding activation whose fragments are still present in the current model context."
+                                }
                             },
-                            "required": ["id", "new_path"],
+                            "required": ["query"],
                             "additionalProperties": false
                         },
-                        "delete": {
+                        "load": {
                             "type": "object",
+                            "description": "Load complete current memory resources by stable id or exact path. Use for deep reading or before editing a known resource; activate already returns directly usable fragments and does not require a follow-up load.",
                             "properties": {
-                                "id": {"type": "string", "minLength": 1},
-                                "description": {"type": "string"}
+                                "ids": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "uniqueItems": true,
+                                    "items": {"type": "string", "minLength": 1},
+                                    "description": "Stable resource ids or exact paths."
+                                },
+                                "knownHashes": {
+                                    "type": "object",
+                                    "description": "Optional known content hashes keyed by requested id or path. Unchanged resources omit content.",
+                                    "additionalProperties": {"type": "string"}
+                                }
                             },
-                            "required": ["id"],
+                            "required": ["ids"],
                             "additionalProperties": false
                         },
-                        "discard": {
+                        "store": {
                             "type": "object",
-                            "properties": {"id": {"type": "string", "minLength": 1}},
-                            "required": ["id"],
+                            "description": "Create, update, rename, delete, or discard a local Memory Draft when the user explicitly requests memory maintenance. Issues are native objects managed by the kanban tool, not Memory documents. Before update, load the complete resource and use its content_hash with exact text replacements; update never accepts a complete document body. A successful call means durable local persistence and queued synchronization, not authoritative publication. Follow project memory conventions defined at CLUMSIES.md.",
+                            "properties": {
+                                "resource": {
+                                    "type": "string",
+                                    "enum": ["memory"],
+                                    "description": "Memory resource type. Defaults to 'memory'."
+                                },
+                                "create": {"$ref": "#/$defs/writeCreate"},
+                                "update": {"$ref": "#/$defs/writeUpdate"},
+                                "rename": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string", "minLength": 1},
+                                        "new_path": {"type": "string", "minLength": 1},
+                                        "description": {"type": "string"}
+                                    },
+                                    "required": ["id", "new_path"],
+                                    "additionalProperties": false
+                                },
+                                "delete": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {"type": "string", "minLength": 1},
+                                        "description": {"type": "string"}
+                                    },
+                                    "required": ["id"],
+                                    "additionalProperties": false
+                                },
+                                "discard": {
+                                    "type": "object",
+                                    "properties": {"id": {"type": "string", "minLength": 1}},
+                                    "required": ["id"],
+                                    "additionalProperties": false
+                                }
+                            },
                             "additionalProperties": false
                         }
                     },
                     "additionalProperties": false
                 }
             },
-            "required": ["resource", "op"],
+            "required": ["op"],
             "additionalProperties": false,
             "$defs": {
                 "writeCreate": {
@@ -1328,17 +1387,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn schemas_expose_only_the_four_agent_tools() {
+    fn schemas_expose_only_the_two_agent_tools() {
         let tools = tool_definitions();
         let names = tools
             .iter()
             .map(|tool| tool["name"].as_str().unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(names, ["activate", "load", "store", "kanban"]);
+        assert_eq!(names, ["memory", "kanban"]);
         assert_eq!(
-            tools[3]["inputSchema"]["properties"]["op"]["properties"]["create"]["properties"]["verification_steps"]
+            tools[1]["inputSchema"]["properties"]["op"]["properties"]["create"]["properties"]["verification_steps"]
                 ["items"]["type"],
             "string"
+        );
+        assert!(
+            tools[0]["inputSchema"]["properties"]["op"]["properties"]["activate"].is_object()
+        );
+        assert!(
+            tools[0]["inputSchema"]["properties"]["op"]["properties"]["load"].is_object()
+        );
+        assert!(
+            tools[0]["inputSchema"]["properties"]["op"]["properties"]["store"].is_object()
         );
     }
 
@@ -1372,16 +1440,16 @@ mod tests {
     fn strict_contract_rejects_unknown_and_null_fields() {
         let unknown = parse_tool_call(
             "prj_test",
-            ACTIVATE_TOOL_NAME,
-            json!({"query": "hello", "raw_payload": "secret"}),
+            MEMORY_TOOL_NAME,
+            json!({"op": {"activate": {"query": "hello", "raw_payload": "secret"}}}),
         )
         .unwrap_err();
         assert!(unknown.to_string().contains("unknown field"));
 
         let null = parse_tool_call(
             "prj_test",
-            ACTIVATE_TOOL_NAME,
-            json!({"query": "hello", "state": null}),
+            MEMORY_TOOL_NAME,
+            json!({"op": {"activate": {"query": "hello", "state": null}}}),
         )
         .unwrap_err();
         assert_eq!(null.to_string(), "arguments must not contain null values");
@@ -1403,10 +1471,14 @@ mod tests {
     fn store_create_builds_the_existing_typed_draft_request() {
         let request = parse_tool_call(
             "prj_test",
-            STORE_TOOL_NAME,
+            MEMORY_TOOL_NAME,
             json!({
-                "resource": "memory",
-                "op": {"create": {"path": "workflow/release.md", "body": "# Release"}}
+                "op": {
+                    "store": {
+                        "resource": "memory",
+                        "create": {"path": "workflow/release.md", "body": "# Release"}
+                    }
+                }
             }),
         )
         .unwrap();

--- a/crates/daemon/src/agent_runtime/mcp_contract.rs
+++ b/crates/daemon/src/agent_runtime/mcp_contract.rs
@@ -136,7 +136,7 @@ struct MemoryInput {
 enum MemoryOperation {
     Activate(ActivateInput),
     Load(LoadInput),
-    Store(StoreInput),
+    Store(Box<StoreInput>),
 }
 
 impl MemoryInput {
@@ -1399,15 +1399,9 @@ mod tests {
                 ["items"]["type"],
             "string"
         );
-        assert!(
-            tools[0]["inputSchema"]["properties"]["op"]["properties"]["activate"].is_object()
-        );
-        assert!(
-            tools[0]["inputSchema"]["properties"]["op"]["properties"]["load"].is_object()
-        );
-        assert!(
-            tools[0]["inputSchema"]["properties"]["op"]["properties"]["store"].is_object()
-        );
+        assert!(tools[0]["inputSchema"]["properties"]["op"]["properties"]["activate"].is_object());
+        assert!(tools[0]["inputSchema"]["properties"]["op"]["properties"]["load"].is_object());
+        assert!(tools[0]["inputSchema"]["properties"]["op"]["properties"]["store"].is_object());
     }
 
     #[test]

--- a/crates/daemon/src/agent_runtime/mod.rs
+++ b/crates/daemon/src/agent_runtime/mod.rs
@@ -73,6 +73,10 @@ pub trait AgentRuntimeBackend {
         &self,
         request: mcp_contract::AgentRuntimeRequest,
     ) -> Result<DaemonIpcResponse, DaemonError>;
+
+    fn guidelines_path(&self) -> Result<Option<String>, DaemonError> {
+        Ok(None)
+    }
 }
 
 impl AgentRuntimeBackend for DaemonIpcClient {
@@ -81,6 +85,11 @@ impl AgentRuntimeBackend for DaemonIpcClient {
         request: mcp_contract::AgentRuntimeRequest,
     ) -> Result<DaemonIpcResponse, DaemonError> {
         self.call(request.into_ipc_request()?)
+    }
+
+    fn guidelines_path(&self) -> Result<Option<String>, DaemonError> {
+        let resp = self.project_config()?;
+        Ok(resp.memory_guidelines_path)
     }
 }
 

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -34,6 +34,7 @@ pub struct DaemonConfig {
 pub struct ProjectConfig {
     pub server_url: String,
     pub project_id: Option<String>,
+    pub memory_guidelines_path: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -575,6 +576,9 @@ impl ProjectConfig {
             project_id: env::var("CLUMSIES_PROJECT_ID")
                 .ok()
                 .and_then(non_empty_string),
+            memory_guidelines_path: env::var("CLUMSIES_MEMORY_GUIDELINES_PATH")
+                .ok()
+                .and_then(non_empty_string),
         }
     }
 
@@ -594,6 +598,7 @@ impl ProjectConfig {
 pub(crate) struct RuntimeProjectConfig {
     pub(crate) server_url: String,
     pub(crate) project_id: Option<String>,
+    pub(crate) memory_guidelines_path: Option<String>,
     pub(crate) access_token: Option<String>,
     pub(crate) refresh_token: Option<String>,
 }
@@ -603,6 +608,7 @@ impl RuntimeProjectConfig {
         ProjectConfig {
             server_url: self.server_url.clone(),
             project_id: self.project_id.clone(),
+            memory_guidelines_path: self.memory_guidelines_path.clone(),
         }
         .validate()?;
         if self.access_token.is_none() && self.refresh_token.is_some() {
@@ -617,6 +623,7 @@ impl RuntimeProjectConfig {
         ProjectConfig {
             server_url: self.server_url.clone(),
             project_id: self.project_id.clone(),
+            memory_guidelines_path: self.memory_guidelines_path.clone(),
         }
     }
 

--- a/crates/daemon/src/migration.rs
+++ b/crates/daemon/src/migration.rs
@@ -1391,10 +1391,14 @@ pub(crate) async fn load_project_config(
     let project_id = load_meta_value(pool, "project_config_project_id")
         .await?
         .or_else(|| defaults.project_id.clone());
+    let memory_guidelines_path = load_meta_value(pool, "project_config_memory_guidelines_path")
+        .await?
+        .or_else(|| defaults.memory_guidelines_path.clone());
     let credentials = credentials.filter(|credentials| credentials.server_url == server_url);
     Ok(RuntimeProjectConfig {
         server_url,
         project_id,
+        memory_guidelines_path,
         access_token: credentials
             .as_ref()
             .map(|credentials| credentials.access_token.clone()),
@@ -1417,6 +1421,12 @@ pub(crate) async fn save_project_metadata(
         &mut tx,
         "project_config_project_id",
         config.project_id.as_deref(),
+    )
+    .await?;
+    upsert_meta_value(
+        &mut tx,
+        "project_config_memory_guidelines_path",
+        config.memory_guidelines_path.as_deref(),
     )
     .await?;
     tx.commit().await?;

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -186,6 +186,7 @@ impl DaemonState {
         let project_config = RuntimeProjectConfig {
             server_url: request.server_url.trim().to_owned(),
             project_id: request.project_id.and_then(non_empty_string),
+            memory_guidelines_path: request.memory_guidelines_path.and_then(non_empty_string),
             access_token: request.access_token.and_then(non_empty_string),
             refresh_token: request.refresh_token.and_then(non_empty_string),
         };
@@ -614,6 +615,7 @@ impl DaemonState {
         DaemonProjectConfig {
             server_url: project_config.server_url,
             project_id: project_config.project_id,
+            memory_guidelines_path: project_config.memory_guidelines_path,
             has_access_token: project_config.access_token.is_some(),
             has_refresh_token: project_config.refresh_token.is_some(),
             ready: readiness.ready,
@@ -2224,6 +2226,7 @@ mod tests {
             .replace_project_config(DaemonProjectConfigUpdateRequest {
                 server_url: "https://clumsies.example.test".to_owned(),
                 project_id: Some("prj_test".to_owned()),
+                memory_guidelines_path: None,
                 access_token: Some("existing-access".to_owned()),
                 refresh_token: Some("existing-refresh".to_owned()),
             })

--- a/crates/daemon/src/types.rs
+++ b/crates/daemon/src/types.rs
@@ -181,6 +181,8 @@ impl LaunchAgentRuntimeStatus {
 pub struct DaemonProjectConfig {
     pub server_url: String,
     pub project_id: Option<String>,
+    #[serde(default)]
+    pub memory_guidelines_path: Option<String>,
     pub has_access_token: bool,
     pub has_refresh_token: bool,
     pub ready: bool,
@@ -191,6 +193,8 @@ pub struct DaemonProjectConfig {
 pub struct DaemonProjectConfigUpdateRequest {
     pub server_url: String,
     pub project_id: Option<String>,
+    #[serde(default)]
+    pub memory_guidelines_path: Option<String>,
     pub access_token: Option<String>,
     pub refresh_token: Option<String>,
 }

--- a/crates/daemon/src/util.rs
+++ b/crates/daemon/src/util.rs
@@ -24,6 +24,7 @@ pub(crate) fn canonical_server_url(server_url: &str) -> Result<String, DaemonErr
     ProjectConfig {
         server_url: server_url.to_owned(),
         project_id: None,
+        memory_guidelines_path: None,
     }
     .validate()?;
     Ok(server_url.trim().trim_end_matches('/').to_owned())

--- a/crates/daemon/tests/agent_runtime_xpc_e2e.rs
+++ b/crates/daemon/tests/agent_runtime_xpc_e2e.rs
@@ -129,8 +129,8 @@ async fn real_clumsiesd_process_proxies_use_xpc_and_reject_stale_identity() {
             "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
             "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}\n",
             "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"kanban\",\"arguments\":{\"op\":{\"list\":{}}}}}\n",
-            "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"activate\",\"arguments\":{\"query\":\"agent runtime e2e\"}}}\n",
-            "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"load\",\"arguments\":{\"ids\":[\"workflow/CODING.md\"]}}}\n"
+            "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"memory\",\"arguments\":{\"op\":{\"activate\":{\"query\":\"agent runtime e2e\"}}}}}\n",
+            "{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"memory\",\"arguments\":{\"op\":{\"load\":{\"ids\":[\"workflow/CODING.md\"]}}}}}\n"
         ),
         &[],
     );

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -2478,6 +2478,7 @@ async fn ipc_dispatch_routes_the_complete_daemon_api() {
             serde_json::to_value(DaemonProjectConfigUpdateRequest {
                 server_url: "http://127.0.0.1:8080".to_owned(),
                 project_id: Some("prj_test".to_owned()),
+                memory_guidelines_path: None,
                 access_token: Some("secret".to_owned()),
                 refresh_token: Some("refresh-secret".to_owned()),
             })
@@ -2787,6 +2788,7 @@ async fn project_config_can_be_replaced_and_persists_across_restarts() {
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: "http://127.0.0.1:18080".to_owned(),
             project_id: Some("prj_config".to_owned()),
+            memory_guidelines_path: None,
             access_token: Some("secret-token".to_owned()),
             refresh_token: Some("refresh-token".to_owned()),
         })
@@ -2843,6 +2845,7 @@ async fn project_config_can_be_replaced_and_persists_across_restarts() {
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: "http://127.0.0.1:18080".to_owned(),
             project_id: Some("prj_config".to_owned()),
+            memory_guidelines_path: None,
             access_token: None,
             refresh_token: None,
         })
@@ -2851,6 +2854,45 @@ async fn project_config_can_be_replaced_and_persists_across_restarts() {
     assert!(!signed_out.has_access_token);
     assert!(!signed_out.has_refresh_token);
     assert!(credential_store.credentials().is_none());
+}
+
+#[tokio::test]
+async fn project_config_supports_custom_memory_guidelines_path() {
+    let root = tempfile::tempdir().unwrap();
+    let credential_store = common::TestCredentialStore::default();
+    let state = common::initialize_daemon(
+        DaemonConfig::for_root(root.path()),
+        credential_store.clone(),
+    )
+    .await;
+    let service = DaemonIpcService::new(state);
+
+    let updated = service
+        .replace_project_config(DaemonProjectConfigUpdateRequest {
+            server_url: "http://127.0.0.1:18080".to_owned(),
+            project_id: Some("prj_custom".to_owned()),
+            memory_guidelines_path: Some("./README.md".to_owned()),
+            access_token: Some("secret-token".to_owned()),
+            refresh_token: None,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        updated.memory_guidelines_path.as_deref(),
+        Some("./README.md")
+    );
+
+    let restarted = common::initialize_daemon(
+        DaemonConfig::for_root(root.path()),
+        credential_store.clone(),
+    )
+    .await;
+    let restarted_service = DaemonIpcService::new(restarted);
+    let persisted = restarted_service.project_config();
+    assert_eq!(
+        persisted.memory_guidelines_path.as_deref(),
+        Some("./README.md")
+    );
 }
 
 #[tokio::test]
@@ -2868,6 +2910,7 @@ async fn selecting_a_project_preserves_credentials_and_persists_the_active_proje
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: "https://clumsies.example.com".to_owned(),
             project_id: Some("prj_first".to_owned()),
+            memory_guidelines_path: None,
             access_token: Some("access-token".to_owned()),
             refresh_token: Some("refresh-token".to_owned()),
         })
@@ -3571,6 +3614,7 @@ async fn refresh_token_without_access_token_is_rejected_before_persistence() {
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: "https://clumsies.example.com".to_owned(),
             project_id: Some("prj_test".to_owned()),
+            memory_guidelines_path: None,
             access_token: None,
             refresh_token: Some("orphan-refresh".to_owned()),
         })
@@ -3597,6 +3641,7 @@ async fn credential_write_failure_does_not_change_project_metadata_or_runtime_st
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: "https://clumsies.example.com".to_owned(),
             project_id: Some("prj_test".to_owned()),
+            memory_guidelines_path: None,
             access_token: Some("access-secret".to_owned()),
             refresh_token: Some("refresh-secret".to_owned()),
         })
@@ -4028,6 +4073,7 @@ async fn queued_draft_syncs_after_project_config_is_set() {
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: server.url.clone(),
             project_id: Some("prj_late".to_owned()),
+            memory_guidelines_path: None,
             access_token: Some("test-token".to_owned()),
             refresh_token: None,
         })
@@ -4487,6 +4533,7 @@ async fn server_proxy_uses_stale_cache_only_for_read_failures() {
         .replace_project_config(DaemonProjectConfigUpdateRequest {
             server_url: format!("http://{address}"),
             project_id: Some("prj_cache".to_owned()),
+            memory_guidelines_path: None,
             access_token: Some("replacement-token".to_owned()),
             refresh_token: None,
         })

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -1060,6 +1060,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             project_id: Some(bootstrap.project_id.clone()),
             access_token: Some(access_token.to_owned()),
             refresh_token: None,
+            memory_guidelines_path: None,
         })
         .await
         .unwrap();
@@ -1162,6 +1163,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             project_id: Some(bootstrap.project_id.clone()),
             access_token: Some(access_token.to_owned()),
             refresh_token: None,
+            memory_guidelines_path: None,
         })
         .await
         .unwrap();
@@ -1228,6 +1230,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             project_id: Some(bootstrap.project_id.clone()),
             access_token: Some(access_token.to_owned()),
             refresh_token: None,
+            memory_guidelines_path: None,
         })
         .await
         .unwrap();
@@ -1283,6 +1286,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             project_id: Some(bootstrap.project_id.clone()),
             access_token: Some(access_token.to_owned()),
             refresh_token: None,
+            memory_guidelines_path: None,
         })
         .await
         .unwrap();

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,18 +1,16 @@
 # MCP
 
-Clumsies exposes four agent-facing tools:
+Clumsies exposes two agent-facing tools:
 
 | Tool | Purpose |
 |---|---|
-| `activate` | Retrieve ranked, directly usable memory fragments for the current task. |
-| `load` | Read complete resources by a known stable ID or exact path. |
-| `store` | Persist an explicitly requested Memory Draft. |
+| `memory` | Manage project memory: retrieve ranked fragments (`activate`), read complete resources (`load`), or persist memory drafts (`store`). |
 | `kanban` | Create, update, list, or semantically transition native Issues. |
 
 The App-bundled Rust `clumsiesd mcp serve` process is a protocol proxy.
 Effective Memory construction, indexing, retrieval, exact loading, Draft
 persistence, and AgentRun projection belong to the resident `clumsiesd` and
-are reached over local XPC. The proxy exposes only the four typed MCP tools; it
+are reached over local XPC. The proxy exposes only the two typed MCP tools; it
 cannot pass arbitrary JSON through to daemon methods.
 
 The proxy verifies the resident's Agent runtime protocol revision and build
@@ -25,14 +23,31 @@ There is no setup call. The removed `retrieve` tool, host-session binding,
 dispatch. Runtime guidance is delivered by `InitializeResult.instructions` and
 the tool descriptions.
 
-## Activate
+## Memory
 
-Call `activate` once at the beginning of each substantive task:
+`memory` unifies all memory operations under a single tool with an `op` tagged enum: `activate`, `load`, and `store`.
+
+### Memory Guidelines (`CLUMSIES.md`)
+
+Each project may define a memory guidelines document (conventionally `CLUMSIES.md` or `README.md` at the workspace root). This document establishes:
+1. **Taxonomy & Organization**: Standard directory layouts (e.g. `architecture/*`, `decisions/*`, `guides/*`).
+2. **Update Rules & Mutation Policy**: When the agent should propose drafts, what descriptions to write, and what not to persist.
+3. **Deprecation Policy**: How conflicting or obsolete memories should be superseded.
+
+Agents can read this document via `memory` with `op: { load: { ids: ["CLUMSIES.md"] } }` before making substantial memory updates.
+
+### Activate
+
+Call `memory` with `op: { activate: ... }` once at the beginning of each substantive task:
 
 ```json
 {
-  "query": "adjust the MCP hybrid retrieval interface",
-  "state": "optional-opaque-state"
+  "op": {
+    "activate": {
+      "query": "adjust the MCP hybrid retrieval interface",
+      "state": "optional-opaque-state"
+    }
+  }
 }
 ```
 
@@ -90,15 +105,19 @@ ready, activation returns `search_model_preparing` with current and total byte
 counts instead of holding the MCP request open. Model preparation retries in
 the background and has no lexical-only fallback.
 
-## Load
+### Load
 
-Use `load` for complete resources already identified by ID or exact path:
+Use `memory` with `op: { load: ... }` for complete resources already identified by ID or exact path (including project guidelines like `CLUMSIES.md`):
 
 ```json
 {
-  "ids": ["mem_123", "architecture/retrieval.md"],
-  "knownHashes": {
-    "mem_123": "sha256:..."
+  "op": {
+    "load": {
+      "ids": ["mem_123", "CLUMSIES.md", "architecture/retrieval.md"],
+      "knownHashes": {
+        "mem_123": "sha256:..."
+      }
+    }
   }
 }
 ```
@@ -111,30 +130,23 @@ optional. When a known hash matches the current complete resource,
 `load` reads the same Effective Memory as `activate`, including current local
 Draft overlays. It does not perform fuzzy search, embedding, or reranking.
 
-## Store
+### Store
 
-Call `store` only when the user explicitly asks to create, update, rename,
+Call `memory` with `op: { store: ... }` only when the user explicitly asks to create, update, rename,
 delete, or discard managed memory. Issues are native objects managed by
 `kanban`; do not model them as Memory documents.
-
-Top-level input:
-
-| Field | Type | Meaning |
-|---|---|---|
-| `resource` | `memory` | The unified Memory type. Legacy `context`, `rule`, and `workflow` values are accepted and treated as memory. |
-| `op` | tagged object | Exactly one of `create`, `update`, `rename`, `delete`, or `discard`. |
 
 Operations:
 
 | Operation | Required fields | Optional fields |
 |---|---|---|
-| `create` | `path`, `body` | `description` |
-| `update` | `id`, `expected_hash`, `replacements` | `description` |
-| `rename` | `id`, `new_path` | `description` |
-| `delete` | `id` | `description` |
-| `discard` | `id` | none |
+| `create` | `path`, `body` | `description`, `resource` |
+| `update` | `id`, `expected_hash`, `replacements` | `description`, `resource` |
+| `rename` | `id`, `new_path` | `description`, `resource` |
+| `delete` | `id` | `description`, `resource` |
+| `discard` | `id` | `resource` |
 
-IDs may be `mem_`-prefixed or legacy `ctx_` / `rul_` / `wfl_` values; legacy
+`resource` defaults to `memory`. IDs may be `mem_`-prefixed or legacy `ctx_` / `rul_` / `wfl_` values; legacy
 IDs stay stable and opaque and are never rewritten.
 
 `delete` removes the addressed item from Local Effective Memory. When the item
@@ -142,16 +154,17 @@ is an unpublished Create Draft, daemon normalizes the operation to `discard`;
 only deletion of an authoritative resource remains an open deletion Draft that
 can be submitted for Review.
 
-Example:
+Example Create:
 
 ```json
 {
-  "resource": "memory",
   "op": {
-    "create": {
-      "path": "release/RELEASE.md",
-      "description": "Release procedure for the project",
-      "body": "# Release\n\nRun verification before publishing."
+    "store": {
+      "create": {
+        "path": "release/RELEASE.md",
+        "description": "Release procedure for the project",
+        "body": "# Release\n\nRun verification before publishing."
+      }
     }
   }
 }
@@ -163,17 +176,18 @@ replacements:
 
 ```json
 {
-  "resource": "memory",
   "op": {
-    "update": {
-      "id": "mem_123",
-      "expected_hash": "sha256:...",
-      "replacements": [
-        {
-          "old_text": "The original exact text.",
-          "new_text": "The replacement text."
-        }
-      ]
+    "store": {
+      "update": {
+        "id": "mem_123",
+        "expected_hash": "sha256:...",
+        "replacements": [
+          {
+            "old_text": "The original exact text.",
+            "new_text": "The replacement text."
+          }
+        ]
+      }
     }
   }
 }

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -72,13 +72,13 @@ keystroke.
 ## MCP write path
 
 The adapter-managed MCP entrypoint is `clumsiesd mcp serve`. This process owns
-only bounded JSON-RPC framing, the typed four-tool contract, Project binding,
-and XPC forwarding. Before accepting Agent traffic it verifies that its Agent
-runtime protocol revision and build identity match the resident daemon. It does
-not initialize `DaemonState`, open SQLite, load models, or start background
-workers.
+only bounded JSON-RPC framing, the typed two-tool contract (`memory` and
+`kanban`), Project binding, and XPC forwarding. Before accepting Agent traffic it
+verifies that its Agent runtime protocol revision and build identity match the
+resident daemon. It does not initialize `DaemonState`, open SQLite, load models,
+or start background workers.
 
-MCP keeps the public `store(resource, op)` tool shape. Internally it adds the
+MCP keeps the public `memory` (`op.store`) tool shape. Internally it adds the
 current bound project ID and project scope before sending the operation to
 daemon. At process startup, MCP gives its current working directory to daemon;
 daemon canonicalizes the path and resolves the nearest bound ancestor in


### PR DESCRIPTION
## Summary

Consolidate MCP top-level tools into `memory` and `kanban` domain tools, and introduce project memory guidelines path configuration.

The unified `memory` tool encapsulates `activate`, `load`, and `store` operations via an `op` tagged enum, supporting flat CRUD mutations that default to memory resources. The memory guidelines path defaults to `CLUMSIES.md` and can be customized per project, persisting in SQLite metadata and dynamically injecting into MCP server instructions and tool descriptions.

## Test plan

- [ ] Verify `cargo test --package daemon --lib` unit and contract tests pass
- [ ] Verify `daemon_lifecycle` project configuration and persistence tests pass
- [ ] Verify `agent_runtime_xpc_e2e` real daemon process proxy communication passes