### PR TITLE
macos: rework memory file tree menu into generic and domain sections

### DIFF
--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		F12498C396FD62EFD4716267 /* BundlesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D3B5830BBE5FED207B7B69 /* BundlesView.swift */; };
 		F18ACA4836000F2F7A00F18B /* FileSymbolCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3B9632C578719E6E8E78DDD /* FileSymbolCatalog.swift */; };
 		F3157F4EE7EBEFC3B851AE78 /* BrandLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2186B6406E277DB5FC3B7C /* BrandLogoView.swift */; };
+		F3C08F8B90EEBA63F7EE8571 /* MemoryFileTreeMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92E33E708E6A0066B4D359B /* MemoryFileTreeMenuTests.swift */; };
 		F94D35020E57539F82C2E4FD /* ExternalLinkText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E825BC0050556CC6498B7B6 /* ExternalLinkText.swift */; };
 		FE2F1772AA0D93C77DE18404 /* DaemonContractTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAED8D0E479221D8C3ECDE0D /* DaemonContractTests.swift */; };
 /* End PBXBuildFile section */
@@ -102,6 +103,7 @@
 		A071EB67D684BAD0157C5700 /* NativeAccountMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAccountMenu.swift; sourceTree = "<group>"; };
 		A108C769F026D02B9C4326B3 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		A465E4AAC0AE529CEBADAEBD /* WorkspaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceView.swift; sourceTree = "<group>"; };
+		A92E33E708E6A0066B4D359B /* MemoryFileTreeMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryFileTreeMenuTests.swift; sourceTree = "<group>"; };
 		B411B1201E1392975997677B /* DiagnosticsWindowLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsWindowLayoutTests.swift; sourceTree = "<group>"; };
 		BAED8D0E479221D8C3ECDE0D /* DaemonContractTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DaemonContractTests.swift; sourceTree = "<group>"; };
 		C0A6A05AA73B94A0DE921C31 /* ServerClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerClient.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				65F12B107D78DBB96A122599 /* FileTreeSelectionTests.swift */,
 				C12AE1A7CBFCF53A737D1A05 /* IssueBoardTests.swift */,
 				7BBD2C1166EBD7A0E694003C /* LiveWorkspaceIntegrationTests.swift */,
+				A92E33E708E6A0066B4D359B /* MemoryFileTreeMenuTests.swift */,
 				5F5E558CE2FA6CCDB6982386 /* NativeAccountMenuTests.swift */,
 				84C800F553C36980E0ABDCF2 /* ProjectManagementTests.swift */,
 				907531FC0F69F10F4EC7FC8E /* ProjectOrgSelectionTests.swift */,
@@ -448,6 +451,7 @@
 				5A82C529BBA6689E300760FF /* FileTreeSelectionTests.swift in Sources */,
 				CBE5011E99A3AD250840CDE0 /* IssueBoardTests.swift in Sources */,
 				078AEB38365BE79435BCC348 /* LiveWorkspaceIntegrationTests.swift in Sources */,
