### PR TITLE
macos: replace retired Hub/Local terms with Organization/Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
           shellcheck dev/check-agent-runtime-boundary.sh
           sh dev/check-agent-runtime-boundary.sh
 
+      - name: Check retired terminology
+        run: |
+          shellcheck dev/check-retired-terms.sh
+          sh dev/check-retired-terms.sh
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -160,19 +160,19 @@ enum ProjectSetupError: LocalizedError, Sendable {
         case .bundleNotFound:
             "The selected Bundle is no longer available."
         case .bundleContainsUnavailableMemory:
-            "The selected Bundle contains memory that is not available in Hub."
+            "The selected Bundle contains memory that is not available in the Organization."
         }
     }
 }
 
 enum ProjectMemorySelectionError: LocalizedError, Sendable {
-    case invalidHubResources
+    case invalidOrgResources
     case projectUnavailable
 
     var errorDescription: String? {
         switch self {
-        case .invalidHubResources:
-            "Only current Hub memory can be added to or removed from a Project."
+        case .invalidOrgResources:
+            "Only current Organization memory can be added to or removed from a Project."
         case .projectUnavailable:
             "The selected Project is no longer available."
         }
@@ -1205,7 +1205,7 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    func addHubMemory(resourceIds: Set<String>, toProject projectId: String) async throws {
+    func addOrgMemories(resourceIds: Set<String>, toProject projectId: String) async throws {
         try await mutateProjectOrgSelection(
             projectId: projectId,
             resourceIds: resourceIds,
@@ -1213,7 +1213,7 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
-    func removeHubMemoryFromActiveProject(resourceIds: Set<String>) async throws {
+    func removeOrgMemoriesFromActiveProject(resourceIds: Set<String>) async throws {
         guard let projectId = activeProjectId else { throw WorkspaceLoadError.noProjects }
         try await mutateProjectOrgSelection(
             projectId: projectId,
@@ -1228,12 +1228,12 @@ final class WorkspaceStore: ObservableObject {
         mutation: ProjectOrgSelectionMutation
     ) async throws {
         guard canManageOrgSelection else {
-            throw ServerClientError.forbidden("Organization owners and admins manage project Hub memory.")
+            throw ServerClientError.forbidden("Only Organization owners and admins can manage project memory.")
         }
         guard projects.contains(where: { $0.id == projectId }) else {
             throw ProjectMemorySelectionError.projectUnavailable
         }
-        try validateHubResourceIds(resourceIds)
+        try validateOrgResourceIds(resourceIds)
         try await withProjectOrgSelectionMutation {
             let current: ProjectOrgSelection = try await server.get(
                 "/api/v1/projects/\(projectId)/org-selections"
@@ -1303,7 +1303,7 @@ final class WorkspaceStore: ObservableObject {
         }
         let resourceIds = Set(bundle.resourceIds)
         do {
-            try validateHubResourceIds(resourceIds)
+            try validateOrgResourceIds(resourceIds)
         } catch {
             throw ProjectSetupError.bundleContainsUnavailableMemory
         }
@@ -1315,10 +1315,10 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
-    private func validateHubResourceIds(_ resourceIds: Set<String>) throws {
+    private func validateOrgResourceIds(_ resourceIds: Set<String>) throws {
         let available = Set(resources.lazy.filter { $0.scope == .org }.map(\.id))
         guard resourceIds.isSubset(of: available) else {
-            throw ProjectMemorySelectionError.invalidHubResources
+            throw ProjectMemorySelectionError.invalidOrgResources
         }
     }
 
@@ -1362,7 +1362,7 @@ final class WorkspaceStore: ObservableObject {
     ) async throws {
         try await withBundleMutation {
             guard let current = bundles.first(where: { $0.id == bundle.id }) else { return }
-            try validateHubResourceIds(resourceIds)
+            try validateOrgResourceIds(resourceIds)
             let selected = resources.filter {
                 $0.scope == .org && resourceIds.contains($0.id)
             }

--- a/apps/macos/Sources/Features/BundlesView.swift
+++ b/apps/macos/Sources/Features/BundlesView.swift
@@ -168,7 +168,7 @@ private struct BundleEditor: View {
     }
 
     private func resourceLocation(_ resource: MemoryResource) -> String {
-        let scope = resource.scope == .org ? "Hub" : resource.projectName ?? "Project"
+        let scope = resource.scope == .org ? "Organization" : resource.projectName ?? "Project"
         return "\(scope) · \(resource.kind.singularTitle)"
     }
 
@@ -278,6 +278,6 @@ private struct BundleResourcePicker: View {
     }
 
     private func resourceLocation(_ resource: MemoryResource) -> String {
-        resource.scope == .org ? "Hub" : resource.projectName ?? "Project"
+        resource.scope == .org ? "Organization" : resource.projectName ?? "Project"
     }
 }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -319,14 +319,14 @@ private struct FileTreeView: View {
         }
 
         if !addableItems.isEmpty {
-            Menu(addToLocalTitle(count: addableItems.count)) {
+            Menu(addToProjectTitle(count: addableItems.count)) {
                 if store.projects.isEmpty {
                     Button("No Projects") {}
                         .disabled(true)
                 } else {
                     ForEach(store.projects) { project in
-                        Button(project.name) {
-                            addToLocal(addableItems, projectId: project.id)
+                        Button("Add to \(project.name)") {
+                            addToProject(addableItems, projectId: project.id)
                         }
                     }
                 }
@@ -335,8 +335,8 @@ private struct FileTreeView: View {
         }
 
         if !removableItems.isEmpty {
-            Button(removeFromLocalTitle(count: removableItems.count)) {
-                removeFromLocal(removableItems)
+            Button(removeFromProjectTitle(count: removableItems.count)) {
+                removeFromProject(removableItems)
             }
             .disabled(!store.canManageOrgSelection)
         }
@@ -388,10 +388,10 @@ private struct FileTreeView: View {
         selectionAnchorId = itemId
     }
 
-    private func addToLocal(_ items: [MemoryListItem], projectId: String) {
+    private func addToProject(_ items: [MemoryListItem], projectId: String) {
         Task {
             do {
-                try await store.addHubMemory(
+                try await store.addOrgMemories(
                     resourceIds: Set(items.map(\.id)),
                     toProject: projectId
                 )
@@ -401,10 +401,10 @@ private struct FileTreeView: View {
         }
     }
 
-    private func removeFromLocal(_ items: [MemoryListItem]) {
+    private func removeFromProject(_ items: [MemoryListItem]) {
         Task {
             do {
-                try await store.removeHubMemoryFromActiveProject(
+                try await store.removeOrgMemoriesFromActiveProject(
                     resourceIds: Set(items.map(\.id))
                 )
             } catch {
@@ -413,12 +413,12 @@ private struct FileTreeView: View {
         }
     }
 
-    private func addToLocalTitle(count: Int) -> String {
-        count == 1 ? "Add to Local" : "Add \(count) Items to Local"
+    private func addToProjectTitle(count: Int) -> String {
+        count == 1 ? "Add to Project" : "Add \(count) Items to Project"
     }
 
-    private func removeFromLocalTitle(count: Int) -> String {
-        count == 1 ? "Remove from Local" : "Remove \(count) Items from Local"
+    private func removeFromProjectTitle(count: Int) -> String {
+        count == 1 ? "Remove from Project" : "Remove \(count) Items from Project"
     }
 }
 
@@ -458,7 +458,7 @@ private struct FileTreeRow: View {
                 reconciliation: item?.draft?.reconciliation
             )
         }
-        .help(item?.inherited == true ? "Inherited from Hub" : entry.node.name)
+        .help(item?.inherited == true ? "Inherited from Organization" : entry.node.name)
     }
 
     private var titleColor: Color {

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -92,7 +92,7 @@ struct ProjectCreationSheet: View {
                         }
                     }
 
-                    Text("A Bundle imports its Hub memory into the new Project.")
+                    Text("A Bundle imports its Organization memory into the new Project.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -1553,7 +1553,7 @@ private struct SearchEntry: Identifiable {
         .init(
             id: "memory:\(item.id)",
             title: item.document.title,
-            detail: "\(item.scope == .org ? "Hub" : "Local") · \(item.kind.title) · \(item.document.path)",
+            detail: "\(item.scope == .org ? "Organization" : "Project") · \(item.kind.title) · \(item.document.path)",
             symbol: item.kind.symbol,
             destination: .memory(item)
         )

--- a/dev/check-retired-terms.sh
+++ b/dev/check-retired-terms.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -eu
 
 # Retired terminology gate (ISSUE-063).
 #
@@ -19,7 +19,7 @@ matches="$(grep -rnE '"[^"]*\b(Hub|Local)\b[^"]*"' \
   "$root/apps/macos/Sources" --include='*.swift' \
   | grep -vE 'Local (Runtime|edits remain saved)' || true)"
 
-if [[ -n "$matches" ]]; then
+if [ -n "$matches" ]; then
   printf 'Retired Hub/Local terminology found in user-visible strings:\n%s\n' \
     "$matches" >&2
   status=1

--- a/dev/check-retired-terms.sh
+++ b/dev/check-retired-terms.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Retired terminology gate (ISSUE-063).
+#
+# The unified Memory model has exactly two scopes: org (Organization) and
+# project (Project). "Hub" and "Local" are retired concepts and must not
+# appear as Memory scope labels in user-visible strings of the macOS app.
+# The allowlist below covers legitimate non-Memory uses:
+#   - Local Runtime      : installation-level runtime setting
+#   - Local edits...     : device-local (offline) edits, not Memory scope
+# Add to this list only for genuinely unrelated uses; Memory scope labels
+# must use Organization / Project.
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+status=0
+
+matches="$(grep -rnE '"[^"]*\b(Hub|Local)\b[^"]*"' \
+  "$root/apps/macos/Sources" --include='*.swift' \
+  | grep -vE 'Local (Runtime|edits remain saved)' || true)"
+
+if [[ -n "$matches" ]]; then
+  printf 'Retired Hub/Local terminology found in user-visible strings:\n%s\n' \
+    "$matches" >&2
+  status=1
+fi
+
+exit "$status"

--- a/experience/003-memory-file-tree-menu-design-vs-impl.md
+++ b/experience/003-memory-file-tree-menu-design-vs-impl.md
@@ -1,0 +1,73 @@
+# Memory 文件树右键菜单：需求设计 vs 当前实现（差距分析）
+
+> 日期：2026-08-17 ｜ 范围：macOS Memory 导航器文件树 dropdown（context menu）
+> 需求来源：ISSUE-004（核心）、ISSUE-006/041（投影）、ISSUE-012（统一模型）、macOS 交互惯例
+
+## 1. 需求设计应有的操作（按组）
+
+### A. 打开与查看
+1. **Open** —— 默认打开（Markdown 预览）；
+2. **Open Source** —— 源码模式打开；
+3. ~~Open in Hub~~ —— ISSUE-004 证据提及的历史操作；统一 Memory（org/project 合并）后
+   该概念被项目引用关系操作取代，需确认是有意移除。
+
+### B. 项目引用关系（ISSUE-004 核心交付）
+4. **Add to Project** —— org(Organization) 资源加入当前项目（project scope 引用，多选批量、一次原子更新）；
+5. **Remove from Project** —— 继承自 org 的、已被当前项目引用的资源移除引用；
+6. **批量语义**：一次请求、携带最新 revision（If-Match 并发控制）；
+7. **混合选择**：已引用+未引用同时选中时文案与作用域明确，不静默反转；
+8. **权限**：无管理权限时禁用。
+
+### C. 生命周期
+9. **Rename**；10. **Discard Draft**；11. **Move to Trash**；
+12. **Review Changes / Update Draft**（draft behind 时的差异审查入口）。
+
+### D. 新建
+13. **New Memory**（空选区/空白处右键）。
+
+### E. 选区语义（决定菜单行为的基础，非菜单项）
+- 单击选择、Cmd+Click 多选、Shift 范围选择；
+- 右键未选中文件 → 该文件成为目标；右键已选中集合 → 保留多选；
+- 失败不改变本地可见状态；成功后 org 与 project 投影立即一致。
+
+## 2. 当前实现（MemoryWorkspaceView.fileTreeMenu + contextMenu(forSelectionType:)）
+
+已实现：Open / Open Source / Review Changes / Update Draft / Add to Project（项目子菜单）/
+Remove from Project / Rename / Discard Draft / Move to Trash / New Memory（空选区）。
+多选模型（selectedNodeIds + FileTreeSelectionInteraction）、右键目标语义（原生 contextMenu）、
+原子批量更新（mutateProjectOrgSelection → 单次 PUT + If-Match）、权限门控（canManageOrgSelection）、
+成功刷新（applyProjectOrgSelection + daemon retrySync）均已就位；旧的 Choose Hub Memory 入口（历史概念）与 ProjectOrgSelectionView 已移除。
+
+## 3. 差距表
+
+| # | 需求项 | 当前状态 | 差距/说明 |
+| --- | --- | --- | --- |
+| 1-2 | Open / Open Source | 完整 | — |
+| 3 | Open in Hub | 已移除 | 设计演进（统一 Memory）；需确认是有意为之并更新 ISSUE-004 表述 |
+| 4 | Add to Project | 已实现 | 当前为选择项目子菜单；仅一个项目时多一步选择，可优化为直接对当前项目执行 |
+| 5 | Remove from Project | 完整 | — |
+| 6-8 | 批量/混合/权限 | 已实现 | 混合选择同时显示 Add N 与 Remove M，作用域明确；文案可打磨 |
+| 9-12 | 生命周期操作 | 完整 | — |
+| 13 | New Memory | 空选区可建 | 无法在指定目录内创建（ISSUE-041 投影落地后可增强为目录级新建） |
+| 14 | 多选模型 | 完整 | FileTreeSelectionTests 已覆盖单/多/Shift/Cmd/目录展开 |
+| 15 | 右键目标语义 | 原生实现 | — |
+| 16 | 原子更新+revision | 完整 | 单次 PUT + If-Match |
+| 17 | 失败一致性 | 完整 | guard 前置校验，失败不改状态 |
+| 18 | 成功刷新 | 基本 | 非 active 项目的投影刷新时机待验证（低风险） |
+| 19 | **验收测试覆盖** | 部分 | **主要缺口**：ISSUE-004 验收第 11 条要求变更类测试（add/remove 混合选择、权限拒绝、revision 冲突、成功刷新），现有测试仅覆盖选择交互 |
+| 20 | 旧入口移除 | 已移除 | — |
+| 21 | 看板状态 | todo | 功能已落地但 ISSUE-004 看板状态未推进 |
+
+## 4. 其他发现
+
+1. **MemoryKind（context/rules/workflows）仍是新建类型选择**：与 ISSUE-012 统一 Memory 模型的
+   关系需明确（目录结构保留还是统一）；
+2. **ISSUE-041（可见文件投影）落地后**，菜单应补充文件系统层操作（如 Reveal in Finder、目录内新建）；
+3. **Add to Project 交互优化**：单项目场景直接执行，多项目才出子菜单（保持批量+无窗口原则）。
+
+## 5. 建议下一步
+
+1. 补 ISSUE-004 缺失的变更类 Swift 测试（add/remove 混合、权限拒绝、revision 冲突、成功刷新）；
+2. 核实已实现范围后推进 ISSUE-004 看板状态（begin_work → request_closure）；
+3. 小优化：单项目 Add to Project 直执行；确认 Open in Hub 移除为有意设计；
+4. 明确 MemoryKind 与统一 Memory 模型的演进路线（联动 ISSUE-012/041）。


### PR DESCRIPTION
## Bug

After the unified Memory model (Hub and Local merged into one Memory section,
ISSUE-012 follow-up), the app still used the retired Hub/Local terminology in
user-visible copy and internal names. Memory now has exactly two scopes:
`org` (Organization) and `project`.

Affected surfaces:

- File tree context menu: `Add to Local` / `Remove from Local` (+ plural variants);
- Row tooltip: `Inherited from Hub`;
- Document title scope prefix: `Hub · <kind> · <path>` / `Local · ...`;
- Bundles resource location: `Hub`;
- Copy: "imports its Hub memory", "not available in Hub", "Only current Hub memory
  can be added to or removed from a Project.", "Organization owners and admins manage
  project Hub memory.";
- Internal names: `addHubMemory`, `removeHubMemoryFromActiveProject`,
  `validateHubResourceIds`, `invalidHubResources`, `addToLocal`, `removeFromLocal`.

## Fix

- User-visible copy migrated to `Organization` / `Project` (e.g. `Add to Project`,
  `Remove from Project`, `Inherited from Organization`);
- Menu items for the per-project add now read `Add to <project name>`;
- Internal names aligned with the existing `orgSelection*` convention
  (`addOrgMemories`, `removeOrgMemoriesFromActiveProject`, `validateOrgResourceIds`,
  `invalidOrgResources`).

## Verification

- Full macOS build passes; macOS unit tests pass;
- `grep` over the app sources shows no remaining user-visible Hub/Local leftovers
  (domain terms `LocalDraft` / `Local Runtime` intentionally unchanged).
