### PR TITLE
daemon: migrate legacy search index schema missing description column

### DIFF
--- a/crates/daemon/src/search/index.rs
+++ b/crates/daemon/src/search/index.rs
@@ -15,7 +15,12 @@ use super::{
     RetrievalUnit, SearchFailure, SearchModels, SourceResource,
 };
 
-const PROJECT_INDEX_SCHEMA_VERSION: i64 = 6;
+// Schema 7 guarantees search_resources carries the description column and the
+// widened kind CHECK. Version 6 was written in two flavors: before commit
+// 232eaac the column and the 'memory' kind were missing from the CREATE TABLE
+// without a version bump, so rebuilds below are keyed on column presence
+// rather than the version marker alone.
+const PROJECT_INDEX_SCHEMA_VERSION: i64 = 7;
 pub(super) const VECTOR_INPUT_VERSION: &str = "search-passage.v1:fastembed-prefix=passage";
 
 #[derive(Clone, Debug)]
@@ -148,6 +153,53 @@ async fn migrate_project_index(pool: &SqlitePool) -> Result<(), DaemonError> {
         .execute(&mut *tx)
         .await?;
         tx.commit().await?;
+    }
+    // Pre-232eaac databases carry schema_version 6 while search_resources is
+    // missing the description column and still checks kind against
+    // ('context', 'rule', 'workflow'); older schemas (3-5) never had the
+    // column either. Adding the column alone cannot repair a restrictive
+    // kind CHECK because SQLite cannot alter a CHECK constraint, so those
+    // index tables are rebuilt here and the next background build recreates
+    // the index from the current generation with the unified Memory schema.
+    // Tables without a restrictive kind CHECK only need the column added
+    // and keep their ready heads. Fresh databases are untouched because the
+    // CREATE TABLE below already includes the column and the widened CHECK.
+    let has_search_resources: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'search_resources'",
+    )
+    .fetch_one(pool)
+    .await?;
+    let has_description_column: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pragma_table_info('search_resources') WHERE name = 'description'",
+    )
+    .fetch_one(pool)
+    .await?;
+    if has_search_resources > 0 && has_description_column == 0 {
+        let create_sql: String = sqlx::query_scalar(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'search_resources'",
+        )
+        .fetch_one(pool)
+        .await?;
+        if create_sql.contains("kind IN") && !create_sql.contains("'memory'") {
+            let mut tx = pool.begin().await?;
+            for statement in [
+                "DROP TABLE IF EXISTS search_units_fts",
+                "DROP TABLE IF EXISTS search_heads",
+                "DROP TABLE IF EXISTS search_units",
+                "DROP TABLE IF EXISTS search_resources",
+                "DROP TABLE IF EXISTS search_revisions",
+                "DROP TABLE IF EXISTS search_vector_cache",
+            ] {
+                sqlx::query(statement).execute(&mut *tx).await?;
+            }
+            tx.commit().await?;
+        } else {
+            sqlx::query(
+                "ALTER TABLE search_resources ADD COLUMN description TEXT NOT NULL DEFAULT ''",
+            )
+            .execute(pool)
+            .await?;
+        }
     }
     // Keep the fresh schema and its version marker in one SQLite transaction.
     // A process crash must never leave a partial set of tables that a later
@@ -2072,5 +2124,87 @@ mod tests {
             base,
             vector_input_hash("embedding.v1", 384, "path\nheading\nchanged")
         );
+    }
+
+    #[tokio::test]
+    async fn migrate_rebuilds_legacy_schema_six_without_description_column() {
+        // Reproduces the pre-232eaac database flavor: schema_version 6 with a
+        // search_resources table that lacks the description column and still
+        // checks kind against the legacy values. The daemon's index build
+        // failed on these with "table search_resources has no column named
+        // description" because the schema version had not been bumped when
+        // the column was added.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("index.sqlite");
+        {
+            let legacy = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(
+                    SqliteConnectOptions::from_str(&path.display().to_string())
+                        .unwrap()
+                        .create_if_missing(true),
+                )
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE search_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )",
+            )
+            .execute(&legacy)
+            .await
+            .unwrap();
+            sqlx::query("INSERT INTO search_meta (key, value) VALUES ('schema_version', '6')")
+                .execute(&legacy)
+                .await
+                .unwrap();
+            sqlx::query(
+                "CREATE TABLE search_resources (
+                    revision_id TEXT NOT NULL,
+                    resource_id TEXT NOT NULL,
+                    project_id TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    kind TEXT NOT NULL CHECK (kind IN ('context', 'rule', 'workflow')),
+                    path TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    content TEXT NOT NULL,
+                    content_hash TEXT NOT NULL,
+                    source_commit_id TEXT,
+                    draft_id TEXT,
+                    draft_revision TEXT,
+                    PRIMARY KEY (revision_id, resource_id)
+                )",
+            )
+            .execute(&legacy)
+            .await
+            .unwrap();
+            legacy.close().await;
+        }
+
+        let pool = connect_project_index(&path).await.unwrap();
+        let has_description: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM pragma_table_info('search_resources')
+             WHERE name = 'description'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(has_description, 1);
+        let create_sql: String = sqlx::query_scalar(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'search_resources'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(create_sql.contains("'memory'"), "kind CHECK must accept memory");
+        let version: String = sqlx::query_scalar(
+            "SELECT value FROM search_meta WHERE key = 'schema_version'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(version, PROJECT_INDEX_SCHEMA_VERSION.to_string());
+        pool.close().await;
     }
 }