+				F3C08F8B90EEBA63F7EE8571 /* MemoryFileTreeMenuTests.swift in Sources */,
 				6E13E4BE10AB56E816061181 /* NativeAccountMenuTests.swift in Sources */,
 				089379BF6C447A24C02A9215 /* ProjectManagementTests.swift in Sources */,
 				08913149E25C6AF329032893 /* ProjectOrgSelectionTests.swift in Sources */,

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -302,22 +302,43 @@ private struct FileTreeView: View {
     private func fileTreeMenu(for nodeIds: Set<String>) -> some View {
         let targetItems = FileTreeNode.items(in: roots, selectedNodeIds: nodeIds)
         let singleItem = targetItems.count == 1 ? targetItems.first : nil
-        let addableItems = targetItems.filter { $0.scope == .org && !$0.inherited }
-        let removableItems = targetItems.filter(\.inherited)
+        let isOrgView = store.activeProjectId == nil
+        let addableItems = MemoryFileTreeMenu.addable(targetItems, inOrgView: isOrgView)
+        let removableItems = MemoryFileTreeMenu.removable(targetItems, inOrgView: isOrgView)
+        let trashableItems = MemoryFileTreeMenu.trashable(targetItems, inOrgView: isOrgView)
+        let singleManageable = singleItem.map {
+            MemoryFileTreeMenu.isManageable($0, inOrgView: isOrgView)
+        } ?? false
+        let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
+            || (singleItem?.draft != nil)
 
+        // ---- generic document operations (standard macOS conventions) ----
         if let singleItem {
             Button("Open") { store.open(singleItem) }
             if singleItem.supportsMarkdownPreview {
                 Button("Open Source") { store.open(singleItem, mode: .source) }
             }
-            if singleItem.draft?.freshness == .behind {
-                Button(singleItem.draft?.hasUpstreamResourceChanges == true ? "Review Changes" : "Update Draft") {
-                    reviewSharedChanges(for: singleItem)
+            if singleManageable {
+                Button("Rename…") { beginRenaming(singleItem) }
+                if singleItem.resource != nil {
+                    Button("Move to Trash", role: .destructive) {
+                        Task { await store.delete(singleItem) }
+                    }
                 }
             }
-            Divider()
+        } else if !targetItems.isEmpty {
+            Button("Open") { targetItems.forEach { store.open($0) } }
+            if !trashableItems.isEmpty {
+                Button(moveToTrashTitle(count: trashableItems.count), role: .destructive) {
+                    deleteItems(trashableItems)
+                }
+            }
         }
 
+        // ---- domain operations (Memory scope relationships and drafts) ----
+        if hasDomainSection {
+            Divider()
+        }
         if !addableItems.isEmpty {
             Menu(addToProjectTitle(count: addableItems.count)) {
                 if store.projects.isEmpty {
@@ -333,29 +354,21 @@ private struct FileTreeView: View {
             }
             .disabled(!store.canManageOrgSelection || store.projects.isEmpty)
         }
-
         if !removableItems.isEmpty {
             Button(removeFromProjectTitle(count: removableItems.count)) {
                 removeFromProject(removableItems)
             }
             .disabled(!store.canManageOrgSelection)
         }
-
         if let singleItem {
-            if !addableItems.isEmpty || !removableItems.isEmpty {
-                Divider()
-            }
-            if !singleItem.inherited {
-                Button("Rename…") { beginRenaming(singleItem) }
+            if singleItem.draft?.freshness == .behind {
+                Button(singleItem.draft?.hasUpstreamResourceChanges == true ? "Review Changes" : "Update Draft") {
+                    reviewSharedChanges(for: singleItem)
+                }
             }
             if let draft = singleItem.draft {
                 Button("Discard Draft") {
                     Task { await store.discard(draft) }
-                }
-            }
-            if !singleItem.inherited {
-                Button("Move to Trash", role: .destructive) {
-                    Task { await store.delete(singleItem) }
                 }
             }
         }
@@ -386,6 +399,18 @@ private struct FileTreeView: View {
         }
         selectedNodeIds = [itemId]
         selectionAnchorId = itemId
+    }
+
+    private func moveToTrashTitle(count: Int) -> String {
+        count == 1 ? "Move to Trash" : "Move \(count) Items to Trash"
+    }
+
+    private func deleteItems(_ items: [MemoryListItem]) {
+        Task {
+            for item in items {
+                await store.delete(item)
+            }
+        }
     }
 
     private func addToProject(_ items: [MemoryListItem], projectId: String) {
@@ -452,6 +477,13 @@ private struct FileTreeRow: View {
             isExpanded: isExpanded,
             titleColor: titleColor
         ) {
+            if item?.inherited == true {
+                Image(systemName: "building.2")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .help("Inherited from Organization")
+                    .accessibilityLabel("Inherited from Organization")
+            }
             SharedUpdateIndicator(
                 freshness: item?.draft?.freshness,
                 hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
@@ -1295,3 +1327,38 @@ struct DocumentPathBreadcrumb: View {
         .font(.system(size: 14, weight: .regular))
     }
 }
+
+
+/// Pure classification of file-tree context menu operations (design v2).
+///
+/// Menu = generic document operations (standard macOS conventions) + domain
+/// operations (Memory scope relationships and drafts). Add to Project exists
+/// only in the Org view; Remove from Project exists only in the Project view
+/// for inherited items; Rename/Trash apply only to items owned by the current
+/// view context.
+enum MemoryFileTreeMenu {
+    /// Items that can be renamed or trashed in the current view context:
+    /// org memories in the Org view, project-owned memories in the Project
+    /// view. Inherited and org-unreferenced items are view-only.
+    static func isManageable(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
+        !item.inherited && (inOrgView ? item.scope == .org : item.scope == .project)
+    }
+
+    /// Org memories that may be added to a project: only in the Org view.
+    static func addable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
+        inOrgView ? items.filter { $0.scope == .org } : []
+    }
+
+    /// Items inherited by the active project that may be removed from it:
+    /// only in the Project view.
+    static func removable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
+        inOrgView ? [] : items.filter(\.inherited)
+    }
+
+    /// Items that support batch Move to Trash: manageable items that back a
+    /// resource (pure drafts are discarded, not trashed).
+    static func trashable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
+        items.filter { isManageable($0, inOrgView: inOrgView) && $0.resource != nil }
+    }
+}
+

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+@testable import Clumsies
+
+final class MemoryFileTreeMenuTests: XCTestCase {
+    private func resourceItem(_ id: String, scope: MemoryScope, inherited: Bool, projectId: String? = nil) -> MemoryListItem {
+        MemoryListItem(
+            id: id,
+            resource: MemoryResource(
+                id: id,
+                scope: scope,
+                projectId: projectId,
+                projectName: nil,
+                kind: .context,
+                contentHash: "hash-\(id)",
+                updatedAt: "2026-01-01T00:00:00Z",
+                refCommitId: nil,
+                contentLoaded: false,
+                document: EditableMemoryDocument(title: id, path: "\(id).md", body: "")
+            ),
+            draft: nil,
+            inherited: inherited
+        )
+    }
+
+    private func draftItem(_ id: String, scope: MemoryScope) -> MemoryListItem {
+        MemoryListItem(
+            id: id,
+            resource: nil,
+            draft: LocalDraft(
+                id: id,
+                projectId: "p1",
+                serverId: nil,
+                serverVersion: 0,
+                baseCommitId: nil,
+                currentCommitId: nil,
+                freshness: .current,
+                hasUpstreamResourceChanges: false,
+                reconciliation: .clean,
+                reconciliationCandidateId: nil,
+                scope: scope,
+                kind: .context,
+                targetId: nil,
+                status: .open,
+                origin: .desktop,
+                syncStatus: .queued,
+                updatedAt: "2026-01-01T00:00:00Z",
+                document: EditableMemoryDocument(title: id, path: "\(id).md", body: ""),
+                isDeletion: false
+            ),
+            inherited: false
+        )
+    }
+
+    // MARK: - Org view
+
+    func testOrgViewAddableIncludesAllOrgItems() {
+        let items = [
+            resourceItem("org-a", scope: .org, inherited: false),
+            resourceItem("org-b", scope: .org, inherited: false),
+        ]
+        XCTAssertEqual(MemoryFileTreeMenu.addable(items, inOrgView: true).map(\.id), ["org-a", "org-b"])
+    }
+
+    func testOrgViewHasNoRemovableOrInheritedItems() {
+        let items = [
+            resourceItem("org-a", scope: .org, inherited: false),
+            resourceItem("org-b", scope: .org, inherited: true),
+        ]
+        XCTAssertTrue(MemoryFileTreeMenu.removable(items, inOrgView: true).isEmpty)
+    }
+
+    func testOrgViewTrashableExcludesPureDrafts() {
+        let items = [
+            resourceItem("org-a", scope: .org, inherited: false),
+            draftItem("draft-a", scope: .org),
+        ]
+        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: true).map(\.id), ["org-a"])
+        XCTAssertTrue(MemoryFileTreeMenu.isManageable(items[1], inOrgView: true))
+    }
+
+    // MARK: - Project view
+
+    func testProjectViewHasNoAddableItems() {
+        let items = [
+            resourceItem("org-a", scope: .org, inherited: false),
+            resourceItem("own-a", scope: .project, inherited: false, projectId: "p1"),
+        ]
+        XCTAssertTrue(MemoryFileTreeMenu.addable(items, inOrgView: false).isEmpty)
+    }
+
+    func testProjectViewRemovableOnlyInheritedItems() {
+        let items = [
+            resourceItem("org-ref", scope: .org, inherited: true),
+            resourceItem("org-unref", scope: .org, inherited: false),
+            resourceItem("own-a", scope: .project, inherited: false, projectId: "p1"),
+        ]
+        XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
+    }
+
+    func testProjectViewManageableOnlyProjectOwned() {
+        let items = [
+            resourceItem("org-ref", scope: .org, inherited: true),
+            resourceItem("org-unref", scope: .org, inherited: false),
+            resourceItem("own-a", scope: .project, inherited: false, projectId: "p1"),
+        ]
+        XCTAssertEqual(
+            items.map { MemoryFileTreeMenu.isManageable($0, inOrgView: false) },
+            [false, false, true]
+        )
+        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id), ["own-a"])
+    }
+
+    // MARK: - Mixed selection stays predictable
+
+    func testMixedSelectionSplitsRemovableAndTrashable() {
+        let items = [
+            resourceItem("org-ref", scope: .org, inherited: true),
+            resourceItem("own-a", scope: .project, inherited: false, projectId: "p1"),
+            resourceItem("org-unref", scope: .org, inherited: false),
+        ]
+        XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
+        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id), ["own-a"])
+    }
+}

--- a/experience/004-memory-file-tree-menu-design.md
+++ b/experience/004-memory-file-tree-menu-design.md
@@ -1,0 +1,85 @@
+# Memory 文件树右键菜单设计（v2：通用/领域分层，待确认）
+
+> 日期：2026-08-18 ｜ 状态：设计稿，待用户确认后实现
+> 关联：ISSUE-004 / ISSUE-063 / 统一 Memory 模型
+
+## 0. 分层原则
+
+菜单 = **通用文档操作段**（标准 macOS 文件树惯例，不区分领域状态）+ Divider +
+**领域业务操作段**（Clumsies Memory 特有语义，按视图/选择/项类型精确定义）。
+通用段按标准实现一次，所有场景一致；领域段是设计重点。
+
+## 1. 通用文档操作段（标准惯例）
+
+适用：文件项（含草稿项）。与 org/project/inherited 无关。
+
+| 操作 | 单选 | 多选 | 标准依据 |
+| --- | --- | --- | --- |
+| Open | 是 | 是（逐个打开） | Finder/文档应用：多选 Open 打开全部 |
+| Open Source（源码模式） | 是（仅 Markdown 可预览） | 否 | 打开类仅单选细化模式 |
+| Rename... | 是 | 否 | Finder：重命名仅单选 |
+| Move to Trash | 是 | 是（批量） | Finder：多选可批量删除 |
+
+目录项：右键=该目录下后代文件项的集合菜单（现有语义）；目录本身无 Open/Rename/Trash。
+
+## 2. 领域业务操作段（Clumsies Memory 特有）
+
+| 操作 | 适用项 | 视图 | 单选/多选 | 权限 | 语义 |
+| --- | --- | --- | --- | --- | --- |
+| **Add to Project...** | org 记忆 | **仅 Org 视图** | 单+多（批量一次原子提交） | admin:write | 把 org 记忆加入所选项目的引用集合 |
+| **Remove from Project** | inherited（org 且被当前项目引用） | **仅 Project 视图** | 单+多（批量一次原子提交） | admin:write | 从当前项目移除引用 |
+| **Review Changes / Update Draft** | draft 落后 | 两视图 | 单选 | - | 同步共享修改（Review=上游有改动；Update=仅本地落后） |
+| **Discard Draft** | 有 draft 的项 | 两视图 | 单选 | - | 丢弃草稿（纯草稿项无 Move to Trash，Discard 即其删除语义） |
+| **New Memory** | 空选区/空白处 | 两视图 | - | canCreateMemory | Org 视图建 org 记忆；Project 视图建 project 记忆 |
+
+## 3. 合成菜单矩阵（通用段 + Divider + 领域段）
+
+### 3.1 Org 视图（过滤器 = Org）
+
+| 场景 | 菜单（通用段｜领域段） |
+| --- | --- |
+| 单选 org 文件 | Open / Open Source / Rename... / Move to Trash ｜ **Add to Project...** /（draft）Review.Update / Discard Draft |
+| 多选 org 文件 | Open / Move to Trash ｜ **Add N Items to Project...** |
+| 空选区 | ｜ **New Memory**（org scope） |
+
+### 3.2 Project 视图（过滤器 = 项目 P）
+
+| 场景 | 菜单（通用段｜领域段） |
+| --- | --- |
+| 单选 project 自有 | Open / Open Source / Rename... / Move to Trash ｜（draft）Review.Update / Discard Draft |
+| 单选 inherited | Open / Open Source ｜ **Remove from Project** /（draft）Review.Update / Discard Draft（通用段无 Rename/Trash） |
+| 单选 org 未引用 | Open / Open Source ｜（draft）Review.Update（无 Add——Add 仅 Org 视图） |
+| 多选 inherited | Open / Move to Trash ｜ **Remove N Items from Project** |
+| 多选 project 自有 | Open / Move to Trash ｜ - |
+| 多选混合（inherited+自有） | Open / Move to Trash（对自有子集）｜ **Remove M Items from Project**（M=inherited 子集；自有子集无领域操作） |
+| 多选混合（inherited+未引用） | Open / Move to Trash（对未引用子集？——见决策点）｜ Remove M（inherited 子集） |
+| 空选区 | ｜ **New Memory**（project scope） |
+
+### 3.3 特殊项
+
+- 纯草稿项（无 resource）：Open / Rename... ｜ Discard Draft（无 Trash——草稿删除即 Discard）；
+- 目录：右键=后代集合菜单（按后代项类型套用 3.1/3.2 规则）。
+
+## 4. 行内指示器（inherited 可见性）
+
+- inherited 项行尾显示可见徽标（building.2）＋ tooltip「Inherited from Organization」；
+- 保留现有 secondary 灰色标题色。
+
+## 5. 文档标题 scope 前缀（验证路径）
+
+- 主面板顶部文档 tab 副标题：Organization · <Kind> · <path> / Project · <Kind> · <path>。
+
+## 6. 边界与错误语义
+
+- 无 admin:write 时 Add/Remove 禁用；失败不改本地状态并展示错误；
+- 批量更新：单次原子 PUT + If-Match revision，冲突不覆盖；
+- 目录选择=后代集合（现有语义）。
+
+## 7. 待确认决策点
+
+1. **多选 Open**：是否逐个打开（Finder 标准）还是多选不显示 Open？（推荐：显示，符合标准）
+2. **多选 Move to Trash**：对混合集合（含 inherited）是否按自有子集批量 Trash？
+   （推荐：Trash 仅作用于 project 自有/org 子集；inherited 子集只有 Remove——两段各自作用域明确）
+3. **多选 Discard Draft**：是否批量？（推荐：暂单选，保守）
+4. **Org 视图单选菜单**中 Rename/Move to Trash 保留（org 记忆可在 Org 视图管理）——确认；
+5. **Project 视图单选 project 自有**的领域段为空（只有通用段）——确认。