--- a/crates/daemon/src/search/index.rs
+++ b/crates/daemon/src/search/index.rs
@@ -2197,13 +2197,15 @@ mod tests {
         .fetch_one(&pool)
         .await
         .unwrap();
-        assert!(create_sql.contains("'memory'"), "kind CHECK must accept memory");
-        let version: String = sqlx::query_scalar(
-            "SELECT value FROM search_meta WHERE key = 'schema_version'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        assert!(
+            create_sql.contains("'memory'"),
+            "kind CHECK must accept memory"
+        );
+        let version: String =
+            sqlx::query_scalar("SELECT value FROM search_meta WHERE key = 'schema_version'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
         assert_eq!(version, PROJECT_INDEX_SCHEMA_VERSION.to_string());
         pool.close().await;
     }

--- a/experience/005-search-index-schema-drift.md
+++ b/experience/005-search-index-schema-drift.md
@@ -1,0 +1,81 @@
+# 搜索索引 schema 漂移复盘：一次“版本号没升”引发的持续构建失败
+
+> 关联：Kanban ISSUE-065（search index schema drift）｜日期：2026-08-18｜状态：已修复（v6→v7 迁移 + 列存在性守卫）
+
+## 1. 业务场景：用户到底经历了什么
+
+### 1.1 症状
+
+用户反馈“服务器是不是不响应了”，排查后发现：
+
+1. 服务端健康检查一切正常（200，全部服务 green）；
+2. **daemon 日志每 ~30 秒刷两条 WARN**：
+   `background search index build failed: ... table search_resources has no column named description`，
+   且只针对两个项目（prj_4d77be / prj_ec9250）；
+3. 这两个项目是 **custom storage**（外置卷 `/Volumes/ORICO/workspace/DylanVault/…`），
+   它们的 search index 库不在 `~/Library/Caches/ai.clumsies/projects/` 下，而在
+   `.clumsies/cache-v1/<org-hash>/<project>/search/index.sqlite` —— 排查时先找错了地方；
+4. 每次失败后 scheduler 进入退避重试，**永续循环**，项目检索长期不可用。
+
+### 1.2 影响面
+
+| 影响 | 说明 |
+| --- | --- |
+| 项目检索不可用 | 两个项目（DylanVault/clumsies、DylanVault/infinite）激活/检索全部失败 |
+| 日志噪音 | 每 30s 两条 WARN 持续刷屏，掩盖其他问题 |
+| 数据同步停滞 | 这两个项目的索引永远停在旧 revision |
+
+## 2. 根因：版本号没升 + 迁移路径缺失
+
+### 2.1 提交史实
+
+- `4b18f79`（8-12）引入 `PROJECT_INDEX_SCHEMA_VERSION = 6`，并为 v3/v4/v5 写了 ALTER 迁移；
+- `232eaac`（8-15）给 `search_resources` 的 **CREATE TABLE** 加了 `description` 列、
+  把 kind CHECK 扩为含 `'memory'` —— **但没有升版本号，也没有补 ALTER TABLE**。
+
+结果：8-15 之前创建（或迁移到）v6 的库，version 标记是 6，表结构却是旧版：
+无 `description` 列、kind CHECK 只允许 `('context','rule','workflow')`。
+新代码打开库时看到 version 6 == 当前版本 → 跳过所有迁移 → 构建时 INSERT 带 `description`
+的语句直接报 “no column named description”。
+
+### 2.2 为什么 5 个项目的库没坏、2 个坏了
+
+同一 org 下 5 个项目在 cache 目录（8-16 之后由新二进制重建过，含 description 列）；
+而 2 个 custom-storage 项目在**外置卷**上，库还是 8-15 之前的旧二进制写的，
+一直没被重建 → 恰好命中旧 flavor。这也是“本机只有部分项目坏”的原因。
+
+### 2.3 为什么没早报出来
+
+1. **版本号撒谎**：v6 有两个 flavor（有/无 description），靠 version 无法区分；
+2. **无 schema 漂移检测**：迁移逻辑只比对版本号，从不校验列存在性；
+3. **错误被降级成 WARN**：后台构建失败只打 WARN + 重试，没有上报/告警；
+4. **失败项目不在默认 cache 目录**：如果两个坏库在 `~/Library/Caches` 下，
+   8-16 的 daemon 重启后就会被重建，问题可能当时就暴露/自愈了。
+
+## 3. 修复方案
+
+原则：**schema 迁移必须同时考虑“列存在性”与“版本号”**；SQLite 不能改 CHECK 约束，
+所以要么重建表、要么整库重建。
+
+`crates/daemon/src/search/index.rs`：
+
+1. `PROJECT_INDEX_SCHEMA_VERSION` 6 → 7；
+2. 迁移函数新增守卫：`search_resources` 存在但缺 `description` 列时——
+   - 若表带**旧 kind CHECK**（不含 `'memory'`）：整库重建（drop 全部索引表，下一次
+     后台构建从当前 generation 重建，统一 Memory schema）；
+   - 否则（如 v3 时代的无 CHECK 表）：只 `ALTER TABLE ADD COLUMN description`，
+     保留 ready head，避免全量重嵌入。
+
+并回退了错误的全局 `SEARCH_SCHEMA_VERSION` 3→4 改动：全局 local.db 表走
+drop-recreate 干净路径，版本 bump 既不必要也无效果（每个 project 库才是问题所在）。
+
+## 4. 教训
+
+1. **改 CREATE TABLE 必须同步升 schema 版本**；改表结构（加列/改 CHECK）必须写迁移。
+   这是 ISSUE-062（blob 内容寻址）之后第二次同型事故；
+2. **迁移守卫用“列存在性”而非仅版本号**：当历史上有“同版本多 flavor”时，版本号不可信；
+3. **SQLite 的 CHECK 无法 ALTER**：遇到 CHECK 变更，数据保留需要
+   foreign_keys 开关/重建表（有连接池状态泄漏风险），直接整库重建更安全——反正
+   后台构建会自动补齐；
+4. **custom-storage 项目的索引不在 cache 下**：排查 search 问题时先查
+   `project_storage_locations`，再找 `.clumsies/cache-v1/`。


### PR DESCRIPTION
## Problem

Background search index builds fail every ~30s for projects whose per-project index database was created before commit `232eaac`:

```
background search index build failed: table search_resources has no column named description
```

`232eaac` added the `description` column and the `'memory'` kind to the `search_resources` CREATE TABLE but did not bump the schema version or add an ALTER migration. Databases created before it carry `schema_version = 6` while missing the column and still checking `kind IN ('context','rule','workflow')`, so the unified-Memory inserts (`kind = 'memory'`, `description = ...`) fail. The column and the widened CHECK are two halves of the same commit, so a version-6 database can no longer be distinguished by its version marker alone.

Affected databases live under the project storage root for custom-storage projects (e.g. `DylanVault/*/.clumsies/cache-v1/...`), which is why only some projects broke and the failure is easy to miss.

## Fix

In `crates/daemon/src/search/index.rs`:

- Bump `PROJECT_INDEX_SCHEMA_VERSION` 6 -> 7.
- Guard migration on **column presence** instead of the version marker: when `search_resources` exists without the `description` column,
  - if the table still has the restrictive kind CHECK (pre-`232eaac` flavor), rebuild the index tables — SQLite cannot alter a CHECK constraint; the background builder recreates the index from the current generation under the unified Memory schema;
  - otherwise (legacy schemas 3-5 without a CHECK), add the column with `ALTER TABLE`, preserving the ready head so no full re-embed is needed.

Also reverts an earlier mistaken global `SEARCH_SCHEMA_VERSION` 3->4 bump: the local.db global search tables follow a clean drop-and-recreate path and are unrelated to the per-project databases that actually failed.

## Verification

- New regression test `migrate_rebuilds_legacy_schema_six_without_description_column` reproduces the pre-`232eaac` database and asserts the rebuilt schema (description column, `'memory'` kind, version 7).
- Existing `project_index_v3_migration_preserves_ready_head` stays green (preserving branch).
- All 51 search tests pass.
- On the affected machine, both failing projects migrated to schema 7 on daemon restart; the background builder re-indexed them with no further errors.

Docs: `experience/005-search-index-schema-drift.md` postmortem.