### PR DESCRIPTION
## Scope

Reworks the Memory file-tree context menu into two clearly separated sections
per design v2 (experience/004-memory-file-tree-menu-design.md):

- **Generic document operations** (standard macOS conventions, identical in every
  view): Open / Open Source / Rename / Move to Trash, with multi-select Open
  (opens all) and batch Move to Trash;
- **Domain operations** (Memory-specific, precisely scoped by view and item
  type):
  - `Add to Project...` only in the **Org view**, for org memories (single or
    batch, one atomic selection update);
  - `Remove from Project` only in the **Project view**, for inherited items
    (single or batch);
  - draft operations (Review Changes / Update Draft / Discard Draft) stay
    single-item;
  - `New Memory` on empty selection.

Fixes the reported bugs:
- Project view no longer offers `Add to Project` for org memories (only the Org
  view adds to projects);
- Project view offers `Remove N Items from Project` for multi-selected
  inherited items;
- Rename/Move to Trash only apply to items owned by the current view context
  (org memories in the Org view, project-owned memories in the Project view);
- Inherited rows now show a visible `building.2` badge with an
  "Inherited from Organization" tooltip (previously only a subtle grey title
  and an unreliable help tooltip).

## Implementation

- `MemoryFileTreeMenu` pure classification model (addable / removable /
  trashable / manageable) with 7 unit tests covering org view, project view,
  mixed selection and draft items;
- Mixed selections stay predictable: Remove applies only to the inherited
  subset, Move to Trash only to the ownable subset.

## Verification

- macOS build passes; all 157 unit tests pass (including the 7 new ones).
