### PR TITLE
macos: git-style file tree status and unified three-way diff

### DIFF
--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -108,8 +108,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         }
         if menuItem.action == #selector(newMemory(_:)) {
             guard store.selectedSection == .memory else { return false }
-            let scope: MemoryScope = store.activeProjectId == nil ? .org : .project
-            return store.canCreateMemory(kind: store.selectedKind, scope: scope)
+            return store.canCreateMemory(kind: store.selectedKind, scope: .org)
         }
         if menuItem.action == #selector(closeActiveTab(_:)) {
             return store.activeVisibleTab != nil
@@ -556,8 +555,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     @objc private func newMemory(_ sender: Any?) {
         guard store.selectedSection == .memory else { return }
-        let scope: MemoryScope = store.activeProjectId == nil ? .org : .project
-        Task { await store.createMemory(kind: store.selectedKind, scope: scope) }
+        Task { await store.createMemory(kind: store.selectedKind, scope: .org) }
     }
 
     @objc private func newProject(_ sender: Any?) {

--- a/apps/macos/Sources/Components/SharedUpdateIndicator.swift
+++ b/apps/macos/Sources/Components/SharedUpdateIndicator.swift
@@ -8,28 +8,38 @@ struct SharedUpdateStatusPresentation {
     static func resolve(
         freshness: DraftFreshness?,
         hasUpstreamResourceChanges: Bool,
-        reconciliation: DraftReconciliationStatus?
+        reconciliation: DraftReconciliationStatus?,
+        isStale: Bool = false
     ) -> Self? {
-        guard freshness == .behind else { return nil }
-        if reconciliation == .conflicts {
-            return .init(
-                symbolName: "exclamationmark.triangle",
-                tint: .orange,
-                help: "Shared update has conflicts"
-            )
-        }
-        if hasUpstreamResourceChanges {
+        if freshness == .behind {
+            if reconciliation == .conflicts {
+                return .init(
+                    symbolName: "exclamationmark.triangle",
+                    tint: .orange,
+                    help: "Shared update has conflicts"
+                )
+            }
+            if hasUpstreamResourceChanges {
+                return .init(
+                    symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
+                    tint: .secondary,
+                    help: "The shared version of this file has changed"
+                )
+            }
             return .init(
                 symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
                 tint: .secondary,
-                help: "The shared version of this file has changed"
+                help: "Draft base is behind the shared version"
             )
         }
-        return .init(
-            symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
-            tint: .secondary,
-            help: "Draft base is behind the shared version"
-        )
+        if isStale {
+            return .init(
+                symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
+                tint: .secondary,
+                help: "A newer shared version is available"
+            )
+        }
+        return nil
     }
 }
 
@@ -37,12 +47,26 @@ struct SharedUpdateIndicator: View {
     let freshness: DraftFreshness?
     let hasUpstreamResourceChanges: Bool
     let reconciliation: DraftReconciliationStatus?
+    let isStale: Bool
+
+    init(
+        freshness: DraftFreshness?,
+        hasUpstreamResourceChanges: Bool,
+        reconciliation: DraftReconciliationStatus?,
+        isStale: Bool = false
+    ) {
+        self.freshness = freshness
+        self.hasUpstreamResourceChanges = hasUpstreamResourceChanges
+        self.reconciliation = reconciliation
+        self.isStale = isStale
+    }
 
     var body: some View {
         if let presentation = SharedUpdateStatusPresentation.resolve(
             freshness: freshness,
             hasUpstreamResourceChanges: hasUpstreamResourceChanges,
-            reconciliation: reconciliation
+            reconciliation: reconciliation,
+            isStale: isStale
         ) {
             Image(systemName: presentation.symbolName)
                 .font(.system(size: 10, weight: .regular))

--- a/apps/macos/Sources/Components/SharedUpdateIndicator.swift
+++ b/apps/macos/Sources/Components/SharedUpdateIndicator.swift
@@ -10,7 +10,7 @@ struct SharedUpdateStatusPresentation {
         hasUpstreamResourceChanges: Bool,
         reconciliation: DraftReconciliationStatus?
     ) -> Self? {
-        guard freshness == .behind, hasUpstreamResourceChanges else { return nil }
+        guard freshness == .behind else { return nil }
         if reconciliation == .conflicts {
             return .init(
                 symbolName: "exclamationmark.triangle",
@@ -18,10 +18,17 @@ struct SharedUpdateStatusPresentation {
                 help: "Shared update has conflicts"
             )
         }
+        if hasUpstreamResourceChanges {
+            return .init(
+                symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
+                tint: .secondary,
+                help: "The shared version of this file has changed"
+            )
+        }
         return .init(
             symbolName: "arrow.trianglehead.2.clockwise.rotate.90",
             tint: .secondary,
-            help: "The shared version of this file has changed"
+            help: "Draft base is behind the shared version"
         )
     }
 }
@@ -44,32 +51,5 @@ struct SharedUpdateIndicator: View {
                 .help(presentation.help)
                 .accessibilityLabel(presentation.help)
         }
-    }
-}
-
-struct DraftBaseBehindIndicator: View {
-    var reconciliation: DraftReconciliationStatus?
-
-    init(reconciliation: DraftReconciliationStatus? = nil) {
-        self.reconciliation = reconciliation
-    }
-
-    var body: some View {
-        Image(systemName: reconciliation == .conflicts
-            ? "exclamationmark.triangle"
-            : "arrow.trianglehead.2.clockwise.rotate.90")
-            .font(.system(size: 10, weight: .regular))
-            .foregroundStyle(reconciliation == .conflicts
-                ? Color.orange.opacity(0.72)
-                : Color.secondary.opacity(0.72))
-            .frame(width: 18, height: 18)
-            .help(help)
-            .accessibilityLabel(help)
-    }
-
-    private var help: String {
-        reconciliation == .conflicts
-            ? "Draft update has conflicts"
-            : "Draft base is behind the shared version"
     }
 }

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -386,9 +386,6 @@ struct UnifiedDiffView: View {
     @Binding var commentDraft: String
     let isSubmittingComment: Bool
     let showsCommentControls: Bool
-    /// Standalone usage (no outer scroll container): fill the offered
-    /// height and scroll vertically, like the split diff does.
-    let fillsHeight: Bool
     let onRequestComment: (Int) -> Void
     let onCancelComment: () -> Void
     let onSubmitComment: (Int) -> Void
@@ -422,7 +419,6 @@ struct UnifiedDiffView: View {
         _commentDraft = commentDraft
         self.isSubmittingComment = isSubmittingComment
         self.showsCommentControls = true
-        self.fillsHeight = false
         self.onRequestComment = onRequestComment
         self.onCancelComment = onCancelComment
         self.onSubmitComment = onSubmitComment
@@ -437,7 +433,6 @@ struct UnifiedDiffView: View {
         _commentDraft = .constant("")
         self.isSubmittingComment = false
         self.showsCommentControls = false
-        self.fillsHeight = true
         self.onRequestComment = { _ in }
         self.onCancelComment = {}
         self.onSubmitComment = { _ in }
@@ -452,10 +447,7 @@ struct UnifiedDiffView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 96)
             } else {
-                ScrollView(
-                    fillsHeight ? [.horizontal, .vertical] : [.horizontal],
-                    showsIndicators: true
-                ) {
+                ScrollView(.horizontal, showsIndicators: true) {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(presentation.blocks) { block in
                             blockView(block)
@@ -466,10 +458,6 @@ struct UnifiedDiffView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(
-            maxHeight: fillsHeight ? CGFloat.infinity : nil,
-            alignment: .topLeading
-        )
         .background(Color(nsColor: .textBackgroundColor))
         .background {
             GeometryReader { proxy in

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -4,6 +4,10 @@ enum UnifiedDiffLineKind: Equatable, Sendable {
     case context
     case insertion
     case removal
+    case remoteInsertion
+    case remoteRemoval
+
+    var isChanged: Bool { self != .context }
 }
 
 struct UnifiedDiffLine: Identifiable, Equatable, Sendable {
@@ -189,6 +193,174 @@ struct UnifiedDiffPresentation: Equatable, Sendable {
     }
 }
 
+/// Builds a unified diff stream from three full texts.
+///
+/// - base -> local changes render green/red (the user's own changes).
+/// - base -> remote changes render gray (other people's committed changes
+///   that are not part of the local draft yet).
+enum ThreeWayDiff: Sendable {
+    static func lines(base: String, local: String, remote: String) -> [UnifiedDiffLine] {
+        let baseLines = split(base)
+        let localModel = SplitDiffModel.make(original: base, modified: local)
+        let remoteModel = SplitDiffModel.make(original: base, modified: remote)
+
+        struct BaseMutation {
+            var removed = false
+            var replacement: String?
+            var localLine: Int?
+        }
+
+        var localByBase: [Int: BaseMutation] = [:]
+        var localInsertions: [Int: [(text: String, line: Int)]] = [:]
+        var localAnchor = 0
+        for row in localModel.rows {
+            if let original = row.original {
+                localAnchor = original.lineNumber
+                var mutation = localByBase[original.lineNumber] ?? BaseMutation()
+                mutation.removed = original.kind == .removal
+                mutation.localLine = row.modified?.lineNumber
+                if row.modified?.kind == .insertion {
+                    mutation.replacement = row.modified?.text
+                }
+                localByBase[original.lineNumber] = mutation
+            } else if let modified = row.modified {
+                localInsertions[localAnchor, default: []].append((modified.text, modified.lineNumber))
+            }
+        }
+
+        var remoteByBase: [Int: BaseMutation] = [:]
+        var remoteInsertions: [Int: [String]] = [:]
+        var remoteAnchor = 0
+        for row in remoteModel.rows {
+            if let original = row.original {
+                remoteAnchor = original.lineNumber
+                var mutation = remoteByBase[original.lineNumber] ?? BaseMutation()
+                mutation.removed = original.kind == .removal
+                if row.modified?.kind == .insertion {
+                    mutation.replacement = row.modified?.text
+                }
+                remoteByBase[original.lineNumber] = mutation
+            } else if let modified = row.modified {
+                remoteInsertions[remoteAnchor, default: []].append(modified.text)
+            }
+        }
+
+        var lines: [UnifiedDiffLine] = []
+        var counter = 0
+        func emit(_ kind: UnifiedDiffLineKind, _ text: String, old: Int?, new: Int?) {
+            counter += 1
+            lines.append(.init(
+                id: "three-way-\(counter)",
+                kind: kind,
+                text: text,
+                oldLineNumber: old,
+                newLineNumber: new
+            ))
+        }
+
+        func emitInsertions(at position: Int) {
+            for text in remoteInsertions[position] ?? [] {
+                emit(.remoteInsertion, text, old: nil, new: nil)
+            }
+            for entry in localInsertions[position] ?? [] {
+                emit(.insertion, entry.text, old: nil, new: entry.line)
+            }
+        }
+
+        emitInsertions(at: 0)
+        for baseLine in 1 ... baseLines.count {
+            let text = baseLines[baseLine - 1]
+            let localMutation = localByBase[baseLine] ?? BaseMutation()
+            let remoteMutation = remoteByBase[baseLine] ?? BaseMutation()
+
+            if localMutation.removed, remoteMutation.removed {
+                emit(.removal, text, old: baseLine, new: nil)
+                if let remoteText = remoteMutation.replacement, remoteText != text {
+                    emit(.remoteInsertion, remoteText, old: nil, new: nil)
+                }
+                if let localText = localMutation.replacement, localText != text {
+                    emit(.insertion, localText, old: nil, new: localMutation.localLine)
+                }
+            } else if localMutation.removed {
+                emit(.removal, text, old: baseLine, new: nil)
+                if let localText = localMutation.replacement, localText != text {
+                    emit(.insertion, localText, old: nil, new: localMutation.localLine)
+                }
+            } else if remoteMutation.removed {
+                emit(.remoteRemoval, text, old: baseLine, new: nil)
+                if let remoteText = remoteMutation.replacement, remoteText != text {
+                    emit(.remoteInsertion, remoteText, old: nil, new: nil)
+                }
+            } else {
+                emit(.context, text, old: baseLine, new: localMutation.localLine ?? baseLine)
+            }
+
+            emitInsertions(at: baseLine)
+        }
+        return lines
+    }
+
+    private static func split(_ text: String) -> [String] {
+        guard !text.isEmpty else { return [] }
+        return text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    }
+}
+
+extension UnifiedDiffPresentation {
+    /// Builds a presentation from a fully expanded unified line stream,
+    /// collapsing unchanged runs into omissions like `init(model:)` does.
+    init(lines: [UnifiedDiffLine], contextLineCount: Int = 3) {
+        let changedIndices = lines.indices.filter { lines[$0].kind.isChanged }
+        guard !changedIndices.isEmpty else {
+            blocks = []
+            return
+        }
+        let context = max(0, contextLineCount)
+        var ranges: [ClosedRange<Int>] = []
+        for index in changedIndices {
+            let candidate = max(0, index - context) ... min(lines.count - 1, index + context)
+            if let previous = ranges.last, candidate.lowerBound <= previous.upperBound + 1 {
+                ranges[ranges.count - 1] = previous.lowerBound ... max(previous.upperBound, candidate.upperBound)
+            } else {
+                ranges.append(candidate)
+            }
+        }
+
+        var result: [UnifiedDiffBlockPresentation] = []
+        var cursor = 0
+        for range in ranges {
+            if cursor < range.lowerBound {
+                result.append(.init(
+                    id: result.count,
+                    kind: .omission,
+                    lines: Array(lines[cursor ..< range.lowerBound])
+                ))
+            }
+            let hunkLines = Array(lines[range])
+            result.append(.init(
+                id: result.count,
+                kind: .hunk(Self.hunkLabel(hunkLines)),
+                lines: hunkLines
+            ))
+            cursor = range.upperBound + 1
+        }
+        if cursor < lines.count {
+            result.append(.init(
+                id: result.count,
+                kind: .omission,
+                lines: Array(lines[cursor...])
+            ))
+        }
+        blocks = result
+    }
+
+    private static func hunkLabel(_ lines: [UnifiedDiffLine]) -> String {
+        let oldNumbers = lines.compactMap(\.oldLineNumber)
+        let newNumbers = lines.compactMap(\.newLineNumber)
+        return "@@ -\(oldNumbers.first ?? 1),\(oldNumbers.count) +\(newNumbers.first ?? 1),\(newNumbers.count) @@"
+    }
+}
+
 private enum UnifiedDiffMetrics {
     static let oldLineGutterWidth: CGFloat = 42
     static let newLineGutterWidth: CGFloat = 42
@@ -210,6 +382,7 @@ struct UnifiedDiffView: View {
     let composingLine: Int?
     @Binding var commentDraft: String
     let isSubmittingComment: Bool
+    let showsCommentControls: Bool
     let onRequestComment: (Int) -> Void
     let onCancelComment: () -> Void
     let onSubmitComment: (Int) -> Void
@@ -242,10 +415,25 @@ struct UnifiedDiffView: View {
         self.composingLine = composingLine
         _commentDraft = commentDraft
         self.isSubmittingComment = isSubmittingComment
+        self.showsCommentControls = true
         self.onRequestComment = onRequestComment
         self.onCancelComment = onCancelComment
         self.onSubmitComment = onSubmitComment
         self.onReply = onReply
+    }
+
+    /// Read-only presentation without review comment plumbing.
+    init(presentation: UnifiedDiffPresentation) {
+        self.presentation = presentation
+        self.commentsByLine = [:]
+        self.composingLine = nil
+        _commentDraft = .constant("")
+        self.isSubmittingComment = false
+        self.showsCommentControls = false
+        self.onRequestComment = { _ in }
+        self.onCancelComment = {}
+        self.onSubmitComment = { _ in }
+        self.onReply = { _ in }
     }
 
     var body: some View {
@@ -413,7 +601,7 @@ struct UnifiedDiffView: View {
 
     @ViewBuilder
     private func commentControl(for line: UnifiedDiffLine) -> some View {
-        if let anchor = line.commentAnchorLine {
+        if showsCommentControls, let anchor = line.commentAnchorLine {
             Button {
                 onRequestComment(anchor)
             } label: {
@@ -472,8 +660,8 @@ struct UnifiedDiffView: View {
     private func marker(for kind: UnifiedDiffLineKind) -> String {
         switch kind {
         case .context: " "
-        case .insertion: "+"
-        case .removal: "−"
+        case .insertion, .remoteInsertion: "+"
+        case .removal, .remoteRemoval: "−"
         }
     }
 
@@ -482,6 +670,7 @@ struct UnifiedDiffView: View {
         case .context: .secondary
         case .insertion: .green
         case .removal: .red
+        case .remoteInsertion, .remoteRemoval: .gray
         }
     }
 
@@ -490,6 +679,7 @@ struct UnifiedDiffView: View {
         case .context: .clear
         case .insertion: .green.opacity(0.08)
         case .removal: .red.opacity(0.08)
+        case .remoteInsertion, .remoteRemoval: .gray.opacity(0.08)
         }
     }
 }

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -386,6 +386,9 @@ struct UnifiedDiffView: View {
     @Binding var commentDraft: String
     let isSubmittingComment: Bool
     let showsCommentControls: Bool
+    /// Standalone usage (no outer scroll container): fill the offered
+    /// height and scroll vertically, like the split diff does.
+    let fillsHeight: Bool
     let onRequestComment: (Int) -> Void
     let onCancelComment: () -> Void
     let onSubmitComment: (Int) -> Void
@@ -419,6 +422,7 @@ struct UnifiedDiffView: View {
         _commentDraft = commentDraft
         self.isSubmittingComment = isSubmittingComment
         self.showsCommentControls = true
+        self.fillsHeight = false
         self.onRequestComment = onRequestComment
         self.onCancelComment = onCancelComment
         self.onSubmitComment = onSubmitComment
@@ -433,6 +437,7 @@ struct UnifiedDiffView: View {
         _commentDraft = .constant("")
         self.isSubmittingComment = false
         self.showsCommentControls = false
+        self.fillsHeight = true
         self.onRequestComment = { _ in }
         self.onCancelComment = {}
         self.onSubmitComment = { _ in }
@@ -447,7 +452,10 @@ struct UnifiedDiffView: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 96)
             } else {
-                ScrollView(.horizontal, showsIndicators: true) {
+                ScrollView(
+                    fillsHeight ? [.horizontal, .vertical] : [.horizontal],
+                    showsIndicators: true
+                ) {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(presentation.blocks) { block in
                             blockView(block)
@@ -458,6 +466,10 @@ struct UnifiedDiffView: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(
+            maxHeight: fillsHeight ? CGFloat.infinity : nil,
+            alignment: .topLeading
+        )
         .background(Color(nsColor: .textBackgroundColor))
         .background {
             GeometryReader { proxy in

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -268,6 +268,9 @@ enum ThreeWayDiff: Sendable {
         }
 
         emitInsertions(at: 0)
+        // An empty base (e.g. a newly created draft) has no lines to
+        // anchor; every line is a pure insertion, already emitted above.
+        guard !baseLines.isEmpty else { return lines }
         for baseLine in 1 ... baseLines.count {
             let text = baseLines[baseLine - 1]
             let localMutation = localByBase[baseLine] ?? BaseMutation()

--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -16,6 +16,23 @@ struct UnifiedDiffLine: Identifiable, Equatable, Sendable {
     let text: String
     let oldLineNumber: Int?
     let newLineNumber: Int?
+    let remoteLineNumber: Int?
+
+    init(
+        id: String,
+        kind: UnifiedDiffLineKind,
+        text: String,
+        oldLineNumber: Int?,
+        newLineNumber: Int?,
+        remoteLineNumber: Int? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.text = text
+        self.oldLineNumber = oldLineNumber
+        self.newLineNumber = newLineNumber
+        self.remoteLineNumber = remoteLineNumber
+    }
 
     var commentAnchorLine: Int? {
         kind == .removal ? nil : newLineNumber
@@ -30,8 +47,10 @@ struct UnifiedDiffBlockPresentation: Identifiable, Equatable, Sendable {
 
 struct UnifiedDiffPresentation: Equatable, Sendable {
     let blocks: [UnifiedDiffBlockPresentation]
+    let showsRemoteLineNumbers: Bool
 
     init(model: SplitDiffModel, anchoredLines: Set<Int> = []) {
+        showsRemoteLineNumbers = false
         if model.blocks.isEmpty, !anchoredLines.isEmpty {
             blocks = Self.anchoredContextBlocks(
                 rows: model.rows,
@@ -199,108 +218,340 @@ struct UnifiedDiffPresentation: Equatable, Sendable {
 /// - base -> remote changes render gray (other people's committed changes
 ///   that are not part of the local draft yet).
 enum ThreeWayDiff: Sendable {
+    private struct VersionLine: Equatable, Sendable {
+        let text: String
+        let lineNumber: Int
+    }
+
+    private struct Edit: Sendable {
+        let baseRange: Range<Int>
+        let replacement: [VersionLine]
+    }
+
+    private struct SideDiff: Sendable {
+        let edits: [Edit]
+        let unchangedLineNumbers: [Int: Int]
+
+        func lineNumber(forBaseIndex index: Int) -> Int {
+            unchangedLineNumbers[index] ?? index + 1
+        }
+
+        func applying(
+            _ selectedEdits: [Edit],
+            to baseRange: Range<Int>,
+            baseLines: [String]
+        ) -> [VersionLine] {
+            var result: [VersionLine] = []
+            var cursor = baseRange.lowerBound
+
+            for edit in selectedEdits {
+                if cursor < edit.baseRange.lowerBound {
+                    result.append(contentsOf: (cursor ..< edit.baseRange.lowerBound).map { index in
+                        VersionLine(
+                            text: baseLines[index],
+                            lineNumber: lineNumber(forBaseIndex: index)
+                        )
+                    })
+                }
+                result.append(contentsOf: edit.replacement)
+                cursor = max(cursor, edit.baseRange.upperBound)
+            }
+
+            if cursor < baseRange.upperBound {
+                result.append(contentsOf: (cursor ..< baseRange.upperBound).map { index in
+                    VersionLine(
+                        text: baseLines[index],
+                        lineNumber: lineNumber(forBaseIndex: index)
+                    )
+                })
+            }
+            return result
+        }
+    }
+
+    private enum Side: Sendable {
+        case local
+        case remote
+    }
+
+    private struct TaggedEdit: Sendable {
+        let side: Side
+        let edit: Edit
+    }
+
+    private struct EditRegion: Sendable {
+        var baseRange: Range<Int>
+        var localEdits: [Edit] = []
+        var remoteEdits: [Edit] = []
+
+        mutating func add(_ taggedEdit: TaggedEdit) {
+            baseRange = min(baseRange.lowerBound, taggedEdit.edit.baseRange.lowerBound)
+                ..< max(baseRange.upperBound, taggedEdit.edit.baseRange.upperBound)
+            switch taggedEdit.side {
+            case .local:
+                localEdits.append(taggedEdit.edit)
+            case .remote:
+                remoteEdits.append(taggedEdit.edit)
+            }
+        }
+    }
+
     static func lines(base: String, local: String, remote: String) -> [UnifiedDiffLine] {
         let baseLines = split(base)
-        let localModel = SplitDiffModel.make(original: base, modified: local)
-        let remoteModel = SplitDiffModel.make(original: base, modified: remote)
-
-        struct BaseMutation {
-            var removed = false
-            var replacement: String?
-            var localLine: Int?
-        }
-
-        var localByBase: [Int: BaseMutation] = [:]
-        var localInsertions: [Int: [(text: String, line: Int)]] = [:]
-        var localAnchor = 0
-        for row in localModel.rows {
-            if let original = row.original {
-                localAnchor = original.lineNumber
-                var mutation = localByBase[original.lineNumber] ?? BaseMutation()
-                mutation.removed = original.kind == .removal
-                mutation.localLine = row.modified?.lineNumber
-                if row.modified?.kind == .insertion {
-                    mutation.replacement = row.modified?.text
-                }
-                localByBase[original.lineNumber] = mutation
-            } else if let modified = row.modified {
-                localInsertions[localAnchor, default: []].append((modified.text, modified.lineNumber))
-            }
-        }
-
-        var remoteByBase: [Int: BaseMutation] = [:]
-        var remoteInsertions: [Int: [String]] = [:]
-        var remoteAnchor = 0
-        for row in remoteModel.rows {
-            if let original = row.original {
-                remoteAnchor = original.lineNumber
-                var mutation = remoteByBase[original.lineNumber] ?? BaseMutation()
-                mutation.removed = original.kind == .removal
-                if row.modified?.kind == .insertion {
-                    mutation.replacement = row.modified?.text
-                }
-                remoteByBase[original.lineNumber] = mutation
-            } else if let modified = row.modified {
-                remoteInsertions[remoteAnchor, default: []].append(modified.text)
-            }
-        }
+        let localDiff = sideDiff(base: base, version: local)
+        let remoteDiff = sideDiff(base: base, version: remote)
+        let regions = editRegions(local: localDiff.edits, remote: remoteDiff.edits)
 
         var lines: [UnifiedDiffLine] = []
         var counter = 0
-        func emit(_ kind: UnifiedDiffLineKind, _ text: String, old: Int?, new: Int?) {
+        func emit(
+            _ kind: UnifiedDiffLineKind,
+            _ text: String,
+            old: Int?,
+            new: Int?,
+            remote: Int?
+        ) {
             counter += 1
             lines.append(.init(
                 id: "three-way-\(counter)",
                 kind: kind,
                 text: text,
                 oldLineNumber: old,
-                newLineNumber: new
+                newLineNumber: new,
+                remoteLineNumber: remote
             ))
         }
 
-        func emitInsertions(at position: Int) {
-            for text in remoteInsertions[position] ?? [] {
-                emit(.remoteInsertion, text, old: nil, new: nil)
-            }
-            for entry in localInsertions[position] ?? [] {
-                emit(.insertion, entry.text, old: nil, new: entry.line)
+        func emitContext(_ range: Range<Int>) {
+            for index in range {
+                emit(
+                    .context,
+                    baseLines[index],
+                    old: index + 1,
+                    new: localDiff.lineNumber(forBaseIndex: index),
+                    remote: remoteDiff.lineNumber(forBaseIndex: index)
+                )
             }
         }
 
-        emitInsertions(at: 0)
-        // An empty base (e.g. a newly created draft) has no lines to
-        // anchor; every line is a pure insertion, already emitted above.
-        guard !baseLines.isEmpty else { return lines }
-        for baseLine in 1 ... baseLines.count {
-            let text = baseLines[baseLine - 1]
-            let localMutation = localByBase[baseLine] ?? BaseMutation()
-            let remoteMutation = remoteByBase[baseLine] ?? BaseMutation()
+        func emitRegion(_ region: EditRegion) {
+            let localChanged = !region.localEdits.isEmpty
+            let remoteChanged = !region.remoteEdits.isEmpty
+            let localResult = localDiff.applying(
+                region.localEdits,
+                to: region.baseRange,
+                baseLines: baseLines
+            )
+            let remoteResult = remoteDiff.applying(
+                region.remoteEdits,
+                to: region.baseRange,
+                baseLines: baseLines
+            )
 
-            if localMutation.removed, remoteMutation.removed {
-                emit(.removal, text, old: baseLine, new: nil)
-                if let remoteText = remoteMutation.replacement, remoteText != text {
-                    emit(.remoteInsertion, remoteText, old: nil, new: nil)
+            if localChanged, remoteChanged {
+                for index in region.baseRange {
+                    emit(.removal, baseLines[index], old: index + 1, new: nil, remote: nil)
                 }
-                if let localText = localMutation.replacement, localText != text {
-                    emit(.insertion, localText, old: nil, new: localMutation.localLine)
+
+                let maximumPrefixCount = min(localResult.count, remoteResult.count)
+                var sharedPrefixCount = 0
+                while sharedPrefixCount < maximumPrefixCount,
+                      localResult[sharedPrefixCount].text == remoteResult[sharedPrefixCount].text {
+                    sharedPrefixCount += 1
                 }
-            } else if localMutation.removed {
-                emit(.removal, text, old: baseLine, new: nil)
-                if let localText = localMutation.replacement, localText != text {
-                    emit(.insertion, localText, old: nil, new: localMutation.localLine)
+
+                let maximumSuffixCount = maximumPrefixCount - sharedPrefixCount
+                var sharedSuffixCount = 0
+                while sharedSuffixCount < maximumSuffixCount,
+                      localResult[localResult.count - sharedSuffixCount - 1].text
+                        == remoteResult[remoteResult.count - sharedSuffixCount - 1].text {
+                    sharedSuffixCount += 1
                 }
-            } else if remoteMutation.removed {
-                emit(.remoteRemoval, text, old: baseLine, new: nil)
-                if let remoteText = remoteMutation.replacement, remoteText != text {
-                    emit(.remoteInsertion, remoteText, old: nil, new: nil)
+
+                for offset in 0 ..< sharedPrefixCount {
+                    let localLine = localResult[offset]
+                    let remoteLine = remoteResult[offset]
+                    emit(
+                        .insertion,
+                        localLine.text,
+                        old: nil,
+                        new: localLine.lineNumber,
+                        remote: remoteLine.lineNumber
+                    )
                 }
-            } else {
-                emit(.context, text, old: baseLine, new: localMutation.localLine ?? baseLine)
+
+                let remoteMiddleEnd = remoteResult.count - sharedSuffixCount
+                for line in remoteResult[sharedPrefixCount ..< remoteMiddleEnd] {
+                    emit(
+                        .remoteInsertion,
+                        line.text,
+                        old: nil,
+                        new: nil,
+                        remote: line.lineNumber
+                    )
+                }
+
+                let localMiddleEnd = localResult.count - sharedSuffixCount
+                for line in localResult[sharedPrefixCount ..< localMiddleEnd] {
+                    emit(
+                        .insertion,
+                        line.text,
+                        old: nil,
+                        new: line.lineNumber,
+                        remote: nil
+                    )
+                }
+
+                for offset in 0 ..< sharedSuffixCount {
+                    let localLine = localResult[localMiddleEnd + offset]
+                    let remoteLine = remoteResult[remoteMiddleEnd + offset]
+                    emit(
+                        .insertion,
+                        localLine.text,
+                        old: nil,
+                        new: localLine.lineNumber,
+                        remote: remoteLine.lineNumber
+                    )
+                }
+                return
             }
 
-            emitInsertions(at: baseLine)
+            if localChanged {
+                for index in region.baseRange {
+                    emit(
+                        .removal,
+                        baseLines[index],
+                        old: index + 1,
+                        new: nil,
+                        remote: remoteDiff.lineNumber(forBaseIndex: index)
+                    )
+                }
+                for line in localResult {
+                    emit(
+                        .insertion,
+                        line.text,
+                        old: nil,
+                        new: line.lineNumber,
+                        remote: nil
+                    )
+                }
+                return
+            }
+
+            for index in region.baseRange {
+                emit(
+                    .remoteRemoval,
+                    baseLines[index],
+                    old: index + 1,
+                    new: localDiff.lineNumber(forBaseIndex: index),
+                    remote: nil
+                )
+            }
+            for line in remoteResult {
+                emit(
+                    .remoteInsertion,
+                    line.text,
+                    old: nil,
+                    new: nil,
+                    remote: line.lineNumber
+                )
+            }
+        }
+
+        var baseCursor = 0
+        for region in regions {
+            if baseCursor < region.baseRange.lowerBound {
+                emitContext(baseCursor ..< region.baseRange.lowerBound)
+            }
+            emitRegion(region)
+            baseCursor = max(baseCursor, region.baseRange.upperBound)
+        }
+        if baseCursor < baseLines.count {
+            emitContext(baseCursor ..< baseLines.count)
         }
         return lines
+    }
+
+    private static func sideDiff(base: String, version: String) -> SideDiff {
+        let rows = SplitDiffModel.make(original: base, modified: version).rows
+        var edits: [Edit] = []
+        var unchangedLineNumbers: [Int: Int] = [:]
+        var baseOffset = 0
+        var rowIndex = 0
+
+        while rowIndex < rows.count {
+            let row = rows[rowIndex]
+            if !row.isChanged {
+                if let original = row.original, let modified = row.modified {
+                    unchangedLineNumbers[original.lineNumber - 1] = modified.lineNumber
+                    baseOffset = original.lineNumber
+                }
+                rowIndex += 1
+                continue
+            }
+
+            let start = baseOffset
+            var replacement: [VersionLine] = []
+            while rowIndex < rows.count, rows[rowIndex].isChanged {
+                let changedRow = rows[rowIndex]
+                if let original = changedRow.original {
+                    baseOffset = original.lineNumber
+                }
+                if let modified = changedRow.modified {
+                    replacement.append(.init(
+                        text: modified.text,
+                        lineNumber: modified.lineNumber
+                    ))
+                }
+                rowIndex += 1
+            }
+            edits.append(.init(baseRange: start ..< baseOffset, replacement: replacement))
+        }
+
+        return .init(edits: edits, unchangedLineNumbers: unchangedLineNumbers)
+    }
+
+    private static func editRegions(local: [Edit], remote: [Edit]) -> [EditRegion] {
+        var tagged = local.map { TaggedEdit(side: .local, edit: $0) }
+        tagged.append(contentsOf: remote.map { TaggedEdit(side: .remote, edit: $0) })
+        tagged.sort { lhs, rhs in
+            if lhs.edit.baseRange.lowerBound != rhs.edit.baseRange.lowerBound {
+                return lhs.edit.baseRange.lowerBound < rhs.edit.baseRange.lowerBound
+            }
+            if lhs.edit.baseRange.upperBound != rhs.edit.baseRange.upperBound {
+                return lhs.edit.baseRange.upperBound < rhs.edit.baseRange.upperBound
+            }
+            switch (lhs.side, rhs.side) {
+            case (.remote, .local): return true
+            default: return false
+            }
+        }
+
+        var regions: [EditRegion] = []
+        for taggedEdit in tagged {
+            if let lastIndex = regions.indices.last,
+               overlaps(regions[lastIndex].baseRange, taggedEdit.edit.baseRange) {
+                regions[lastIndex].add(taggedEdit)
+            } else {
+                var region = EditRegion(baseRange: taggedEdit.edit.baseRange)
+                region.add(taggedEdit)
+                regions.append(region)
+            }
+        }
+        return regions
+    }
+
+    private static func overlaps(_ lhs: Range<Int>, _ rhs: Range<Int>) -> Bool {
+        if lhs.isEmpty, rhs.isEmpty {
+            return lhs.lowerBound == rhs.lowerBound
+        }
+        if lhs.isEmpty {
+            return lhs.lowerBound > rhs.lowerBound && lhs.lowerBound < rhs.upperBound
+        }
+        if rhs.isEmpty {
+            return rhs.lowerBound > lhs.lowerBound && rhs.lowerBound < lhs.upperBound
+        }
+        return lhs.overlaps(rhs)
     }
 
     private static func split(_ text: String) -> [String] {
@@ -313,6 +564,7 @@ extension UnifiedDiffPresentation {
     /// Builds a presentation from a fully expanded unified line stream,
     /// collapsing unchanged runs into omissions like `init(model:)` does.
     init(lines: [UnifiedDiffLine], contextLineCount: Int = 3) {
+        showsRemoteLineNumbers = true
         let changedIndices = lines.indices.filter { lines[$0].kind.isChanged }
         guard !changedIndices.isEmpty else {
             blocks = []
@@ -340,9 +592,15 @@ extension UnifiedDiffPresentation {
                 ))
             }
             let hunkLines = Array(lines[range])
+            let precedingLines = lines[..<range.lowerBound]
             result.append(.init(
                 id: result.count,
-                kind: .hunk(Self.hunkLabel(hunkLines)),
+                kind: .hunk(Self.threeWayHunkLabel(
+                    hunkLines,
+                    baseBefore: precedingLines.compactMap(\.oldLineNumber).last ?? 0,
+                    localBefore: precedingLines.compactMap(\.newLineNumber).last ?? 0,
+                    remoteBefore: precedingLines.compactMap(\.remoteLineNumber).last ?? 0
+                )),
                 lines: hunkLines
             ))
             cursor = range.upperBound + 1
@@ -357,10 +615,37 @@ extension UnifiedDiffPresentation {
         blocks = result
     }
 
-    private static func hunkLabel(_ lines: [UnifiedDiffLine]) -> String {
-        let oldNumbers = lines.compactMap(\.oldLineNumber)
-        let newNumbers = lines.compactMap(\.newLineNumber)
-        return "@@ -\(oldNumbers.first ?? 1),\(oldNumbers.count) +\(newNumbers.first ?? 1),\(newNumbers.count) @@"
+    private static func threeWayHunkLabel(
+        _ lines: [UnifiedDiffLine],
+        baseBefore: Int,
+        localBefore: Int,
+        remoteBefore: Int
+    ) -> String {
+        let base = coordinateLabel(
+            "base",
+            numbers: lines.compactMap(\.oldLineNumber),
+            before: baseBefore
+        )
+        let local = coordinateLabel(
+            "local",
+            numbers: lines.compactMap(\.newLineNumber),
+            before: localBefore
+        )
+        let remote = coordinateLabel(
+            "remote",
+            numbers: lines.compactMap(\.remoteLineNumber),
+            before: remoteBefore
+        )
+        return "@@ \(base) · \(local) · \(remote) @@"
+    }
+
+    private static func coordinateLabel(
+        _ name: String,
+        numbers: [Int],
+        before: Int
+    ) -> String {
+        guard let first = numbers.first else { return "\(name) \(before),0" }
+        return "\(name) \(first),\(numbers.count)"
     }
 }
 
@@ -565,6 +850,9 @@ struct UnifiedDiffView: View {
         HStack(alignment: .top, spacing: 0) {
             lineNumber(line.oldLineNumber, width: UnifiedDiffMetrics.oldLineGutterWidth)
             lineNumber(line.newLineNumber, width: UnifiedDiffMetrics.newLineGutterWidth)
+            if presentation.showsRemoteLineNumbers {
+                lineNumber(line.remoteLineNumber, width: UnifiedDiffMetrics.newLineGutterWidth)
+            }
 
             Text(marker(for: line.kind))
                 .foregroundStyle(markerColor(for: line.kind))

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -205,9 +205,26 @@ struct RuntimeState: Sendable {
     let serverDataSource: String
 }
 
-enum WorkbenchTabMode: String, Hashable, Sendable {
-    case source
+enum WorkbenchTabMode: String, CaseIterable, Hashable, Sendable {
     case preview
+    case source
+    case diff
+
+    var title: String {
+        switch self {
+        case .preview: "Preview"
+        case .source: "Source"
+        case .diff: "Diff"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .preview: "eye"
+        case .source: "doc.plaintext"
+        case .diff: "arrow.left.arrow.right"
+        }
+    }
 }
 
 struct WorkbenchTab: Identifiable, Hashable, Sendable {

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -124,6 +124,7 @@ struct LocalDraft: Identifiable, Hashable, Sendable {
     let updatedAt: String
     var document: EditableMemoryDocument
     var isDeletion: Bool
+    var documentBaselineAvailable: Bool = true
 }
 
 struct MemoryListItem: Identifiable, Hashable, Sendable {
@@ -131,6 +132,10 @@ struct MemoryListItem: Identifiable, Hashable, Sendable {
     let resource: MemoryResource?
     let draft: LocalDraft?
     let inherited: Bool
+    /// Project whose effective-memory view produced this item. This is the
+    /// stable carrier for a new local Draft on selected Org authority; it is
+    /// deliberately distinct from resource ownership.
+    var projectContextId: String? = nil
 
     var document: EditableMemoryDocument {
         draft?.document ?? resource?.document ?? .init(
@@ -142,8 +147,10 @@ struct MemoryListItem: Identifiable, Hashable, Sendable {
 
     var kind: MemoryKind { draft?.kind ?? resource?.kind ?? .context }
     var scope: MemoryScope { draft?.scope ?? resource?.scope ?? .project }
-    var projectId: String? { draft?.projectId ?? resource?.projectId }
-    var contentLoaded: Bool { draft != nil || resource?.contentLoaded == true }
+    var projectId: String? { draft?.projectId ?? resource?.projectId ?? projectContextId }
+    var contentLoaded: Bool {
+        draft?.documentBaselineAvailable ?? (resource?.contentLoaded == true)
+    }
 
     var supportsMarkdownPreview: Bool {
         draft?.isDeletion != true && kind.supportsMarkdownPreview(path: document.path)
@@ -229,20 +236,21 @@ enum WorkbenchTabMode: String, CaseIterable, Hashable, Sendable {
 
 struct WorkbenchTab: Identifiable, Hashable, Sendable {
     var id: String {
-        "\(section.rawValue):\(projectId ?? "shared"):\(itemId):\(mode.rawValue)"
+        "\(section.rawValue):\(projectId ?? "shared"):\(itemId)"
     }
 
     let section: WorkspaceSection
     let projectId: String?
     let itemId: String
-    let mode: WorkbenchTabMode
-    let title: String
+    var mode: WorkbenchTabMode
+    var title: String
 
     func isVisible(in section: WorkspaceSection, projectId: String?) -> Bool {
         guard self.section == section else { return false }
         guard section == .memory else { return true }
-        // Org-scope (Hub) tabs stay visible regardless of the active project;
-        // project-scope tabs are only visible while their project is active.
-        return self.projectId == nil || self.projectId == projectId
+        // A document tab belongs to the view context in which it was opened.
+        // This keeps an Org authority tab separate from a Project-local draft
+        // overlay of the same memory.
+        return self.projectId == projectId
     }
 }

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -157,6 +157,14 @@ struct MemoryListItem: Identifiable, Hashable, Sendable {
     }
 }
 
+/// Identifies one editor/sync session in the Project view that owns it.
+/// Org authority and each Project overlay can address the same resource id,
+/// so the bare resource id is not a safe key for mutable document state.
+struct MemoryDocumentSessionKey: Hashable, Sendable {
+    let projectId: String
+    let itemId: String
+}
+
 struct PersonalBundle: Identifiable, Hashable, Sendable {
     let id: String
     var name: String

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -1,10 +1,10 @@
 import Combine
+import CryptoKit
 import Foundation
 
 enum DocumentSessionCommand: Equatable, Sendable {
     case requestReview(itemId: String, draft: LocalDraft)
     case discardDraft(itemId: String, draft: LocalDraft)
-    case reviewSharedChanges(itemId: String, draft: LocalDraft)
     case applyReconciliation(itemId: String)
     case closeReconciliation(itemId: String)
     case moveToTrash(itemId: String)
@@ -13,7 +13,6 @@ enum DocumentSessionCommand: Equatable, Sendable {
         switch self {
         case .requestReview(let itemId, _),
              .discardDraft(let itemId, _),
-             .reviewSharedChanges(let itemId, _),
              .applyReconciliation(let itemId),
              .closeReconciliation(let itemId),
              .moveToTrash(let itemId):
@@ -62,11 +61,14 @@ struct LocalAgentAdapterReconciliationResult: Equatable, Sendable {
 enum WorkspaceLoadError: LocalizedError, Sendable {
     case authenticationRequired
     case noProjects
+    case sharedStateChangedDuringLoad
 
     var errorDescription: String? {
         switch self {
         case .authenticationRequired: "Sign in to connect Clumsies to your organization."
         case .noProjects: "The signed-in account has no accessible project."
+        case .sharedStateChangedDuringLoad:
+            "Shared memory changed while the workspace was loading. Refresh to load one consistent version."
         }
     }
 }
@@ -74,27 +76,106 @@ enum WorkspaceLoadError: LocalizedError, Sendable {
 enum MemoryValidationError: LocalizedError, Sendable {
     case invalidPath(String)
     case emptyRule
+    case unpublishedMemoryCannotBeRenamed
 
     var errorDescription: String? {
         switch self {
         case .invalidPath(let message): message
         case .emptyRule: "A Rule needs content."
+        case .unpublishedMemoryCannotBeRenamed:
+            "A new memory can be renamed after it becomes shared."
         }
     }
 }
 
 enum ReviewRequestError: LocalizedError, Sendable {
     case draftNotSynchronized
+    case projectLocalDraftCannotBePublished
     case reconciliationRequired
 
     var errorDescription: String? {
         switch self {
         case .draftNotSynchronized:
             "Wait for this draft to finish syncing before requesting a review."
+        case .projectLocalDraftCannotBePublished:
+            "This Project-local draft can stay local indefinitely. Publishing it to the Organization is not available yet."
         case .reconciliationRequired:
             "Merge the latest shared version before requesting a review."
         }
     }
+}
+
+enum DocumentSyncError: LocalizedError, Equatable, Sendable {
+    case checkoutNoLongerCurrent
+    case draftUploadFailed(String?)
+    case draftUploadTimedOut
+    case mutationWhileSynchronizing
+
+    var errorDescription: String? {
+        switch self {
+        case .checkoutNoLongerCurrent:
+            "The shared version changed again. Refresh sync status and try again."
+        case .draftUploadFailed(let message):
+            message ?? "The local draft could not be uploaded. Retry sync before reviewing shared changes."
+        case .draftUploadTimedOut:
+            "The local draft is still uploading. Wait a moment and try Sync again."
+        case .mutationWhileSynchronizing:
+            "Shared changes are being prepared for this document. Wait for Sync to finish before editing it."
+        }
+    }
+}
+
+enum DocumentDiffError: LocalizedError, Equatable, Sendable {
+    case baselineUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .baselineUnavailable:
+            "The previous shared content is unavailable, so an accurate Diff cannot be shown."
+        }
+    }
+}
+
+enum DraftUploadBarrierDecision: Equatable, Sendable {
+    case wait
+    case ready
+    case failed(String?)
+}
+
+struct StaleResourceSyncSnapshot: Equatable, Sendable {
+    let projectId: String
+    let observedProjectRefCommitId: String?
+    let observedSelectedOrgResourceIds: Set<String>
+    let observedOrgSelectionRevision: Int
+    let authoritativeCommitId: String
+    let authoritativeRefEtag: String?
+    let selectedOrgResourceIds: Set<String>
+    let orgSelectionRevision: Int
+    let generation: UUID
+    let local: MemoryResource?
+    let remote: MemoryResource?
+}
+
+enum DocumentPathChangeSource: String, Equatable, Sendable {
+    case draft
+    case shared
+    case draftAndShared
+}
+
+struct DocumentPathChange: Equatable, Sendable {
+    let source: DocumentPathChangeSource
+    let from: String?
+    let to: String?
+}
+
+struct DocumentDiffResult: Equatable, Sendable {
+    let presentation: UnifiedDiffPresentation?
+    let pathChanges: [DocumentPathChange]
+}
+
+struct DocumentRenamePlan: Equatable, Sendable {
+    let targetId: String
+    let newPath: String
 }
 
 enum ReviewMenuAction: Sendable, Equatable {
@@ -198,6 +279,11 @@ struct DraftInventoryPlan: Equatable, Sendable {
     let terminalIds: Set<String>
 }
 
+private struct ResourceLoadRequest: Sendable {
+    let resource: MemoryResource
+    let generation: UUID
+}
+
 @MainActor
 final class WorkspaceStore: ObservableObject {
     @Published private(set) var phase: ApplicationPhase = .launching
@@ -241,16 +327,27 @@ final class WorkspaceStore: ObservableObject {
     @Published var documentReconciliationToolbarState: DocumentReconciliationToolbarState?
     @Published private(set) var loadingResourceIds: Set<String> = []
     @Published private(set) var loadingProjectId: String?
+    @Published private(set) var isSwitchingMemoryContext = false
     @Published private(set) var isPreparingWorkspaceIndex = false
     /// Project resources whose shared version moved forward after the app
     /// loaded its snapshot; they show a sync icon and can be refreshed.
     @Published private(set) var staleResourceIds: Set<String> = []
+    /// Incremented when authoritative content replaces the document currently
+    /// held by a long-lived editor session.
+    @Published private(set) var documentContentGenerations: [String: UInt64] = [:]
+    @Published private(set) var synchronizingDocumentIds: Set<String> = []
+    @Published private(set) var pendingDocumentReconciliationCandidates:
+        [String: DraftReconciliationCandidate] = [:]
+    @Published private(set) var applyingDocumentReconciliationIds: Set<String> = []
+    @Published private(set) var projectOrgSelectionMutatingIds: Set<String> = []
 
     let daemon = DaemonXPCClient()
     private let bootstrap = DaemonBootstrapController()
     private lazy var authentication = AuthenticationClient(daemon: daemon)
     private lazy var server = ServerClient(daemon: daemon)
+    private var workspaceReloadGeneration = UUID()
     private var projectSelectionGeneration = UUID()
+    private let projectSelectionSideEffectGate = ProjectSelectionSideEffectGate()
     private let draftMutationGate = AsyncMutex()
     private let bundleMutationGate = AsyncMutex()
     private let projectOrgSelectionMutationGate = AsyncMutex()
@@ -258,6 +355,13 @@ final class WorkspaceStore: ObservableObject {
     private var documentSaveTasks: [String: Task<Void, Never>] = [:]
     private var pendingBundleSaves: [String: PendingBundleSave] = [:]
     private var bundleSaveTasks: [String: Task<Void, Never>] = [:]
+    private var staleResourceSnapshots: [String: StaleResourceSyncSnapshot] = [:]
+    private var provisionalStaleAdditionIds: Set<String> = []
+    private var resourceLoadRequests: [String: ResourceLoadRequest] = [:]
+    private var staleResourceRefreshGenerations: [String: UUID] = [:]
+    private var documentSynchronizationGenerations: [String: UUID] = [:]
+    private var documentSynchronizationTasks: [String: Task<Void, Never>] = [:]
+    private var documentReconciliationResolutions: [String: ReconciliationResourceState] = [:]
 
     var activeProject: ProjectState? {
         projects.first { $0.id == activeProjectId }
@@ -284,7 +388,25 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func canCreateMemory(kind: MemoryKind, scope: MemoryScope) -> Bool {
-        scope == .org || activeProjectId != nil
+        guard !isSwitchingMemoryContext else { return false }
+        if scope == .org {
+            return canManageOrgSelection && !projects.isEmpty
+        }
+        return activeProjectId != nil
+    }
+
+    /// Authority is never edited in place: editable documents are persisted
+    /// as local Draft operations. Org-targeted Drafts still require the
+    /// Server's organization write capability.
+    func canEditMemory(_ item: MemoryListItem) -> Bool {
+        let projectContextId = item.projectContextId
+            ?? (item.scope == .project ? item.projectId : nil)
+        if projectContextId.map(projectOrgSelectionMutatingIds.contains) == true {
+            return false
+        }
+        if item.scope == .project { return item.projectId != nil }
+        return canManageOrgSelection
+            && (item.projectId != nil || activeProjectId != nil || !projects.isEmpty)
     }
 
     var selectedItem: MemoryListItem? {
@@ -293,7 +415,81 @@ final class WorkspaceStore: ObservableObject {
     }
 
     var visibleTabs: [WorkbenchTab] {
-        tabs.filter { $0.isVisible(in: selectedSection, projectId: activeProjectId) }
+        tabs.filter { tab in
+            guard tab.isVisible(in: selectedSection, projectId: activeProjectId) else {
+                return false
+            }
+            guard selectedSection == .memory else { return true }
+            let allowsUnresolved = phase != .ready || activeProject?.isLoaded == false
+            guard let activeProjectId else {
+                return Self.orgMemoryTabIsAvailable(
+                    itemId: tab.itemId,
+                    resources: resources,
+                    drafts: drafts,
+                    allowsUnresolved: allowsUnresolved
+                )
+            }
+            guard tab.projectId == activeProjectId else { return false }
+            return Self.memoryTabIsAvailable(
+                itemId: tab.itemId,
+                projectId: activeProjectId,
+                selectedOrgResourceIds: activeProject?.selectedOrgResourceIds ?? [],
+                resources: resources,
+                drafts: drafts,
+                allowsUnresolved: allowsUnresolved
+            )
+        }
+    }
+
+    nonisolated static func orgMemoryTabIsAvailable(
+        itemId: String,
+        resources: [MemoryResource],
+        drafts: [LocalDraft],
+        allowsUnresolved: Bool = false
+    ) -> Bool {
+        if resources.contains(where: { $0.id == itemId && $0.scope == .org }) {
+            return true
+        }
+        if drafts.contains(where: { draft in
+            (draft.id == itemId || draft.targetId == itemId)
+                && draft.scope == .org
+                && draft.status != .discarded
+                && draft.status != .merged
+        }) {
+            return true
+        }
+        return allowsUnresolved
+    }
+
+    nonisolated static func memoryTabIsAvailable(
+        itemId: String,
+        projectId: String,
+        selectedOrgResourceIds: Set<String>,
+        resources: [MemoryResource],
+        drafts: [LocalDraft],
+        allowsUnresolved: Bool = false
+    ) -> Bool {
+        let resource = resources.first(where: { $0.id == itemId })
+        if let resource {
+            switch resource.scope {
+            case .project:
+                return resource.projectId == projectId
+            case .org:
+                if selectedOrgResourceIds.contains(resource.id) { return true }
+            }
+        }
+        if drafts.contains(where: { draft in
+            (draft.id == itemId || draft.targetId == itemId)
+                && draft.projectId == projectId
+                && draft.status != .discarded
+                && draft.status != .merged
+        }) {
+            return true
+        }
+        // Keep unresolved tabs while a workspace generation is loading. A
+        // known, unselected Org resource is intentionally hidden; a document
+        // whose resource has not arrived yet must not be dropped prematurely.
+        return allowsUnresolved && resource == nil
     }
 
     var activeVisibleTab: WorkbenchTab? {
@@ -315,6 +511,131 @@ final class WorkspaceStore: ObservableObject {
 
     var currentTabMode: WorkbenchTabMode? {
         activeVisibleTab?.mode
+    }
+
+    func documentContentGeneration(for itemId: String) -> UInt64 {
+        documentContentGenerations[itemId, default: 0]
+    }
+
+    func staleResourceGeneration(for resourceId: String) -> UUID? {
+        staleResourceSnapshots[resourceId]?.generation
+    }
+
+    func isSynchronizingDocument(_ itemId: String) -> Bool {
+        synchronizingDocumentIds.contains(itemId)
+    }
+
+    func pendingDocument(for item: MemoryListItem) -> EditableMemoryDocument? {
+        [item.id, item.draft?.targetId, item.draft?.id]
+            .compactMap { $0 }
+            .lazy
+            .compactMap { self.pendingDocumentSaves[$0]?.document }
+            .first
+    }
+
+    func documentReconciliationResolution(for itemId: String) -> ReconciliationResourceState? {
+        documentReconciliationResolutions[itemId]
+    }
+
+    func updateDocumentReconciliationResolution(
+        _ resolution: ReconciliationResourceState,
+        for itemId: String
+    ) {
+        guard pendingDocumentReconciliationCandidates[itemId] != nil else { return }
+        documentReconciliationResolutions[itemId] = resolution
+    }
+
+    func finishDocumentReconciliation(for itemId: String) {
+        guard !applyingDocumentReconciliationIds.contains(itemId) else { return }
+        documentSynchronizationTasks.removeValue(forKey: itemId)?.cancel()
+        pendingDocumentReconciliationCandidates.removeValue(forKey: itemId)
+        documentReconciliationResolutions.removeValue(forKey: itemId)
+        synchronizingDocumentIds.remove(itemId)
+        documentSynchronizationGenerations.removeValue(forKey: itemId)
+        if documentReconciliationToolbarState?.itemId == itemId {
+            documentReconciliationToolbarState = nil
+        }
+        if pendingDocumentCommand?.itemId == itemId {
+            pendingDocumentCommand = nil
+        }
+    }
+
+    private func synchronizationItemId(for item: MemoryListItem) -> String? {
+        [item.id, item.resource?.id, item.draft?.targetId, item.draft?.id]
+            .compactMap { $0 }
+            .first { synchronizingDocumentIds.contains($0) }
+    }
+
+    private func synchronizationItemId(for draft: LocalDraft) -> String? {
+        [draft.targetId, draft.id]
+            .compactMap { $0 }
+            .first { synchronizingDocumentIds.contains($0) }
+    }
+
+    private func hasDocumentSynchronization(in projectId: String) -> Bool {
+        synchronizingDocumentIds.contains { itemId in
+            if resources.contains(where: { $0.id == itemId && $0.projectId == projectId }) {
+                return true
+            }
+            return drafts.contains {
+                ($0.id == itemId || $0.targetId == itemId) && $0.projectId == projectId
+            }
+        }
+    }
+
+    private func isCurrentDocumentSynchronization(_ itemId: String, generation: UUID) -> Bool {
+        synchronizingDocumentIds.contains(itemId)
+            && documentSynchronizationGenerations[itemId] == generation
+    }
+
+    private func endDocumentSynchronization(_ itemId: String, generation: UUID) {
+        guard documentSynchronizationGenerations[itemId] == generation else { return }
+        documentSynchronizationTasks.removeValue(forKey: itemId)
+        synchronizingDocumentIds.remove(itemId)
+        documentSynchronizationGenerations.removeValue(forKey: itemId)
+    }
+
+    func documentPathChanges(for item: MemoryListItem) -> [DocumentPathChange] {
+        if let draft = item.draft {
+            // The mapped document for a behind draft is based on the currently
+            // displayed resource and cannot attribute a remote rename. The
+            // candidate owns the exact base/current/draft paths instead.
+            guard draft.freshness != .behind else { return [] }
+            let basePath = item.resource?.document.path
+            return Self.documentPathChanges(
+                basePath: basePath,
+                localPath: draft.isDeletion ? nil : draft.document.path,
+                remotePath: basePath
+            )
+        }
+        guard let resource = item.resource,
+              let snapshot = staleResourceSnapshots[resource.id] else { return [] }
+        let basePath = snapshot.local?.document.path
+        return Self.documentPathChanges(
+            basePath: basePath,
+            localPath: basePath,
+            remotePath: snapshot.remote?.document.path
+        )
+    }
+
+    nonisolated static func documentPathChanges(
+        basePath: String?,
+        localPath: String?,
+        remotePath: String?
+    ) -> [DocumentPathChange] {
+        let hasLocalChange = localPath != basePath
+        let hasRemoteChange = remotePath != basePath
+        if hasLocalChange, hasRemoteChange, localPath == remotePath {
+            return [.init(source: .draftAndShared, from: basePath, to: localPath)]
+        }
+        var changes: [DocumentPathChange] = []
+        if hasLocalChange {
+            changes.append(.init(source: .draft, from: basePath, to: localPath))
+        }
+        if hasRemoteChange {
+            changes.append(.init(source: .shared, from: basePath, to: remotePath))
+        }
+        return changes
     }
 
     var selectedBundle: PersonalBundle? {
@@ -375,32 +696,26 @@ final class WorkspaceStore: ObservableObject {
     }
 
     var visibleMemoryItems: [MemoryListItem] {
-        let authoritative: [MemoryResource]
         switch selectedSection {
         case .memory:
-            // Unified Memory: org-scope (Hub) memories are always visible;
-            // the active project's project-scope memories are merged in.
-            let orgResources = resources.filter { $0.scope == .org }
-            let projectResources = resources.filter {
-                $0.scope == .project && $0.projectId == activeProjectId
-            }
-            authoritative = orgResources + projectResources
+            break
         case .issues, .bundles, .reviews:
             return []
         }
 
-        let activeDrafts = drafts.filter { draft in
-            guard draft.status != .discarded && draft.status != .merged else {
-                return false
-            }
-            if draft.scope == .org {
-                return true
-            }
-            return draft.projectId == activeProjectId
-        }
+        let authoritative = Self.memoryTreeResources(
+            resources,
+            activeProjectId: activeProjectId,
+            selectedOrgResourceIds: activeProject?.selectedOrgResourceIds ?? []
+        )
+        let activeDrafts = Self.preferredMemoryTreeDrafts(
+            Self.memoryTreeDrafts(drafts, activeProjectId: activeProjectId)
+        )
         let draftByTarget = Dictionary(
             activeDrafts.compactMap { draft in draft.targetId.map { ($0, draft) } },
-            uniquingKeysWith: { _, latest in latest }
+            uniquingKeysWith: { current, candidate in
+                candidate.updatedAt > current.updatedAt ? candidate : current
+            }
         )
         var items = authoritative.map { resource in
             MemoryListItem(
@@ -409,23 +724,131 @@ final class WorkspaceStore: ObservableObject {
                 draft: draftByTarget[resource.id],
                 inherited: resource.scope == .org
                     && activeProjectId != nil
-                    && (activeProject?.selectedOrgResourceIds.contains(resource.id) ?? false)
+                    && (activeProject?.selectedOrgResourceIds.contains(resource.id) ?? false),
+                projectContextId: activeProjectId
             )
         }
-        items.append(contentsOf: activeDrafts.filter { $0.targetId == nil }.map {
-            MemoryListItem(id: $0.id, resource: nil, draft: $0, inherited: false)
+        let authoritativeIds = Set(authoritative.map(\.id))
+        items.append(contentsOf: Self.unrepresentedDrafts(
+            activeDrafts,
+            authoritativeResourceIds: authoritativeIds
+        ).map {
+            MemoryListItem(
+                id: $0.targetId ?? $0.id,
+                resource: nil,
+                draft: $0,
+                inherited: false,
+                projectContextId: activeProjectId
+            )
         })
         return items.sorted { $0.document.path.localizedStandardCompare($1.document.path) == .orderedAscending }
+    }
+
+    /// The Project tree is the Project's effective Memory surface: selected
+    /// Org authority plus its local Draft overlay. Existing project-scope
+    /// authority remains visible as a compatibility layer until that legacy
+    /// publication path is migrated separately.
+    nonisolated static func memoryTreeResources(
+        _ resources: [MemoryResource],
+        activeProjectId: String?,
+        selectedOrgResourceIds: Set<String>
+    ) -> [MemoryResource] {
+        guard let activeProjectId else {
+            return resources.filter { $0.scope == .org }
+        }
+        return resources.filter { resource in
+            switch resource.scope {
+            case .org:
+                selectedOrgResourceIds.contains(resource.id)
+            case .project:
+                resource.projectId == activeProjectId
+            }
+        }
+    }
+
+    nonisolated static func memoryTreeDrafts(
+        _ drafts: [LocalDraft],
+        activeProjectId: String?
+    ) -> [LocalDraft] {
+        drafts.filter { draft in
+            guard draft.status != .discarded && draft.status != .merged else {
+                return false
+            }
+            if let activeProjectId {
+                return draft.projectId == activeProjectId
+            }
+            return draft.scope == .org
+        }
+    }
+
+    nonisolated static func preferredMemoryTreeDrafts(
+        _ drafts: [LocalDraft]
+    ) -> [LocalDraft] {
+        var preferred: [String: LocalDraft] = [:]
+        for draft in drafts {
+            let key = draft.targetId ?? "draft:\(draft.id)"
+            if let current = preferred[key], current.updatedAt >= draft.updatedAt {
+                continue
+            }
+            preferred[key] = draft
+        }
+        return preferred.values.sorted { lhs, rhs in
+            if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
+            return lhs.id < rhs.id
+        }
+    }
+
+    nonisolated static func unrepresentedDrafts(
+        _ activeDrafts: [LocalDraft],
+        authoritativeResourceIds: Set<String>
+    ) -> [LocalDraft] {
+        activeDrafts.filter { draft in
+            guard let targetId = draft.targetId else { return true }
+            return !authoritativeResourceIds.contains(targetId)
+        }
+    }
+
+    nonisolated static func resourceGenerationMatches(
+        _ lhs: MemoryResource,
+        _ rhs: MemoryResource
+    ) -> Bool {
+        lhs.id == rhs.id
+            && lhs.scope == rhs.scope
+            && lhs.projectId == rhs.projectId
+            && lhs.kind == rhs.kind
+            && lhs.contentHash == rhs.contentHash
+            && lhs.refCommitId == rhs.refCommitId
+            && lhs.document.path == rhs.document.path
+    }
+
+    @discardableResult
+    private func installLoadedResourceIfCurrent(_ loaded: MemoryResource) -> Bool {
+        guard let index = resources.firstIndex(where: { $0.id == loaded.id }),
+              !resources[index].contentLoaded,
+              Self.resourceGenerationMatches(resources[index], loaded) else {
+            return false
+        }
+        resources[index] = loaded
+        bumpDocumentContentGeneration(for: loaded.id)
+        return true
     }
 
     func start() {
         Task { await reload() }
     }
 
-    func reload() async {
+    func reload(allowsDuringDocumentReconciliation: Bool = false) async {
+        guard allowsDuringDocumentReconciliation
+                || applyingDocumentReconciliationIds.isEmpty else {
+            return
+        }
+        let generation = UUID()
+        workspaceReloadGeneration = generation
         if phase == .ready, hasPendingChanges, !(await flushPendingChanges()) {
             return
         }
+        guard workspaceReloadGeneration == generation else { return }
+        let preservesLoadedWorkspace = account != nil
         phase = .loading
         errorMessage = nil
         do {
@@ -434,13 +857,23 @@ final class WorkspaceStore: ObservableObject {
                 bootstrap: bootstrap,
                 server: server
             ).load { [weak self] result in
+                guard self?.workspaceReloadGeneration == generation else { return }
                 self?.applyLocalAgentAdapterResult(result)
+            }
+            guard workspaceReloadGeneration == generation else { return }
+            // Stale-cache data keeps a cold start usable while offline, but it
+            // must never replace a newer generation already held in memory.
+            guard !preservesLoadedWorkspace || snapshot.runtime.serverDataSource != "stale" else {
+                phase = .ready
+                return
             }
             apply(snapshot)
             phase = .ready
         } catch WorkspaceLoadError.authenticationRequired {
+            guard workspaceReloadGeneration == generation else { return }
             phase = .authenticationRequired
         } catch {
+            guard workspaceReloadGeneration == generation else { return }
             let messages = [error.localizedDescription, errorMessage]
                 .compactMap { $0 }
                 .filter { !$0.isEmpty }
@@ -646,8 +1079,26 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    func showOrgMemory() {
-        guard activeProjectId != nil else { return }
+    func showOrgMemory() async {
+        guard activeProjectId != nil || loadingProjectId != nil else { return }
+        guard synchronizingDocumentIds.isEmpty,
+              applyingDocumentReconciliationIds.isEmpty else {
+            errorMessage = "Finish or cancel the active document Sync before switching Memory context."
+            return
+        }
+        // Showing Org supersedes every in-flight Project selection. A stale
+        // daemon reply must not be allowed to switch the UI back afterward.
+        let generation = UUID()
+        projectSelectionGeneration = generation
+        loadingProjectId = nil
+        isSwitchingMemoryContext = true
+        defer {
+            if projectSelectionGeneration == generation {
+                isSwitchingMemoryContext = false
+            }
+        }
+        guard await flushPendingDocumentChanges(),
+              projectSelectionGeneration == generation else { return }
         activeProjectId = nil
         showsProjectSettings = false
         selectedItemId = nil
@@ -657,19 +1108,40 @@ final class WorkspaceStore: ObservableObject {
 
     func selectProject(_ projectId: String) async {
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
-        guard projectId != activeProjectId || !project.isLoaded else { return }
-        guard await flushPendingDocumentChanges() else { return }
+        if projectId == activeProjectId,
+           project.isLoaded,
+           loadingProjectId == nil,
+           !isSwitchingMemoryContext {
+            return
+        }
+        guard synchronizingDocumentIds.isEmpty,
+              applyingDocumentReconciliationIds.isEmpty else {
+            errorMessage = "Finish or cancel the active document Sync before switching Memory context."
+            return
+        }
         let generation = UUID()
+        // Publish the newest intent before the first suspension point. This
+        // closes the window where two clicks could both start a daemon-side
+        // selection while a pending document save was flushing.
         projectSelectionGeneration = generation
         loadingProjectId = projectId
+        isSwitchingMemoryContext = true
         defer {
             if projectSelectionGeneration == generation {
                 loadingProjectId = nil
+                isSwitchingMemoryContext = false
             }
         }
+        guard await flushPendingDocumentChanges(),
+              projectSelectionGeneration == generation else { return }
         do {
-            _ = try await daemon.selectProject(projectId)
-            guard projectSelectionGeneration == generation else { return }
+            let selectedLatestIntent = try await projectSelectionSideEffectGate.run {
+                guard projectSelectionGeneration == generation else { return false }
+                _ = try await daemon.selectProject(projectId)
+                return true
+            }
+            guard selectedLatestIntent,
+                  projectSelectionGeneration == generation else { return }
             activeProjectId = projectId
             let tab = visibleTabs.last
             activeTabId = tab?.id
@@ -691,8 +1163,7 @@ final class WorkspaceStore: ObservableObject {
                 if let index = projects.firstIndex(where: { $0.id == projectId }) {
                     projects[index] = loadedProject.state
                 }
-                resources.removeAll { $0.projectId == projectId }
-                resources += loadedProject.resources
+                replaceProjectResources(projectId: projectId, with: loadedProject.resources)
                 try await remapDrafts(projectId: projectId)
             }
             guard projectSelectionGeneration == generation else { return }
@@ -706,6 +1177,7 @@ final class WorkspaceStore: ObservableObject {
                 }
             }
         } catch {
+            guard projectSelectionGeneration == generation else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -735,11 +1207,11 @@ final class WorkspaceStore: ObservableObject {
                 try await loader.loadProject(id: project.id, name: project.name)
             }
             for loaded in loadedProjects {
+                clearStaleResourceState(for: loaded.state.id)
                 if let index = projects.firstIndex(where: { $0.id == loaded.state.id }) {
                     projects[index] = loaded.state
                 }
-                resources.removeAll { $0.projectId == loaded.state.id }
-                resources += loaded.resources
+                replaceProjectResources(projectId: loaded.state.id, with: loaded.resources)
             }
 
             if includeContent {
@@ -748,9 +1220,7 @@ final class WorkspaceStore: ObservableObject {
                     try await loader.loadContent(for: $0)
                 }
                 for loaded in loadedResources {
-                    if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
-                        resources[index] = loaded
-                    }
+                    installLoadedResourceIfCurrent(loaded)
                 }
             }
 
@@ -765,22 +1235,29 @@ final class WorkspaceStore: ObservableObject {
     func open(_ item: MemoryListItem, mode: WorkbenchTabMode? = nil) {
         showsProjectSettings = false
         let previousTabId = activeVisibleTab?.id
-        let resolvedMode = mode ?? (item.supportsMarkdownPreview ? .preview : .source)
-        // Org-scope tabs are always visible regardless of the active project,
-        // so the tab's projectId must reflect scope (nil for Org), not the
-        // carrying project of an Org-scope draft. Reusing item.projectId here
-        // leaked the draft's carrying project and hid Org documents while the
-        // Org view (or another project) was active.
-        let tab = WorkbenchTab(
+        // Project-local overlays need a separate session from the Org
+        // authority view even when both address the same Org memory id.
+        let tabProjectId = activeProjectId ?? (item.scope == .org ? nil : item.projectId)
+        let existingMode = tabs.first {
+            $0.section == selectedSection
+                && $0.projectId == tabProjectId
+                && $0.itemId == item.id
+        }?.mode
+        let resolvedMode = mode
+            ?? existingMode
+            ?? (item.supportsMarkdownPreview ? .preview : .source)
+        let compatibleMode: WorkbenchTabMode = resolvedMode == .preview
+            && !item.supportsMarkdownPreview ? .source : resolvedMode
+        let safeMode: WorkbenchTabMode = item.draft?.documentBaselineAvailable == false
+            ? .diff : compatibleMode
+        let requestedTab = WorkbenchTab(
             section: selectedSection,
-            projectId: item.scope == .org ? nil : item.projectId,
+            projectId: tabProjectId,
             itemId: item.id,
-            mode: resolvedMode,
+            mode: safeMode,
             title: item.document.title
         )
-        if !tabs.contains(where: { $0.id == tab.id }) {
-            tabs.append(tab)
-        }
+        let tab = installDocumentTab(requestedTab)
         selectedItemId = item.id
         if let previousTabId, previousTabId != tab.id {
             navigationBackStack.append(previousTabId)
@@ -794,56 +1271,130 @@ final class WorkspaceStore: ObservableObject {
     /// second tab for the same document.
     func switchDocumentMode(_ mode: WorkbenchTabMode) {
         guard let tab = activeVisibleTab, tab.mode != mode else { return }
-        let updated = WorkbenchTab(
-            section: tab.section,
-            projectId: tab.projectId,
-            itemId: tab.itemId,
-            mode: mode,
-            title: tab.title
-        )
-        if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
-            tabs[index] = updated
-        } else {
-            tabs.append(updated)
-        }
-        navigationBackStack = navigationBackStack.map { $0 == tab.id ? updated.id : $0 }
-        navigationForwardStack = navigationForwardStack.map { $0 == tab.id ? updated.id : $0 }
+        var updated = tab
+        updated.mode = mode
+        updated = installDocumentTab(updated)
         selectedItemId = tab.itemId
         activeTabId = updated.id
+    }
+
+    /// Installs one stable tab per document. Older builds encoded the mode in
+    /// the tab identity, so this also collapses any duplicate mode tabs that
+    /// survived in memory while the view hierarchy was updating.
+    @discardableResult
+    private func installDocumentTab(_ requested: WorkbenchTab) -> WorkbenchTab {
+        let matches = tabs.indices.filter { index in
+            let candidate = tabs[index]
+            return candidate.section == requested.section
+                && candidate.projectId == requested.projectId
+                && candidate.itemId == requested.itemId
+        }
+        guard let first = matches.first else {
+            tabs.append(requested)
+            return requested
+        }
+        tabs[first] = requested
+        for index in matches.dropFirst().reversed() {
+            tabs.remove(at: index)
+        }
+        return requested
+    }
+
+    private func refreshDocumentTabs(for itemId: String) {
+        for index in tabs.indices where tabs[index].itemId == itemId {
+            guard let item = item(for: tabs[index]) else { continue }
+            tabs[index].title = item.document.title
+            if item.draft?.documentBaselineAvailable == false {
+                tabs[index].mode = .diff
+            } else if tabs[index].mode == .preview, !item.supportsMarkdownPreview {
+                tabs[index].mode = .source
+            }
+        }
+    }
+
+    private func refreshAllDocumentTabs() {
+        for itemId in Set(tabs.map(\.itemId)) {
+            refreshDocumentTabs(for: itemId)
+        }
+    }
+
+    /// Remove document sessions whose authority and active LocalDraft are
+    /// both gone. `visibleTabs` still performs context filtering, but keeping
+    /// terminal draft tabs in the backing array would resurrect stale modes
+    /// and navigation entries if an unrelated item later reused that route.
+    private func pruneOrphanedMemoryTabs() {
+        let liveItemIds = Set(resources.map(\.id)).union(
+            drafts.compactMap { draft in
+                guard draft.status != .discarded && draft.status != .merged else { return nil }
+                return draft.targetId ?? draft.id
+            }
+        )
+        let removedTabIds = Set(tabs.compactMap { tab in
+            tab.section == .memory && !liveItemIds.contains(tab.itemId) ? tab.id : nil
+        })
+        guard !removedTabIds.isEmpty else { return }
+        tabs.removeAll { removedTabIds.contains($0.id) }
+        navigationBackStack.removeAll { removedTabIds.contains($0) }
+        navigationForwardStack.removeAll { removedTabIds.contains($0) }
+        if let activeTabId, removedTabIds.contains(activeTabId) {
+            self.activeTabId = nil
+            selectedItemId = nil
+        }
     }
 
     func reveal(_ item: MemoryListItem) async {
         selectedSection = .memory
         selectedKind = item.kind
-        // Only project-scope items need a project switch; Org-scope items stay
-        // in the Org view even when their draft is carried by a project.
-        if item.scope == .project, let projectId = item.projectId {
+        if let projectId = item.projectContextId {
             await selectProject(projectId)
+            guard activeProjectId == projectId else { return }
+        } else if item.scope == .project, let projectId = item.projectId {
+            await selectProject(projectId)
+            guard activeProjectId == projectId else { return }
+        } else if activeProjectId != nil,
+                  !(activeProject?.selectedOrgResourceIds.contains(item.id) ?? false) {
+            await showOrgMemory()
+            guard activeProjectId == nil else { return }
         }
         open(item)
     }
 
     func item(for tab: WorkbenchTab) -> MemoryListItem? {
         if let resource = resources.first(where: { $0.id == tab.itemId }) {
-            let draft = drafts.first {
-                $0.targetId == resource.id && $0.status != .discarded && $0.status != .merged
+            let matchingDrafts = drafts.filter { draft in
+                draft.targetId == resource.id
+                    && draft.status != .discarded
+                    && draft.status != .merged
+                    && (tab.projectId.map { $0 == draft.projectId } ?? (draft.scope == .org))
+            }
+            let draft = Self.preferredMemoryTreeDrafts(matchingDrafts).first
+            let tabProject = tab.projectId.flatMap { projectId in
+                projects.first { $0.id == projectId }
             }
             return .init(
                 id: resource.id,
                 resource: resource,
                 draft: draft,
                 inherited: resource.scope == .org
-                    && activeProjectId != nil
-                    && (activeProject?.selectedOrgResourceIds.contains(resource.id) ?? false)
+                    && tabProject != nil
+                    && (tabProject?.selectedOrgResourceIds.contains(resource.id) ?? false),
+                projectContextId: tab.projectId
             )
         }
-        if let draft = drafts.first(where: { $0.id == tab.itemId }) {
+        let matchingDrafts = drafts.filter { draft in
+            (draft.id == tab.itemId || draft.targetId == tab.itemId)
+                && draft.status != .discarded
+                && draft.status != .merged
+                && (tab.projectId.map { $0 == draft.projectId } ?? (draft.scope == .org))
+        }
+        if let draft = Self.preferredMemoryTreeDrafts(matchingDrafts).first {
             let resource = draft.targetId.flatMap { target in resources.first { $0.id == target } }
             return .init(
-                id: resource?.id ?? draft.id,
+                id: resource?.id ?? draft.targetId ?? draft.id,
                 resource: resource,
                 draft: draft,
-                inherited: false
+                inherited: false,
+                projectContextId: tab.projectId
             )
         }
         return nil
@@ -852,27 +1403,61 @@ final class WorkspaceStore: ObservableObject {
     func loadContentIfNeeded(_ item: MemoryListItem) async {
         guard item.draft == nil,
               let resource = item.resource,
-              !resource.contentLoaded,
-              !loadingResourceIds.contains(resource.id) else { return }
+              !resource.contentLoaded else { return }
+        if let inFlight = resourceLoadRequests[resource.id],
+           Self.resourceGenerationMatches(inFlight.resource, resource) {
+            return
+        }
+        if let snapshot = staleResourceSnapshots[resource.id] {
+            guard let local = snapshot.local, local.contentLoaded else {
+                errorMessage = DocumentDiffError.baselineUnavailable.localizedDescription
+                return
+            }
+            if let index = resources.firstIndex(where: { $0.id == resource.id }) {
+                resources[index] = local
+                bumpDocumentContentGeneration(for: resource.id)
+            }
+            return
+        }
+        let generation = UUID()
+        resourceLoadRequests[resource.id] = .init(resource: resource, generation: generation)
         loadingResourceIds.insert(resource.id)
-        defer { loadingResourceIds.remove(resource.id) }
+        defer {
+            if resourceLoadRequests[resource.id]?.generation == generation {
+                resourceLoadRequests.removeValue(forKey: resource.id)
+                loadingResourceIds.remove(resource.id)
+            }
+        }
         do {
             let loaded = try await WorkspaceLoader(
                 daemon: daemon,
                 bootstrap: bootstrap,
                 server: server
             ).loadContent(for: resource)
-            if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
-                resources[index] = loaded
-            }
+            installLoadedResourceIfCurrent(loaded)
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
     func closeTab(_ tab: WorkbenchTab) {
-        guard let index = tabs.firstIndex(of: tab) else { return }
-        let visibleIndex = visibleTabs.firstIndex(of: tab)
+        guard !applyingDocumentReconciliationIds.contains(tab.itemId) else {
+            errorMessage = "Wait for the shared update to finish before closing this tab."
+            return
+        }
+        guard let index = tabs.firstIndex(where: { $0.id == tab.id }) else { return }
+        if pendingDocumentCommand?.itemId == tab.itemId {
+            pendingDocumentCommand = nil
+        }
+        if documentReconciliationToolbarState?.itemId == tab.itemId {
+            documentReconciliationToolbarState = nil
+        }
+        documentSynchronizationTasks.removeValue(forKey: tab.itemId)?.cancel()
+        pendingDocumentReconciliationCandidates.removeValue(forKey: tab.itemId)
+        documentReconciliationResolutions.removeValue(forKey: tab.itemId)
+        synchronizingDocumentIds.remove(tab.itemId)
+        documentSynchronizationGenerations.removeValue(forKey: tab.itemId)
+        let visibleIndex = visibleTabs.firstIndex(where: { $0.id == tab.id })
         tabs.remove(at: index)
         navigationBackStack.removeAll { $0 == tab.id }
         navigationForwardStack.removeAll { $0 == tab.id }
@@ -1000,6 +1585,18 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func stageDocumentSave(_ item: MemoryListItem, document: EditableMemoryDocument) {
+        guard canEditMemory(item) else {
+            errorMessage = "You do not have permission to edit this memory."
+            return
+        }
+        guard synchronizationItemId(for: item) == nil else {
+            errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
+            return
+        }
+        guard !isSwitchingMemoryContext else {
+            errorMessage = "Wait for the Memory context switch to finish before editing."
+            return
+        }
         let generation = UUID()
         pendingDocumentSaves[item.id] = .init(item: item, document: document, generation: generation)
         documentSaveTasks[item.id]?.cancel()
@@ -1014,16 +1611,29 @@ final class WorkspaceStore: ObservableObject {
         documentSaveTasks[itemId]?.cancel()
         documentSaveTasks[itemId] = nil
         guard let pending = pendingDocumentSaves[itemId] else { return }
-        try await save(pending.item, document: pending.document)
-        if pendingDocumentSaves[itemId]?.generation == pending.generation {
-            pendingDocumentSaves[itemId] = nil
-        }
+        try await save(
+            pending.item,
+            document: pending.document,
+            allowingDuringSynchronization: true,
+            pendingSaveItemId: itemId,
+            pendingSaveGeneration: pending.generation
+        )
     }
 
     func cancelDocumentSave(_ itemId: String) {
         documentSaveTasks[itemId]?.cancel()
         documentSaveTasks[itemId] = nil
         pendingDocumentSaves[itemId] = nil
+    }
+
+    private func finishPendingDocumentSaveIfCurrent(
+        itemId: String?,
+        generation: UUID?
+    ) {
+        guard let itemId, let generation,
+              pendingDocumentSaves[itemId]?.generation == generation else { return }
+        pendingDocumentSaves[itemId] = nil
+        documentSaveTasks[itemId] = nil
     }
 
     func stageBundleSave(
@@ -1094,16 +1704,56 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    func save(_ item: MemoryListItem, document: EditableMemoryDocument) async throws {
+    func save(
+        _ item: MemoryListItem,
+        document: EditableMemoryDocument,
+        allowingDuringSynchronization: Bool = false,
+        pendingSaveItemId: String? = nil,
+        pendingSaveGeneration: UUID? = nil
+    ) async throws {
+        let flushesSelectionMutation = pendingSaveItemId != nil
+            && item.projectContextId.map(projectOrgSelectionMutatingIds.contains) == true
+        guard canEditMemory(item) || flushesSelectionMutation else {
+            throw ServerClientError.forbidden("You do not have permission to edit this memory.")
+        }
+        if isSwitchingMemoryContext, pendingSaveItemId == nil {
+            throw ServerClientError.forbidden(
+                "Wait for the Memory context switch to finish before editing."
+            )
+        }
+        if !allowingDuringSynchronization,
+           synchronizationItemId(for: item) != nil {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
         try validate(kind: item.kind, document: document)
         try await withDraftMutation {
+            if let pendingSaveItemId, let pendingSaveGeneration {
+                guard pendingDocumentSaves[pendingSaveItemId]?.generation
+                    == pendingSaveGeneration else { return }
+            }
+            if !allowingDuringSynchronization,
+               synchronizationItemId(for: item) != nil {
+                throw DocumentSyncError.mutationWhileSynchronizing
+            }
             let resource = item.resource
             let draft = currentDraft(for: item)
-            guard let projectId = draft?.projectId ?? item.projectId ?? activeProjectId else {
+            guard let projectId = draftCarrierProjectId(for: item, currentDraft: draft) else {
                 throw WorkspaceLoadError.noProjects
             }
-            guard item.draft == nil || draft != nil else { return }
-            guard draft?.isDeletion != true else { return }
+            if item.draft != nil, draft == nil {
+                finishPendingDocumentSaveIfCurrent(
+                    itemId: pendingSaveItemId,
+                    generation: pendingSaveGeneration
+                )
+                return
+            }
+            if draft?.isDeletion == true {
+                finishPendingDocumentSaveIfCurrent(
+                    itemId: pendingSaveItemId,
+                    generation: pendingSaveGeneration
+                )
+                return
+            }
             let draftId = draft?.id
             let projectRefCommitId = projects.first { $0.id == projectId }?.refCommitId
             let baseCommitId = draft?.baseCommitId
@@ -1155,14 +1805,142 @@ final class WorkspaceStore: ObservableObject {
                 try await refreshDraft(response.draftId)
                 selectedItemId = resource?.id ?? response.draftId
             }
+            finishPendingDocumentSaveIfCurrent(
+                itemId: pendingSaveItemId,
+                generation: pendingSaveGeneration
+            )
         }
     }
 
+    /// Renames a target-backed memory without coupling the path mutation to
+    /// whatever body happens to be loaded in the file tree. In particular,
+    /// metadata-only resources carry an empty placeholder body and must never
+    /// turn a rename into an empty-content update.
+    func rename(_ item: MemoryListItem, to newPath: String) async throws {
+        guard !isSwitchingMemoryContext else {
+            throw ServerClientError.forbidden(
+                "Wait for the Memory context switch to finish before renaming."
+            )
+        }
+        guard canEditMemory(item) else {
+            throw ServerClientError.forbidden("You do not have permission to rename this memory.")
+        }
+        guard synchronizationItemId(for: item) == nil else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        try validatePath(kind: item.kind, path: newPath)
+
+        // Preserve a dirty editor before changing the path. The draft gate in
+        // save prevents an already-running debounce and this explicit flush
+        // from persisting the same generation twice.
+        let initialSaveIds = Set([item.id, item.draft?.id, item.draft?.targetId].compactMap { $0 })
+        for saveId in initialSaveIds where pendingDocumentSaves[saveId] != nil {
+            try await flushDocumentSave(saveId)
+        }
+
+        try await withDraftMutation {
+            guard synchronizationItemId(for: item) == nil else {
+                throw DocumentSyncError.mutationWhileSynchronizing
+            }
+            let resource = item.resource
+            let draft = currentDraft(for: item)
+            if item.draft != nil, draft == nil { return }
+            if draft?.isDeletion == true { return }
+            guard let plan = Self.documentRenamePlan(
+                for: item,
+                currentDraft: draft,
+                newPath: newPath
+            ) else {
+                throw MemoryValidationError.unpublishedMemoryCannotBeRenamed
+            }
+            guard let projectId = draftCarrierProjectId(for: item, currentDraft: draft) else {
+                throw WorkspaceLoadError.noProjects
+            }
+            let currentPath = draft?.document.path ?? resource?.document.path
+            guard currentPath != newPath else { return }
+
+            let projectRefCommitId = projects.first { $0.id == projectId }?.refCommitId
+            let response = try await daemon.store(
+                .init(
+                    draftId: draft?.id,
+                    baseCommitId: draft?.baseCommitId
+                        ?? resource?.refCommitId
+                        ?? (item.scope == .org ? orgRefCommitId : projectRefCommitId),
+                    projectId: projectId,
+                    scope: item.scope == .org ? .org : .project,
+                    resource: item.kind.daemonKind,
+                    op: .rename(id: plan.targetId, newPath: plan.newPath, description: nil),
+                    source: .desktop
+                )
+            )
+            // Editing remains available while the daemon request is in
+            // flight. Any save staged in that window still carries the old
+            // path; retarget it so its later body update cannot rename the
+            // document back.
+            let saveIds = Set([item.id, response.draftId, plan.targetId])
+            retargetPendingDocumentSaves(saveIds, to: newPath)
+            try await refreshDraft(response.draftId)
+            retargetPendingDocumentSaves(saveIds, to: newPath)
+            selectedItemId = resource?.id ?? plan.targetId
+        }
+    }
+
+    private func retargetPendingDocumentSaves(_ itemIds: Set<String>, to newPath: String) {
+        for itemId in itemIds {
+            guard let pending = pendingDocumentSaves[itemId] else { continue }
+            pendingDocumentSaves[itemId] = .init(
+                item: pending.item,
+                document: Self.documentByRetargetingPendingSave(
+                    pending.document,
+                    to: newPath
+                ),
+                generation: pending.generation
+            )
+        }
+    }
+
+    static func documentRenamePlan(
+        for item: MemoryListItem,
+        currentDraft: LocalDraft?,
+        newPath: String
+    ) -> DocumentRenamePlan? {
+        guard let targetId = item.resource?.id ?? currentDraft?.targetId else { return nil }
+        return .init(targetId: targetId, newPath: newPath)
+    }
+
+    static func documentByRetargetingPendingSave(
+        _ document: EditableMemoryDocument,
+        to newPath: String
+    ) -> EditableMemoryDocument {
+        var retargeted = document
+        retargeted.path = newPath
+        return retargeted
+    }
+
     func delete(_ item: MemoryListItem) async {
-        guard let projectId = item.projectId ?? activeProjectId,
+        guard item.draft?.isDeletion != true else { return }
+        guard !isSwitchingMemoryContext else {
+            errorMessage = "Wait for the Memory context switch to finish before deleting."
+            return
+        }
+        guard canEditMemory(item) else {
+            errorMessage = "You do not have permission to delete this memory."
+            return
+        }
+        guard synchronizationItemId(for: item) == nil else {
+            errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
+            return
+        }
+        for itemId in Set([item.id, item.draft?.id, item.draft?.targetId].compactMap { $0 }) {
+            cancelDocumentSave(itemId)
+        }
+        guard let projectId = draftCarrierProjectId(for: item, currentDraft: item.draft),
               let targetId = item.resource?.id ?? item.draft?.targetId else { return }
         do {
             try await withDraftMutation {
+                guard synchronizationItemId(for: item) == nil else {
+                    throw DocumentSyncError.mutationWhileSynchronizing
+                }
                 let draft = currentDraft(for: item)
                 let response = try await daemon.store(
                     .init(
@@ -1183,8 +1961,18 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func discard(_ draft: LocalDraft) async {
+        guard synchronizationItemId(for: draft) == nil else {
+            errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
+            return
+        }
+        for itemId in Set([draft.id, draft.targetId].compactMap { $0 }) {
+            cancelDocumentSave(itemId)
+        }
         do {
             try await withDraftMutation {
+                guard synchronizationItemId(for: draft) == nil else {
+                    throw DocumentSyncError.mutationWhileSynchronizing
+                }
                 _ = try await daemon.store(
                     .init(
                         draftId: draft.id,
@@ -1197,6 +1985,7 @@ final class WorkspaceStore: ObservableObject {
                     )
                 )
                 drafts.removeAll { $0.id == draft.id }
+                pruneOrphanedMemoryTabs()
                 selectedItemId = nil
             }
         } catch {
@@ -1232,41 +2021,231 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    nonisolated static func staleResourcePlan(
+        displayedResources: [MemoryResource],
+        projectName: String,
+        observedProjectRefCommitId: String?,
+        observedSelectedOrgResourceIds: Set<String> = [],
+        observedOrgSelectionRevision: Int = 0,
+        authoritativeCommitId: String?,
+        serverCursor: String?,
+        checkout: DaemonProjectCheckout,
+        authoritativeRefEtag: String? = nil,
+        authoritativeResponseIsStale: Bool = false,
+        provisionalResourceIds: Set<String> = [],
+        generation: UUID = UUID()
+    ) -> [String: StaleResourceSyncSnapshot]? {
+        // A cursor mismatch has no direction information. Only a fresh Server
+        // commit-state response can prove that the installed checkout is the
+        // current shared version rather than an older checkout catching up.
+        guard !authoritativeResponseIsStale,
+              checkout.ready,
+              let authoritativeCommitId,
+              serverCursor == authoritativeCommitId,
+              checkout.commitId == authoritativeCommitId else {
+            return nil
+        }
+        guard observedProjectRefCommitId != authoritativeCommitId else { return [:] }
+
+        let projectId = checkout.projectId
+        let localProjectResources = displayedResources.filter {
+            $0.scope == .project
+                && $0.projectId == projectId
+                && !provisionalResourceIds.contains($0.id)
+        }
+        // A Project checkout may include a pinned selection of Org memories,
+        // but that is not proof of the current Org head. Applying those rows
+        // to the global Org resource collection could roll it backward.
+        let checkoutResources = checkout.resources.filter { $0.scope == .project }
+        let localById = Dictionary(
+            localProjectResources.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let remoteById = Dictionary(
+            checkoutResources.map { resource -> (String, MemoryResource) in
+                let scope: MemoryScope = resource.scope == .org ? .org : .project
+                let local = localById[resource.resourceId]
+                return (
+                    resource.resourceId,
+                    MemoryResource(
+                        id: resource.resourceId,
+                        scope: scope,
+                        projectId: scope == .project ? projectId : nil,
+                        projectName: scope == .project ? projectName : nil,
+                        kind: .init(resource.resourceKind),
+                        contentHash: resource.contentHash,
+                        updatedAt: checkout.commitCreatedAt ?? local?.updatedAt ?? "",
+                        refCommitId: scope == .project
+                            ? authoritativeCommitId
+                            : local?.refCommitId,
+                        contentLoaded: true,
+                        document: .init(
+                            title: URL(fileURLWithPath: resource.path)
+                                .deletingPathExtension().lastPathComponent,
+                            path: resource.path,
+                            body: resource.content.content
+                        )
+                    )
+                )
+            },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let projectRemoteIds = Set(checkoutResources.map(\.resourceId))
+        let ids = Set(localProjectResources.map(\.id))
+            .union(projectRemoteIds)
+        var result: [String: StaleResourceSyncSnapshot] = [:]
+        for id in ids {
+            let local = localById[id]
+            let remote = remoteById[id]
+            if let local, let remote,
+               local.scope == remote.scope,
+               local.kind == remote.kind,
+               local.document.path == remote.document.path,
+               local.contentHash == remote.contentHash {
+                continue
+            }
+            result[id] = .init(
+                projectId: projectId,
+                observedProjectRefCommitId: observedProjectRefCommitId,
+                observedSelectedOrgResourceIds: observedSelectedOrgResourceIds,
+                observedOrgSelectionRevision: observedOrgSelectionRevision,
+                authoritativeCommitId: authoritativeCommitId,
+                authoritativeRefEtag: authoritativeRefEtag ?? checkout.refEtag,
+                selectedOrgResourceIds: Set(checkout.selectedOrgResourceIds),
+                orgSelectionRevision: checkout.orgSelectionRevision,
+                generation: generation,
+                local: local,
+                remote: remote
+            )
+        }
+        return result
+    }
+
+    nonisolated static func draftUploadBarrierDecision(
+        serverDraftId: String?,
+        pendingOperationCount: Int,
+        failedOperationCount: Int,
+        operationStates: [DaemonDraftSyncState],
+        failureMessage: String?
+    ) -> DraftUploadBarrierDecision {
+        if failedOperationCount > 0 || operationStates.contains(.failed) {
+            return .failed(failureMessage)
+        }
+        if pendingOperationCount == 0,
+           serverDraftId != nil,
+           operationStates.allSatisfy({ $0 == .synced }) {
+            return .ready
+        }
+        return .wait
+    }
+
+    nonisolated static func staleResourcePlansMatch(
+        _ lhs: [String: StaleResourceSyncSnapshot],
+        _ rhs: [String: StaleResourceSyncSnapshot]
+    ) -> Bool {
+        guard Set(lhs.keys) == Set(rhs.keys) else { return false }
+        return lhs.allSatisfy { resourceId, left in
+            guard let right = rhs[resourceId],
+                  left.local?.contentLoaded != false,
+                  right.local?.contentLoaded != false else { return false }
+            return left.projectId == right.projectId
+                && left.observedProjectRefCommitId == right.observedProjectRefCommitId
+                && left.observedSelectedOrgResourceIds == right.observedSelectedOrgResourceIds
+                && left.observedOrgSelectionRevision == right.observedOrgSelectionRevision
+                && left.authoritativeCommitId == right.authoritativeCommitId
+                && left.authoritativeRefEtag == right.authoritativeRefEtag
+                && left.selectedOrgResourceIds == right.selectedOrgResourceIds
+                && left.orgSelectionRevision == right.orgSelectionRevision
+                && left.local == right.local
+                && left.remote == right.remote
+        }
+    }
+
     private func refreshStaleResourcesIfNeeded(sync: DaemonSyncStatus) async {
         guard let projectId = activeProjectId,
-              let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
-              let syncedCommitId = sync.commitSync.serverCursor,
-              syncedCommitId != projects[projectIndex].refCommitId else {
+              let project = projects.first(where: { $0.id == projectId }),
+              let serverCursor = sync.commitSync.serverCursor,
+              serverCursor != project.refCommitId else {
             return
         }
+        let observedRef = project.refCommitId
+        let refreshGeneration = UUID()
+        staleResourceRefreshGenerations[projectId] = refreshGeneration
         do {
-            let checkout = try await daemon.projectCheckout(projectId)
-            guard checkout.ready else { return }
-            let hashes = Dictionary(
-                checkout.resources.map { ($0.resourceId, $0.contentHash) },
-                uniquingKeysWith: { _, latest in latest }
-            )
-            staleResourceIds = Set(
-                resources.compactMap { resource -> String? in
-                    guard resource.projectId == projectId,
-                          let hash = hashes[resource.id],
-                          hash != resource.contentHash else { return nil }
-                    return resource.id
+            let commit: (value: CommitStateResponse, response: DaemonServerResponse) =
+                try await server.getWithMetadata("/api/v1/projects/\(projectId)/commit-state")
+            guard activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == project,
+                  staleResourceRefreshGenerations[projectId] == refreshGeneration,
+                  !commit.response.isStaleCache else {
+                return
+            }
+            let authoritativeCommitId = commit.value.ref.commitId
+            let authoritativeRefEtag = commit.response.headers.first {
+                $0.key.caseInsensitiveCompare("etag") == .orderedSame
+            }?.value
+            if authoritativeCommitId == observedRef {
+                clearStaleResourceState(for: projectId)
+                if let authoritativeCommitId {
+                    advanceProjectRefIfPlanCompleted(
+                        projectId: projectId,
+                        authoritativeCommitId: authoritativeCommitId,
+                        authoritativeRefEtag: authoritativeRefEtag,
+                        selectedOrgResourceIds: project.selectedOrgResourceIds,
+                        orgSelectionRevision: project.orgSelectionRevision
+                    )
                 }
-            )
-            let current = projects[projectIndex]
-            projects[projectIndex] = ProjectState(
-                id: current.id,
-                name: current.name,
-                refCommitId: syncedCommitId,
-                refEtag: checkout.refEtag ?? current.refEtag,
-                selectedOrgResourceIds: current.selectedOrgResourceIds,
-                orgSelectionRevision: current.orgSelectionRevision,
-                isLoaded: current.isLoaded
-            )
+                return
+            }
+            let checkout = try await daemon.projectCheckout(projectId)
+            guard activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == project,
+                  staleResourceRefreshGenerations[projectId] == refreshGeneration,
+                  let plan = Self.staleResourcePlan(
+                    displayedResources: resources,
+                    projectName: project.name,
+                    observedProjectRefCommitId: observedRef,
+                    observedSelectedOrgResourceIds: project.selectedOrgResourceIds,
+                    observedOrgSelectionRevision: project.orgSelectionRevision,
+                    authoritativeCommitId: authoritativeCommitId,
+                    serverCursor: serverCursor,
+                    checkout: checkout,
+                    authoritativeRefEtag: authoritativeRefEtag,
+                    authoritativeResponseIsStale: commit.response.isStaleCache,
+                    // Remote-only additions are inserted provisionally so the
+                    // file tree can expose their Sync action. They are not
+                    // part of the observed local generation and must not make
+                    // the next poll conclude that the plan is already applied.
+                    provisionalResourceIds: provisionalStaleAdditionIds
+                  ) else {
+                return
+            }
+            let installedPlan = staleResourceSnapshots.filter { _, snapshot in
+                snapshot.projectId == projectId
+            }
+            if !plan.isEmpty, Self.staleResourcePlansMatch(plan, installedPlan) {
+                return
+            }
+            let hydratedPlan = await hydrateStaleResourcePlan(plan)
+            guard activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == project,
+                  staleResourceRefreshGenerations[projectId] == refreshGeneration else {
+                return
+            }
+            installStaleResourcePlan(hydratedPlan, for: projectId)
+            if hydratedPlan.isEmpty {
+                advanceProjectRefIfPlanCompleted(
+                    projectId: projectId,
+                    authoritativeCommitId: authoritativeCommitId ?? serverCursor,
+                    authoritativeRefEtag: authoritativeRefEtag ?? checkout.refEtag,
+                    selectedOrgResourceIds: Set(checkout.selectedOrgResourceIds),
+                    orgSelectionRevision: checkout.orgSelectionRevision
+                )
+            }
         } catch {
-            // Commit sync reports refresh failures separately; keep the
-            // previously computed stale set.
+            // Commit sync reports refresh failures separately. Retain a
+            // previously validated plan rather than replacing it with an
+            // unverified checkout.
         }
     }
 
@@ -1274,57 +2253,121 @@ final class WorkspaceStore: ObservableObject {
     /// - a behind draft opens the shared-change review flow;
     /// - a stale resource (no local draft) is refreshed from the synced checkout.
     func syncDocument(_ item: MemoryListItem) {
-        if let draft = item.draft, draft.freshness == .behind {
-            open(item)
-            pendingDocumentCommand = .reviewSharedChanges(itemId: item.id, draft: draft)
+        if let projectId = item.projectId,
+           projectOrgSelectionMutatingIds.contains(projectId) {
+            errorMessage = "Wait for the Project memory selection to finish updating before syncing this document."
             return
         }
-        guard let resource = item.resource, staleResourceIds.contains(resource.id) else { return }
-        Task { await syncStaleResource(resource.id) }
-    }
+        let behindDraft = item.draft.flatMap { $0.freshness == .behind ? $0 : nil }
+        let hasStaleResource = item.resource.map {
+            staleResourceSnapshots[$0.id] != nil
+        } ?? false
+        guard behindDraft != nil || hasStaleResource,
+              synchronizingDocumentIds.insert(item.id).inserted else { return }
 
-    private func syncStaleResource(_ resourceId: String) async {
-        guard let projectId = resources.first(where: { $0.id == resourceId })?.projectId
-            ?? activeProjectId else { return }
-        do {
-            let checkout = try await daemon.projectCheckout(projectId)
-            guard checkout.ready,
-                  let checkoutResource = checkout.resources.first(where: { $0.resourceId == resourceId }),
-                  let index = resources.firstIndex(where: { $0.id == resourceId }) else { return }
-            let current = resources[index]
-            resources[index] = .init(
-                id: current.id,
-                scope: current.scope,
-                projectId: current.projectId,
-                projectName: current.projectName,
-                kind: current.kind,
-                contentHash: checkoutResource.contentHash,
-                updatedAt: current.updatedAt,
-                refCommitId: checkout.commitId,
-                contentLoaded: true,
-                document: .init(
-                    title: URL(fileURLWithPath: checkoutResource.path)
-                        .deletingPathExtension().lastPathComponent,
-                    path: checkoutResource.path,
-                    body: checkoutResource.content.content
+        let generation = UUID()
+        documentSynchronizationGenerations[item.id] = generation
+        if behindDraft != nil {
+            openDocumentForSync(item)
+        }
+        documentSynchronizationTasks[item.id] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let behindDraft {
+                await prepareBehindDraftSync(
+                    itemId: item.id,
+                    draft: behindDraft,
+                    generation: generation
                 )
-            )
-            staleResourceIds.remove(resourceId)
-        } catch {
-            errorMessage = error.localizedDescription
+            } else {
+                await syncStaleResource(item, generation: generation)
+            }
         }
     }
 
-    /// The synced content of one resource from the daemon checkout,
-    /// used to render the remote layer of a stale document's diff.
-    func checkoutContent(for resourceId: String) async -> String? {
-        guard let projectId = resources.first(where: { $0.id == resourceId })?.projectId
-            ?? activeProjectId else { return nil }
-        guard let checkout = try? await daemon.projectCheckout(projectId), checkout.ready,
-              let checkoutResource = checkout.resources.first(where: { $0.resourceId == resourceId }) else {
-            return nil
+    private func openDocumentForSync(_ item: MemoryListItem) {
+        let tabProjectId = item.projectContextId ?? (item.scope == .org ? nil : item.projectId)
+        let existingMode = tabs.first {
+            $0.section == selectedSection
+                && $0.projectId == tabProjectId
+                && $0.itemId == item.id
+        }?.mode
+        // The command is consumed by a DocumentSession. Keep an existing
+        // Source/Diff mode, and use Source for a newly opened document so Sync
+        // never silently switches the user to the default Preview.
+        open(item, mode: existingMode ?? .source)
+    }
+
+    private func syncStaleResource(_ item: MemoryListItem, generation: UUID) async {
+        guard let resourceId = item.resource?.id else { return }
+        guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
+        do {
+            // A debounce save may not have materialized its draft yet. Flush
+            // before applying a remote deletion/update so that local text can
+            // enter reconciliation instead of becoming an invisible orphan.
+            try await flushDocumentSave(resourceId)
+            guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
+            if let draft = currentDraft(for: item) {
+                openDocumentForSync(item)
+                await prepareBehindDraftSync(
+                    itemId: item.id,
+                    draft: draft,
+                    generation: generation
+                )
+                return
+            }
+        } catch is CancellationError {
+            endDocumentSynchronization(item.id, generation: generation)
+            return
+        } catch {
+            guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
+            endDocumentSynchronization(item.id, generation: generation)
+            errorMessage = error.localizedDescription
+            return
         }
-        return checkoutResource.content.content
+
+        // A repeated click after the first task completed is already satisfied.
+        guard let snapshot = staleResourceSnapshots[resourceId] else {
+            endDocumentSynchronization(item.id, generation: generation)
+            return
+        }
+        guard projects.first(where: { $0.id == snapshot.projectId })?.refCommitId
+            == snapshot.observedProjectRefCommitId,
+              projects.first(where: { $0.id == snapshot.projectId })?.selectedOrgResourceIds
+            == snapshot.observedSelectedOrgResourceIds,
+              projects.first(where: { $0.id == snapshot.projectId })?.orgSelectionRevision
+            == snapshot.observedOrgSelectionRevision else {
+            endDocumentSynchronization(item.id, generation: generation)
+            errorMessage = DocumentSyncError.checkoutNoLongerCurrent.localizedDescription
+            return
+        }
+        if let remote = snapshot.remote {
+            staleResourceRefreshGenerations[snapshot.projectId] = UUID()
+            if let index = resources.firstIndex(where: { $0.id == resourceId }) {
+                resources[index] = remote
+            } else {
+                resources.append(remote)
+            }
+            provisionalStaleAdditionIds.remove(resourceId)
+            refreshDocumentTabs(for: resourceId)
+        } else {
+            staleResourceRefreshGenerations[snapshot.projectId] = UUID()
+            resources.removeAll { $0.id == resourceId }
+            provisionalStaleAdditionIds.remove(resourceId)
+            if let tab = tabs.first(where: { $0.itemId == resourceId }) {
+                closeTab(tab)
+            }
+        }
+        staleResourceSnapshots.removeValue(forKey: resourceId)
+        staleResourceIds = Set(staleResourceSnapshots.keys)
+        bumpDocumentContentGeneration(for: resourceId)
+        advanceProjectRefIfPlanCompleted(
+            projectId: snapshot.projectId,
+            authoritativeCommitId: snapshot.authoritativeCommitId,
+            authoritativeRefEtag: snapshot.authoritativeRefEtag,
+            selectedOrgResourceIds: snapshot.selectedOrgResourceIds,
+            orgSelectionRevision: snapshot.orgSelectionRevision
+        )
+        endDocumentSynchronization(item.id, generation: generation)
     }
 
     /// Builds the three-way unified diff presentation for one document:
@@ -1333,33 +2376,388 @@ final class WorkspaceStore: ObservableObject {
     func documentDiffPresentation(
         for item: MemoryListItem,
         localText: String
-    ) async -> UnifiedDiffPresentation? {
-        if let draft = item.draft, !draft.isDeletion {
-            if draft.freshness == .behind,
-               let candidate = try? await reconciliationCandidate(for: draft) {
-                return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
-                    base: candidate.baseState.exists ? (candidate.baseState.content?.content ?? "") : "",
-                    local: localText,
-                    remote: candidate.currentState.exists ? (candidate.currentState.content?.content ?? "") : ""
-                ))
+    ) async throws -> DocumentDiffResult? {
+        if let draft = item.draft {
+            if draft.freshness == .behind {
+                let candidate = try await reconciliationCandidate(for: draft)
+                return .init(
+                    presentation: UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                        base: candidate.baseState.exists
+                            ? (candidate.baseState.content?.content ?? "") : "",
+                        local: candidate.draftState.exists
+                            ? (candidate.draftState.content?.content ?? "") : "",
+                        remote: candidate.currentState.exists
+                            ? (candidate.currentState.content?.content ?? "") : ""
+                    )),
+                    pathChanges: Self.documentPathChanges(
+                        basePath: candidate.baseState.exists
+                            ? candidate.baseState.resource.path : nil,
+                        localPath: candidate.draftState.exists
+                            ? candidate.draftState.resource.path : nil,
+                        remotePath: candidate.currentState.exists
+                            ? candidate.currentState.resource.path : nil
+                    )
+                )
             }
             let sharedText = item.resource?.document.body ?? ""
-            return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
-                base: sharedText,
-                local: localText,
-                remote: sharedText
-            ))
+            return .init(
+                presentation: UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                    base: sharedText,
+                    local: draft.isDeletion ? "" : localText,
+                    remote: sharedText
+                )),
+                pathChanges: documentPathChanges(for: item)
+            )
         }
-        if let resource = item.resource, staleResourceIds.contains(resource.id) {
-            guard let checkoutText = await checkoutContent(for: resource.id) else { return nil }
-            let snapshot = resource.document.body
-            return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
-                base: snapshot,
-                local: snapshot,
-                remote: checkoutText
-            ))
+        if let resource = item.resource,
+           let snapshot = staleResourceSnapshots[resource.id] {
+            let texts = try Self.staleDocumentDiffTexts(snapshot)
+            return .init(
+                presentation: UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                    base: texts.base,
+                    local: texts.base,
+                    remote: texts.remote
+                )),
+                pathChanges: documentPathChanges(for: item)
+            )
         }
         return nil
+    }
+
+    nonisolated static func staleDocumentDiffTexts(
+        _ snapshot: StaleResourceSyncSnapshot
+    ) throws -> (base: String, remote: String) {
+        if let local = snapshot.local, !local.contentLoaded {
+            throw DocumentDiffError.baselineUnavailable
+        }
+        return (
+            base: snapshot.local?.document.body ?? "",
+            remote: snapshot.remote?.document.body ?? ""
+        )
+    }
+
+    private func hydrateStaleResourcePlan(
+        _ plan: [String: StaleResourceSyncSnapshot]
+    ) async -> [String: StaleResourceSyncSnapshot] {
+        var hydrated = plan
+        var payloads: [String: CommitPayload] = [:]
+        var unavailableCommitIds = Set<String>()
+
+        for (resourceId, snapshot) in plan {
+            guard var local = snapshot.local else { continue }
+            // Some files may already have applied an earlier generation while
+            // the Project ref intentionally remains at the all-files barrier.
+            // Hydrate each file from its own generation first.
+            let commitId = local.refCommitId ?? snapshot.observedProjectRefCommitId
+            var historicalBody: String?
+            if let commitId, !unavailableCommitIds.contains(commitId) {
+                let payload: CommitPayload?
+                if let cached = payloads[commitId] {
+                    payload = cached
+                } else {
+                    do {
+                        let loaded = try await loadCommit(commitId)
+                        if let loaded {
+                            payloads[commitId] = loaded
+                        } else {
+                            unavailableCommitIds.insert(commitId)
+                        }
+                        payload = loaded
+                    } catch {
+                        unavailableCommitIds.insert(commitId)
+                        payload = nil
+                    }
+                }
+                if let payload,
+                   let entry = payload.tree.entries.first(where: { entry in
+                    entry.type == .memory && entry.id == local.id
+                   }),
+                   let blob = payload.blobs.first(where: { $0.blobId == entry.blobId }),
+                   Self.contentHash(blob.content) == local.contentHash {
+                    historicalBody = blob.content
+                }
+            }
+
+            if let historicalBody {
+                local.document.body = historicalBody
+                local.contentLoaded = true
+            } else if Self.contentHash(local.document.body) == local.contentHash {
+                // A loaded body is only an acceptable fallback when its hash
+                // proves it belongs to the observed generation.
+                local.contentLoaded = true
+            } else {
+                local.document.body = ""
+                local.contentLoaded = false
+            }
+            hydrated[resourceId] = .init(
+                projectId: snapshot.projectId,
+                observedProjectRefCommitId: snapshot.observedProjectRefCommitId,
+                observedSelectedOrgResourceIds: snapshot.observedSelectedOrgResourceIds,
+                observedOrgSelectionRevision: snapshot.observedOrgSelectionRevision,
+                authoritativeCommitId: snapshot.authoritativeCommitId,
+                authoritativeRefEtag: snapshot.authoritativeRefEtag,
+                selectedOrgResourceIds: snapshot.selectedOrgResourceIds,
+                orgSelectionRevision: snapshot.orgSelectionRevision,
+                generation: snapshot.generation,
+                local: local,
+                remote: snapshot.remote
+            )
+        }
+        return hydrated
+    }
+
+    nonisolated private static func contentHash(_ content: String) -> String {
+        let digest = SHA256.hash(data: Data(content.utf8))
+        return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func installStaleResourcePlan(
+        _ plan: [String: StaleResourceSyncSnapshot],
+        for projectId: String
+    ) {
+        let applicablePlan = plan.filter { resourceId, snapshot in
+            if let local = snapshot.local {
+                guard let current = resources.first(where: { $0.id == resourceId }) else {
+                    return false
+                }
+                return Self.resourceGenerationMatches(current, local)
+            }
+            return !resources.contains(where: { $0.id == resourceId })
+                || provisionalStaleAdditionIds.contains(resourceId)
+        }
+        clearStaleResourceState(for: projectId)
+        for (resourceId, snapshot) in applicablePlan {
+            staleResourceSnapshots[resourceId] = snapshot
+            if let local = snapshot.local,
+               local.contentLoaded,
+               let index = resources.firstIndex(where: { $0.id == resourceId }),
+               resources[index] != local {
+                resources[index] = local
+                bumpDocumentContentGeneration(for: resourceId)
+            }
+            if snapshot.local == nil,
+               let remote = snapshot.remote,
+               !resources.contains(where: { $0.id == resourceId }) {
+                resources.append(remote)
+                provisionalStaleAdditionIds.insert(resourceId)
+            }
+        }
+        staleResourceIds = Set(staleResourceSnapshots.keys)
+    }
+
+    private func clearStaleResourceState(for projectId: String) {
+        staleResourceRefreshGenerations[projectId] = UUID()
+        let ids = Set(staleResourceSnapshots.compactMap { resourceId, snapshot in
+            snapshot.projectId == projectId ? resourceId : nil
+        })
+        let provisionalIds = ids.intersection(provisionalStaleAdditionIds)
+        if !provisionalIds.isEmpty {
+            resources.removeAll { provisionalIds.contains($0.id) }
+            provisionalStaleAdditionIds.subtract(provisionalIds)
+            for resourceId in provisionalIds {
+                bumpDocumentContentGeneration(for: resourceId)
+            }
+        }
+        staleResourceSnapshots = staleResourceSnapshots.filter { _, snapshot in
+            snapshot.projectId != projectId
+        }
+        staleResourceIds = Set(staleResourceSnapshots.keys)
+    }
+
+    private func clearAllStaleResourceState() {
+        if !provisionalStaleAdditionIds.isEmpty {
+            resources.removeAll { provisionalStaleAdditionIds.contains($0.id) }
+        }
+        provisionalStaleAdditionIds.removeAll()
+        staleResourceSnapshots.removeAll()
+        staleResourceIds.removeAll()
+        staleResourceRefreshGenerations.removeAll()
+    }
+
+    private func advanceProjectRefIfPlanCompleted(
+        projectId: String,
+        authoritativeCommitId: String,
+        authoritativeRefEtag: String?,
+        selectedOrgResourceIds: Set<String>,
+        orgSelectionRevision: Int
+    ) {
+        guard !staleResourceSnapshots.values.contains(where: { $0.projectId == projectId }),
+              let index = projects.firstIndex(where: { $0.id == projectId }) else {
+            return
+        }
+        let current = projects[index]
+        projects[index] = .init(
+            id: current.id,
+            name: current.name,
+            refCommitId: authoritativeCommitId,
+            refEtag: authoritativeRefEtag ?? current.refEtag,
+            selectedOrgResourceIds: selectedOrgResourceIds,
+            orgSelectionRevision: orgSelectionRevision,
+            isLoaded: current.isLoaded
+        )
+        for resourceIndex in resources.indices
+        where resources[resourceIndex].scope == .project
+            && resources[resourceIndex].projectId == projectId
+            && resources[resourceIndex].refCommitId != authoritativeCommitId {
+            let resource = resources[resourceIndex]
+            resources[resourceIndex] = .init(
+                id: resource.id,
+                scope: resource.scope,
+                projectId: resource.projectId,
+                projectName: resource.projectName,
+                kind: resource.kind,
+                contentHash: resource.contentHash,
+                updatedAt: resource.updatedAt,
+                refCommitId: authoritativeCommitId,
+                contentLoaded: resource.contentLoaded,
+                document: resource.document
+            )
+        }
+    }
+
+    private func bumpDocumentContentGeneration(for resourceId: String) {
+        documentContentGenerations[resourceId, default: 0] &+= 1
+    }
+
+    private func replaceProjectResources(
+        projectId: String,
+        with replacements: [MemoryResource]
+    ) {
+        let previous = Dictionary(
+            resources.lazy.filter { $0.projectId == projectId }.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        resources.removeAll { $0.projectId == projectId }
+        resources += replacements
+        let next = Dictionary(
+            replacements.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        for resourceId in Set(previous.keys).union(next.keys)
+        where previous[resourceId] != next[resourceId] {
+            bumpDocumentContentGeneration(for: resourceId)
+        }
+        refreshAllDocumentTabs()
+    }
+
+    private func prepareBehindDraftSync(
+        itemId: String,
+        draft: LocalDraft,
+        generation: UUID
+    ) async {
+        guard isCurrentDocumentSynchronization(itemId, generation: generation) else { return }
+        do {
+            // Keep the editor locked across the single upload barrier and the
+            // candidate POST so a late keystroke cannot be omitted.
+            let synchronized = try await synchronizedDraftForReconciliation(
+                itemId: itemId,
+                draft: draft
+            )
+            guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+                return
+            }
+            installSynchronizedDraft(synchronized)
+            guard synchronized.freshness == .behind else {
+                // A provisional remote addition already uses the authoritative
+                // generation as its draft base. It needs adoption, not a
+                // reconciliation candidate for an already-current draft.
+                if let resourceId = synchronized.targetId {
+                    adoptCurrentStaleResource(resourceId)
+                }
+                endDocumentSynchronization(itemId, generation: generation)
+                return
+            }
+            let candidate = try await requestReconciliationCandidate(for: synchronized)
+            guard isCurrentDocumentSynchronization(itemId, generation: generation),
+                  tabs.contains(where: { $0.itemId == itemId }) else {
+                endDocumentSynchronization(itemId, generation: generation)
+                return
+            }
+            pendingDocumentReconciliationCandidates[itemId] = candidate
+                documentReconciliationResolutions[itemId] = candidate.proposedState ?? candidate.draftState
+        } catch is CancellationError {
+            endDocumentSynchronization(itemId, generation: generation)
+            return
+        } catch {
+            guard isCurrentDocumentSynchronization(itemId, generation: generation) else { return }
+            endDocumentSynchronization(itemId, generation: generation)
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func adoptCurrentStaleResource(_ resourceId: String) {
+        guard let snapshot = staleResourceSnapshots.removeValue(forKey: resourceId) else { return }
+        staleResourceRefreshGenerations[snapshot.projectId] = UUID()
+        provisionalStaleAdditionIds.remove(resourceId)
+        staleResourceIds = Set(staleResourceSnapshots.keys)
+        advanceProjectRefIfPlanCompleted(
+            projectId: snapshot.projectId,
+            authoritativeCommitId: snapshot.authoritativeCommitId,
+            authoritativeRefEtag: snapshot.authoritativeRefEtag,
+            selectedOrgResourceIds: snapshot.selectedOrgResourceIds,
+            orgSelectionRevision: snapshot.orgSelectionRevision
+        )
+    }
+
+    private func synchronizedDraftForReconciliation(
+        itemId: String,
+        draft: LocalDraft
+    ) async throws -> LocalDraft {
+        let saveIds = Set([itemId, draft.id, draft.targetId].compactMap { $0 })
+        for saveId in saveIds where pendingDocumentSaves[saveId] != nil {
+            try await flushDocumentSave(saveId)
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(15))
+        var requestedRetry = false
+        while clock.now < deadline {
+            try Task.checkCancellation()
+            let detail = try await daemon.draft(draft.id)
+            let failure = detail.operations.reversed().first {
+                $0.syncStatus == .failed
+            }?.lastError
+            switch Self.draftUploadBarrierDecision(
+                serverDraftId: detail.draft.serverDraftId,
+                pendingOperationCount: detail.draft.pendingOperationCount,
+                failedOperationCount: detail.draft.failedOperationCount,
+                operationStates: detail.operations.map(\.syncStatus),
+                failureMessage: failure
+            ) {
+            case .failed(let message):
+                throw DocumentSyncError.draftUploadFailed(message)
+            case .wait:
+                if !requestedRetry {
+                    _ = try await daemon.retrySync(channel: "drafts")
+                    requestedRetry = true
+                }
+            case .ready:
+                // A user edit may have been staged while the daemon was
+                // uploading. Flush it and repeat the barrier before creating
+                // a candidate with an authoritative serverVersion.
+                let newlyPending = saveIds.filter { pendingDocumentSaves[$0] != nil }
+                if !newlyPending.isEmpty {
+                    for saveId in newlyPending {
+                        try await flushDocumentSave(saveId)
+                    }
+                    requestedRetry = false
+                    continue
+                }
+                let mapped = WorkspaceLoader.mapDraft(detail, resources: resources)
+                return mapped
+            }
+            try await Task.sleep(for: .milliseconds(150))
+        }
+        throw DocumentSyncError.draftUploadTimedOut
+    }
+
+    private func installSynchronizedDraft(_ draft: LocalDraft) {
+        if let index = drafts.firstIndex(where: { $0.id == draft.id }) {
+            guard drafts[index].serverVersion <= draft.serverVersion else { return }
+            drafts[index] = draft
+        } else {
+            drafts.append(draft)
+        }
     }
 
     func addOrgMemories(resourceIds: Set<String>, toProject projectId: String) async throws {
@@ -1370,8 +2768,10 @@ final class WorkspaceStore: ObservableObject {
         )
     }
 
-    func removeOrgMemoriesFromActiveProject(resourceIds: Set<String>) async throws {
-        guard let projectId = activeProjectId else { throw WorkspaceLoadError.noProjects }
+    func removeOrgMemories(
+        resourceIds: Set<String>,
+        fromProject projectId: String
+    ) async throws {
         try await mutateProjectOrgSelection(
             projectId: projectId,
             resourceIds: resourceIds,
@@ -1387,17 +2787,69 @@ final class WorkspaceStore: ObservableObject {
         guard canManageOrgSelection else {
             throw ServerClientError.forbidden("Only Organization owners and admins can manage project memory.")
         }
+        guard !hasDocumentSynchronization(in: projectId) else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
         guard projects.contains(where: { $0.id == projectId }) else {
             throw ProjectMemorySelectionError.projectUnavailable
         }
         try validateOrgResourceIds(resourceIds)
         try await withProjectOrgSelectionMutation {
+            guard canManageOrgSelection else {
+                throw ServerClientError.forbidden(
+                    "Only Organization owners and admins can manage project memory."
+                )
+            }
+            guard projects.contains(where: { $0.id == projectId }) else {
+                throw ProjectMemorySelectionError.projectUnavailable
+            }
+            try validateOrgResourceIds(resourceIds)
+            guard !hasDocumentSynchronization(in: projectId),
+                  projectOrgSelectionMutatingIds.insert(projectId).inserted else {
+                throw DocumentSyncError.mutationWhileSynchronizing
+            }
+            defer { projectOrgSelectionMutatingIds.remove(projectId) }
+            // Removing a selected Org resource can make its Project tab and
+            // tree row disappear. Materialize every dirty editor in that
+            // Project first so a failed save remains visible and recoverable
+            // as a LocalDraft instead of being stranded in a debounce buffer.
+            let pendingSaveIds = pendingDocumentSaves.compactMap { itemId, pending in
+                let pendingIds = Set(
+                    [pending.item.id, pending.item.draft?.id, pending.item.draft?.targetId]
+                        .compactMap { $0 }
+                )
+                let belongsToProject = pending.item.projectContextId == projectId
+                    || (pending.item.scope == .project && pending.item.projectId == projectId)
+                return belongsToProject && !pendingIds.isDisjoint(with: resourceIds)
+                    ? itemId
+                    : nil
+            }
+            for itemId in pendingSaveIds {
+                try await flushDocumentSave(itemId)
+            }
             let current: ProjectOrgSelection = try await server.get(
                 "/api/v1/projects/\(projectId)/org-selections"
             )
             let currentIds = projectOrgResourceIds(current)
             let nextIds = mutation.applying(resourceIds, to: currentIds)
-            guard nextIds != currentIds else { return }
+            guard nextIds != currentIds else {
+                // The Server may already reflect the requested state while a
+                // stale local snapshot does not. Treat the authoritative GET
+                // as a successful repair instead of leaving the UI behind.
+                await applyProjectOrgSelection(current, toProject: projectId)
+                return
+            }
+            guard canManageOrgSelection else {
+                throw ServerClientError.forbidden(
+                    "Only Organization owners and admins can manage project memory."
+                )
+            }
+            guard projects.contains(where: { $0.id == projectId }) else {
+                throw ProjectMemorySelectionError.projectUnavailable
+            }
+            guard !hasDocumentSynchronization(in: projectId) else {
+                throw DocumentSyncError.mutationWhileSynchronizing
+            }
             let selection = try await replaceProjectOrgSelection(
                 projectId: projectId,
                 expectedRevision: current.revision,
@@ -1411,16 +2863,19 @@ final class WorkspaceStore: ObservableObject {
         _ selection: ProjectOrgSelection,
         toProject projectId: String
     ) async {
-        guard let index = projects.firstIndex(where: { $0.id == projectId }) else { return }
-        let project = projects[index]
         let commit: (value: CommitStateResponse, response: DaemonServerResponse)? = try? await server.getWithMetadata(
             "/api/v1/projects/\(projectId)/commit-state"
         )
+        let freshCommit = commit.flatMap { $0.response.isStaleCache ? nil : $0 }
+        guard let index = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        let project = projects[index]
+        guard selection.revision >= project.orgSelectionRevision else { return }
+        clearStaleResourceState(for: projectId)
         projects[index] = ProjectState(
             id: project.id,
             name: project.name,
-            refCommitId: commit?.value.ref.commitId ?? project.refCommitId,
-            refEtag: commit?.response.headers.first {
+            refCommitId: freshCommit?.value.ref.commitId ?? project.refCommitId,
+            refEtag: freshCommit?.response.headers.first {
                 $0.key.caseInsensitiveCompare("etag") == .orderedSame
             }?.value ?? project.refEtag,
             selectedOrgResourceIds: projectOrgResourceIds(selection),
@@ -1437,8 +2892,7 @@ final class WorkspaceStore: ObservableObject {
         expectedRevision: Int,
         resourceIds: Set<String>
     ) async throws -> ProjectOrgSelection {
-        let selected = resources.filter { $0.scope == .org && resourceIds.contains($0.id) }
-        let request = ReplaceProjectOrgSelectionRequest(resourceIds: selected.map(\.id))
+        let request = ReplaceProjectOrgSelectionRequest(resourceIds: resourceIds.sorted())
         return try await server.send(
             method: "PUT",
             path: "/api/v1/projects/\(projectId)/org-selections",
@@ -1575,6 +3029,12 @@ final class WorkspaceStore: ObservableObject {
         candidate: DraftReconciliationCandidate? = nil,
         resolvedState: ReconciliationResourceState? = nil
     ) async throws {
+        if synchronizationItemId(for: draft) != nil {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        guard Self.canRequestReview(draft) else {
+            throw ReviewRequestError.projectLocalDraftCannotBePublished
+        }
         guard let serverId = draft.serverId else {
             throw ReviewRequestError.draftNotSynchronized
         }
@@ -1606,6 +3066,9 @@ final class WorkspaceStore: ObservableObject {
         candidate: DraftReconciliationCandidate? = nil,
         resolvedState: ReconciliationResourceState? = nil
     ) async throws {
+        guard !Self.isProjectLocalCreate(detail.draft) else {
+            throw ReviewRequestError.projectLocalDraftCannotBePublished
+        }
         guard isReviewAuthor(review) else {
             throw ServerClientError.forbidden("Only the draft author can resubmit this Review.")
         }
@@ -1640,14 +3103,41 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func reconciliationCandidate(for draft: LocalDraft) async throws -> DraftReconciliationCandidate {
-        guard let serverId = draft.serverId else {
+        let itemId = draft.targetId ?? draft.id
+        guard synchronizingDocumentIds.insert(itemId).inserted else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        let generation = UUID()
+        documentSynchronizationGenerations[itemId] = generation
+        defer { endDocumentSynchronization(itemId, generation: generation) }
+
+        let synchronized = try await synchronizedDraftForReconciliation(
+            itemId: itemId,
+            draft: draft
+        )
+        try Task.checkCancellation()
+        guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+            throw CancellationError()
+        }
+        let candidate = try await requestReconciliationCandidate(for: synchronized)
+        try Task.checkCancellation()
+        guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+            throw CancellationError()
+        }
+        return candidate
+    }
+
+    private func requestReconciliationCandidate(
+        for synchronized: LocalDraft
+    ) async throws -> DraftReconciliationCandidate {
+        guard let serverId = synchronized.serverId else {
             throw ReviewRequestError.draftNotSynchronized
         }
         return try await server.send(
             method: "POST",
             path: "/api/v1/drafts/\(serverId)/reconciliation-candidates",
             body: CreateDraftReconciliationCandidateRequest(
-                expectedDraftVersion: draft.serverVersion
+                expectedDraftVersion: synchronized.serverVersion
             )
         )
     }
@@ -1664,22 +3154,35 @@ final class WorkspaceStore: ObservableObject {
 
     func applyReconciliation(
         draftId: String,
-        draftVersion: Int,
         candidate: DraftReconciliationCandidate,
-        resolvedState: ReconciliationResourceState?
+        resolvedState: ReconciliationResourceState?,
+        documentItemId: String? = nil
     ) async throws {
+        if let documentItemId {
+            guard synchronizingDocumentIds.contains(documentItemId),
+                  pendingDocumentReconciliationCandidates[documentItemId]?.candidateId
+                    == candidate.candidateId,
+                  applyingDocumentReconciliationIds.insert(documentItemId).inserted else {
+                throw DocumentSyncError.mutationWhileSynchronizing
+            }
+        }
+        defer {
+            if let documentItemId {
+                applyingDocumentReconciliationIds.remove(documentItemId)
+            }
+        }
         let _: DraftRebaseResult = try await server.send(
             method: "POST",
             path: "/api/v1/drafts/\(draftId)/rebases",
             headers: ["If-Match": Self.refETag(candidate.currentCommitId)],
             body: CreateDraftRebaseRequest(
                 candidateId: candidate.candidateId,
-                expectedDraftVersion: draftVersion,
+                expectedDraftVersion: candidate.draftVersion,
                 resolvedState: resolvedState
             )
         )
         _ = try? await daemon.retrySync(channel: "drafts")
-        await reload()
+        await reload(allowsDuringDocumentReconciliation: true)
     }
 
     func reviewDetail(_ reviewId: String) async throws -> ReviewDetail {
@@ -1722,16 +3225,29 @@ final class WorkspaceStore: ObservableObject {
         guard canMergeReviews else {
             throw ServerClientError.forbidden("Your account cannot merge Reviews.")
         }
-        guard let project = projects.first(where: { $0.id == review.projectId }), !project.refEtag.isEmpty else {
-            throw ServerClientError.invalidResponse("The project Ref ETag is unavailable.")
+        // A Review belongs to its carrying Project, but its Draft may target
+        // either the Org or Project authority. The coordination commit is the
+        // exact target Ref generation for both scopes; the carrying Project's
+        // ETag is wrong for Org-targeted Drafts.
+        let detail = try await reviewDetail(review.id)
+        guard !Self.isProjectLocalCreate(detail.draft) else {
+            throw ReviewRequestError.projectLocalDraftCannotBePublished
         }
         let _: ReviewMergeResponse = try await server.send(
             method: "POST",
             path: "/api/v1/reviews/\(review.id)/merges",
-            headers: ["If-Match": project.refEtag],
+            headers: ["If-Match": Self.refETag(detail.draft.coordination.currentCommitId)],
             body: CreateReviewMergeRequest(expectedReviewVersion: review.version)
         )
         await reload()
+    }
+
+    nonisolated static func canRequestReview(_ draft: LocalDraft) -> Bool {
+        draft.scope == .org || draft.targetId != nil
+    }
+
+    private nonisolated static func isProjectLocalCreate(_ draft: ServerDraft) -> Bool {
+        draft.resource.scope == MemoryScope.project.rawValue && draft.resource.id == nil
     }
 
     private func currentDraft(for item: MemoryListItem) -> LocalDraft? {
@@ -1740,9 +3256,25 @@ final class WorkspaceStore: ObservableObject {
             return draft
         }
         guard let resourceId = item.resource?.id else { return item.draft }
-        return drafts.first {
-            $0.targetId == resourceId && $0.status != .discarded && $0.status != .merged
+        let projectContext = item.draft?.projectId ?? item.projectContextId ?? activeProjectId
+        return drafts.first { draft in
+            draft.targetId == resourceId
+                && draft.status != .discarded
+                && draft.status != .merged
+                && (projectContext.map { $0 == draft.projectId } ?? (draft.scope == .org))
         }
+    }
+
+    private func draftCarrierProjectId(
+        for item: MemoryListItem,
+        currentDraft: LocalDraft?
+    ) -> String? {
+        currentDraft?.projectId
+            ?? item.draft?.projectId
+            ?? item.resource?.projectId
+            ?? item.projectContextId
+            ?? activeProjectId
+            ?? (item.scope == .org ? projects.first?.id : nil)
     }
 
     private func withDraftMutation<T>(_ operation: () async throws -> T) async throws -> T {
@@ -1788,12 +3320,17 @@ final class WorkspaceStore: ObservableObject {
 
     private func persistDocumentSave(_ itemId: String, generation: UUID) async {
         guard let pending = pendingDocumentSaves[itemId], pending.generation == generation else { return }
+        guard synchronizationItemId(for: pending.item) == nil else {
+            documentSaveTasks[itemId] = nil
+            return
+        }
         do {
-            try await save(pending.item, document: pending.document)
-            if pendingDocumentSaves[itemId]?.generation == generation {
-                pendingDocumentSaves[itemId] = nil
-                documentSaveTasks[itemId] = nil
-            }
+            try await save(
+                pending.item,
+                document: pending.document,
+                pendingSaveItemId: itemId,
+                pendingSaveGeneration: generation
+            )
         } catch is CancellationError {
             return
         } catch {
@@ -1828,6 +3365,21 @@ final class WorkspaceStore: ObservableObject {
     }
 
     private func apply(_ snapshot: WorkspaceSnapshot) {
+        let previousResources = Dictionary(
+            resources.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        clearAllStaleResourceState()
+        resourceLoadRequests.removeAll()
+        loadingResourceIds.removeAll()
+        documentSynchronizationTasks.values.forEach { $0.cancel() }
+        documentSynchronizationTasks.removeAll()
+        pendingDocumentReconciliationCandidates.removeAll()
+        documentReconciliationResolutions.removeAll()
+        pendingDocumentCommand = nil
+        documentReconciliationToolbarState = nil
+        synchronizingDocumentIds.removeAll()
+        documentSynchronizationGenerations.removeAll()
         account = snapshot.account
         organization = snapshot.organization
         capabilities = snapshot.capabilities
@@ -1839,7 +3391,17 @@ final class WorkspaceStore: ObservableObject {
         orgRefEtag = snapshot.orgRefEtag
         activeProjectId = snapshot.activeProjectId
         resources = snapshot.resources
+        let nextResources = Dictionary(
+            resources.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        for resourceId in Set(previousResources.keys).union(nextResources.keys)
+        where previousResources[resourceId] != nextResources[resourceId] {
+            bumpDocumentContentGeneration(for: resourceId)
+        }
         drafts = snapshot.drafts
+        pruneOrphanedMemoryTabs()
+        refreshAllDocumentTabs()
         bundles = snapshot.bundles
         reviews = snapshot.reviews
         runtime = snapshot.runtime
@@ -1894,18 +3456,21 @@ final class WorkspaceStore: ObservableObject {
         } else {
             drafts.append(mapped)
         }
+        refreshDocumentTabs(for: mapped.targetId ?? mapped.id)
     }
 
     private func remapDrafts(projectId: String) async throws {
         let projectDrafts = drafts.filter { $0.projectId == projectId }
+        let originalById = Dictionary(
+            projectDrafts.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
         let targetIds = Set(projectDrafts.compactMap(\.targetId))
         let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
         let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
         let loadedBaselines = try await concurrentMap(baselines) { try await loader.loadContent(for: $0) }
         for loaded in loadedBaselines {
-            if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
-                resources[index] = loaded
-            }
+            installLoadedResourceIfCurrent(loaded)
         }
         let resourceSnapshot = resources
         let mapped = try await concurrentMap(projectDrafts) { draft in
@@ -1914,8 +3479,13 @@ final class WorkspaceStore: ObservableObject {
                 resources: resourceSnapshot
             )
         }
-        drafts.removeAll { $0.projectId == projectId }
-        drafts += mapped
+        for candidate in mapped {
+            guard let original = originalById[candidate.id],
+                  let index = drafts.firstIndex(where: { $0.id == candidate.id }),
+                  drafts[index] == original else { continue }
+            drafts[index] = candidate
+            refreshDocumentTabs(for: candidate.targetId ?? candidate.id)
+        }
     }
 
     nonisolated static func draftInventoryPlan(
@@ -1983,10 +3553,15 @@ final class WorkspaceStore: ObservableObject {
         drafts.removeAll {
             plan.terminalIds.contains($0.id) && !pendingDraftIds.contains($0.id)
         }
+        pruneOrphanedMemoryTabs()
 
         let refreshIds = plan.refreshIds.subtracting(pendingDraftIds)
         guard !refreshIds.isEmpty else { return }
         let summaries = page.items.filter { refreshIds.contains($0.draftId) }
+        let originalById = Dictionary(
+            drafts.filter { refreshIds.contains($0.id) }.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
         let targetIds = Set(summaries.compactMap(\.targetId))
         let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
         let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
@@ -1995,9 +3570,7 @@ final class WorkspaceStore: ObservableObject {
         }
         if let loadedBaselines {
             for loaded in loadedBaselines {
-                if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
-                    resources[index] = loaded
-                }
+                installLoadedResourceIfCurrent(loaded)
             }
         }
 
@@ -2011,10 +3584,12 @@ final class WorkspaceStore: ObservableObject {
         guard let mappedDrafts else { return }
         for mapped in mappedDrafts {
             if let index = drafts.firstIndex(where: { $0.id == mapped.id }) {
+                guard originalById[mapped.id] == drafts[index] else { continue }
                 drafts[index] = mapped
-            } else {
+            } else if originalById[mapped.id] == nil {
                 drafts.append(mapped)
             }
+            refreshDocumentTabs(for: mapped.targetId ?? mapped.id)
         }
     }
 
@@ -2024,17 +3599,22 @@ final class WorkspaceStore: ObservableObject {
         generation: UUID
     ) async {
         do {
+            guard let observedProject = projects.first(where: { $0.id == projectId }),
+                  observedProject.name == projectName else { return }
             let loaded = try await WorkspaceLoader(
                 daemon: daemon,
                 bootstrap: bootstrap,
                 server: server
-            ).loadProject(id: projectId, name: projectName)
-            guard projectSelectionGeneration == generation, activeProjectId == projectId else { return }
+            ).loadProjectWithMetadata(id: projectId, name: projectName)
+            guard projectSelectionGeneration == generation,
+                  activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == observedProject,
+                  !loaded.hasStaleServerResponse else { return }
+            clearStaleResourceState(for: projectId)
             if let index = projects.firstIndex(where: { $0.id == projectId }) {
                 projects[index] = loaded.state
             }
-            resources.removeAll { $0.projectId == projectId }
-            resources += loaded.resources
+            replaceProjectResources(projectId: projectId, with: loaded.resources)
             try await remapDrafts(projectId: projectId)
         } catch {
             // The installed Commit remains usable; commit sync reports refresh failures separately.
@@ -2070,8 +3650,21 @@ final class WorkspaceStore: ObservableObject {
         case .rules: base = "untitled.md"
         case .workflows: base = "workflow/untitled.md"
         }
-        let paths = Set(resources.filter { $0.kind == kind && $0.scope == scope }.map(\.document.path))
-            .union(drafts.filter { $0.kind == kind && $0.scope == scope }.map(\.document.path))
+        let scopedResources: [MemoryResource]
+        let scopedDrafts: [LocalDraft]
+        if scope == .project, let activeProjectId {
+            scopedResources = Self.memoryTreeResources(
+                resources,
+                activeProjectId: activeProjectId,
+                selectedOrgResourceIds: activeProject?.selectedOrgResourceIds ?? []
+            )
+            scopedDrafts = Self.memoryTreeDrafts(drafts, activeProjectId: activeProjectId)
+        } else {
+            scopedResources = resources.filter { $0.scope == scope }
+            scopedDrafts = drafts.filter { $0.scope == scope }
+        }
+        let paths = Set(scopedResources.filter { $0.kind == kind }.map(\.document.path))
+            .union(scopedDrafts.filter { $0.kind == kind }.map(\.document.path))
         guard paths.contains(base) else { return base }
         let extensionStart = base.lastIndex(of: ".") ?? base.endIndex
         let stem = String(base[..<extensionStart])
@@ -2121,8 +3714,7 @@ final class WorkspaceStore: ObservableObject {
         .init(description: nil, content: document.body)
     }
 
-    private func validate(kind: MemoryKind, document: EditableMemoryDocument) throws {
-        let path = document.path
+    private func validatePath(kind: MemoryKind, path: String) throws {
         let segments = path.split(separator: "/", omittingEmptySubsequences: false)
         if path.isEmpty
             || path.hasPrefix("/")
@@ -2136,6 +3728,10 @@ final class WorkspaceStore: ObservableObject {
         if kind == .rules && path.lowercased().hasPrefix("workflow/") {
             throw MemoryValidationError.invalidPath("Rule paths cannot use the workflow/ namespace.")
         }
+    }
+
+    private func validate(kind: MemoryKind, document: EditableMemoryDocument) throws {
+        try validatePath(kind: kind, path: document.path)
         if kind == .rules && document.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw MemoryValidationError.emptyRule
         }
@@ -2224,7 +3820,9 @@ struct WorkspaceLoader: Sendable {
         }
         let targetIds = Set(activeDrafts.compactMap(\.targetId))
         let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
-        let loadedBaselines = try await concurrentMap(baselines) { try await loadContent(for: $0) }
+        let loadedBaselines = try await concurrentMap(baselines) {
+            try await loadContent(for: $0, allowingStaleCache: true)
+        }
         for loaded in loadedBaselines {
             if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
                 resources[index] = loaded
@@ -2241,6 +3839,21 @@ struct WorkspaceLoader: Sendable {
             syncRequest,
             mcpRequest
         )
+        let verifiedOrgCommit: (value: CommitStateResponse, response: DaemonServerResponse) =
+            try await server.getWithMetadata("/api/v1/org/commit-state")
+        guard verifiedOrgCommit.value.ref.commitId == orgCommit.value.ref.commitId else {
+            throw WorkspaceLoadError.sharedStateChangedDuringLoad
+        }
+        if let activeProjectId,
+           let initialProject = projectStates.first(where: { $0.id == activeProjectId }),
+           let reference = me.projects.first(where: { $0.projectId == activeProjectId }) {
+            let verifiedProject = try await loadProjectStateWithMetadata(reference).state
+            guard verifiedProject.refCommitId == initialProject.refCommitId,
+                  verifiedProject.selectedOrgResourceIds == initialProject.selectedOrgResourceIds,
+                  verifiedProject.orgSelectionRevision == initialProject.orgSelectionRevision else {
+                throw WorkspaceLoadError.sharedStateChangedDuringLoad
+            }
+        }
         return .init(
             account: me.user,
             organization: me.org,
@@ -2265,13 +3878,39 @@ struct WorkspaceLoader: Sendable {
     }
 
     func loadProject(id: String, name: String) async throws -> (state: ProjectState, resources: [MemoryResource]) {
-        let state = try await loadProjectState(.init(projectId: id, name: name))
-        let resources = try await loadResources(
-            projectId: state.id,
-            projectName: state.name,
-            refCommitId: state.refCommitId
+        let loaded = try await loadProjectWithMetadata(id: id, name: name)
+        return (loaded.state, loaded.resources)
+    }
+
+    func loadProjectWithMetadata(
+        id: String,
+        name: String
+    ) async throws -> (
+        state: ProjectState,
+        resources: [MemoryResource],
+        hasStaleServerResponse: Bool
+    ) {
+        let state = try await loadProjectStateWithMetadata(.init(projectId: id, name: name))
+        let resources = try await loadResourcesWithMetadata(
+            projectId: state.state.id,
+            projectName: state.state.name,
+            refCommitId: state.state.refCommitId
         )
-        return (state, resources)
+        let verifiedState = try await loadProjectStateWithMetadata(
+            .init(projectId: id, name: name)
+        )
+        guard state.state.refCommitId == verifiedState.state.refCommitId,
+              state.state.selectedOrgResourceIds == verifiedState.state.selectedOrgResourceIds,
+              state.state.orgSelectionRevision == verifiedState.state.orgSelectionRevision else {
+            throw WorkspaceLoadError.sharedStateChangedDuringLoad
+        }
+        return (
+            state.state,
+            resources.resources,
+            state.hasStaleServerResponse
+                || resources.hasStaleServerResponse
+                || verifiedState.hasStaleServerResponse
+        )
     }
 
     func loadCachedProject(
@@ -2323,14 +3962,47 @@ struct WorkspaceLoader: Sendable {
         )
     }
 
-    func loadContent(for resource: MemoryResource) async throws -> MemoryResource {
+    func loadContent(
+        for resource: MemoryResource,
+        allowingStaleCache: Bool = false
+    ) async throws -> MemoryResource {
         guard !resource.contentLoaded else { return resource }
         let prefix = resource.projectId.map { "/api/v1/projects/\($0)" } ?? "/api/v1/org"
         var loaded = resource
-        let detail: MemoryDetail = try await server.get("\(prefix)/memories/\(resource.id)")
-        loaded.document.body = detail.content
+        let result: (value: MemoryDetail, response: DaemonServerResponse) =
+            try await server.getWithMetadata("\(prefix)/memories/\(resource.id)")
+        loaded.document.body = try Self.validatedMemoryContent(
+            for: resource,
+            detail: result.value,
+            response: result.response,
+            allowingStaleCache: allowingStaleCache
+        )
         loaded.contentLoaded = true
         return loaded
+    }
+
+    nonisolated static func validatedMemoryContent(
+        for resource: MemoryResource,
+        detail: MemoryDetail,
+        response: DaemonServerResponse,
+        allowingStaleCache: Bool = false
+    ) throws -> String {
+        guard allowingStaleCache || !response.isStaleCache else {
+            throw ServerClientError.invalidResponse(
+                "A stale cached memory body cannot be attached to the current shared version."
+            )
+        }
+        let digest = SHA256.hash(data: Data(detail.content.utf8))
+        let actualContentHash = "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+        guard detail.memory.memoryId == resource.id,
+              detail.memory.contentHash == resource.contentHash,
+              detail.memory.path == resource.document.path,
+              actualContentHash == resource.contentHash else {
+            throw ServerClientError.invalidResponse(
+                "The memory body no longer matches the requested shared version."
+            )
+        }
+        return detail.content
     }
 
     private func ensureDaemon() async throws -> DaemonHealth {
@@ -2492,21 +4164,30 @@ struct WorkspaceLoader: Sendable {
     }
 
     private func loadProjectState(_ project: ProjectReference) async throws -> ProjectState {
+        try await loadProjectStateWithMetadata(project).state
+    }
+
+    private func loadProjectStateWithMetadata(
+        _ project: ProjectReference
+    ) async throws -> (state: ProjectState, hasStaleServerResponse: Bool) {
         async let commitRequest: (value: CommitStateResponse, response: DaemonServerResponse) = server.getWithMetadata(
             "/api/v1/projects/\(project.projectId)/commit-state"
         )
-        async let selectionRequest: ProjectOrgSelection = server.get(
+        async let selectionRequest: (value: ProjectOrgSelection, response: DaemonServerResponse) = server.getWithMetadata(
             "/api/v1/projects/\(project.projectId)/org-selections"
         )
         let (commit, selection) = try await (commitRequest, selectionRequest)
-        return .init(
-            id: project.projectId,
-            name: project.name,
-            refCommitId: commit.value.ref.commitId,
-            refEtag: etag(from: commit.response),
-            selectedOrgResourceIds: Set(selection.memories.map(\.memoryId)),
-            orgSelectionRevision: selection.revision,
-            isLoaded: true
+        return (
+            .init(
+                id: project.projectId,
+                name: project.name,
+                refCommitId: commit.value.ref.commitId,
+                refEtag: etag(from: commit.response),
+                selectedOrgResourceIds: Set(selection.value.memories.map(\.memoryId)),
+                orgSelectionRevision: selection.value.revision,
+                isLoaded: true
+            ),
+            commit.response.isStaleCache || selection.response.isStaleCache
         )
     }
 
@@ -2515,9 +4196,22 @@ struct WorkspaceLoader: Sendable {
         projectName: String?,
         refCommitId: String?
     ) async throws -> [MemoryResource] {
+        try await loadResourcesWithMetadata(
+            projectId: projectId,
+            projectName: projectName,
+            refCommitId: refCommitId
+        ).resources
+    }
+
+    private func loadResourcesWithMetadata(
+        projectId: String?,
+        projectName: String?,
+        refCommitId: String?
+    ) async throws -> (resources: [MemoryResource], hasStaleServerResponse: Bool) {
         let prefix = projectId.map { "/api/v1/projects/\($0)" } ?? "/api/v1/org"
-        let metadataItems: [MemoryMetadata] = try await loadAll("\(prefix)/memories")
-        return metadataItems.map { metadata in
+        let metadata: (items: [MemoryMetadata], hasStaleServerResponse: Bool) =
+            try await loadAllWithMetadata("\(prefix)/memories")
+        return (metadata.items.map { metadata in
             .init(
                 id: metadata.memoryId,
                 scope: projectId == nil ? .org : .project,
@@ -2534,7 +4228,7 @@ struct WorkspaceLoader: Sendable {
                     body: ""
                 )
             )
-        }
+        }, metadata.hasStaleServerResponse)
     }
 
     private func loadBundles() async throws -> [PersonalBundle] {
@@ -2558,16 +4252,25 @@ struct WorkspaceLoader: Sendable {
     }
 
     private func loadAll<Item: Decodable & Sendable>(_ path: String) async throws -> [Item] {
+        try await loadAllWithMetadata(path).items
+    }
+
+    private func loadAllWithMetadata<Item: Decodable & Sendable>(
+        _ path: String
+    ) async throws -> (items: [Item], hasStaleServerResponse: Bool) {
         var output: [Item] = []
         var cursor: String?
+        var hasStaleServerResponse = false
         repeat {
             var query = [URLQueryItem(name: "limit", value: "200")]
             if let cursor { query.append(.init(name: "cursor", value: cursor)) }
-            let page: ListResponse<Item> = try await server.get(path, query: query)
-            output += page.items
-            cursor = page.pageInfo.hasMore ? page.pageInfo.nextCursor : nil
+            let page: (value: ListResponse<Item>, response: DaemonServerResponse) =
+                try await server.getWithMetadata(path, query: query)
+            output += page.value.items
+            hasStaleServerResponse = hasStaleServerResponse || page.response.isStaleCache
+            cursor = page.value.pageInfo.hasMore ? page.value.pageInfo.nextCursor : nil
         } while cursor != nil
-        return output
+        return (output, hasStaleServerResponse)
     }
 
     static func mapReview(_ detail: ReviewDetail) -> ReviewRecord {
@@ -2657,7 +4360,15 @@ struct WorkspaceLoader: Sendable {
 
     static func mapDraft(_ detail: DaemonDraftDetail, resources: [MemoryResource]) -> LocalDraft {
         let summary = detail.draft
-        let base = summary.targetId.flatMap { id in resources.first { $0.id == id } }
+        let base = summary.targetId.flatMap { id in
+            resources.first { $0.id == id && $0.contentLoaded }
+        }
+        let hasSelfContainedContent = detail.operations.contains { operation in
+            switch operation.operation {
+            case .create, .update: true
+            case .rename, .delete, .discard: false
+            }
+        }
         var document = base?.document ?? .init(
             title: title(from: summary.path ?? "Untitled"),
             path: summary.path ?? "untitled.md",
@@ -2681,6 +4392,7 @@ struct WorkspaceLoader: Sendable {
                 break
             }
         }
+        document.title = title(from: document.path)
         return .init(
             id: summary.draftId,
             projectId: summary.projectId,
@@ -2700,7 +4412,10 @@ struct WorkspaceLoader: Sendable {
             syncStatus: detail.operations.last?.syncStatus ?? .synced,
             updatedAt: summary.updatedAt,
             document: document,
-            isDeletion: deletion
+            isDeletion: deletion,
+            documentBaselineAvailable: base != nil
+                || summary.targetId == nil
+                || hasSelfContainedContent
         )
     }
 
@@ -2745,6 +4460,23 @@ private struct PendingBundleSave {
     let description: String
     let resourceIds: Set<String>
     let generation: UUID
+}
+
+@MainActor
+final class ProjectSelectionSideEffectGate {
+    private let mutex = AsyncMutex()
+
+    func run<Output>(_ operation: () async throws -> Output) async rethrows -> Output {
+        await mutex.lock()
+        do {
+            let output = try await operation()
+            await mutex.unlock()
+            return output
+        } catch {
+            await mutex.unlock()
+            throw error
+        }
+    }
 }
 
 private actor AsyncMutex {

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -3,26 +3,26 @@ import CryptoKit
 import Foundation
 
 enum DocumentSessionCommand: Equatable, Sendable {
-    case requestReview(itemId: String, draft: LocalDraft)
-    case discardDraft(itemId: String, draft: LocalDraft)
-    case applyReconciliation(itemId: String)
-    case closeReconciliation(itemId: String)
-    case moveToTrash(itemId: String)
+    case requestReview(sessionKey: MemoryDocumentSessionKey, draft: LocalDraft)
+    case discardDraft(sessionKey: MemoryDocumentSessionKey, draft: LocalDraft)
+    case applyReconciliation(sessionKey: MemoryDocumentSessionKey)
+    case closeReconciliation(sessionKey: MemoryDocumentSessionKey)
+    case moveToTrash(sessionKey: MemoryDocumentSessionKey)
 
-    var itemId: String {
+    var sessionKey: MemoryDocumentSessionKey {
         switch self {
-        case .requestReview(let itemId, _),
-             .discardDraft(let itemId, _),
-             .applyReconciliation(let itemId),
-             .closeReconciliation(let itemId),
-             .moveToTrash(let itemId):
-            itemId
+        case .requestReview(let sessionKey, _),
+             .discardDraft(let sessionKey, _),
+             .applyReconciliation(let sessionKey),
+             .closeReconciliation(let sessionKey),
+             .moveToTrash(let sessionKey):
+            sessionKey
         }
     }
 }
 
 struct DocumentReconciliationToolbarState: Equatable, Sendable {
-    let itemId: String
+    let sessionKey: MemoryDocumentSessionKey
     let isLoading: Bool
     let canUpdate: Bool
     let isUpdating: Bool
@@ -90,15 +90,15 @@ enum MemoryValidationError: LocalizedError, Sendable {
 
 enum ReviewRequestError: LocalizedError, Sendable {
     case draftNotSynchronized
-    case projectLocalDraftCannotBePublished
+    case legacyProjectDraftCannotBePublished
     case reconciliationRequired
 
     var errorDescription: String? {
         switch self {
         case .draftNotSynchronized:
             "Wait for this draft to finish syncing before requesting a review."
-        case .projectLocalDraftCannotBePublished:
-            "This Project-local draft can stay local indefinitely. Publishing it to the Organization is not available yet."
+        case .legacyProjectDraftCannotBePublished:
+            "Legacy Project-scoped drafts are read-only and cannot be published."
         case .reconciliationRequired:
             "Merge the latest shared version before requesting a review."
         }
@@ -247,11 +247,14 @@ enum ProjectSetupError: LocalizedError, Sendable {
 }
 
 enum ProjectMemorySelectionError: LocalizedError, Sendable {
+    case activeDrafts
     case invalidOrgResources
     case projectUnavailable
 
     var errorDescription: String? {
         switch self {
+        case .activeDrafts:
+            "Discard or finish this Project's LocalDraft before removing its Organization Memory."
         case .invalidOrgResources:
             "Only current Organization memory can be added to or removed from a Project."
         case .projectUnavailable:
@@ -335,10 +338,12 @@ final class WorkspaceStore: ObservableObject {
     /// Incremented when authoritative content replaces the document currently
     /// held by a long-lived editor session.
     @Published private(set) var documentContentGenerations: [String: UInt64] = [:]
-    @Published private(set) var synchronizingDocumentIds: Set<String> = []
-    @Published private(set) var pendingDocumentReconciliationCandidates:
-        [String: DraftReconciliationCandidate] = [:]
-    @Published private(set) var applyingDocumentReconciliationIds: Set<String> = []
+    @Published private(set) var synchronizingDocumentSessions:
+        Set<MemoryDocumentSessionKey> = []
+    @Published private var pendingDocumentReconciliationCandidatesBySession:
+        [MemoryDocumentSessionKey: DraftReconciliationCandidate] = [:]
+    @Published private var applyingDocumentReconciliationSessions:
+        Set<MemoryDocumentSessionKey> = []
     @Published private(set) var projectOrgSelectionMutatingIds: Set<String> = []
 
     let daemon = DaemonXPCClient()
@@ -351,17 +356,22 @@ final class WorkspaceStore: ObservableObject {
     private let draftMutationGate = AsyncMutex()
     private let bundleMutationGate = AsyncMutex()
     private let projectOrgSelectionMutationGate = AsyncMutex()
-    private var pendingDocumentSaves: [String: PendingDocumentSave] = [:]
-    private var documentSaveTasks: [String: Task<Void, Never>] = [:]
+    private var pendingDocumentSaves: [MemoryDocumentSessionKey: PendingDocumentSave] = [:]
+    private var documentSaveTasks: [MemoryDocumentSessionKey: Task<Void, Never>] = [:]
     private var pendingBundleSaves: [String: PendingBundleSave] = [:]
     private var bundleSaveTasks: [String: Task<Void, Never>] = [:]
     private var staleResourceSnapshots: [String: StaleResourceSyncSnapshot] = [:]
     private var provisionalStaleAdditionIds: Set<String> = []
     private var resourceLoadRequests: [String: ResourceLoadRequest] = [:]
     private var staleResourceRefreshGenerations: [String: UUID] = [:]
-    private var documentSynchronizationGenerations: [String: UUID] = [:]
-    private var documentSynchronizationTasks: [String: Task<Void, Never>] = [:]
-    private var documentReconciliationResolutions: [String: ReconciliationResourceState] = [:]
+    private var orgResourceRefreshGeneration: UUID?
+    private var documentSynchronizationGenerations: [MemoryDocumentSessionKey: UUID] = [:]
+    private var documentSynchronizationTasks: [MemoryDocumentSessionKey: Task<Void, Never>] = [:]
+    private var documentReconciliationResolutions:
+        [MemoryDocumentSessionKey: ReconciliationResourceState] = [:]
+    /// Review reconciliation has no open document session, but it still must
+    /// exclude a daemon Project-context switch while a candidate/rebase is in flight.
+    private var standaloneReconciliationActivityIds: Set<UUID> = []
 
     var activeProject: ProjectState? {
         projects.first { $0.id == activeProjectId }
@@ -388,25 +398,25 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func canCreateMemory(kind: MemoryKind, scope: MemoryScope) -> Bool {
-        guard !isSwitchingMemoryContext else { return false }
-        if scope == .org {
-            return canManageOrgSelection && !projects.isEmpty
-        }
-        return activeProjectId != nil
+        !isSwitchingMemoryContext && activeProjectId != nil && scope == .org
     }
 
-    /// Authority is never edited in place: editable documents are persisted
-    /// as local Draft operations. Org-targeted Drafts still require the
-    /// Server's organization write capability.
+    /// Authority is never edited in place: a Project member edits selected
+    /// Organization Memory through a Project-bound LocalDraft. Legacy
+    /// Project-scoped authority remains visible but read-only.
     func canEditMemory(_ item: MemoryListItem) -> Bool {
         let projectContextId = item.projectContextId
             ?? (item.scope == .project ? item.projectId : nil)
-        if projectContextId.map(projectOrgSelectionMutatingIds.contains) == true {
+        guard let projectContextId,
+              projectContextId == activeProjectId else {
             return false
         }
-        if item.scope == .project { return item.projectId != nil }
-        return canManageOrgSelection
-            && (item.projectId != nil || activeProjectId != nil || !projects.isEmpty)
+        if projectOrgSelectionMutatingIds.contains(projectContextId) {
+            return false
+        }
+        guard item.scope == .org else { return false }
+        if let draft = item.draft, draft.targetId == nil { return true }
+        return item.inherited
     }
 
     var selectedItem: MemoryListItem? {
@@ -425,7 +435,6 @@ final class WorkspaceStore: ObservableObject {
                 return Self.orgMemoryTabIsAvailable(
                     itemId: tab.itemId,
                     resources: resources,
-                    drafts: drafts,
                     allowsUnresolved: allowsUnresolved
                 )
             }
@@ -444,18 +453,9 @@ final class WorkspaceStore: ObservableObject {
     nonisolated static func orgMemoryTabIsAvailable(
         itemId: String,
         resources: [MemoryResource],
-        drafts: [LocalDraft],
         allowsUnresolved: Bool = false
     ) -> Bool {
         if resources.contains(where: { $0.id == itemId && $0.scope == .org }) {
-            return true
-        }
-        if drafts.contains(where: { draft in
-            (draft.id == itemId || draft.targetId == itemId)
-                && draft.scope == .org
-                && draft.status != .discarded
-                && draft.status != .merged
-        }) {
             return true
         }
         return allowsUnresolved
@@ -492,6 +492,55 @@ final class WorkspaceStore: ObservableObject {
         return allowsUnresolved && resource == nil
     }
 
+    /// Resolves whether a stored tab still belongs to its own view context.
+    /// A globally live Org resource is not enough to retain a clean Project
+    /// tab after that Project removes the resource from its selection.
+    nonisolated static func memoryTabIsAvailable(
+        _ tab: WorkbenchTab,
+        projects: [ProjectState],
+        resources: [MemoryResource],
+        drafts: [LocalDraft],
+        allowsUnresolvedOrg: Bool = false
+    ) -> Bool {
+        guard tab.section == .memory else { return true }
+        guard let projectId = tab.projectId else {
+            return orgMemoryTabIsAvailable(
+                itemId: tab.itemId,
+                resources: resources,
+                allowsUnresolved: allowsUnresolvedOrg
+            )
+        }
+        guard let project = projects.first(where: { $0.id == projectId }) else {
+            return false
+        }
+        return memoryTabIsAvailable(
+            itemId: tab.itemId,
+            projectId: projectId,
+            selectedOrgResourceIds: project.selectedOrgResourceIds,
+            resources: resources,
+            drafts: drafts,
+            allowsUnresolved: !project.isLoaded
+        )
+    }
+
+    nonisolated static func retainedMemoryTabs(
+        _ tabs: [WorkbenchTab],
+        projects: [ProjectState],
+        resources: [MemoryResource],
+        drafts: [LocalDraft],
+        allowsUnresolvedOrg: Bool = false
+    ) -> [WorkbenchTab] {
+        tabs.filter {
+            memoryTabIsAvailable(
+                $0,
+                projects: projects,
+                resources: resources,
+                drafts: drafts,
+                allowsUnresolvedOrg: allowsUnresolvedOrg
+            )
+        }
+    }
+
     var activeVisibleTab: WorkbenchTab? {
         visibleTabs.first { $0.id == activeTabId } ?? visibleTabs.last
     }
@@ -513,86 +562,177 @@ final class WorkspaceStore: ObservableObject {
         activeVisibleTab?.mode
     }
 
+    /// UI compatibility view of reconciliation state for the active Project.
+    /// The stored state remains context-scoped so an equal Org resource id in
+    /// another Project can never be rendered or applied here.
+    var pendingDocumentReconciliationCandidates: [String: DraftReconciliationCandidate] {
+        guard let activeProjectId else { return [:] }
+        return Dictionary(
+            uniqueKeysWithValues: pendingDocumentReconciliationCandidatesBySession.compactMap {
+                key, candidate in
+                key.projectId == activeProjectId ? (key.itemId, candidate) : nil
+            }
+        )
+    }
+
     func documentContentGeneration(for itemId: String) -> UInt64 {
         documentContentGenerations[itemId, default: 0]
     }
 
     func staleResourceGeneration(for resourceId: String) -> UUID? {
-        staleResourceSnapshots[resourceId]?.generation
+        guard let activeProjectId,
+              let snapshot = staleResourceSnapshots[resourceId],
+              snapshot.projectId == activeProjectId else { return nil }
+        return snapshot.generation
     }
 
     func isSynchronizingDocument(_ itemId: String) -> Bool {
-        synchronizingDocumentIds.contains(itemId)
+        guard let key = activeDocumentSessionKey(for: itemId) else { return false }
+        return synchronizingDocumentSessions.contains(key)
     }
 
     func pendingDocument(for item: MemoryListItem) -> EditableMemoryDocument? {
-        [item.id, item.draft?.targetId, item.draft?.id]
-            .compactMap { $0 }
-            .lazy
-            .compactMap { self.pendingDocumentSaves[$0]?.document }
-            .first
+        guard let key = documentSessionKey(for: item) else { return nil }
+        return pendingDocumentSaves[key]?.document
     }
 
     func documentReconciliationResolution(for itemId: String) -> ReconciliationResourceState? {
-        documentReconciliationResolutions[itemId]
+        guard let key = activeDocumentSessionKey(for: itemId) else { return nil }
+        return documentReconciliationResolutions[key]
     }
 
     func updateDocumentReconciliationResolution(
         _ resolution: ReconciliationResourceState,
         for itemId: String
     ) {
-        guard pendingDocumentReconciliationCandidates[itemId] != nil else { return }
-        documentReconciliationResolutions[itemId] = resolution
+        guard let key = activeDocumentSessionKey(for: itemId),
+              pendingDocumentReconciliationCandidatesBySession[key] != nil else { return }
+        documentReconciliationResolutions[key] = resolution
     }
 
-    func finishDocumentReconciliation(for itemId: String) {
-        guard !applyingDocumentReconciliationIds.contains(itemId) else { return }
-        documentSynchronizationTasks.removeValue(forKey: itemId)?.cancel()
-        pendingDocumentReconciliationCandidates.removeValue(forKey: itemId)
-        documentReconciliationResolutions.removeValue(forKey: itemId)
-        synchronizingDocumentIds.remove(itemId)
-        documentSynchronizationGenerations.removeValue(forKey: itemId)
-        if documentReconciliationToolbarState?.itemId == itemId {
+    func finishDocumentReconciliation(for key: MemoryDocumentSessionKey) {
+        guard key.projectId == activeProjectId,
+              !applyingDocumentReconciliationSessions.contains(key) else { return }
+        documentSynchronizationTasks.removeValue(forKey: key)?.cancel()
+        pendingDocumentReconciliationCandidatesBySession.removeValue(forKey: key)
+        documentReconciliationResolutions.removeValue(forKey: key)
+        synchronizingDocumentSessions.remove(key)
+        documentSynchronizationGenerations.removeValue(forKey: key)
+        if documentReconciliationToolbarState?.sessionKey == key {
             documentReconciliationToolbarState = nil
         }
-        if pendingDocumentCommand?.itemId == itemId {
+        if pendingDocumentCommand?.sessionKey == key {
             pendingDocumentCommand = nil
         }
     }
 
+    private func activeDocumentSessionKey(for itemId: String) -> MemoryDocumentSessionKey? {
+        activeProjectId.map { MemoryDocumentSessionKey(projectId: $0, itemId: itemId) }
+    }
+
+    func documentSessionKey(for item: MemoryListItem) -> MemoryDocumentSessionKey? {
+        Self.memoryDocumentSessionKey(for: item)
+    }
+
+    nonisolated static func memoryDocumentSessionKey(
+        for item: MemoryListItem
+    ) -> MemoryDocumentSessionKey? {
+        let projectId = item.projectContextId
+            ?? (item.scope == .project ? item.projectId : nil)
+        return projectId.map { MemoryDocumentSessionKey(projectId: $0, itemId: item.id) }
+    }
+
+    private func documentSessionKey(for tab: WorkbenchTab) -> MemoryDocumentSessionKey? {
+        tab.projectId.map { MemoryDocumentSessionKey(projectId: $0, itemId: tab.itemId) }
+    }
+
     private func synchronizationItemId(for item: MemoryListItem) -> String? {
-        [item.id, item.resource?.id, item.draft?.targetId, item.draft?.id]
+        guard let projectId = documentSessionKey(for: item)?.projectId else { return nil }
+        return [item.id, item.resource?.id, item.draft?.targetId, item.draft?.id]
             .compactMap { $0 }
-            .first { synchronizingDocumentIds.contains($0) }
+            .first {
+                synchronizingDocumentSessions.contains(
+                    .init(projectId: projectId, itemId: $0)
+                )
+            }
     }
 
     private func synchronizationItemId(for draft: LocalDraft) -> String? {
         [draft.targetId, draft.id]
             .compactMap { $0 }
-            .first { synchronizingDocumentIds.contains($0) }
+            .first {
+                synchronizingDocumentSessions.contains(
+                    .init(projectId: draft.projectId, itemId: $0)
+                )
+            }
     }
 
     private func hasDocumentSynchronization(in projectId: String) -> Bool {
-        synchronizingDocumentIds.contains { itemId in
-            if resources.contains(where: { $0.id == itemId && $0.projectId == projectId }) {
-                return true
-            }
-            return drafts.contains {
-                ($0.id == itemId || $0.targetId == itemId) && $0.projectId == projectId
-            }
-        }
+        synchronizingDocumentSessions.contains { $0.projectId == projectId }
     }
 
-    private func isCurrentDocumentSynchronization(_ itemId: String, generation: UUID) -> Bool {
-        synchronizingDocumentIds.contains(itemId)
-            && documentSynchronizationGenerations[itemId] == generation
+    private func isCurrentDocumentSynchronization(
+        _ key: MemoryDocumentSessionKey,
+        generation: UUID
+    ) -> Bool {
+        activeProjectId == key.projectId
+            && !isSwitchingMemoryContext
+            && synchronizingDocumentSessions.contains(key)
+            && documentSynchronizationGenerations[key] == generation
     }
 
-    private func endDocumentSynchronization(_ itemId: String, generation: UUID) {
-        guard documentSynchronizationGenerations[itemId] == generation else { return }
-        documentSynchronizationTasks.removeValue(forKey: itemId)
-        synchronizingDocumentIds.remove(itemId)
-        documentSynchronizationGenerations.removeValue(forKey: itemId)
+    private func endDocumentSynchronization(
+        _ key: MemoryDocumentSessionKey,
+        generation: UUID
+    ) {
+        guard documentSynchronizationGenerations[key] == generation else { return }
+        documentSynchronizationTasks.removeValue(forKey: key)
+        synchronizingDocumentSessions.remove(key)
+        documentSynchronizationGenerations.removeValue(forKey: key)
+    }
+
+    nonisolated static func canStartDocumentSynchronization(
+        isSwitchingMemoryContext: Bool,
+        activeProjectId: String?,
+        itemProjectContextId: String?
+    ) -> Bool {
+        guard let itemProjectContextId else { return false }
+        return projectContextIsCurrent(
+            isSwitchingMemoryContext: isSwitchingMemoryContext,
+            activeProjectId: activeProjectId,
+            expectedProjectId: itemProjectContextId
+        )
+    }
+
+    nonisolated static func projectContextIsCurrent(
+        isSwitchingMemoryContext: Bool,
+        activeProjectId: String?,
+        expectedProjectId: String
+    ) -> Bool {
+        !isSwitchingMemoryContext && activeProjectId == expectedProjectId
+    }
+
+    nonisolated static func canCommitMemoryContextSwitch(
+        hasDocumentSynchronization: Bool,
+        hasApplyingDocumentReconciliation: Bool,
+        hasStandaloneReconciliationActivity: Bool
+    ) -> Bool {
+        !hasDocumentSynchronization
+            && !hasApplyingDocumentReconciliation
+            && !hasStandaloneReconciliationActivity
+    }
+
+    private var canCommitMemoryContextSwitch: Bool {
+        Self.canCommitMemoryContextSwitch(
+            hasDocumentSynchronization: !synchronizingDocumentSessions.isEmpty,
+            hasApplyingDocumentReconciliation: !applyingDocumentReconciliationSessions.isEmpty,
+            hasStandaloneReconciliationActivity: !standaloneReconciliationActivityIds.isEmpty
+        )
+    }
+
+    private func clearPendingDocumentSessionPresentation() {
+        pendingDocumentCommand = nil
+        documentReconciliationToolbarState = nil
     }
 
     func documentPathChanges(for item: MemoryListItem) -> [DocumentPathChange] {
@@ -609,13 +749,27 @@ final class WorkspaceStore: ObservableObject {
             )
         }
         guard let resource = item.resource,
-              let snapshot = staleResourceSnapshots[resource.id] else { return [] }
+              let snapshot = staleResourceSnapshot(for: item),
+              snapshot.local?.id == resource.id || snapshot.remote?.id == resource.id else {
+            return []
+        }
         let basePath = snapshot.local?.document.path
         return Self.documentPathChanges(
             basePath: basePath,
             localPath: basePath,
             remotePath: snapshot.remote?.document.path
         )
+    }
+
+    private func staleResourceSnapshot(
+        for item: MemoryListItem
+    ) -> StaleResourceSyncSnapshot? {
+        guard let resourceId = item.resource?.id,
+              let projectId = item.projectContextId,
+              projectId == activeProjectId,
+              let snapshot = staleResourceSnapshots[resourceId],
+              snapshot.projectId == projectId else { return nil }
+        return snapshot
     }
 
     nonisolated static func documentPathChanges(
@@ -770,14 +924,14 @@ final class WorkspaceStore: ObservableObject {
         _ drafts: [LocalDraft],
         activeProjectId: String?
     ) -> [LocalDraft] {
-        drafts.filter { draft in
+        // LocalDraft is always a Project-bound overlay, including an Org-
+        // targeted Draft. The Org catalog presents shared authority only.
+        guard let activeProjectId else { return [] }
+        return drafts.filter { draft in
             guard draft.status != .discarded && draft.status != .merged else {
                 return false
             }
-            if let activeProjectId {
-                return draft.projectId == activeProjectId
-            }
-            return draft.scope == .org
+            return draft.projectId == activeProjectId
         }
     }
 
@@ -796,6 +950,34 @@ final class WorkspaceStore: ObservableObject {
             if lhs.updatedAt != rhs.updatedAt { return lhs.updatedAt > rhs.updatedAt }
             return lhs.id < rhs.id
         }
+    }
+
+    nonisolated static func hasActiveDraft(
+        in projectId: String,
+        targetingAny resourceIds: Set<String>,
+        drafts: [LocalDraft]
+    ) -> Bool {
+        drafts.contains { draft in
+            draft.projectId == projectId
+                && draft.status != .discarded
+                && draft.status != .merged
+                && draft.targetId.map(resourceIds.contains) == true
+        }
+    }
+
+    nonisolated static func memoryTabDraft(
+        itemId: String,
+        projectId: String?,
+        drafts: [LocalDraft]
+    ) -> LocalDraft? {
+        guard let projectId else { return nil }
+        let matchingDrafts = drafts.filter { draft in
+            (draft.id == itemId || draft.targetId == itemId)
+                && draft.projectId == projectId
+                && draft.status != .discarded
+                && draft.status != .merged
+        }
+        return preferredMemoryTreeDrafts(matchingDrafts).first
     }
 
     nonisolated static func unrepresentedDrafts(
@@ -839,7 +1021,8 @@ final class WorkspaceStore: ObservableObject {
 
     func reload(allowsDuringDocumentReconciliation: Bool = false) async {
         guard allowsDuringDocumentReconciliation
-                || applyingDocumentReconciliationIds.isEmpty else {
+                || (applyingDocumentReconciliationSessions.isEmpty
+                    && standaloneReconciliationActivityIds.isEmpty) else {
             return
         }
         let generation = UUID()
@@ -1081,8 +1264,7 @@ final class WorkspaceStore: ObservableObject {
 
     func showOrgMemory() async {
         guard activeProjectId != nil || loadingProjectId != nil else { return }
-        guard synchronizingDocumentIds.isEmpty,
-              applyingDocumentReconciliationIds.isEmpty else {
+        guard canCommitMemoryContextSwitch else {
             errorMessage = "Finish or cancel the active document Sync before switching Memory context."
             return
         }
@@ -1092,6 +1274,7 @@ final class WorkspaceStore: ObservableObject {
         projectSelectionGeneration = generation
         loadingProjectId = nil
         isSwitchingMemoryContext = true
+        clearPendingDocumentSessionPresentation()
         defer {
             if projectSelectionGeneration == generation {
                 isSwitchingMemoryContext = false
@@ -1099,7 +1282,13 @@ final class WorkspaceStore: ObservableObject {
         }
         guard await flushPendingDocumentChanges(),
               projectSelectionGeneration == generation else { return }
+        guard canCommitMemoryContextSwitch else {
+            errorMessage = "Finish or cancel the active document Sync before switching Memory context."
+            return
+        }
+        clearPendingDocumentSessionPresentation()
         activeProjectId = nil
+        refreshVisibleStaleResourceIds()
         showsProjectSettings = false
         selectedItemId = nil
         let tab = visibleTabs.last
@@ -1114,8 +1303,7 @@ final class WorkspaceStore: ObservableObject {
            !isSwitchingMemoryContext {
             return
         }
-        guard synchronizingDocumentIds.isEmpty,
-              applyingDocumentReconciliationIds.isEmpty else {
+        guard canCommitMemoryContextSwitch else {
             errorMessage = "Finish or cancel the active document Sync before switching Memory context."
             return
         }
@@ -1126,6 +1314,7 @@ final class WorkspaceStore: ObservableObject {
         projectSelectionGeneration = generation
         loadingProjectId = projectId
         isSwitchingMemoryContext = true
+        clearPendingDocumentSessionPresentation()
         defer {
             if projectSelectionGeneration == generation {
                 loadingProjectId = nil
@@ -1134,6 +1323,10 @@ final class WorkspaceStore: ObservableObject {
         }
         guard await flushPendingDocumentChanges(),
               projectSelectionGeneration == generation else { return }
+        guard canCommitMemoryContextSwitch else {
+            errorMessage = "Finish or cancel the active document Sync before switching Memory context."
+            return
+        }
         do {
             let selectedLatestIntent = try await projectSelectionSideEffectGate.run {
                 guard projectSelectionGeneration == generation else { return false }
@@ -1142,7 +1335,13 @@ final class WorkspaceStore: ObservableObject {
             }
             guard selectedLatestIntent,
                   projectSelectionGeneration == generation else { return }
+            guard canCommitMemoryContextSwitch else {
+                errorMessage = "Finish or cancel the active document Sync before switching Memory context."
+                return
+            }
+            clearPendingDocumentSessionPresentation()
             activeProjectId = projectId
+            refreshVisibleStaleResourceIds()
             let tab = visibleTabs.last
             activeTabId = tab?.id
             selectedItemId = tab?.itemId
@@ -1233,6 +1432,10 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func open(_ item: MemoryListItem, mode: WorkbenchTabMode? = nil) {
+        guard let item = Self.memoryItemForViewContext(
+            item,
+            activeProjectId: activeProjectId
+        ) else { return }
         showsProjectSettings = false
         let previousTabId = activeVisibleTab?.id
         // Project-local overlays need a separate session from the Org
@@ -1265,6 +1468,27 @@ final class WorkspaceStore: ObservableObject {
         }
         activeTabId = tab.id
         Task { await loadContentIfNeeded(item) }
+    }
+
+    nonisolated static func memoryItemForViewContext(
+        _ item: MemoryListItem,
+        activeProjectId: String?
+    ) -> MemoryListItem? {
+        guard let activeProjectId else {
+            guard let resource = item.resource, resource.scope == .org else { return nil }
+            return MemoryListItem(
+                id: resource.id,
+                resource: resource,
+                draft: nil,
+                inherited: false,
+                projectContextId: nil
+            )
+        }
+        let itemProjectId = item.projectContextId
+            ?? item.draft?.projectId
+            ?? (item.scope == .project ? item.projectId : nil)
+        guard itemProjectId == nil || itemProjectId == activeProjectId else { return nil }
+        return item
     }
 
     /// Switches the active tab's view mode in place instead of stacking a
@@ -1318,25 +1542,38 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    /// Remove document sessions whose authority and active LocalDraft are
-    /// both gone. `visibleTabs` still performs context filtering, but keeping
-    /// terminal draft tabs in the backing array would resurrect stale modes
-    /// and navigation entries if an unrelated item later reused that route.
+    /// Remove document sessions that no longer exist in their own view
+    /// context. In particular, a clean selected Org memory stops belonging to
+    /// Project P as soon as P removes it, even though the Org authority remains
+    /// globally live. A P-bound LocalDraft still retains P's draft-only tab.
     private func pruneOrphanedMemoryTabs() {
-        let liveItemIds = Set(resources.map(\.id)).union(
-            drafts.compactMap { draft in
-                guard draft.status != .discarded && draft.status != .merged else { return nil }
-                return draft.targetId ?? draft.id
-            }
+        let retainedTabs = Self.retainedMemoryTabs(
+            tabs,
+            projects: projects,
+            resources: resources,
+            drafts: drafts
         )
-        let removedTabIds = Set(tabs.compactMap { tab in
-            tab.section == .memory && !liveItemIds.contains(tab.itemId) ? tab.id : nil
-        })
+        let retainedTabIds = Set(retainedTabs.map(\.id))
+        let removedTabs = tabs.filter { !retainedTabIds.contains($0.id) }
+        let removedTabIds = Set(removedTabs.map(\.id))
         guard !removedTabIds.isEmpty else { return }
-        tabs.removeAll { removedTabIds.contains($0.id) }
+        for tab in removedTabs {
+            clearDocumentSynchronizationState(for: tab)
+        }
+        tabs = retainedTabs
         navigationBackStack.removeAll { removedTabIds.contains($0) }
         navigationForwardStack.removeAll { removedTabIds.contains($0) }
         if let activeTabId, removedTabIds.contains(activeTabId) {
+            if let activeTab = removedTabs.first(where: { $0.id == activeTabId }) {
+                if let sessionKey = documentSessionKey(for: activeTab) {
+                    if pendingDocumentCommand?.sessionKey == sessionKey {
+                        pendingDocumentCommand = nil
+                    }
+                    if documentReconciliationToolbarState?.sessionKey == sessionKey {
+                        documentReconciliationToolbarState = nil
+                    }
+                }
+            }
             self.activeTabId = nil
             selectedItemId = nil
         }
@@ -1361,13 +1598,12 @@ final class WorkspaceStore: ObservableObject {
 
     func item(for tab: WorkbenchTab) -> MemoryListItem? {
         if let resource = resources.first(where: { $0.id == tab.itemId }) {
-            let matchingDrafts = drafts.filter { draft in
-                draft.targetId == resource.id
-                    && draft.status != .discarded
-                    && draft.status != .merged
-                    && (tab.projectId.map { $0 == draft.projectId } ?? (draft.scope == .org))
-            }
-            let draft = Self.preferredMemoryTreeDrafts(matchingDrafts).first
+            guard tab.projectId != nil || resource.scope == .org else { return nil }
+            let draft = Self.memoryTabDraft(
+                itemId: resource.id,
+                projectId: tab.projectId,
+                drafts: drafts
+            )
             let tabProject = tab.projectId.flatMap { projectId in
                 projects.first { $0.id == projectId }
             }
@@ -1381,13 +1617,11 @@ final class WorkspaceStore: ObservableObject {
                 projectContextId: tab.projectId
             )
         }
-        let matchingDrafts = drafts.filter { draft in
-            (draft.id == tab.itemId || draft.targetId == tab.itemId)
-                && draft.status != .discarded
-                && draft.status != .merged
-                && (tab.projectId.map { $0 == draft.projectId } ?? (draft.scope == .org))
-        }
-        if let draft = Self.preferredMemoryTreeDrafts(matchingDrafts).first {
+        if let draft = Self.memoryTabDraft(
+            itemId: tab.itemId,
+            projectId: tab.projectId,
+            drafts: drafts
+        ) {
             let resource = draft.targetId.flatMap { target in resources.first { $0.id == target } }
             return .init(
                 id: resource?.id ?? draft.targetId ?? draft.id,
@@ -1408,7 +1642,7 @@ final class WorkspaceStore: ObservableObject {
            Self.resourceGenerationMatches(inFlight.resource, resource) {
             return
         }
-        if let snapshot = staleResourceSnapshots[resource.id] {
+        if let snapshot = staleResourceSnapshot(for: item) {
             guard let local = snapshot.local, local.contentLoaded else {
                 errorMessage = DocumentDiffError.baselineUnavailable.localizedDescription
                 return
@@ -1441,22 +1675,21 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func closeTab(_ tab: WorkbenchTab) {
-        guard !applyingDocumentReconciliationIds.contains(tab.itemId) else {
+        if let key = documentSessionKey(for: tab),
+           applyingDocumentReconciliationSessions.contains(key) {
             errorMessage = "Wait for the shared update to finish before closing this tab."
             return
         }
         guard let index = tabs.firstIndex(where: { $0.id == tab.id }) else { return }
-        if pendingDocumentCommand?.itemId == tab.itemId {
-            pendingDocumentCommand = nil
+        if let sessionKey = documentSessionKey(for: tab) {
+            if pendingDocumentCommand?.sessionKey == sessionKey {
+                pendingDocumentCommand = nil
+            }
+            if documentReconciliationToolbarState?.sessionKey == sessionKey {
+                documentReconciliationToolbarState = nil
+            }
         }
-        if documentReconciliationToolbarState?.itemId == tab.itemId {
-            documentReconciliationToolbarState = nil
-        }
-        documentSynchronizationTasks.removeValue(forKey: tab.itemId)?.cancel()
-        pendingDocumentReconciliationCandidates.removeValue(forKey: tab.itemId)
-        documentReconciliationResolutions.removeValue(forKey: tab.itemId)
-        synchronizingDocumentIds.remove(tab.itemId)
-        documentSynchronizationGenerations.removeValue(forKey: tab.itemId)
+        clearDocumentSynchronizationState(for: tab)
         let visibleIndex = visibleTabs.firstIndex(where: { $0.id == tab.id })
         tabs.remove(at: index)
         navigationBackStack.removeAll { $0 == tab.id }
@@ -1467,6 +1700,15 @@ final class WorkspaceStore: ObservableObject {
             activeTabId = replacementIndex >= 0 ? remaining[replacementIndex].id : nil
             selectedItemId = tabs.first { $0.id == activeTabId }?.itemId
         }
+    }
+
+    private func clearDocumentSynchronizationState(for tab: WorkbenchTab) {
+        guard let key = documentSessionKey(for: tab) else { return }
+        documentSynchronizationTasks.removeValue(forKey: key)?.cancel()
+        pendingDocumentReconciliationCandidatesBySession.removeValue(forKey: key)
+        documentReconciliationResolutions.removeValue(forKey: key)
+        synchronizingDocumentSessions.remove(key)
+        documentSynchronizationGenerations.removeValue(forKey: key)
     }
 
     func selectTab(_ tab: WorkbenchTab) {
@@ -1551,22 +1793,40 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func createMemory(kind: MemoryKind, scope: MemoryScope) async {
-        // Org-scope drafts are carried by a project in the daemon; when the
-        // user is browsing the Org view without an active project, fall back
-        // to the first project as the carrying project.
-        let projectId = activeProjectId ?? (scope == .org ? projects.first?.id : nil)
-        guard let projectId else { return }
-        guard canCreateMemory(kind: kind, scope: scope) else { return }
-        let path = uniqueDefaultPath(for: kind, scope: scope)
-        let document = defaultDocument(kind: kind, path: path)
+        guard scope == .org, canCreateMemory(kind: kind, scope: scope) else { return }
+        guard let projectId = activeProjectId else { return }
         do {
+            guard let authority = try await loadStableOrgAuthoritySnapshot(
+                allowingEmptyHead: true
+            ) else {
+                throw ServerClientError.invalidResponse(
+                    "A fresh Organization Memory snapshot is required to create a Draft."
+                )
+            }
+            guard Self.projectContextIsCurrent(
+                isSwitchingMemoryContext: isSwitchingMemoryContext,
+                activeProjectId: activeProjectId,
+                expectedProjectId: projectId
+            ) else { return }
             try await withDraftMutation {
+                guard Self.projectContextIsCurrent(
+                    isSwitchingMemoryContext: isSwitchingMemoryContext,
+                    activeProjectId: activeProjectId,
+                    expectedProjectId: projectId
+                ) else { return }
+                let path = uniqueDefaultPath(
+                    for: kind,
+                    scope: scope,
+                    authoritativeOrgResources: authority.resources,
+                    projectId: projectId
+                )
+                let document = Self.defaultDocument(kind: kind, path: path)
                 let response = try await daemon.store(
                     .init(
                         draftId: nil,
-                        baseCommitId: scope == .org ? orgRefCommitId : activeProject?.refCommitId,
+                        baseCommitId: authority.commitId,
                         projectId: projectId,
-                        scope: scope == .org ? .org : .project,
+                        scope: .org,
                         resource: kind.daemonKind,
                         op: .create(
                             path: path,
@@ -1576,7 +1836,17 @@ final class WorkspaceStore: ObservableObject {
                         source: .desktop
                     )
                 )
+                guard Self.projectContextIsCurrent(
+                    isSwitchingMemoryContext: isSwitchingMemoryContext,
+                    activeProjectId: activeProjectId,
+                    expectedProjectId: projectId
+                ) else { return }
                 try await refreshDraft(response.draftId)
+                guard Self.projectContextIsCurrent(
+                    isSwitchingMemoryContext: isSwitchingMemoryContext,
+                    activeProjectId: activeProjectId,
+                    expectedProjectId: projectId
+                ) else { return }
                 selectedItemId = response.draftId
             }
         } catch {
@@ -1597,43 +1867,57 @@ final class WorkspaceStore: ObservableObject {
             errorMessage = "Wait for the Memory context switch to finish before editing."
             return
         }
+        guard let key = documentSessionKey(for: item) else {
+            errorMessage = "Open this memory from a Project before editing it."
+            return
+        }
         let generation = UUID()
-        pendingDocumentSaves[item.id] = .init(item: item, document: document, generation: generation)
-        documentSaveTasks[item.id]?.cancel()
-        documentSaveTasks[item.id] = Task { [weak self] in
+        pendingDocumentSaves[key] = .init(item: item, document: document, generation: generation)
+        documentSaveTasks[key]?.cancel()
+        documentSaveTasks[key] = Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(600))
             guard !Task.isCancelled else { return }
-            await self?.persistDocumentSave(item.id, generation: generation)
+            await self?.persistDocumentSave(key, generation: generation)
         }
     }
 
-    func flushDocumentSave(_ itemId: String) async throws {
-        documentSaveTasks[itemId]?.cancel()
-        documentSaveTasks[itemId] = nil
-        guard let pending = pendingDocumentSaves[itemId] else { return }
+    func flushDocumentSave(_ item: MemoryListItem) async throws {
+        guard let key = documentSessionKey(for: item) else { return }
+        try await flushDocumentSave(key)
+    }
+
+    private func flushDocumentSave(_ key: MemoryDocumentSessionKey) async throws {
+        documentSaveTasks[key]?.cancel()
+        documentSaveTasks[key] = nil
+        guard let pending = pendingDocumentSaves[key] else { return }
         try await save(
             pending.item,
             document: pending.document,
             allowingDuringSynchronization: true,
-            pendingSaveItemId: itemId,
+            pendingSaveKey: key,
             pendingSaveGeneration: pending.generation
         )
     }
 
-    func cancelDocumentSave(_ itemId: String) {
-        documentSaveTasks[itemId]?.cancel()
-        documentSaveTasks[itemId] = nil
-        pendingDocumentSaves[itemId] = nil
+    func cancelDocumentSave(_ item: MemoryListItem) {
+        guard let key = documentSessionKey(for: item) else { return }
+        cancelDocumentSave(key)
+    }
+
+    private func cancelDocumentSave(_ key: MemoryDocumentSessionKey) {
+        documentSaveTasks[key]?.cancel()
+        documentSaveTasks[key] = nil
+        pendingDocumentSaves[key] = nil
     }
 
     private func finishPendingDocumentSaveIfCurrent(
-        itemId: String?,
+        key: MemoryDocumentSessionKey?,
         generation: UUID?
     ) {
-        guard let itemId, let generation,
-              pendingDocumentSaves[itemId]?.generation == generation else { return }
-        pendingDocumentSaves[itemId] = nil
-        documentSaveTasks[itemId] = nil
+        guard let key, let generation,
+              pendingDocumentSaves[key]?.generation == generation else { return }
+        pendingDocumentSaves[key] = nil
+        documentSaveTasks[key] = nil
     }
 
     func stageBundleSave(
@@ -1694,8 +1978,8 @@ final class WorkspaceStore: ObservableObject {
 
     private func flushPendingDocumentChanges() async -> Bool {
         do {
-            for itemId in Array(pendingDocumentSaves.keys) {
-                try await flushDocumentSave(itemId)
+            for key in Array(pendingDocumentSaves.keys) {
+                try await flushDocumentSave(key)
             }
             return true
         } catch {
@@ -1708,15 +1992,15 @@ final class WorkspaceStore: ObservableObject {
         _ item: MemoryListItem,
         document: EditableMemoryDocument,
         allowingDuringSynchronization: Bool = false,
-        pendingSaveItemId: String? = nil,
+        pendingSaveKey: MemoryDocumentSessionKey? = nil,
         pendingSaveGeneration: UUID? = nil
     ) async throws {
-        let flushesSelectionMutation = pendingSaveItemId != nil
+        let flushesSelectionMutation = pendingSaveKey != nil
             && item.projectContextId.map(projectOrgSelectionMutatingIds.contains) == true
         guard canEditMemory(item) || flushesSelectionMutation else {
             throw ServerClientError.forbidden("You do not have permission to edit this memory.")
         }
-        if isSwitchingMemoryContext, pendingSaveItemId == nil {
+        if isSwitchingMemoryContext, pendingSaveKey == nil {
             throw ServerClientError.forbidden(
                 "Wait for the Memory context switch to finish before editing."
             )
@@ -1727,8 +2011,8 @@ final class WorkspaceStore: ObservableObject {
         }
         try validate(kind: item.kind, document: document)
         try await withDraftMutation {
-            if let pendingSaveItemId, let pendingSaveGeneration {
-                guard pendingDocumentSaves[pendingSaveItemId]?.generation
+            if let pendingSaveKey, let pendingSaveGeneration {
+                guard pendingDocumentSaves[pendingSaveKey]?.generation
                     == pendingSaveGeneration else { return }
             }
             if !allowingDuringSynchronization,
@@ -1742,14 +2026,14 @@ final class WorkspaceStore: ObservableObject {
             }
             if item.draft != nil, draft == nil {
                 finishPendingDocumentSaveIfCurrent(
-                    itemId: pendingSaveItemId,
+                    key: pendingSaveKey,
                     generation: pendingSaveGeneration
                 )
                 return
             }
             if draft?.isDeletion == true {
                 finishPendingDocumentSaveIfCurrent(
-                    itemId: pendingSaveItemId,
+                    key: pendingSaveKey,
                     generation: pendingSaveGeneration
                 )
                 return
@@ -1803,10 +2087,12 @@ final class WorkspaceStore: ObservableObject {
             )
             if let response {
                 try await refreshDraft(response.draftId)
-                selectedItemId = resource?.id ?? response.draftId
+                if activeProjectId == projectId {
+                    selectedItemId = resource?.id ?? response.draftId
+                }
             }
             finishPendingDocumentSaveIfCurrent(
-                itemId: pendingSaveItemId,
+                key: pendingSaveKey,
                 generation: pendingSaveGeneration
             )
         }
@@ -1825,6 +2111,11 @@ final class WorkspaceStore: ObservableObject {
         guard canEditMemory(item) else {
             throw ServerClientError.forbidden("You do not have permission to rename this memory.")
         }
+        guard let sessionKey = documentSessionKey(for: item) else {
+            throw ServerClientError.forbidden(
+                "Open this memory from a Project before renaming it."
+            )
+        }
         guard synchronizationItemId(for: item) == nil else {
             throw DocumentSyncError.mutationWhileSynchronizing
         }
@@ -1833,9 +2124,8 @@ final class WorkspaceStore: ObservableObject {
         // Preserve a dirty editor before changing the path. The draft gate in
         // save prevents an already-running debounce and this explicit flush
         // from persisting the same generation twice.
-        let initialSaveIds = Set([item.id, item.draft?.id, item.draft?.targetId].compactMap { $0 })
-        for saveId in initialSaveIds where pendingDocumentSaves[saveId] != nil {
-            try await flushDocumentSave(saveId)
+        if pendingDocumentSaves[sessionKey] != nil {
+            try await flushDocumentSave(sessionKey)
         }
 
         try await withDraftMutation {
@@ -1877,26 +2167,28 @@ final class WorkspaceStore: ObservableObject {
             // flight. Any save staged in that window still carries the old
             // path; retarget it so its later body update cannot rename the
             // document back.
-            let saveIds = Set([item.id, response.draftId, plan.targetId])
-            retargetPendingDocumentSaves(saveIds, to: newPath)
+            retargetPendingDocumentSave(sessionKey, to: newPath)
             try await refreshDraft(response.draftId)
-            retargetPendingDocumentSaves(saveIds, to: newPath)
-            selectedItemId = resource?.id ?? plan.targetId
+            retargetPendingDocumentSave(sessionKey, to: newPath)
+            if activeProjectId == sessionKey.projectId {
+                selectedItemId = resource?.id ?? plan.targetId
+            }
         }
     }
 
-    private func retargetPendingDocumentSaves(_ itemIds: Set<String>, to newPath: String) {
-        for itemId in itemIds {
-            guard let pending = pendingDocumentSaves[itemId] else { continue }
-            pendingDocumentSaves[itemId] = .init(
-                item: pending.item,
-                document: Self.documentByRetargetingPendingSave(
-                    pending.document,
-                    to: newPath
-                ),
-                generation: pending.generation
-            )
-        }
+    private func retargetPendingDocumentSave(
+        _ key: MemoryDocumentSessionKey,
+        to newPath: String
+    ) {
+        guard let pending = pendingDocumentSaves[key] else { return }
+        pendingDocumentSaves[key] = .init(
+            item: pending.item,
+            document: Self.documentByRetargetingPendingSave(
+                pending.document,
+                to: newPath
+            ),
+            generation: pending.generation
+        )
     }
 
     static func documentRenamePlan(
@@ -1931,9 +2223,7 @@ final class WorkspaceStore: ObservableObject {
             errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
             return
         }
-        for itemId in Set([item.id, item.draft?.id, item.draft?.targetId].compactMap { $0 }) {
-            cancelDocumentSave(itemId)
-        }
+        cancelDocumentSave(item)
         guard let projectId = draftCarrierProjectId(for: item, currentDraft: item.draft),
               let targetId = item.resource?.id ?? item.draft?.targetId else { return }
         do {
@@ -1965,9 +2255,9 @@ final class WorkspaceStore: ObservableObject {
             errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
             return
         }
-        for itemId in Set([draft.id, draft.targetId].compactMap { $0 }) {
-            cancelDocumentSave(itemId)
-        }
+        cancelDocumentSave(
+            .init(projectId: draft.projectId, itemId: draft.targetId ?? draft.id)
+        )
         do {
             try await withDraftMutation {
                 guard synchronizationItemId(for: draft) == nil else {
@@ -2004,6 +2294,8 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func refreshSyncStatus() async {
+        guard phase == .ready else { return }
+        await refreshOrgResourcesIfNeeded()
         guard phase == .ready, let runtime else { return }
         do {
             let sync = try await daemon.syncStatus()
@@ -2021,6 +2313,188 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    nonisolated static func stableOrgAuthorityCommitId(
+        beforeCommitId: String?,
+        afterCommitId: String?,
+        responseIsStale: Bool
+    ) -> String? {
+        guard !responseIsStale,
+              let beforeCommitId,
+              afterCommitId == beforeCommitId else {
+            return nil
+        }
+        return beforeCommitId
+    }
+
+    private func loadStableOrgAuthoritySnapshot(
+        allowingEmptyHead: Bool = false
+    ) async throws
+        -> (commitId: String?, refEtag: String?, resources: [MemoryResource])? {
+        let before: (value: CommitStateResponse, response: DaemonServerResponse) =
+            try await server.getWithMetadata("/api/v1/org/commit-state")
+
+        var metadata: [MemoryMetadata] = []
+        var cursor: String?
+        var listingIsStale = false
+        repeat {
+            var query = [URLQueryItem(name: "limit", value: "200")]
+            if let cursor { query.append(.init(name: "cursor", value: cursor)) }
+            let page: (value: ListResponse<MemoryMetadata>, response: DaemonServerResponse) =
+                try await server.getWithMetadata("/api/v1/org/memories", query: query)
+            listingIsStale = listingIsStale || page.response.isStaleCache
+            metadata += page.value.items
+            cursor = page.value.pageInfo.hasMore ? page.value.pageInfo.nextCursor : nil
+        } while cursor != nil
+
+        let after: (value: CommitStateResponse, response: DaemonServerResponse) =
+            try await server.getWithMetadata("/api/v1/org/commit-state")
+        let responseIsStale = before.response.isStaleCache
+            || listingIsStale
+            || after.response.isStaleCache
+        let commitId = before.value.ref.commitId
+        guard !responseIsStale,
+              after.value.ref.commitId == commitId,
+              allowingEmptyHead || commitId != nil else {
+            return nil
+        }
+        let refEtag = after.response.headers.first {
+            $0.key.caseInsensitiveCompare("etag") == .orderedSame
+        }?.value ?? before.response.headers.first {
+            $0.key.caseInsensitiveCompare("etag") == .orderedSame
+        }?.value
+        return (
+            commitId,
+            refEtag,
+            metadata.map { item in
+                MemoryResource(
+                    id: item.memoryId,
+                    scope: .org,
+                    projectId: nil,
+                    projectName: nil,
+                    kind: .init(.memory),
+                    contentHash: item.contentHash,
+                    updatedAt: item.updatedAt,
+                    refCommitId: commitId,
+                    contentLoaded: false,
+                    document: .init(title: item.name, path: item.path, body: "")
+                )
+            }
+        )
+    }
+
+    nonisolated static func reconciledOrgResources(
+        existing: [MemoryResource],
+        authoritative: [MemoryResource]
+    ) -> [MemoryResource] {
+        let existingById = Dictionary(
+            existing.lazy.filter { $0.scope == .org }.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        return authoritative.filter { $0.scope == .org }.map { authority in
+            guard let current = existingById[authority.id],
+                  current.kind == authority.kind,
+                  current.document.path == authority.document.path,
+                  current.contentHash == authority.contentHash,
+                  current.contentLoaded,
+                  Self.contentHash(current.document.body) == current.contentHash else {
+                return authority
+            }
+            var preserved = authority
+            preserved.contentLoaded = true
+            preserved.document.body = current.document.body
+            return preserved
+        }
+    }
+
+    private func refreshOrgResourcesIfNeeded() async {
+        guard selectedSection == .memory,
+              activeProjectId == nil,
+              !isSwitchingMemoryContext,
+              orgResourceRefreshGeneration == nil else {
+            return
+        }
+        let observedOrgRefCommitId = orgRefCommitId
+        let generation = UUID()
+        orgResourceRefreshGeneration = generation
+        defer {
+            if orgResourceRefreshGeneration == generation {
+                orgResourceRefreshGeneration = nil
+            }
+        }
+        do {
+            let head: (value: CommitStateResponse, response: DaemonServerResponse) =
+                try await server.getWithMetadata("/api/v1/org/commit-state")
+            guard !head.response.isStaleCache,
+                  head.value.ref.commitId != observedOrgRefCommitId else {
+                return
+            }
+            guard let snapshot = try await loadStableOrgAuthoritySnapshot(),
+                  let snapshotCommitId = snapshot.commitId,
+                  snapshotCommitId == head.value.ref.commitId,
+                  phase == .ready,
+                  selectedSection == .memory,
+                  activeProjectId == nil,
+                  !isSwitchingMemoryContext,
+                  orgResourceRefreshGeneration == generation,
+                  orgRefCommitId == observedOrgRefCommitId else {
+                return
+            }
+
+            // Any inactive Project plan containing an Org row was derived
+            // from an older global authority generation. Drop the whole plan
+            // before installing the new Org snapshot so returning to that
+            // Project can never apply an old checkout and advance its ref.
+            let projectsWithOrgStalePlans = Set(staleResourceSnapshots.values.compactMap {
+                snapshot in
+                snapshot.local?.scope == .org || snapshot.remote?.scope == .org
+                    ? snapshot.projectId
+                    : nil
+            })
+            for projectId in projectsWithOrgStalePlans {
+                clearStaleResourceState(for: projectId)
+            }
+            let previousOrgResources = resources.filter { $0.scope == .org }
+            let nextOrgResources = Self.reconciledOrgResources(
+                existing: previousOrgResources,
+                authoritative: snapshot.resources
+            )
+            let previousById = Dictionary(
+                previousOrgResources.map { ($0.id, $0) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            let nextById = Dictionary(
+                nextOrgResources.map { ($0.id, $0) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+
+            // Publish the complete authority generation in one assignment so
+            // the tree cannot observe a mixed old/new Org catalog.
+            resources = resources.filter { $0.scope != .org } + nextOrgResources
+            orgRefCommitId = snapshotCommitId
+            orgRefEtag = snapshot.refEtag ?? ""
+            for resourceId in Set(previousById.keys).union(nextById.keys) {
+                let previous = previousById[resourceId]
+                let next = nextById[resourceId]
+                if previous?.kind != next?.kind
+                    || previous?.contentHash != next?.contentHash
+                    || previous?.contentLoaded != next?.contentLoaded
+                    || previous?.document != next?.document {
+                    bumpDocumentContentGeneration(for: resourceId)
+                }
+            }
+            if let selectedItemId,
+               previousById[selectedItemId] != nil,
+               nextById[selectedItemId] == nil {
+                self.selectedItemId = nil
+            }
+            pruneOrphanedMemoryTabs()
+            refreshAllDocumentTabs()
+        } catch {
+            // Retain the installed Org generation. A later poll retries from
+            // a fresh commit-state response.
+        }
+    }
+
     nonisolated static func staleResourcePlan(
         displayedResources: [MemoryResource],
         projectName: String,
@@ -2032,6 +2506,9 @@ final class WorkspaceStore: ObservableObject {
         checkout: DaemonProjectCheckout,
         authoritativeRefEtag: String? = nil,
         authoritativeResponseIsStale: Bool = false,
+        authoritativeOrgResources: [MemoryResource]? = nil,
+        authoritativeOrgRefCommitId: String? = nil,
+        authoritativeOrgResponseIsStale: Bool = false,
         provisionalResourceIds: Set<String> = [],
         generation: UUID = UUID()
     ) -> [String: StaleResourceSyncSnapshot]? {
@@ -2053,31 +2530,89 @@ final class WorkspaceStore: ObservableObject {
                 && $0.projectId == projectId
                 && !provisionalResourceIds.contains($0.id)
         }
-        // A Project checkout may include a pinned selection of Org memories,
-        // but that is not proof of the current Org head. Applying those rows
-        // to the global Org resource collection could roll it backward.
-        let checkoutResources = checkout.resources.filter { $0.scope == .project }
-        let localById = Dictionary(
-            localProjectResources.map { ($0.id, $0) },
+        let selectedOrgResourceIds = Set(checkout.selectedOrgResourceIds)
+        let checkoutOrgResources = checkout.resources.filter { $0.scope == .org }
+        let checkoutOrgResourceIds = Set(checkoutOrgResources.map(\.resourceId))
+        guard checkoutOrgResourceIds == selectedOrgResourceIds else { return nil }
+
+        // A Project checkout proves which Org blobs were materialized for that
+        // Project, but absence from the checkout can mean either an Org delete
+        // or a harmless Project deselection. Only a fresh, stable Org listing
+        // can distinguish those cases and prove the checkout body still points
+        // forward to the current Org authority.
+        let orgIdsRequiringAuthority = observedSelectedOrgResourceIds
+            .union(selectedOrgResourceIds)
+        let authoritativeOrgById: [String: MemoryResource]
+        if orgIdsRequiringAuthority.isEmpty {
+            authoritativeOrgById = [:]
+        } else {
+            guard !authoritativeOrgResponseIsStale,
+                  let authoritativeOrgResources,
+                  let authoritativeOrgRefCommitId else {
+                return nil
+            }
+            authoritativeOrgById = Dictionary(
+                authoritativeOrgResources.compactMap { resource in
+                    guard resource.scope == .org,
+                          resource.projectId == nil,
+                          resource.refCommitId == authoritativeOrgRefCommitId else {
+                        return nil
+                    }
+                    return (resource.id, resource)
+                },
+                uniquingKeysWith: { _, latest in latest }
+            )
+        }
+
+        let checkoutOrgById = Dictionary(
+            checkoutOrgResources.map { ($0.resourceId, $0) },
             uniquingKeysWith: { _, latest in latest }
         )
-        let remoteById = Dictionary(
+        for resourceId in selectedOrgResourceIds {
+            guard let checkoutResource = checkoutOrgById[resourceId],
+                  let authority = authoritativeOrgById[resourceId],
+                  authority.kind == .init(checkoutResource.resourceKind),
+                  authority.document.path == checkoutResource.path,
+                  authority.contentHash == checkoutResource.contentHash,
+                  Self.contentHash(checkoutResource.content.content)
+                    == checkoutResource.contentHash else {
+                return nil
+            }
+        }
+
+        // A resource removed from Project selection remains Org authority and
+        // must stay in the global collection. It becomes a deletion candidate
+        // only when the authoritative Org listing also says it is gone.
+        let deletedSelectedOrgResourceIds = observedSelectedOrgResourceIds
+            .subtracting(selectedOrgResourceIds)
+            .filter { authoritativeOrgById[$0] == nil }
+        let relevantOrgResourceIds = selectedOrgResourceIds
+            .union(deletedSelectedOrgResourceIds)
+        let localOrgResources = displayedResources.filter {
+            $0.scope == .org
+                && relevantOrgResourceIds.contains($0.id)
+                && !provisionalResourceIds.contains($0.id)
+        }
+        let localResources = localProjectResources + localOrgResources
+        let checkoutResources = checkout.resources.filter { $0.scope == .project }
+        let localById = Dictionary(
+            localResources.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        var remoteById = Dictionary(
             checkoutResources.map { resource -> (String, MemoryResource) in
-                let scope: MemoryScope = resource.scope == .org ? .org : .project
                 let local = localById[resource.resourceId]
                 return (
                     resource.resourceId,
                     MemoryResource(
                         id: resource.resourceId,
-                        scope: scope,
-                        projectId: scope == .project ? projectId : nil,
-                        projectName: scope == .project ? projectName : nil,
+                        scope: .project,
+                        projectId: projectId,
+                        projectName: projectName,
                         kind: .init(resource.resourceKind),
                         contentHash: resource.contentHash,
                         updatedAt: checkout.commitCreatedAt ?? local?.updatedAt ?? "",
-                        refCommitId: scope == .project
-                            ? authoritativeCommitId
-                            : local?.refCommitId,
+                        refCommitId: authoritativeCommitId,
                         contentLoaded: true,
                         document: .init(
                             title: URL(fileURLWithPath: resource.path)
@@ -2090,9 +2625,32 @@ final class WorkspaceStore: ObservableObject {
             },
             uniquingKeysWith: { _, latest in latest }
         )
+        for resourceId in selectedOrgResourceIds {
+            guard let checkoutResource = checkoutOrgById[resourceId],
+                  let authority = authoritativeOrgById[resourceId] else {
+                return nil
+            }
+            remoteById[resourceId] = MemoryResource(
+                id: resourceId,
+                scope: .org,
+                projectId: nil,
+                projectName: nil,
+                kind: authority.kind,
+                contentHash: authority.contentHash,
+                updatedAt: authority.updatedAt,
+                refCommitId: authority.refCommitId,
+                contentLoaded: true,
+                document: .init(
+                    title: authority.document.title,
+                    path: authority.document.path,
+                    body: checkoutResource.content.content
+                )
+            )
+        }
         let projectRemoteIds = Set(checkoutResources.map(\.resourceId))
-        let ids = Set(localProjectResources.map(\.id))
+        let ids = Set(localResources.map(\.id))
             .union(projectRemoteIds)
+            .union(selectedOrgResourceIds)
         var result: [String: StaleResourceSyncSnapshot] = [:]
         for id in ids {
             let local = localById[id]
@@ -2101,7 +2659,10 @@ final class WorkspaceStore: ObservableObject {
                local.scope == remote.scope,
                local.kind == remote.kind,
                local.document.path == remote.document.path,
-               local.contentHash == remote.contentHash {
+               local.contentHash == remote.contentHash,
+               (local.scope == .project
+                    || !local.contentLoaded
+                    || Self.contentHash(local.document.body) == local.contentHash) {
                 continue
             }
             result[id] = .init(
@@ -2200,7 +2761,32 @@ final class WorkspaceStore: ObservableObject {
             let checkout = try await daemon.projectCheckout(projectId)
             guard activeProjectId == projectId,
                   projects.first(where: { $0.id == projectId }) == project,
+                  staleResourceRefreshGenerations[projectId] == refreshGeneration else {
+                return
+            }
+            let needsOrgAuthority = !project.selectedOrgResourceIds.isEmpty
+                || !checkout.selectedOrgResourceIds.isEmpty
+            let orgAuthority: (
+                commitId: String,
+                refEtag: String?,
+                resources: [MemoryResource]
+            )?
+            if needsOrgAuthority {
+                guard let snapshot = try await loadStableOrgAuthoritySnapshot(),
+                      let commitId = snapshot.commitId else { return }
+                orgAuthority = (commitId, snapshot.refEtag, snapshot.resources)
+            } else {
+                orgAuthority = nil
+            }
+            let verifiedCommit: (value: CommitStateResponse, response: DaemonServerResponse) =
+                try await server.getWithMetadata(
+                    "/api/v1/projects/\(projectId)/commit-state"
+                )
+            guard activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == project,
                   staleResourceRefreshGenerations[projectId] == refreshGeneration,
+                  !verifiedCommit.response.isStaleCache,
+                  verifiedCommit.value.ref.commitId == authoritativeCommitId,
                   let plan = Self.staleResourcePlan(
                     displayedResources: resources,
                     projectName: project.name,
@@ -2212,6 +2798,8 @@ final class WorkspaceStore: ObservableObject {
                     checkout: checkout,
                     authoritativeRefEtag: authoritativeRefEtag,
                     authoritativeResponseIsStale: commit.response.isStaleCache,
+                    authoritativeOrgResources: orgAuthority?.resources,
+                    authoritativeOrgRefCommitId: orgAuthority?.commitId,
                     // Remote-only additions are inserted provisionally so the
                     // file tree can expose their Sync action. They are not
                     // part of the observed local generation and must not make
@@ -2253,33 +2841,40 @@ final class WorkspaceStore: ObservableObject {
     /// - a behind draft opens the shared-change review flow;
     /// - a stale resource (no local draft) is refreshed from the synced checkout.
     func syncDocument(_ item: MemoryListItem) {
-        if let projectId = item.projectId,
-           projectOrgSelectionMutatingIds.contains(projectId) {
+        guard Self.canStartDocumentSynchronization(
+            isSwitchingMemoryContext: isSwitchingMemoryContext,
+            activeProjectId: activeProjectId,
+            itemProjectContextId: item.projectContextId
+        ), let key = documentSessionKey(for: item) else {
+            errorMessage = "Wait for the Memory context switch to finish before syncing this document."
+            return
+        }
+        if projectOrgSelectionMutatingIds.contains(key.projectId) {
             errorMessage = "Wait for the Project memory selection to finish updating before syncing this document."
             return
         }
         let behindDraft = item.draft.flatMap { $0.freshness == .behind ? $0 : nil }
-        let hasStaleResource = item.resource.map {
-            staleResourceSnapshots[$0.id] != nil
+        let hasStaleResource = item.resource.map { resource in
+            staleResourceSnapshots[resource.id]?.projectId == key.projectId
         } ?? false
         guard behindDraft != nil || hasStaleResource,
-              synchronizingDocumentIds.insert(item.id).inserted else { return }
+              synchronizingDocumentSessions.insert(key).inserted else { return }
 
         let generation = UUID()
-        documentSynchronizationGenerations[item.id] = generation
+        documentSynchronizationGenerations[key] = generation
         if behindDraft != nil {
             openDocumentForSync(item)
         }
-        documentSynchronizationTasks[item.id] = Task { @MainActor [weak self] in
+        documentSynchronizationTasks[key] = Task { @MainActor [weak self] in
             guard let self else { return }
             if let behindDraft {
                 await prepareBehindDraftSync(
-                    itemId: item.id,
+                    key: key,
                     draft: behindDraft,
                     generation: generation
                 )
             } else {
-                await syncStaleResource(item, generation: generation)
+                await syncStaleResource(item, key: key, generation: generation)
             }
         }
     }
@@ -2297,37 +2892,42 @@ final class WorkspaceStore: ObservableObject {
         open(item, mode: existingMode ?? .source)
     }
 
-    private func syncStaleResource(_ item: MemoryListItem, generation: UUID) async {
+    private func syncStaleResource(
+        _ item: MemoryListItem,
+        key: MemoryDocumentSessionKey,
+        generation: UUID
+    ) async {
         guard let resourceId = item.resource?.id else { return }
-        guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
+        guard isCurrentDocumentSynchronization(key, generation: generation) else { return }
         do {
             // A debounce save may not have materialized its draft yet. Flush
             // before applying a remote deletion/update so that local text can
             // enter reconciliation instead of becoming an invisible orphan.
-            try await flushDocumentSave(resourceId)
-            guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
+            try await flushDocumentSave(key)
+            guard isCurrentDocumentSynchronization(key, generation: generation) else { return }
             if let draft = currentDraft(for: item) {
                 openDocumentForSync(item)
                 await prepareBehindDraftSync(
-                    itemId: item.id,
+                    key: key,
                     draft: draft,
                     generation: generation
                 )
                 return
             }
         } catch is CancellationError {
-            endDocumentSynchronization(item.id, generation: generation)
+            endDocumentSynchronization(key, generation: generation)
             return
         } catch {
-            guard isCurrentDocumentSynchronization(item.id, generation: generation) else { return }
-            endDocumentSynchronization(item.id, generation: generation)
+            guard isCurrentDocumentSynchronization(key, generation: generation) else { return }
+            endDocumentSynchronization(key, generation: generation)
             errorMessage = error.localizedDescription
             return
         }
 
         // A repeated click after the first task completed is already satisfied.
-        guard let snapshot = staleResourceSnapshots[resourceId] else {
-            endDocumentSynchronization(item.id, generation: generation)
+        guard let snapshot = staleResourceSnapshots[resourceId],
+              snapshot.projectId == key.projectId else {
+            endDocumentSynchronization(key, generation: generation)
             return
         }
         guard projects.first(where: { $0.id == snapshot.projectId })?.refCommitId
@@ -2336,7 +2936,7 @@ final class WorkspaceStore: ObservableObject {
             == snapshot.observedSelectedOrgResourceIds,
               projects.first(where: { $0.id == snapshot.projectId })?.orgSelectionRevision
             == snapshot.observedOrgSelectionRevision else {
-            endDocumentSynchronization(item.id, generation: generation)
+            endDocumentSynchronization(key, generation: generation)
             errorMessage = DocumentSyncError.checkoutNoLongerCurrent.localizedDescription
             return
         }
@@ -2353,12 +2953,14 @@ final class WorkspaceStore: ObservableObject {
             staleResourceRefreshGenerations[snapshot.projectId] = UUID()
             resources.removeAll { $0.id == resourceId }
             provisionalStaleAdditionIds.remove(resourceId)
-            if let tab = tabs.first(where: { $0.itemId == resourceId }) {
+            if let tab = tabs.first(where: {
+                $0.itemId == resourceId && $0.projectId == key.projectId
+            }) {
                 closeTab(tab)
             }
         }
         staleResourceSnapshots.removeValue(forKey: resourceId)
-        staleResourceIds = Set(staleResourceSnapshots.keys)
+        refreshVisibleStaleResourceIds()
         bumpDocumentContentGeneration(for: resourceId)
         advanceProjectRefIfPlanCompleted(
             projectId: snapshot.projectId,
@@ -2367,7 +2969,7 @@ final class WorkspaceStore: ObservableObject {
             selectedOrgResourceIds: snapshot.selectedOrgResourceIds,
             orgSelectionRevision: snapshot.orgSelectionRevision
         )
-        endDocumentSynchronization(item.id, generation: generation)
+        endDocumentSynchronization(key, generation: generation)
     }
 
     /// Builds the three-way unified diff presentation for one document:
@@ -2409,8 +3011,8 @@ final class WorkspaceStore: ObservableObject {
                 pathChanges: documentPathChanges(for: item)
             )
         }
-        if let resource = item.resource,
-           let snapshot = staleResourceSnapshots[resource.id] {
+        if item.resource != nil,
+           let snapshot = staleResourceSnapshot(for: item) {
             let texts = try Self.staleDocumentDiffTexts(snapshot)
             return .init(
                 presentation: UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
@@ -2542,7 +3144,7 @@ final class WorkspaceStore: ObservableObject {
                 provisionalStaleAdditionIds.insert(resourceId)
             }
         }
-        staleResourceIds = Set(staleResourceSnapshots.keys)
+        refreshVisibleStaleResourceIds()
     }
 
     private func clearStaleResourceState(for projectId: String) {
@@ -2561,7 +3163,7 @@ final class WorkspaceStore: ObservableObject {
         staleResourceSnapshots = staleResourceSnapshots.filter { _, snapshot in
             snapshot.projectId != projectId
         }
-        staleResourceIds = Set(staleResourceSnapshots.keys)
+        refreshVisibleStaleResourceIds()
     }
 
     private func clearAllStaleResourceState() {
@@ -2572,6 +3174,16 @@ final class WorkspaceStore: ObservableObject {
         staleResourceSnapshots.removeAll()
         staleResourceIds.removeAll()
         staleResourceRefreshGenerations.removeAll()
+    }
+
+    private func refreshVisibleStaleResourceIds() {
+        guard let activeProjectId else {
+            staleResourceIds.removeAll()
+            return
+        }
+        staleResourceIds = Set(staleResourceSnapshots.compactMap { resourceId, snapshot in
+            snapshot.projectId == activeProjectId ? resourceId : nil
+        })
     }
 
     private func advanceProjectRefIfPlanCompleted(
@@ -2641,19 +3253,19 @@ final class WorkspaceStore: ObservableObject {
     }
 
     private func prepareBehindDraftSync(
-        itemId: String,
+        key: MemoryDocumentSessionKey,
         draft: LocalDraft,
         generation: UUID
     ) async {
-        guard isCurrentDocumentSynchronization(itemId, generation: generation) else { return }
+        guard isCurrentDocumentSynchronization(key, generation: generation) else { return }
         do {
             // Keep the editor locked across the single upload barrier and the
             // candidate POST so a late keystroke cannot be omitted.
             let synchronized = try await synchronizedDraftForReconciliation(
-                itemId: itemId,
+                itemId: key.itemId,
                 draft: draft
             )
-            guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+            guard isCurrentDocumentSynchronization(key, generation: generation) else {
                 return
             }
             installSynchronizedDraft(synchronized)
@@ -2664,23 +3276,26 @@ final class WorkspaceStore: ObservableObject {
                 if let resourceId = synchronized.targetId {
                     adoptCurrentStaleResource(resourceId)
                 }
-                endDocumentSynchronization(itemId, generation: generation)
+                endDocumentSynchronization(key, generation: generation)
                 return
             }
             let candidate = try await requestReconciliationCandidate(for: synchronized)
-            guard isCurrentDocumentSynchronization(itemId, generation: generation),
-                  tabs.contains(where: { $0.itemId == itemId }) else {
-                endDocumentSynchronization(itemId, generation: generation)
+            guard isCurrentDocumentSynchronization(key, generation: generation),
+                  tabs.contains(where: {
+                      $0.itemId == key.itemId && $0.projectId == key.projectId
+                  }) else {
+                endDocumentSynchronization(key, generation: generation)
                 return
             }
-            pendingDocumentReconciliationCandidates[itemId] = candidate
-                documentReconciliationResolutions[itemId] = candidate.proposedState ?? candidate.draftState
+            pendingDocumentReconciliationCandidatesBySession[key] = candidate
+            documentReconciliationResolutions[key] = candidate.proposedState
+                ?? candidate.draftState
         } catch is CancellationError {
-            endDocumentSynchronization(itemId, generation: generation)
+            endDocumentSynchronization(key, generation: generation)
             return
         } catch {
-            guard isCurrentDocumentSynchronization(itemId, generation: generation) else { return }
-            endDocumentSynchronization(itemId, generation: generation)
+            guard isCurrentDocumentSynchronization(key, generation: generation) else { return }
+            endDocumentSynchronization(key, generation: generation)
             errorMessage = error.localizedDescription
         }
     }
@@ -2689,7 +3304,7 @@ final class WorkspaceStore: ObservableObject {
         guard let snapshot = staleResourceSnapshots.removeValue(forKey: resourceId) else { return }
         staleResourceRefreshGenerations[snapshot.projectId] = UUID()
         provisionalStaleAdditionIds.remove(resourceId)
-        staleResourceIds = Set(staleResourceSnapshots.keys)
+        refreshVisibleStaleResourceIds()
         advanceProjectRefIfPlanCompleted(
             projectId: snapshot.projectId,
             authoritativeCommitId: snapshot.authoritativeCommitId,
@@ -2703,9 +3318,12 @@ final class WorkspaceStore: ObservableObject {
         itemId: String,
         draft: LocalDraft
     ) async throws -> LocalDraft {
-        let saveIds = Set([itemId, draft.id, draft.targetId].compactMap { $0 })
-        for saveId in saveIds where pendingDocumentSaves[saveId] != nil {
-            try await flushDocumentSave(saveId)
+        let sessionKey = MemoryDocumentSessionKey(
+            projectId: draft.projectId,
+            itemId: itemId
+        )
+        if pendingDocumentSaves[sessionKey] != nil {
+            try await flushDocumentSave(sessionKey)
         }
 
         let clock = ContinuousClock()
@@ -2735,11 +3353,8 @@ final class WorkspaceStore: ObservableObject {
                 // A user edit may have been staged while the daemon was
                 // uploading. Flush it and repeat the barrier before creating
                 // a candidate with an authoritative serverVersion.
-                let newlyPending = saveIds.filter { pendingDocumentSaves[$0] != nil }
-                if !newlyPending.isEmpty {
-                    for saveId in newlyPending {
-                        try await flushDocumentSave(saveId)
-                    }
+                if pendingDocumentSaves[sessionKey] != nil {
+                    try await flushDocumentSave(sessionKey)
                     requestedRetry = false
                     continue
                 }
@@ -2813,19 +3428,25 @@ final class WorkspaceStore: ObservableObject {
             // tree row disappear. Materialize every dirty editor in that
             // Project first so a failed save remains visible and recoverable
             // as a LocalDraft instead of being stranded in a debounce buffer.
-            let pendingSaveIds = pendingDocumentSaves.compactMap { itemId, pending in
+            let pendingSaveKeys = pendingDocumentSaves.compactMap { key, pending in
                 let pendingIds = Set(
                     [pending.item.id, pending.item.draft?.id, pending.item.draft?.targetId]
                         .compactMap { $0 }
                 )
-                let belongsToProject = pending.item.projectContextId == projectId
-                    || (pending.item.scope == .project && pending.item.projectId == projectId)
-                return belongsToProject && !pendingIds.isDisjoint(with: resourceIds)
-                    ? itemId
+                return key.projectId == projectId && !pendingIds.isDisjoint(with: resourceIds)
+                    ? key
                     : nil
             }
-            for itemId in pendingSaveIds {
-                try await flushDocumentSave(itemId)
+            for key in pendingSaveKeys {
+                try await flushDocumentSave(key)
+            }
+            if case .remove = mutation,
+               Self.hasActiveDraft(
+                   in: projectId,
+                   targetingAny: resourceIds,
+                   drafts: drafts
+               ) {
+                throw ProjectMemorySelectionError.activeDrafts
             }
             let current: ProjectOrgSelection = try await server.get(
                 "/api/v1/projects/\(projectId)/org-selections"
@@ -2882,6 +3503,7 @@ final class WorkspaceStore: ObservableObject {
             orgSelectionRevision: selection.revision,
             isLoaded: project.isLoaded
         )
+        pruneOrphanedMemoryTabs()
         if projectId == activeProjectId {
             _ = try? await daemon.retrySync(channel: "commits")
         }
@@ -3033,7 +3655,7 @@ final class WorkspaceStore: ObservableObject {
             throw DocumentSyncError.mutationWhileSynchronizing
         }
         guard Self.canRequestReview(draft) else {
-            throw ReviewRequestError.projectLocalDraftCannotBePublished
+            throw ReviewRequestError.legacyProjectDraftCannotBePublished
         }
         guard let serverId = draft.serverId else {
             throw ReviewRequestError.draftNotSynchronized
@@ -3066,8 +3688,8 @@ final class WorkspaceStore: ObservableObject {
         candidate: DraftReconciliationCandidate? = nil,
         resolvedState: ReconciliationResourceState? = nil
     ) async throws {
-        guard !Self.isProjectLocalCreate(detail.draft) else {
-            throw ReviewRequestError.projectLocalDraftCannotBePublished
+        guard Self.isOrganizationDraft(detail.draft) else {
+            throw ReviewRequestError.legacyProjectDraftCannotBePublished
         }
         guard isReviewAuthor(review) else {
             throw ServerClientError.forbidden("Only the draft author can resubmit this Review.")
@@ -3104,24 +3726,27 @@ final class WorkspaceStore: ObservableObject {
 
     func reconciliationCandidate(for draft: LocalDraft) async throws -> DraftReconciliationCandidate {
         let itemId = draft.targetId ?? draft.id
-        guard synchronizingDocumentIds.insert(itemId).inserted else {
+        let key = MemoryDocumentSessionKey(projectId: draft.projectId, itemId: itemId)
+        guard !isSwitchingMemoryContext,
+              activeProjectId == draft.projectId,
+              synchronizingDocumentSessions.insert(key).inserted else {
             throw DocumentSyncError.mutationWhileSynchronizing
         }
         let generation = UUID()
-        documentSynchronizationGenerations[itemId] = generation
-        defer { endDocumentSynchronization(itemId, generation: generation) }
+        documentSynchronizationGenerations[key] = generation
+        defer { endDocumentSynchronization(key, generation: generation) }
 
         let synchronized = try await synchronizedDraftForReconciliation(
             itemId: itemId,
             draft: draft
         )
         try Task.checkCancellation()
-        guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+        guard isCurrentDocumentSynchronization(key, generation: generation) else {
             throw CancellationError()
         }
         let candidate = try await requestReconciliationCandidate(for: synchronized)
         try Task.checkCancellation()
-        guard isCurrentDocumentSynchronization(itemId, generation: generation) else {
+        guard isCurrentDocumentSynchronization(key, generation: generation) else {
             throw CancellationError()
         }
         return candidate
@@ -3143,7 +3768,13 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func reconciliationCandidate(for detail: ReviewDetail) async throws -> DraftReconciliationCandidate {
-        try await server.send(
+        guard !isSwitchingMemoryContext else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        let activityId = UUID()
+        standaloneReconciliationActivityIds.insert(activityId)
+        defer { standaloneReconciliationActivityIds.remove(activityId) }
+        return try await server.send(
             method: "POST",
             path: "/api/v1/drafts/\(detail.draft.draftId)/reconciliation-candidates",
             body: CreateDraftReconciliationCandidateRequest(
@@ -3158,17 +3789,31 @@ final class WorkspaceStore: ObservableObject {
         resolvedState: ReconciliationResourceState?,
         documentItemId: String? = nil
     ) async throws {
+        guard !isSwitchingMemoryContext else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        var documentKey: MemoryDocumentSessionKey?
+        var standaloneActivityId: UUID?
         if let documentItemId {
-            guard synchronizingDocumentIds.contains(documentItemId),
-                  pendingDocumentReconciliationCandidates[documentItemId]?.candidateId
+            guard let key = activeDocumentSessionKey(for: documentItemId),
+                  synchronizingDocumentSessions.contains(key),
+                  pendingDocumentReconciliationCandidatesBySession[key]?.candidateId
                     == candidate.candidateId,
-                  applyingDocumentReconciliationIds.insert(documentItemId).inserted else {
+                  applyingDocumentReconciliationSessions.insert(key).inserted else {
                 throw DocumentSyncError.mutationWhileSynchronizing
             }
+            documentKey = key
+        } else {
+            let activityId = UUID()
+            standaloneReconciliationActivityIds.insert(activityId)
+            standaloneActivityId = activityId
         }
         defer {
-            if let documentItemId {
-                applyingDocumentReconciliationIds.remove(documentItemId)
+            if let documentKey {
+                applyingDocumentReconciliationSessions.remove(documentKey)
+            }
+            if let standaloneActivityId {
+                standaloneReconciliationActivityIds.remove(standaloneActivityId)
             }
         }
         let _: DraftRebaseResult = try await server.send(
@@ -3230,8 +3875,8 @@ final class WorkspaceStore: ObservableObject {
         // exact target Ref generation for both scopes; the carrying Project's
         // ETag is wrong for Org-targeted Drafts.
         let detail = try await reviewDetail(review.id)
-        guard !Self.isProjectLocalCreate(detail.draft) else {
-            throw ReviewRequestError.projectLocalDraftCannotBePublished
+        guard Self.isOrganizationDraft(detail.draft) else {
+            throw ReviewRequestError.legacyProjectDraftCannotBePublished
         }
         let _: ReviewMergeResponse = try await server.send(
             method: "POST",
@@ -3243,11 +3888,11 @@ final class WorkspaceStore: ObservableObject {
     }
 
     nonisolated static func canRequestReview(_ draft: LocalDraft) -> Bool {
-        draft.scope == .org || draft.targetId != nil
+        draft.scope == .org
     }
 
-    private nonisolated static func isProjectLocalCreate(_ draft: ServerDraft) -> Bool {
-        draft.resource.scope == MemoryScope.project.rawValue && draft.resource.id == nil
+    private nonisolated static func isOrganizationDraft(_ draft: ServerDraft) -> Bool {
+        draft.resource.scope == MemoryScope.org.rawValue
     }
 
     private func currentDraft(for item: MemoryListItem) -> LocalDraft? {
@@ -3256,12 +3901,14 @@ final class WorkspaceStore: ObservableObject {
             return draft
         }
         guard let resourceId = item.resource?.id else { return item.draft }
-        let projectContext = item.draft?.projectId ?? item.projectContextId ?? activeProjectId
+        let projectContext = item.projectContextId
+            ?? (item.scope == .project ? item.projectId : nil)
+        guard let projectContext else { return nil }
         return drafts.first { draft in
             draft.targetId == resourceId
                 && draft.status != .discarded
                 && draft.status != .merged
-                && (projectContext.map { $0 == draft.projectId } ?? (draft.scope == .org))
+                && draft.projectId == projectContext
         }
     }
 
@@ -3274,7 +3921,6 @@ final class WorkspaceStore: ObservableObject {
             ?? item.resource?.projectId
             ?? item.projectContextId
             ?? activeProjectId
-            ?? (item.scope == .org ? projects.first?.id : nil)
     }
 
     private func withDraftMutation<T>(_ operation: () async throws -> T) async throws -> T {
@@ -3318,24 +3964,27 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    private func persistDocumentSave(_ itemId: String, generation: UUID) async {
-        guard let pending = pendingDocumentSaves[itemId], pending.generation == generation else { return }
+    private func persistDocumentSave(
+        _ key: MemoryDocumentSessionKey,
+        generation: UUID
+    ) async {
+        guard let pending = pendingDocumentSaves[key], pending.generation == generation else { return }
         guard synchronizationItemId(for: pending.item) == nil else {
-            documentSaveTasks[itemId] = nil
+            documentSaveTasks[key] = nil
             return
         }
         do {
             try await save(
                 pending.item,
                 document: pending.document,
-                pendingSaveItemId: itemId,
+                pendingSaveKey: key,
                 pendingSaveGeneration: generation
             )
         } catch is CancellationError {
             return
         } catch {
-            if pendingDocumentSaves[itemId]?.generation == generation {
-                documentSaveTasks[itemId] = nil
+            if pendingDocumentSaves[key]?.generation == generation {
+                documentSaveTasks[key] = nil
                 errorMessage = error.localizedDescription
             }
         }
@@ -3374,11 +4023,11 @@ final class WorkspaceStore: ObservableObject {
         loadingResourceIds.removeAll()
         documentSynchronizationTasks.values.forEach { $0.cancel() }
         documentSynchronizationTasks.removeAll()
-        pendingDocumentReconciliationCandidates.removeAll()
+        pendingDocumentReconciliationCandidatesBySession.removeAll()
         documentReconciliationResolutions.removeAll()
         pendingDocumentCommand = nil
         documentReconciliationToolbarState = nil
-        synchronizingDocumentIds.removeAll()
+        synchronizingDocumentSessions.removeAll()
         documentSynchronizationGenerations.removeAll()
         account = snapshot.account
         organization = snapshot.organization
@@ -3542,10 +4191,10 @@ final class WorkspaceStore: ObservableObject {
             includeFailed: includeFailed
         )
         let pendingDraftIds = Set(drafts.compactMap { draft in
-            if pendingDocumentSaves[draft.id] != nil {
-                return draft.id
-            }
-            if let targetId = draft.targetId, pendingDocumentSaves[targetId] != nil {
+            let itemId = draft.targetId ?? draft.id
+            if pendingDocumentSaves[
+                .init(projectId: draft.projectId, itemId: itemId)
+            ] != nil {
                 return draft.id
             }
             return nil
@@ -3643,7 +4292,12 @@ final class WorkspaceStore: ObservableObject {
         "\"\(commitId ?? "ref-none")\""
     }
 
-    private func uniqueDefaultPath(for kind: MemoryKind, scope: MemoryScope) -> String {
+    private func uniqueDefaultPath(
+        for kind: MemoryKind,
+        scope: MemoryScope,
+        authoritativeOrgResources: [MemoryResource]? = nil,
+        projectId: String? = nil
+    ) -> String {
         let base: String
         switch kind {
         case .context: base = "untitled.md"
@@ -3652,7 +4306,13 @@ final class WorkspaceStore: ObservableObject {
         }
         let scopedResources: [MemoryResource]
         let scopedDrafts: [LocalDraft]
-        if scope == .project, let activeProjectId {
+        if scope == .org, let authoritativeOrgResources {
+            scopedResources = authoritativeOrgResources
+            let carrierProjectId = projectId ?? activeProjectId
+            scopedDrafts = drafts.filter {
+                $0.scope == .org && $0.projectId == carrierProjectId
+            }
+        } else if scope == .project, let activeProjectId {
             scopedResources = Self.memoryTreeResources(
                 resources,
                 activeProjectId: activeProjectId,
@@ -3663,14 +4323,24 @@ final class WorkspaceStore: ObservableObject {
             scopedResources = resources.filter { $0.scope == scope }
             scopedDrafts = drafts.filter { $0.scope == scope }
         }
-        let paths = Set(scopedResources.filter { $0.kind == kind }.map(\.document.path))
-            .union(scopedDrafts.filter { $0.kind == kind }.map(\.document.path))
-        guard paths.contains(base) else { return base }
+        // Memory kind is unified on the wire. Context/Rules/Workflow are
+        // creation presets, not separate path namespaces, so every effective
+        // resource and LocalDraft participates in collision avoidance.
+        let paths = Set(scopedResources.map(\.document.path))
+            .union(scopedDrafts.map(\.document.path))
+        return Self.uniqueDefaultPath(base: base, occupiedPaths: paths)
+    }
+
+    nonisolated static func uniqueDefaultPath(
+        base: String,
+        occupiedPaths: Set<String>
+    ) -> String {
+        guard occupiedPaths.contains(base) else { return base }
         let extensionStart = base.lastIndex(of: ".") ?? base.endIndex
         let stem = String(base[..<extensionStart])
         let suffix = String(base[extensionStart...])
         var index = 2
-        while paths.contains("\(stem)-\(index)\(suffix)") { index += 1 }
+        while occupiedPaths.contains("\(stem)-\(index)\(suffix)") { index += 1 }
         return "\(stem)-\(index)\(suffix)"
     }
 
@@ -3695,10 +4365,13 @@ final class WorkspaceStore: ObservableObject {
         return path
     }
 
-    private func defaultDocument(kind: MemoryKind, path: String) -> EditableMemoryDocument {
+    nonisolated static func defaultDocument(
+        kind: MemoryKind,
+        path: String
+    ) -> EditableMemoryDocument {
         switch kind {
         case .context:
-            .init(title: "Untitled", path: path, body: "")
+            .init(title: "Untitled", path: path, body: "# Untitled\n")
         case .rules:
             .init(title: "Untitled rule", path: path, body: "# Untitled rule\n")
         case .workflows:

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -769,9 +769,14 @@ final class WorkspaceStore: ObservableObject {
         showsProjectSettings = false
         let previousTabId = activeVisibleTab?.id
         let resolvedMode = mode ?? (item.supportsMarkdownPreview ? .preview : .source)
+        // Org-scope tabs are always visible regardless of the active project,
+        // so the tab's projectId must reflect scope (nil for Org), not the
+        // carrying project of an Org-scope draft. Reusing item.projectId here
+        // leaked the draft's carrying project and hid Org documents while the
+        // Org view (or another project) was active.
         let tab = WorkbenchTab(
             section: selectedSection,
-            projectId: item.projectId,
+            projectId: item.scope == .org ? nil : item.projectId,
             itemId: item.id,
             mode: resolvedMode,
             title: item.document.title
@@ -791,7 +796,9 @@ final class WorkspaceStore: ObservableObject {
     func reveal(_ item: MemoryListItem) async {
         selectedSection = .memory
         selectedKind = item.kind
-        if let projectId = item.projectId {
+        // Only project-scope items need a project switch; Org-scope items stay
+        // in the Org view even when their draft is carried by a project.
+        if item.scope == .project, let projectId = item.projectId {
             await selectProject(projectId)
         }
         open(item)

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -242,6 +242,9 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var loadingResourceIds: Set<String> = []
     @Published private(set) var loadingProjectId: String?
     @Published private(set) var isPreparingWorkspaceIndex = false
+    /// Project resources whose shared version moved forward after the app
+    /// loaded its snapshot; they show a sync icon and can be refreshed.
+    @Published private(set) var staleResourceIds: Set<String> = []
 
     let daemon = DaemonXPCClient()
     private let bootstrap = DaemonBootstrapController()
@@ -793,6 +796,28 @@ final class WorkspaceStore: ObservableObject {
         Task { await loadContentIfNeeded(item) }
     }
 
+    /// Switches the active tab's view mode in place instead of stacking a
+    /// second tab for the same document.
+    func switchDocumentMode(_ mode: WorkbenchTabMode) {
+        guard let tab = activeVisibleTab, tab.mode != mode else { return }
+        let updated = WorkbenchTab(
+            section: tab.section,
+            projectId: tab.projectId,
+            itemId: tab.itemId,
+            mode: mode,
+            title: tab.title
+        )
+        if let index = tabs.firstIndex(where: { $0.id == tab.id }) {
+            tabs[index] = updated
+        } else {
+            tabs.append(updated)
+        }
+        navigationBackStack = navigationBackStack.map { $0 == tab.id ? updated.id : $0 }
+        navigationForwardStack = navigationForwardStack.map { $0 == tab.id ? updated.id : $0 }
+        selectedItemId = tab.itemId
+        activeTabId = updated.id
+    }
+
     func reveal(_ item: MemoryListItem) async {
         selectedSection = .memory
         selectedKind = item.kind
@@ -1207,8 +1232,92 @@ final class WorkspaceStore: ObservableObject {
             )
             syncStatusAvailable = true
             await refreshDraftInventory(includeFailed: sync.pendingOperationCount > 0)
+            await refreshStaleResourcesIfNeeded(sync: sync)
         } catch {
             syncStatusAvailable = false
+        }
+    }
+
+    private func refreshStaleResourcesIfNeeded(sync: DaemonSyncStatus) async {
+        guard let projectId = activeProjectId,
+              let projectIndex = projects.firstIndex(where: { $0.id == projectId }),
+              let syncedCommitId = sync.commitSync.serverCursor,
+              syncedCommitId != projects[projectIndex].refCommitId else {
+            return
+        }
+        do {
+            let checkout = try await daemon.projectCheckout(projectId)
+            guard checkout.ready else { return }
+            let hashes = Dictionary(
+                checkout.resources.map { ($0.resourceId, $0.contentHash) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            staleResourceIds = Set(
+                resources.compactMap { resource -> String? in
+                    guard resource.projectId == projectId,
+                          let hash = hashes[resource.id],
+                          hash != resource.contentHash else { return nil }
+                    return resource.id
+                }
+            )
+            let current = projects[projectIndex]
+            projects[projectIndex] = ProjectState(
+                id: current.id,
+                name: current.name,
+                refCommitId: syncedCommitId,
+                refEtag: checkout.refEtag ?? current.refEtag,
+                selectedOrgResourceIds: current.selectedOrgResourceIds,
+                orgSelectionRevision: current.orgSelectionRevision,
+                isLoaded: current.isLoaded
+            )
+        } catch {
+            // Commit sync reports refresh failures separately; keep the
+            // previously computed stale set.
+        }
+    }
+
+    /// Pulls the latest shared version for one document:
+    /// - a behind draft opens the shared-change review flow;
+    /// - a stale resource (no local draft) is refreshed from the synced checkout.
+    func syncDocument(_ item: MemoryListItem) {
+        if let draft = item.draft, draft.freshness == .behind {
+            open(item)
+            pendingDocumentCommand = .reviewSharedChanges(itemId: item.id, draft: draft)
+            return
+        }
+        guard let resource = item.resource, staleResourceIds.contains(resource.id) else { return }
+        Task { await syncStaleResource(resource.id) }
+    }
+
+    private func syncStaleResource(_ resourceId: String) async {
+        guard let projectId = resources.first(where: { $0.id == resourceId })?.projectId
+            ?? activeProjectId else { return }
+        do {
+            let checkout = try await daemon.projectCheckout(projectId)
+            guard checkout.ready,
+                  let checkoutResource = checkout.resources.first(where: { $0.resourceId == resourceId }),
+                  let index = resources.firstIndex(where: { $0.id == resourceId }) else { return }
+            let current = resources[index]
+            resources[index] = .init(
+                id: current.id,
+                scope: current.scope,
+                projectId: current.projectId,
+                projectName: current.projectName,
+                kind: current.kind,
+                contentHash: checkoutResource.contentHash,
+                updatedAt: current.updatedAt,
+                refCommitId: checkout.commitId,
+                contentLoaded: true,
+                document: .init(
+                    title: URL(fileURLWithPath: checkoutResource.path)
+                        .deletingPathExtension().lastPathComponent,
+                    path: checkoutResource.path,
+                    body: checkoutResource.content.content
+                )
+            )
+            staleResourceIds.remove(resourceId)
+        } catch {
+            errorMessage = error.localizedDescription
         }
     }
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -308,12 +308,6 @@ final class WorkspaceStore: ObservableObject {
         navigationForwardStack.contains(where: isVisibleTab)
     }
 
-    var currentDocumentPath: String? {
-        guard let tab = activeVisibleTab,
-              let item = item(for: tab) else { return nil }
-        return item.document.path
-    }
-
     var currentItem: MemoryListItem? {
         guard let tab = activeVisibleTab else { return nil }
         return item(for: tab)

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -1315,6 +1315,53 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    /// The synced content of one resource from the daemon checkout,
+    /// used to render the remote layer of a stale document's diff.
+    func checkoutContent(for resourceId: String) async -> String? {
+        guard let projectId = resources.first(where: { $0.id == resourceId })?.projectId
+            ?? activeProjectId else { return nil }
+        guard let checkout = try? await daemon.projectCheckout(projectId), checkout.ready,
+              let checkoutResource = checkout.resources.first(where: { $0.resourceId == resourceId }) else {
+            return nil
+        }
+        return checkoutResource.content.content
+    }
+
+    /// Builds the three-way unified diff presentation for one document:
+    /// local changes (base -> draft) render green/red, remote changes
+    /// (base -> latest shared) render gray.
+    func documentDiffPresentation(
+        for item: MemoryListItem,
+        localText: String
+    ) async -> UnifiedDiffPresentation? {
+        if let draft = item.draft, !draft.isDeletion {
+            if draft.freshness == .behind,
+               let candidate = try? await reconciliationCandidate(for: draft) {
+                return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                    base: candidate.baseState.exists ? (candidate.baseState.content?.content ?? "") : "",
+                    local: localText,
+                    remote: candidate.currentState.exists ? (candidate.currentState.content?.content ?? "") : ""
+                ))
+            }
+            let sharedText = item.resource?.document.body ?? ""
+            return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                base: sharedText,
+                local: localText,
+                remote: sharedText
+            ))
+        }
+        if let resource = item.resource, staleResourceIds.contains(resource.id) {
+            guard let checkoutText = await checkoutContent(for: resource.id) else { return nil }
+            let snapshot = resource.document.body
+            return UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+                base: snapshot,
+                local: snapshot,
+                remote: checkoutText
+            ))
+        }
+        return nil
+    }
+
     func addOrgMemories(resourceIds: Set<String>, toProject projectId: String) async throws {
         try await mutateProjectOrgSelection(
             projectId: projectId,

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -806,13 +806,7 @@ private struct DocumentSessionView: View {
     private var documentDiff: some View {
         Group {
             if let presentation = documentDiffPresentation {
-                // The unified view sizes to its content and would be
-                // vertically centered otherwise; fill the pane and scroll
-                // vertically when the diff is taller than the viewport.
-                ScrollView([.vertical]) {
-                    UnifiedDiffView(presentation: presentation)
-                        .frame(maxWidth: .infinity, alignment: .topLeading)
-                }
+                UnifiedDiffView(presentation: presentation)
             } else if loadsDocumentDiff {
                 ProgressView()
                     .controlSize(.small)

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -806,7 +806,13 @@ private struct DocumentSessionView: View {
     private var documentDiff: some View {
         Group {
             if let presentation = documentDiffPresentation {
-                UnifiedDiffView(presentation: presentation)
+                // The unified view sizes to its content and would be
+                // vertically centered otherwise; fill the pane and scroll
+                // vertically when the diff is taller than the viewport.
+                ScrollView([.vertical]) {
+                    UnifiedDiffView(presentation: presentation)
+                        .frame(maxWidth: .infinity, alignment: .topLeading)
+                }
             } else if loadsDocumentDiff {
                 ProgressView()
                     .controlSize(.small)

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -1357,34 +1357,6 @@ private struct ReviewRequestSheet: View {
     }
 }
 
-struct DocumentPathBreadcrumb: View {
-    let path: String
-
-    private var components: [String] {
-        path.split(separator: "/").map(String.init)
-    }
-
-    var body: some View {
-        HStack(spacing: 4) {
-            ForEach(Array(components.enumerated()), id: \.offset) { index, component in
-                if index > 0 {
-                    Image(systemName: "chevron.right")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
-                Text(component)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .fontWeight(index == components.count - 1 ? .medium : .regular)
-                    .foregroundStyle(index == components.count - 1 ? .primary : .secondary)
-                    .layoutPriority(index == components.count - 1 ? 1 : 0)
-            }
-        }
-        .font(.system(size: 14, weight: .regular))
-    }
-}
-
-
 /// Pure classification of file-tree context menu operations (design v2).
 ///
 /// Menu = generic document operations (standard macOS conventions) + domain
@@ -1417,4 +1389,3 @@ enum MemoryFileTreeMenu {
         items.filter { isManageable($0, inOrgView: inOrgView) && $0.resource != nil }
     }
 }
-

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -447,6 +447,35 @@ private struct FileTreeView: View {
     }
 }
 
+/// Git-style title color for a memory file-tree row.
+enum MemoryFileTreeTitleTone: Equatable {
+    case primary
+    case secondary
+    case newDraft
+    case modifiedDraft
+    case deletedDraft
+
+    static func resolve(item: MemoryListItem?) -> Self {
+        guard let item else { return .primary }
+        guard let draft = item.draft else {
+            return item.inherited ? .secondary : .primary
+        }
+        if draft.isDeletion { return .deletedDraft }
+        if draft.targetId == nil { return .newDraft }
+        return .modifiedDraft
+    }
+
+    var color: Color {
+        switch self {
+        case .primary: return .primary
+        case .secondary: return .secondary
+        case .newDraft: return .green
+        case .modifiedDraft: return Color(red: 0.8, green: 0.6, blue: 0.1) // amber, legible in light mode
+        case .deletedDraft: return .red
+        }
+    }
+}
+
 private struct FileTreeRow: View {
     let entry: VisibleFileTreeNode
     let isExpanded: Bool
@@ -494,10 +523,7 @@ private struct FileTreeRow: View {
     }
 
     private var titleColor: Color {
-        guard let item else { return .primary }
-        if item.draft != nil { return .accentColor }
-        if item.inherited { return .secondary }
-        return .primary
+        MemoryFileTreeTitleTone.resolve(item: item).color
     }
 
 }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -804,23 +804,54 @@ private struct DocumentSessionView: View {
 
     @ViewBuilder
     private var documentDiff: some View {
-        Group {
-            if let presentation = documentDiffPresentation {
-                UnifiedDiffView(presentation: presentation)
-            } else if loadsDocumentDiff {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ContentUnavailableView(
-                    "No Changes",
-                    systemImage: "doc.text",
-                    description: Text("No local or remote changes to show for this document.")
-                )
+        // The pane contract for a document view is the same one Preview
+        // uses: the root is a greedy vertical ScrollView that fills the
+        // remaining height, with content pinned to the top. The unified
+        // diff stays a content-sized fragment (as in Reviews) and this
+        // outer scroll handles vertical overflow.
+        ScrollView([.vertical]) {
+            VStack(alignment: .leading, spacing: 0) {
+                if let rename = renameSummary {
+                    HStack(spacing: 6) {
+                        Image(systemName: "arrow.right")
+                            .foregroundStyle(.secondary)
+                        Text("Path: \(rename.from) → \(rename.to)")
+                            .textSelection(.enabled)
+                    }
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+                    .background(Color.accentColor.opacity(0.06))
+                }
+
+                if let presentation = documentDiffPresentation {
+                    UnifiedDiffView(presentation: presentation)
+                } else if loadsDocumentDiff {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(maxWidth: .infinity, minHeight: 320)
+                } else {
+                    ContentUnavailableView(
+                        "No Changes",
+                        systemImage: "doc.text",
+                        description: Text("No local or remote changes to show for this document.")
+                    )
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
         .onAppear { loadDocumentDiff() }
         .onChange(of: documentDiffIdentity) { _, _ in loadDocumentDiff() }
+    }
+
+    /// A draft that only moves the file (rename) has no content diff;
+    /// surface the path change so the pane never looks empty.
+    private var renameSummary: (from: String, to: String)? {
+        guard let draft = item.draft,
+              let resource = item.resource,
+              draft.document.path != resource.document.path else { return nil }
+        return (resource.document.path, draft.document.path)
     }
 
     private var documentDiffIdentity: String {

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -36,12 +36,25 @@ struct MemoryMainPane: View {
 
                 if let tab = store.activeVisibleTab,
                    let item = store.item(for: tab) {
-                    if item.contentLoaded {
+                    let presentsUnavailableStaleDiff = tab.mode == .diff
+                        && item.resource.map { store.staleResourceIds.contains($0.id) } == true
+                    let presentsUnavailableDraftDiff = tab.mode == .diff
+                        && item.draft?.documentBaselineAvailable == false
+                    if item.contentLoaded || presentsUnavailableStaleDiff
+                        || presentsUnavailableDraftDiff {
                         DocumentSessionView(store: store, item: item, mode: tab.mode)
                             .id(tab.id)
+                    } else if item.draft?.documentBaselineAvailable == false {
+                        ContentUnavailableView(
+                            "Draft Source Unavailable",
+                            systemImage: "arrow.trianglehead.2.clockwise.rotate.90",
+                            description: Text(
+                                "The shared file was removed. Open Diff or Sync to reconcile this draft safely."
+                            )
+                        )
                     } else {
                         ResourceLoadingView()
-                            .task { await store.loadContentIfNeeded(item) }
+                            .task(id: item) { await store.loadContentIfNeeded(item) }
                     }
                 } else {
                     emptyState
@@ -221,6 +234,10 @@ private struct FileTreeView: View {
     }
 
     private func beginRenaming(_ item: MemoryListItem) {
+        guard !store.isSynchronizingDocument(item.id) else {
+            store.errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
+            return
+        }
         proposedName = item.document.path.split(separator: "/").last.map(String.init)
             ?? item.document.path
         itemToRename = item
@@ -228,6 +245,12 @@ private struct FileTreeView: View {
 
     private func renameSelectedItem() {
         guard let item = itemToRename else { return }
+        guard !store.isSynchronizingDocument(item.id) else {
+            itemToRename = nil
+            proposedName = ""
+            store.errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
+            return
+        }
         let name = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard isValidProposedName else { return }
         var document = item.document
@@ -240,7 +263,7 @@ private struct FileTreeView: View {
         proposedName = ""
         Task {
             do {
-                try await store.save(item, document: document)
+                try await store.rename(item, to: document.path)
             } catch {
                 store.errorMessage = error.localizedDescription
             }
@@ -304,12 +327,27 @@ private struct FileTreeView: View {
         let addableItems = MemoryFileTreeMenu.addable(targetItems, inOrgView: isOrgView)
         let removableItems = MemoryFileTreeMenu.removable(targetItems, inOrgView: isOrgView)
         let trashableItems = MemoryFileTreeMenu.trashable(targetItems, inOrgView: isOrgView)
+            .filter { store.canEditMemory($0) }
         let singleManageable = singleItem.map {
             MemoryFileTreeMenu.isManageable($0, inOrgView: isOrgView)
+                && store.canEditMemory($0)
+        } ?? false
+        let singleRenameable = singleItem.map {
+            MemoryFileTreeMenu.canRename($0, inOrgView: isOrgView)
+                && store.canEditMemory($0)
         } ?? false
         let singleStale = singleItem.map { item in
             item.resource.map { store.staleResourceIds.contains($0.id) } == true
         } ?? false
+        let singleSynchronizing = singleItem.map {
+            store.isSynchronizingDocument($0.id)
+        } ?? false
+        let selectionContainsSynchronizingDocument = targetItems.contains {
+            store.isSynchronizingDocument($0.id)
+        }
+        let trashSelectionContainsSynchronizingDocument = trashableItems.contains {
+            store.isSynchronizingDocument($0.id)
+        }
         let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
             || (singleItem?.draft != nil) || singleStale
 
@@ -320,11 +358,15 @@ private struct FileTreeView: View {
                 Button("Open Source") { store.open(singleItem, mode: .source) }
             }
             if singleManageable {
-                Button("Rename…") { beginRenaming(singleItem) }
-                if singleItem.resource != nil {
+                if singleRenameable {
+                    Button("Rename…") { beginRenaming(singleItem) }
+                        .disabled(singleSynchronizing)
+                }
+                if singleItem.resource != nil && singleItem.draft?.isDeletion != true {
                     Button("Move to Trash", role: .destructive) {
                         Task { await store.delete(singleItem) }
                     }
+                    .disabled(singleSynchronizing)
                 }
             }
         } else if !targetItems.isEmpty {
@@ -333,6 +375,7 @@ private struct FileTreeView: View {
                 Button(moveToTrashTitle(count: trashableItems.count), role: .destructive) {
                     deleteItems(trashableItems)
                 }
+                .disabled(trashSelectionContainsSynchronizingDocument)
             }
         }
 
@@ -353,21 +396,46 @@ private struct FileTreeView: View {
                     }
                 }
             }
-            .disabled(!store.canManageOrgSelection || store.projects.isEmpty)
+            .disabled(
+                !store.canManageOrgSelection
+                    || store.projects.isEmpty
+                    || selectionContainsSynchronizingDocument
+            )
         }
         if !removableItems.isEmpty {
             Button(removeFromProjectTitle(count: removableItems.count)) {
                 removeFromProject(removableItems)
             }
-            .disabled(!store.canManageOrgSelection)
+            .disabled(!store.canManageOrgSelection || selectionContainsSynchronizingDocument)
         }
         if let singleItem {
-            if singleItem.draft?.freshness == .behind {
-                Button(singleItem.draft?.hasUpstreamResourceChanges == true ? "Review Changes" : "Sync") {
-                    store.syncDocument(singleItem)
+            let resourceIsStale = singleItem.resource.map {
+                store.staleResourceIds.contains($0.id)
+            } == true
+            if store.isSynchronizingDocument(singleItem.id) {
+                Button("Preparing Shared Changes…") {}
+                    .disabled(true)
+            } else if let draft = singleItem.draft,
+                      draft.freshness == .behind || resourceIsStale {
+                switch draft.syncStatus {
+                case .queued, .syncing, .retrying:
+                    Button("Waiting for Draft Sync…") {}
+                        .disabled(true)
+                case .failed:
+                    Button("Retry Draft Sync") {
+                        Task { await store.retrySync() }
+                    }
+                case .synced:
+                    if draft.serverId == nil {
+                        Button("Draft Not Ready") {}
+                            .disabled(true)
+                    } else {
+                        Button(draft.hasUpstreamResourceChanges ? "Review Changes" : "Sync") {
+                            store.syncDocument(singleItem)
+                        }
+                    }
                 }
-            } else if let resource = singleItem.resource,
-                      store.staleResourceIds.contains(resource.id) {
+            } else if resourceIsStale {
                 Button("Sync") {
                     store.syncDocument(singleItem)
                 }
@@ -376,6 +444,7 @@ private struct FileTreeView: View {
                 Button("Discard Draft") {
                     Task { await store.discard(draft) }
                 }
+                .disabled(singleSynchronizing)
             }
         }
 
@@ -433,10 +502,12 @@ private struct FileTreeView: View {
     }
 
     private func removeFromProject(_ items: [MemoryListItem]) {
+        guard let projectId = store.activeProjectId else { return }
         Task {
             do {
-                try await store.removeOrgMemoriesFromActiveProject(
-                    resourceIds: Set(items.map(\.id))
+                try await store.removeOrgMemories(
+                    resourceIds: Set(items.map(\.id)),
+                    fromProject: projectId
                 )
             } catch {
                 store.errorMessage = error.localizedDescription
@@ -456,16 +527,13 @@ private struct FileTreeView: View {
 /// Git-style title color for a memory file-tree row.
 enum MemoryFileTreeTitleTone: Equatable {
     case primary
-    case secondary
     case newDraft
     case modifiedDraft
     case deletedDraft
 
     static func resolve(item: MemoryListItem?) -> Self {
         guard let item else { return .primary }
-        guard let draft = item.draft else {
-            return item.inherited ? .secondary : .primary
-        }
+        guard let draft = item.draft else { return .primary }
         if draft.isDeletion { return .deletedDraft }
         if draft.targetId == nil { return .newDraft }
         return .modifiedDraft
@@ -474,7 +542,6 @@ enum MemoryFileTreeTitleTone: Equatable {
     var color: Color {
         switch self {
         case .primary: return .primary
-        case .secondary: return .secondary
         case .newDraft: return .green
         case .modifiedDraft: return Color(red: 0.8, green: 0.6, blue: 0.1) // amber, legible in light mode
         case .deletedDraft: return .red
@@ -513,13 +580,6 @@ private struct FileTreeRow: View {
             isExpanded: isExpanded,
             titleColor: titleColor
         ) {
-            if item?.inherited == true {
-                Image(systemName: "building.2")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .help("Inherited from Organization")
-                    .accessibilityLabel("Inherited from Organization")
-            }
             SharedUpdateIndicator(
                 freshness: item?.draft?.freshness,
                 hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
@@ -527,7 +587,7 @@ private struct FileTreeRow: View {
                 isStale: isStale
             )
         }
-        .help(item?.inherited == true ? "Inherited from Organization" : entry.node.name)
+        .help(entry.node.name)
     }
 
     private var titleColor: Color {
@@ -712,57 +772,76 @@ struct FileTreeNode: Identifiable {
     }
 }
 
+private struct DocumentDiffIdentity: Hashable {
+    let item: MemoryListItem
+    let localDocument: EditableMemoryDocument
+    let staleResourceGeneration: UUID?
+    let retryRequest: Int
+}
+
 private struct DocumentSessionView: View {
     @ObservedObject var store: WorkspaceStore
     let item: MemoryListItem
     let mode: WorkbenchTabMode
 
     @State private var document: EditableMemoryDocument
+    @State private var authoritativeDocument: EditableMemoryDocument
     @State private var suppressesSaving = false
     @State private var reviewDraft: LocalDraft?
-    @State private var reconciliationCandidate: DraftReconciliationCandidate?
-    @State private var loadsReconciliation = false
     @State private var reconciliationUpdateRequest = 0
     @State private var documentDiffPresentation: UnifiedDiffPresentation?
+    @State private var documentPathChanges: [DocumentPathChange] = []
     @State private var loadsDocumentDiff = false
+    @State private var documentDiffError: String?
+    @State private var documentDiffRetryRequest = 0
 
     init(store: WorkspaceStore, item: MemoryListItem, mode: WorkbenchTabMode) {
         self.store = store
         self.item = item
         self.mode = mode
-        _document = State(initialValue: item.document)
+        _document = State(initialValue: store.pendingDocument(for: item) ?? item.document)
+        _authoritativeDocument = State(initialValue: item.document)
     }
 
     var body: some View {
         Group {
-            if let candidate = reconciliationCandidate {
+            if let candidate = store.pendingDocumentReconciliationCandidates[item.id] {
                 DraftReconciliationView(
                     candidate: candidate,
                     updateRequest: reconciliationUpdateRequest,
                     usesContextualUpdateAction: true,
+                    initialResolvedState: store.documentReconciliationResolution(for: item.id),
+                    onResolvedStateChange: {
+                        store.updateDocumentReconciliationResolution($0, for: item.id)
+                    },
                     onUpdateStateChange: publishReconciliationToolbarState,
                     onCancel: closeReconciliation,
                     onApplied: closeReconciliation
                 ) { resolvedState in
-                    guard let draft = activeDraft, let serverId = draft.serverId else {
-                        throw ReviewRequestError.draftNotSynchronized
-                    }
                     try await store.applyReconciliation(
-                        draftId: serverId,
-                        draftVersion: draft.serverVersion,
+                        draftId: candidate.draftId,
                         candidate: candidate,
-                        resolvedState: resolvedState
+                        resolvedState: resolvedState,
+                        documentItemId: item.id
                     )
                 }
+                .id(candidate.candidateId)
             } else {
                 documentContent
             }
         }
-        .onChange(of: document) { _, _ in scheduleSave() }
+        .onChange(of: item.document) { _, latest in
+            adoptAuthoritativeDocument(latest)
+        }
+        .onChange(of: store.documentContentGeneration(for: item.id)) { _, _ in
+            adoptAuthoritativeDocument(item.document)
+        }
         .onChange(of: store.pendingDocumentCommand) { _, command in
             handleDocumentCommand(command)
         }
-        .onAppear { handleDocumentCommand(store.pendingDocumentCommand) }
+        .onAppear {
+            handleDocumentCommand(store.pendingDocumentCommand)
+        }
         .onDisappear {
             flushSave()
             clearReconciliationToolbarState()
@@ -785,7 +864,9 @@ private struct DocumentSessionView: View {
 
     private var documentContent: some View {
         Group {
-            if item.draft?.isDeletion == true {
+            if mode == .diff {
+                documentDiff
+            } else if item.draft?.isDeletion == true {
                 ContentUnavailableView(
                     "Pending deletion",
                     systemImage: "trash",
@@ -793,86 +874,142 @@ private struct DocumentSessionView: View {
                 )
             } else if mode == .preview {
                 MarkdownPreview(source: renderedSource)
-            } else if mode == .diff {
-                documentDiff
             } else {
                 editor
-                    .disabled(item.inherited)
+                    .disabled(
+                        !store.canEditMemory(item)
+                            || store.isSwitchingMemoryContext
+                            || store.isSynchronizingDocument(item.id)
+                    )
             }
         }
     }
 
     @ViewBuilder
     private var documentDiff: some View {
+        let identity = documentDiffIdentity
         // The pane contract for a document view is the same one Preview
         // uses: the root is a greedy vertical ScrollView that fills the
         // remaining height, with content pinned to the top. The unified
         // diff stays a content-sized fragment (as in Reviews) and this
         // outer scroll handles vertical overflow.
-        ScrollView([.vertical]) {
-            VStack(alignment: .leading, spacing: 0) {
-                if let rename = renameSummary {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.right")
-                            .foregroundStyle(.secondary)
-                        Text("Path: \(rename.from) → \(rename.to)")
-                            .textSelection(.enabled)
+        GeometryReader { geometry in
+            ScrollView([.vertical]) {
+                VStack(alignment: .leading, spacing: 0) {
+                    if !documentPathChanges.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            ForEach(documentPathChanges.indices, id: \.self) { index in
+                                HStack(spacing: 6) {
+                                    Image(systemName: "arrow.right")
+                                        .foregroundStyle(.secondary)
+                                    Text(pathChangeSummary(documentPathChanges[index]))
+                                        .textSelection(.enabled)
+                                }
+                            }
+                        }
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 12)
+                        .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
+                        .background(Color.accentColor.opacity(0.06))
                     }
-                    .font(.caption.monospaced())
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 12)
-                    .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
-                    .background(Color.accentColor.opacity(0.06))
-                }
 
-                if let presentation = documentDiffPresentation {
-                    UnifiedDiffView(presentation: presentation)
-                } else if loadsDocumentDiff {
-                    ProgressView()
-                        .controlSize(.small)
-                        .frame(maxWidth: .infinity, minHeight: 320)
-                } else {
-                    ContentUnavailableView(
-                        "No Changes",
-                        systemImage: "doc.text",
-                        description: Text("No local or remote changes to show for this document.")
-                    )
+                    if let presentation = documentDiffPresentation,
+                       presentation.changedLineCount > 0 {
+                        UnifiedDiffView(presentation: presentation)
+                    } else if loadsDocumentDiff {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else if let documentDiffError {
+                        ContentUnavailableView {
+                            Label("Unable to Load Diff", systemImage: "exclamationmark.triangle")
+                        } description: {
+                            Text(documentDiffError)
+                        } actions: {
+                            Button("Retry") { documentDiffRetryRequest += 1 }
+                        }
+                    } else if documentPathChanges.isEmpty {
+                        ContentUnavailableView(
+                            "No Changes",
+                            systemImage: "doc.text",
+                            description: Text("No local or remote changes to show for this document.")
+                        )
+                    }
                 }
+                .frame(
+                    maxWidth: .infinity,
+                    minHeight: geometry.size.height,
+                    alignment: centersDocumentDiffStatus ? .center : .topLeading
+                )
             }
-            .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        .onAppear { loadDocumentDiff() }
-        .onChange(of: documentDiffIdentity) { _, _ in loadDocumentDiff() }
+        .task(id: identity) {
+            await loadDocumentDiff(for: identity)
+        }
     }
 
-    /// A draft that only moves the file (rename) has no content diff;
-    /// surface the path change so the pane never looks empty.
-    private var renameSummary: (from: String, to: String)? {
-        guard let draft = item.draft,
-              let resource = item.resource,
-              draft.document.path != resource.document.path else { return nil }
-        return (resource.document.path, draft.document.path)
+    private var centersDocumentDiffStatus: Bool {
+        documentPathChanges.isEmpty
+            && (documentDiffPresentation?.changedLineCount ?? 0) == 0
     }
 
-    private var documentDiffIdentity: String {
-        [
-            item.draft?.id ?? "no-draft",
-            item.draft?.freshness.rawValue ?? "-",
-            item.resource?.contentHash ?? "-",
-            String(store.staleResourceIds.contains(item.resource?.id ?? "")),
-        ].joined(separator: ":")
+    /// A path-only change has no content diff. Surface draft and shared
+    /// additions, removals, and renames so the pane never looks empty.
+    private func pathChangeSummary(_ change: DocumentPathChange) -> String {
+        let owner = switch change.source {
+        case .draft: "Draft"
+        case .shared: "Shared"
+        case .draftAndShared: "Draft + Shared"
+        }
+        switch (change.from, change.to) {
+        case let (from?, to?):
+            return "\(owner) path: \(from) → \(to)"
+        case let (nil, to?):
+            return "\(owner) added: \(to)"
+        case let (from?, nil):
+            return "\(owner) deleted: \(from)"
+        case (nil, nil):
+            return owner
+        }
     }
 
-    private func loadDocumentDiff() {
-        guard mode == .diff, !loadsDocumentDiff else { return }
+    private var documentDiffIdentity: DocumentDiffIdentity {
+        DocumentDiffIdentity(
+            item: item,
+            localDocument: document,
+            staleResourceGeneration: item.resource.flatMap {
+                store.staleResourceGeneration(for: $0.id)
+            },
+            retryRequest: documentDiffRetryRequest
+        )
+    }
+
+    private func loadDocumentDiff(for identity: DocumentDiffIdentity) async {
+        guard mode == .diff else { return }
         documentDiffPresentation = nil
+        documentDiffError = nil
+        documentPathChanges = store.documentPathChanges(for: identity.item)
         loadsDocumentDiff = true
-        Task {
-            defer { loadsDocumentDiff = false }
-            documentDiffPresentation = await store.documentDiffPresentation(
-                for: item,
-                localText: document.body
+
+        do {
+            let result = try await store.documentDiffPresentation(
+                for: identity.item,
+                localText: identity.localDocument.body
             )
+            try Task.checkCancellation()
+            guard identity == documentDiffIdentity, mode == .diff else { return }
+            documentDiffPresentation = result?.presentation
+            documentPathChanges = result?.pathChanges ?? []
+            loadsDocumentDiff = false
+        } catch is CancellationError {
+            // `.task(id:)` immediately starts a replacement for a changed
+            // identity. Let that task remain the owner of loading state.
+        } catch {
+            guard !Task.isCancelled,
+                  identity == documentDiffIdentity,
+                  mode == .diff else { return }
+            documentDiffError = error.localizedDescription
+            loadsDocumentDiff = false
         }
     }
 
@@ -880,44 +1017,48 @@ private struct DocumentSessionView: View {
     private var editor: some View {
         switch item.kind {
         case .context, .rules, .workflows:
-            NativeTextEditor(text: $document.body)
+            NativeTextEditor(text: editorText)
         }
+    }
+
+    private var editorText: Binding<String> {
+        Binding(
+            get: { document.body },
+            set: { nextBody in
+                guard nextBody != document.body else { return }
+                var nextDocument = document
+                nextDocument.body = nextBody
+                document = nextDocument
+                stageSave(nextDocument)
+            }
+        )
     }
 
     private var renderedSource: String {
-        let sourceDocument = mode == .preview ? item.document : document
         switch item.kind {
         case .context, .rules, .workflows:
-            return sourceDocument.body
+            return document.body
         }
     }
 
-    private var activeDraft: LocalDraft? {
-        guard let draft = item.draft else { return nil }
-        return store.drafts.first(where: { $0.id == draft.id }) ?? draft
-    }
-
-    private func loadReconciliation(for draft: LocalDraft) {
-        guard !loadsReconciliation else { return }
-        loadsReconciliation = true
-        store.documentReconciliationToolbarState = .init(
-            itemId: item.id,
-            isLoading: true,
-            canUpdate: false,
-            isUpdating: false
-        )
-        Task {
-            defer { loadsReconciliation = false }
-            do {
-                try await store.flushDocumentSave(item.id)
-                let latest = store.drafts.first {
-                    $0.id == draft.id || (draft.targetId != nil && $0.targetId == draft.targetId)
-                } ?? draft
-                reconciliationCandidate = try await store.reconciliationCandidate(for: latest)
-            } catch {
-                clearReconciliationToolbarState()
-                store.errorMessage = error.localizedDescription
-            }
+    private func adoptAuthoritativeDocument(_ latest: EditableMemoryDocument) {
+        let previous = authoritativeDocument
+        authoritativeDocument = latest
+        // A resource sync can replace the authoritative document while this
+        // session stays alive. Adopt it only when the editor still matches the
+        // previous snapshot so an in-flight local edit is never lost.
+        if document == previous {
+            document = latest
+            return
+        }
+        // A file-tree rename is independent of a dirty Source body. Merge
+        // path/title changes from the authoritative draft while keeping the
+        // user's in-flight text, so the next autosave cannot rename it back.
+        if document.path == previous.path {
+            document.path = latest.path
+        }
+        if document.title == previous.title {
+            document.title = latest.title
         }
     }
 
@@ -929,8 +1070,6 @@ private struct DocumentSessionView: View {
             reviewDraft = draft
         case .discardDraft(_, let draft):
             discard(draft)
-        case .reviewSharedChanges(_, let draft):
-            loadReconciliation(for: draft)
         case .applyReconciliation:
             reconciliationUpdateRequest += 1
         case .closeReconciliation:
@@ -950,7 +1089,7 @@ private struct DocumentSessionView: View {
     }
 
     private func closeReconciliation() {
-        reconciliationCandidate = nil
+        store.finishDocumentReconciliation(for: item.id)
         clearReconciliationToolbarState()
     }
 
@@ -959,16 +1098,19 @@ private struct DocumentSessionView: View {
         store.documentReconciliationToolbarState = nil
     }
 
-    private func scheduleSave() {
-        guard !suppressesSaving, !item.inherited, mode == .source else { return }
-        store.stageDocumentSave(item, document: document)
+    private func stageSave(_ nextDocument: EditableMemoryDocument) {
+        guard !suppressesSaving,
+              store.canEditMemory(item),
+              !store.isSwitchingMemoryContext,
+              !store.isSynchronizingDocument(item.id),
+              mode == .source,
+              nextDocument != item.document else { return }
+        store.stageDocumentSave(item, document: nextDocument)
     }
 
     private func flushSave() {
         guard !suppressesSaving,
-              !item.inherited,
-              mode == .source,
-              document != item.document else { return }
+              mode == .source else { return }
         Task {
             do {
                 try await store.flushDocumentSave(item.id)
@@ -986,9 +1128,7 @@ private struct DocumentSessionView: View {
         resolvedState: ReconciliationResourceState?
     ) async throws {
         try await store.flushDocumentSave(item.id)
-        let latest = store.drafts.first {
-            $0.id == draft.id || (draft.targetId != nil && $0.targetId == draft.targetId)
-        } ?? draft
+        let latest = store.drafts.first { $0.id == draft.id } ?? draft
         try await store.requestReview(
             for: latest,
             title: title,
@@ -1000,22 +1140,26 @@ private struct DocumentSessionView: View {
 
     private func loadReviewCandidate(_ draft: LocalDraft) async throws -> DraftReconciliationCandidate {
         try await store.flushDocumentSave(item.id)
-        let latest = store.drafts.first {
-            $0.id == draft.id || (draft.targetId != nil && $0.targetId == draft.targetId)
-        } ?? draft
+        let latest = store.drafts.first { $0.id == draft.id } ?? draft
         return try await store.reconciliationCandidate(for: latest)
     }
 
     private func discard(_ draft: LocalDraft) {
         suppressesSaving = true
         store.cancelDocumentSave(item.id)
-        Task { await store.discard(draft) }
+        Task {
+            await store.discard(draft)
+            suppressesSaving = false
+        }
     }
 
     private func moveToTrash() {
         suppressesSaving = true
         store.cancelDocumentSave(item.id)
-        Task { await store.delete(item) }
+        Task {
+            await store.delete(item)
+            suppressesSaving = false
+        }
     }
 }
 
@@ -1023,6 +1167,7 @@ struct DraftReconciliationView: View {
     let candidate: DraftReconciliationCandidate
     let updateRequest: Int
     let usesContextualUpdateAction: Bool
+    let onResolvedStateChange: ((ReconciliationResourceState) -> Void)?
     let onUpdateStateChange: ((Bool, Bool) -> Void)?
     let onCancel: () -> Void
     let onApplied: () -> Void
@@ -1038,6 +1183,8 @@ struct DraftReconciliationView: View {
         candidate: DraftReconciliationCandidate,
         updateRequest: Int = 0,
         usesContextualUpdateAction: Bool = false,
+        initialResolvedState: ReconciliationResourceState? = nil,
+        onResolvedStateChange: ((ReconciliationResourceState) -> Void)? = nil,
         onUpdateStateChange: ((Bool, Bool) -> Void)? = nil,
         onCancel: @escaping () -> Void,
         onApplied: (() -> Void)? = nil,
@@ -1046,14 +1193,20 @@ struct DraftReconciliationView: View {
         self.candidate = candidate
         self.updateRequest = updateRequest
         self.usesContextualUpdateAction = usesContextualUpdateAction
+        self.onResolvedStateChange = onResolvedStateChange
         self.onUpdateStateChange = onUpdateStateChange
         self.onCancel = onCancel
         self.onApplied = onApplied ?? onCancel
         self.onApply = onApply
-        let initial = candidate.proposedState ?? candidate.draftState
+        let initial = initialResolvedState ?? candidate.proposedState ?? candidate.draftState
         _resolvedExists = State(initialValue: initial.exists)
         _resolvedPath = State(initialValue: initial.resource.path ?? "")
-        _resolvedContent = State(initialValue: initial.content?.primaryText ?? "")
+        _resolvedContent = State(
+            initialValue: Self.resolutionContentTemplate(
+                for: candidate,
+                preferredState: initial
+            ).primaryText
+        )
     }
 
     var body: some View {
@@ -1103,6 +1256,9 @@ struct DraftReconciliationView: View {
         .onAppear { publishUpdateState() }
         .onChange(of: canApply) { _, _ in publishUpdateState() }
         .onChange(of: isApplying) { _, _ in publishUpdateState() }
+        .onChange(of: resolvedExists) { _, _ in publishResolution() }
+        .onChange(of: resolvedPath) { _, _ in publishResolution() }
+        .onChange(of: resolvedContent) { _, _ in publishResolution() }
         .onChange(of: updateRequest) { _, _ in
             guard usesContextualUpdateAction else { return }
             apply()
@@ -1130,6 +1286,10 @@ struct DraftReconciliationView: View {
     private func publishUpdateState() {
         guard usesContextualUpdateAction else { return }
         onUpdateStateChange?(canApply, isApplying)
+    }
+
+    private func publishResolution() {
+        onResolvedStateChange?(resolvedState)
     }
 
     @ViewBuilder
@@ -1267,6 +1427,10 @@ struct DraftReconciliationView: View {
 
     private var resolvedState: ReconciliationResourceState {
         let template = candidate.proposedState ?? candidate.draftState
+        let contentTemplate = Self.resolutionContentTemplate(
+            for: candidate,
+            preferredState: template
+        )
         let resource = ServerDraftResourceReference(
             scope: template.resource.scope,
             id: template.resource.id,
@@ -1276,9 +1440,20 @@ struct DraftReconciliationView: View {
             exists: resolvedExists,
             resource: resource,
             content: resolvedExists
-                ? template.content?.replacingPrimaryText(with: resolvedContent)
+                ? contentTemplate.replacingPrimaryText(with: resolvedContent)
                 : nil
         )
+    }
+
+    static func resolutionContentTemplate(
+        for candidate: DraftReconciliationCandidate,
+        preferredState: ReconciliationResourceState
+    ) -> DaemonDraftContent {
+        preferredState.content
+            ?? candidate.currentState.content
+            ?? candidate.draftState.content
+            ?? candidate.baseState.content
+            ?? .init(description: nil, content: "")
     }
 }
 
@@ -1416,21 +1591,32 @@ private struct ReviewRequestSheet: View {
 /// Pure classification of file-tree context menu operations (design v2).
 ///
 /// Menu = generic document operations (standard macOS conventions) + domain
-/// operations (Memory scope relationships and drafts). Add to Project exists
-/// only in the Org view; Remove from Project exists only in the Project view
-/// for inherited items; Rename/Trash apply only to items owned by the current
-/// view context.
+/// operations (Memory project membership and drafts). Add to Project exists
+/// only in the Org view; Remove from Project exists only in the Project view.
 enum MemoryFileTreeMenu {
-    /// Items that can be renamed or trashed in the current view context:
-    /// org memories in the Org view, project-owned memories in the Project
-    /// view. Inherited and org-unreferenced items are view-only.
+    /// Editing never mutates authority directly; it creates or updates the
+    /// current view's local Draft. An unselected Org resource is not
+    /// manageable from a Project context, but it is also filtered out of the
+    /// Project tree.
     static func isManageable(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
-        !item.inherited && (inOrgView ? item.scope == .org : item.scope == .project)
+        if inOrgView { return item.scope == .org }
+        return item.scope == .project || item.inherited || item.draft?.projectId != nil
+    }
+
+    /// A target-backed memory supports a path-only rename. A pure create
+    /// draft has no stable resource id for the daemon's rename operation and
+    /// must become shared before it can be renamed safely.
+    static func canRename(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
+        isManageable(item, inOrgView: inOrgView)
+            && item.draft?.isDeletion != true
+            && (item.resource != nil || item.draft?.targetId != nil)
     }
 
     /// Org memories that may be added to a project: only in the Org view.
     static func addable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
-        inOrgView ? items.filter { $0.scope == .org } : []
+        inOrgView ? items.filter {
+            $0.scope == .org && $0.resource != nil && $0.draft?.isDeletion != true
+        } : []
     }
 
     /// Items inherited by the active project that may be removed from it:
@@ -1442,6 +1628,10 @@ enum MemoryFileTreeMenu {
     /// Items that support batch Move to Trash: manageable items that back a
     /// resource (pure drafts are discarded, not trashed).
     static func trashable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
-        items.filter { isManageable($0, inOrgView: inOrgView) && $0.resource != nil }
+        items.filter {
+            isManageable($0, inOrgView: inOrgView)
+                && $0.resource != nil
+                && $0.draft?.isDeletion != true
+        }
     }
 }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -723,6 +723,8 @@ private struct DocumentSessionView: View {
     @State private var reconciliationCandidate: DraftReconciliationCandidate?
     @State private var loadsReconciliation = false
     @State private var reconciliationUpdateRequest = 0
+    @State private var documentDiffPresentation: UnifiedDiffPresentation?
+    @State private var loadsDocumentDiff = false
 
     init(store: WorkspaceStore, item: MemoryListItem, mode: WorkbenchTabMode) {
         self.store = store
@@ -802,20 +804,43 @@ private struct DocumentSessionView: View {
 
     @ViewBuilder
     private var documentDiff: some View {
-        if let draft = item.draft, !draft.isDeletion {
-            SplitDiffView(
-                original: item.resource?.document.body ?? "",
-                modified: document.body,
-                originalTitle: "Shared Version",
-                modifiedTitle: "Local Changes",
-                originalPath: item.resource?.document.path ?? draft.document.path,
-                modifiedPath: draft.document.path
-            )
-        } else {
-            ContentUnavailableView(
-                "No Local Changes",
-                systemImage: "doc.text",
-                description: Text("Edit this memory to see a diff against the shared version.")
+        Group {
+            if let presentation = documentDiffPresentation {
+                UnifiedDiffView(presentation: presentation)
+            } else if loadsDocumentDiff {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ContentUnavailableView(
+                    "No Changes",
+                    systemImage: "doc.text",
+                    description: Text("No local or remote changes to show for this document.")
+                )
+            }
+        }
+        .onAppear { loadDocumentDiff() }
+        .onChange(of: documentDiffIdentity) { _, _ in loadDocumentDiff() }
+    }
+
+    private var documentDiffIdentity: String {
+        [
+            item.draft?.id ?? "no-draft",
+            item.draft?.freshness.rawValue ?? "-",
+            item.resource?.contentHash ?? "-",
+            String(store.staleResourceIds.contains(item.resource?.id ?? "")),
+        ].joined(separator: ":")
+    }
+
+    private func loadDocumentDiff() {
+        guard mode == .diff, !loadsDocumentDiff else { return }
+        documentDiffPresentation = nil
+        loadsDocumentDiff = true
+        Task {
+            defer { loadsDocumentDiff = false }
+            documentDiffPresentation = await store.documentDiffPresentation(
+                for: item,
+                localText: document.body
             )
         }
     }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -155,6 +155,10 @@ private struct FileTreeView: View {
                 FileTreeRow(
                     entry: entry,
                     isExpanded: expandedDirectoryIds.contains(entry.id),
+                    isStale: entry.node.item.map {
+                        $0.draft == nil
+                            && $0.resource.map { store.staleResourceIds.contains($0.id) } == true
+                    } == true,
                     onDirectoryClick: { modifierFlags in
                         handleDirectoryClick(entry.id, modifierFlags: modifierFlags)
                     }
@@ -292,12 +296,6 @@ private struct FileTreeView: View {
         }
     }
 
-    private func reviewSharedChanges(for item: MemoryListItem) {
-        guard let draft = item.draft, draft.freshness == .behind else { return }
-        store.open(item)
-        store.pendingDocumentCommand = .reviewSharedChanges(itemId: item.id, draft: draft)
-    }
-
     @ViewBuilder
     private func fileTreeMenu(for nodeIds: Set<String>) -> some View {
         let targetItems = FileTreeNode.items(in: roots, selectedNodeIds: nodeIds)
@@ -309,8 +307,11 @@ private struct FileTreeView: View {
         let singleManageable = singleItem.map {
             MemoryFileTreeMenu.isManageable($0, inOrgView: isOrgView)
         } ?? false
+        let singleStale = singleItem.map { item in
+            item.resource.map { store.staleResourceIds.contains($0.id) } == true
+        } ?? false
         let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
-            || (singleItem?.draft != nil)
+            || (singleItem?.draft != nil) || singleStale
 
         // ---- generic document operations (standard macOS conventions) ----
         if let singleItem {
@@ -362,8 +363,13 @@ private struct FileTreeView: View {
         }
         if let singleItem {
             if singleItem.draft?.freshness == .behind {
-                Button(singleItem.draft?.hasUpstreamResourceChanges == true ? "Review Changes" : "Update Draft") {
-                    reviewSharedChanges(for: singleItem)
+                Button(singleItem.draft?.hasUpstreamResourceChanges == true ? "Review Changes" : "Sync") {
+                    store.syncDocument(singleItem)
+                }
+            } else if let resource = singleItem.resource,
+                      store.staleResourceIds.contains(resource.id) {
+                Button("Sync") {
+                    store.syncDocument(singleItem)
                 }
             }
             if let draft = singleItem.draft {
@@ -479,6 +485,7 @@ enum MemoryFileTreeTitleTone: Equatable {
 private struct FileTreeRow: View {
     let entry: VisibleFileTreeNode
     let isExpanded: Bool
+    let isStale: Bool
     let onDirectoryClick: (NSEvent.ModifierFlags) -> Void
 
     private var item: MemoryListItem? { entry.node.item }
@@ -516,7 +523,8 @@ private struct FileTreeRow: View {
             SharedUpdateIndicator(
                 freshness: item?.draft?.freshness,
                 hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
-                reconciliation: item?.draft?.reconciliation
+                reconciliation: item?.draft?.reconciliation,
+                isStale: isStale
             )
         }
         .help(item?.inherited == true ? "Inherited from Organization" : entry.node.name)
@@ -783,10 +791,32 @@ private struct DocumentSessionView: View {
                 )
             } else if mode == .preview {
                 MarkdownPreview(source: renderedSource)
+            } else if mode == .diff {
+                documentDiff
             } else {
                 editor
                     .disabled(item.inherited)
             }
+        }
+    }
+
+    @ViewBuilder
+    private var documentDiff: some View {
+        if let draft = item.draft, !draft.isDeletion {
+            SplitDiffView(
+                original: item.resource?.document.body ?? "",
+                modified: document.body,
+                originalTitle: "Shared Version",
+                modifiedTitle: "Local Changes",
+                originalPath: item.resource?.document.path ?? draft.document.path,
+                modifiedPath: draft.document.path
+            )
+        } else {
+            ContentUnavailableView(
+                "No Local Changes",
+                systemImage: "doc.text",
+                description: Text("Edit this memory to see a diff against the shared version.")
+            )
         }
     }
 

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -100,25 +100,27 @@ private struct EmptyWorkspaceView: View {
 private struct EmptyMemoryCollectionView: View {
     @ObservedObject var store: WorkspaceStore
 
-    private var scope: MemoryScope {
-        store.activeProjectId == nil ? .org : .project
-    }
-
     var body: some View {
         ContentUnavailableView {
             Label("No Memory", systemImage: "doc")
         } description: {
-            Text("Create the first memory here.")
-        } actions: {
-            Button("New Memory") {
-                Task {
-                    await store.createMemory(kind: store.selectedKind, scope: scope)
-                }
+            if store.activeProjectId == nil {
+                Text("Select a project to propose a new organization memory.")
+            } else {
+                Text("Propose the first organization memory for this project.")
             }
-            .keyboardShortcut(.defaultAction)
-            .disabled(
-                !store.canCreateMemory(kind: store.selectedKind, scope: scope)
-            )
+        } actions: {
+            if let scope = MemoryFileTreeMenu.creationScope(inOrgView: store.activeProjectId == nil) {
+                Button("Propose New Organization Memory") {
+                    Task {
+                        await store.createMemory(kind: store.selectedKind, scope: scope)
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(
+                    !store.canCreateMemory(kind: store.selectedKind, scope: scope)
+                )
+            }
         }
     }
 }
@@ -144,6 +146,31 @@ private struct ProjectPreparationView: View {
     }
 }
 
+private struct PendingOrganizationDeletion: Identifiable {
+    let id = UUID()
+    let items: [MemoryListItem]
+
+    var title: String {
+        items.count == 1
+            ? "Propose Organization Deletion?"
+            : "Propose \(items.count) Organization Deletions?"
+    }
+
+    var confirmationTitle: String {
+        items.count == 1 ? "Propose Deletion" : "Propose Deletions"
+    }
+
+    var message: String {
+        let subject = items.count == 1
+            ? "this organization memory"
+            : "these \(items.count) organization memories"
+        let proposal = items.count == 1 ? "a deletion draft proposal" : "deletion draft proposals"
+        let object = items.count == 1 ? "it" : "them"
+        return "This creates \(proposal). If reviewed and merged, \(subject) "
+            + "will be removed for every project that includes \(object)."
+    }
+}
+
 private struct FileTreeView: View {
     @ObservedObject var store: WorkspaceStore
     let items: [MemoryListItem]
@@ -153,6 +180,7 @@ private struct FileTreeView: View {
     @State private var initializedExpansion = false
     @State private var itemToRename: MemoryListItem?
     @State private var proposedName = ""
+    @State private var pendingOrganizationDeletion: PendingOrganizationDeletion?
 
     private var roots: [FileTreeNode] {
         FileTreeNode.build(items)
@@ -205,8 +233,13 @@ private struct FileTreeView: View {
         .onChange(of: store.activeVisibleTab?.itemId ?? store.selectedItemId) { _, _ in
             synchronizeSelectionWithActiveItem()
         }
+        .onChange(of: store.activeProjectId) { _, _ in
+            itemToRename = nil
+            proposedName = ""
+            pendingOrganizationDeletion = nil
+        }
         .alert(
-            "Rename Memory",
+            "Propose Organization Rename",
             isPresented: Binding(
                 get: { itemToRename != nil },
                 set: {
@@ -221,10 +254,25 @@ private struct FileTreeView: View {
             Button("Cancel", role: .cancel) {
                 itemToRename = nil
             }
-            Button("Rename") {
+            Button("Propose Rename") {
                 renameSelectedItem()
             }
             .disabled(!isValidProposedName)
+        } message: {
+            Text(
+                "This creates a draft proposal. If it is reviewed and merged, "
+                    + "the organization memory will be renamed for every project that includes it."
+            )
+        }
+        .alert(item: $pendingOrganizationDeletion) { deletion in
+            Alert(
+                title: Text(deletion.title),
+                message: Text(deletion.message),
+                primaryButton: .destructive(Text(deletion.confirmationTitle)) {
+                    deleteItems(deletion.items)
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -328,13 +376,12 @@ private struct FileTreeView: View {
         let removableItems = MemoryFileTreeMenu.removable(targetItems, inOrgView: isOrgView)
         let trashableItems = MemoryFileTreeMenu.trashable(targetItems, inOrgView: isOrgView)
             .filter { store.canEditMemory($0) }
-        let singleManageable = singleItem.map {
-            MemoryFileTreeMenu.isManageable($0, inOrgView: isOrgView)
-                && store.canEditMemory($0)
-        } ?? false
         let singleRenameable = singleItem.map {
             MemoryFileTreeMenu.canRename($0, inOrgView: isOrgView)
                 && store.canEditMemory($0)
+        } ?? false
+        let singleTrashable = singleItem.map { item in
+            trashableItems.contains { $0.id == item.id }
         } ?? false
         let singleStale = singleItem.map { item in
             item.resource.map { store.staleResourceIds.contains($0.id) } == true
@@ -348,8 +395,9 @@ private struct FileTreeView: View {
         let trashSelectionContainsSynchronizingDocument = trashableItems.contains {
             store.isSynchronizingDocument($0.id)
         }
+        let hasDraftAction = !isOrgView && singleItem?.draft != nil
         let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
-            || (singleItem?.draft != nil) || singleStale
+            || hasDraftAction || singleStale
 
         // ---- generic document operations (standard macOS conventions) ----
         if let singleItem {
@@ -357,23 +405,21 @@ private struct FileTreeView: View {
             if singleItem.supportsMarkdownPreview {
                 Button("Open Source") { store.open(singleItem, mode: .source) }
             }
-            if singleManageable {
-                if singleRenameable {
-                    Button("Rename…") { beginRenaming(singleItem) }
-                        .disabled(singleSynchronizing)
-                }
-                if singleItem.resource != nil && singleItem.draft?.isDeletion != true {
-                    Button("Move to Trash", role: .destructive) {
-                        Task { await store.delete(singleItem) }
-                    }
+            if singleRenameable {
+                Button("Propose Organization Rename…") { beginRenaming(singleItem) }
                     .disabled(singleSynchronizing)
+            }
+            if singleTrashable {
+                Button("Propose Organization Deletion", role: .destructive) {
+                    proposeOrganizationDeletion([singleItem])
                 }
+                .disabled(singleSynchronizing)
             }
         } else if !targetItems.isEmpty {
             Button("Open") { targetItems.forEach { store.open($0) } }
             if !trashableItems.isEmpty {
-                Button(moveToTrashTitle(count: trashableItems.count), role: .destructive) {
-                    deleteItems(trashableItems)
+                Button(organizationDeletionTitle(count: trashableItems.count), role: .destructive) {
+                    proposeOrganizationDeletion(trashableItems)
                 }
                 .disabled(trashSelectionContainsSynchronizingDocument)
             }
@@ -440,7 +486,7 @@ private struct FileTreeView: View {
                     store.syncDocument(singleItem)
                 }
             }
-            if let draft = singleItem.draft {
+            if !isOrgView, let draft = singleItem.draft {
                 Button("Discard Draft") {
                     Task { await store.discard(draft) }
                 }
@@ -449,20 +495,16 @@ private struct FileTreeView: View {
         }
 
         if targetItems.isEmpty {
-            Button("New Memory") {
-                Task {
-                    await store.createMemory(
-                        kind: store.selectedKind,
-                        scope: store.activeProjectId == nil ? .org : .project
-                    )
+            if let scope = MemoryFileTreeMenu.creationScope(inOrgView: isOrgView) {
+                Button("Propose New Organization Memory") {
+                    Task {
+                        await store.createMemory(kind: store.selectedKind, scope: scope)
+                    }
                 }
-            }
-            .disabled(
-                !store.canCreateMemory(
-                    kind: store.selectedKind,
-                    scope: store.activeProjectId == nil ? .org : .project
+                .disabled(
+                    !store.canCreateMemory(kind: store.selectedKind, scope: scope)
                 )
-            )
+            }
         }
     }
 
@@ -476,8 +518,15 @@ private struct FileTreeView: View {
         selectionAnchorId = itemId
     }
 
-    private func moveToTrashTitle(count: Int) -> String {
-        count == 1 ? "Move to Trash" : "Move \(count) Items to Trash"
+    private func organizationDeletionTitle(count: Int) -> String {
+        count == 1
+            ? "Propose Organization Deletion"
+            : "Propose \(count) Organization Deletions"
+    }
+
+    private func proposeOrganizationDeletion(_ items: [MemoryListItem]) {
+        guard !items.isEmpty else { return }
+        pendingOrganizationDeletion = .init(items: items)
     }
 
     private func deleteItems(_ items: [MemoryListItem]) {
@@ -549,6 +598,22 @@ enum MemoryFileTreeTitleTone: Equatable {
     }
 }
 
+enum MemoryFileTreeRowAccessory: Equatable {
+    case none
+    case legacyProjectReadOnly
+
+    static func resolve(item: MemoryListItem?) -> Self {
+        item?.resource?.scope == .project ? .legacyProjectReadOnly : .none
+    }
+
+    var help: String? {
+        switch self {
+        case .none: nil
+        case .legacyProjectReadOnly: "Legacy Project memory — read-only"
+        }
+    }
+}
+
 private struct FileTreeRow: View {
     let entry: VisibleFileTreeNode
     let isExpanded: Bool
@@ -580,20 +645,32 @@ private struct FileTreeRow: View {
             isExpanded: isExpanded,
             titleColor: titleColor
         ) {
-            SharedUpdateIndicator(
-                freshness: item?.draft?.freshness,
-                hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
-                reconciliation: item?.draft?.reconciliation,
-                isStale: isStale
-            )
+            HStack(spacing: 5) {
+                SharedUpdateIndicator(
+                    freshness: item?.draft?.freshness,
+                    hasUpstreamResourceChanges: item?.draft?.hasUpstreamResourceChanges == true,
+                    reconciliation: item?.draft?.reconciliation,
+                    isStale: isStale
+                )
+                if let help = rowAccessory.help {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .help(help)
+                        .accessibilityLabel(help)
+                }
+            }
         }
-        .help(entry.node.name)
+        .help(rowAccessory.help ?? entry.node.name)
     }
 
     private var titleColor: Color {
         MemoryFileTreeTitleTone.resolve(item: item).color
     }
 
+    private var rowAccessory: MemoryFileTreeRowAccessory {
+        MemoryFileTreeRowAccessory.resolve(item: item)
+    }
 }
 
 struct FileTreeDirectoryClickResult {
@@ -794,6 +871,11 @@ private struct DocumentSessionView: View {
     @State private var loadsDocumentDiff = false
     @State private var documentDiffError: String?
     @State private var documentDiffRetryRequest = 0
+    @State private var confirmsOrganizationDeletion = false
+
+    private var sessionKey: MemoryDocumentSessionKey? {
+        store.documentSessionKey(for: item)
+    }
 
     init(store: WorkspaceStore, item: MemoryListItem, mode: WorkbenchTabMode) {
         self.store = store
@@ -860,6 +942,17 @@ private struct DocumentSessionView: View {
                 )
             }
         }
+        .alert("Propose Organization Deletion?", isPresented: $confirmsOrganizationDeletion) {
+            Button("Cancel", role: .cancel) {}
+            Button("Propose Deletion", role: .destructive) {
+                moveToTrash()
+            }
+        } message: {
+            Text(
+                "This creates a deletion draft proposal. If reviewed and merged, "
+                    + "the organization memory will be removed for every project that includes it."
+            )
+        }
     }
 
     private var documentContent: some View {
@@ -868,9 +961,15 @@ private struct DocumentSessionView: View {
                 documentDiff
             } else if item.draft?.isDeletion == true {
                 ContentUnavailableView(
-                    "Pending deletion",
+                    item.draft?.scope == .org
+                        ? "Pending organization deletion"
+                        : "Pending deletion",
                     systemImage: "trash",
-                    description: Text("Discard the draft to keep this memory.")
+                    description: Text(
+                        item.draft?.scope == .org
+                            ? "Discard the draft proposal to keep this organization memory."
+                            : "Discard the draft to keep this memory."
+                    )
                 )
             } else if mode == .preview {
                 MarkdownPreview(source: renderedSource)
@@ -1063,7 +1162,7 @@ private struct DocumentSessionView: View {
     }
 
     private func handleDocumentCommand(_ command: DocumentSessionCommand?) {
-        guard let command, command.itemId == item.id else { return }
+        guard let command, command.sessionKey == sessionKey else { return }
         store.pendingDocumentCommand = nil
         switch command {
         case .requestReview(_, let draft):
@@ -1075,13 +1174,21 @@ private struct DocumentSessionView: View {
         case .closeReconciliation:
             closeReconciliation()
         case .moveToTrash:
-            moveToTrash()
+            guard store.canEditMemory(item),
+                  MemoryFileTreeMenu.canProposeOrganizationDeletion(
+                      item,
+                      inOrgView: store.activeProjectId == nil
+                  ) else {
+                return
+            }
+            confirmsOrganizationDeletion = true
         }
     }
 
     private func publishReconciliationToolbarState(canUpdate: Bool, isUpdating: Bool) {
+        guard let sessionKey else { return }
         store.documentReconciliationToolbarState = .init(
-            itemId: item.id,
+            sessionKey: sessionKey,
             isLoading: false,
             canUpdate: canUpdate,
             isUpdating: isUpdating
@@ -1089,12 +1196,13 @@ private struct DocumentSessionView: View {
     }
 
     private func closeReconciliation() {
-        store.finishDocumentReconciliation(for: item.id)
+        guard let sessionKey else { return }
+        store.finishDocumentReconciliation(for: sessionKey)
         clearReconciliationToolbarState()
     }
 
     private func clearReconciliationToolbarState() {
-        guard store.documentReconciliationToolbarState?.itemId == item.id else { return }
+        guard store.documentReconciliationToolbarState?.sessionKey == sessionKey else { return }
         store.documentReconciliationToolbarState = nil
     }
 
@@ -1113,7 +1221,7 @@ private struct DocumentSessionView: View {
               mode == .source else { return }
         Task {
             do {
-                try await store.flushDocumentSave(item.id)
+                try await store.flushDocumentSave(item)
             } catch {
                 store.errorMessage = error.localizedDescription
             }
@@ -1127,7 +1235,7 @@ private struct DocumentSessionView: View {
         candidate: DraftReconciliationCandidate?,
         resolvedState: ReconciliationResourceState?
     ) async throws {
-        try await store.flushDocumentSave(item.id)
+        try await store.flushDocumentSave(item)
         let latest = store.drafts.first { $0.id == draft.id } ?? draft
         try await store.requestReview(
             for: latest,
@@ -1139,14 +1247,14 @@ private struct DocumentSessionView: View {
     }
 
     private func loadReviewCandidate(_ draft: LocalDraft) async throws -> DraftReconciliationCandidate {
-        try await store.flushDocumentSave(item.id)
+        try await store.flushDocumentSave(item)
         let latest = store.drafts.first { $0.id == draft.id } ?? draft
         return try await store.reconciliationCandidate(for: latest)
     }
 
     private func discard(_ draft: LocalDraft) {
         suppressesSaving = true
-        store.cancelDocumentSave(item.id)
+        store.cancelDocumentSave(item)
         Task {
             await store.discard(draft)
             suppressesSaving = false
@@ -1154,8 +1262,17 @@ private struct DocumentSessionView: View {
     }
 
     private func moveToTrash() {
+        guard let activeProjectId = store.activeProjectId,
+              item.projectContextId == activeProjectId,
+              store.canEditMemory(item),
+              MemoryFileTreeMenu.canProposeOrganizationDeletion(
+                  item,
+                  inOrgView: false
+              ) else {
+            return
+        }
         suppressesSaving = true
-        store.cancelDocumentSave(item.id)
+        store.cancelDocumentSave(item)
         Task {
             await store.delete(item)
             suppressesSaving = false
@@ -1592,24 +1709,27 @@ private struct ReviewRequestSheet: View {
 ///
 /// Menu = generic document operations (standard macOS conventions) + domain
 /// operations (Memory project membership and drafts). Add to Project exists
-/// only in the Org view; Remove from Project exists only in the Project view.
+/// only in the read-only Org view; Draft proposals and Remove from Project
+/// exist only inside an explicit Project context.
 enum MemoryFileTreeMenu {
-    /// Editing never mutates authority directly; it creates or updates the
-    /// current view's local Draft. An unselected Org resource is not
-    /// manageable from a Project context, but it is also filtered out of the
-    /// Project tree.
-    static func isManageable(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
-        if inOrgView { return item.scope == .org }
-        return item.scope == .project || item.inherited || item.draft?.projectId != nil
+    /// Rename is an organization-authority proposal. Project views only
+    /// expose it for Org resources that are still selected by that project.
+    /// The Org overview is authority-only/read-only because it has no
+    /// unambiguous Project carrier for a LocalDraft.
+    /// Target-backed draft-only rows (for example, after Remove from Project)
+    /// and legacy Project authority are intentionally excluded.
+    static func canRename(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
+        guard item.resource?.scope == .org,
+              item.draft?.isDeletion != true else {
+            return false
+        }
+        return !inOrgView && item.inherited
     }
 
-    /// A target-backed memory supports a path-only rename. A pure create
-    /// draft has no stable resource id for the daemon's rename operation and
-    /// must become shared before it can be renamed safely.
-    static func canRename(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
-        isManageable(item, inOrgView: inOrgView)
-            && item.draft?.isDeletion != true
-            && (item.resource != nil || item.draft?.targetId != nil)
+    /// New memories are Project-bound proposals for Org authority. The Org
+    /// overview is read-only and therefore has no creation scope.
+    static func creationScope(inOrgView: Bool) -> MemoryScope? {
+        inOrgView ? nil : .org
     }
 
     /// Org memories that may be added to a project: only in the Org view.
@@ -1625,13 +1745,20 @@ enum MemoryFileTreeMenu {
         inOrgView ? [] : items.filter(\.inherited)
     }
 
-    /// Items that support batch Move to Trash: manageable items that back a
-    /// resource (pure drafts are discarded, not trashed).
-    static func trashable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
-        items.filter {
-            isManageable($0, inOrgView: inOrgView)
-                && $0.resource != nil
-                && $0.draft?.isDeletion != true
+    /// Items that may propose deletion of Org authority. This is the shared
+    /// predicate for single-row, batch, and document-toolbar actions.
+    static func canProposeOrganizationDeletion(
+        _ item: MemoryListItem,
+        inOrgView: Bool
+    ) -> Bool {
+        guard item.resource?.scope == .org,
+              item.draft?.isDeletion != true else {
+            return false
         }
+        return !inOrgView && item.inherited
+    }
+
+    static func trashable(_ items: [MemoryListItem], inOrgView: Bool) -> [MemoryListItem] {
+        items.filter { canProposeOrganizationDeletion($0, inOrgView: inOrgView) }
     }
 }

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -588,7 +588,6 @@ struct ReviewDetailPage: View {
                     }
                     try await store.applyReconciliation(
                         draftId: detail.draft.draftId,
-                        draftVersion: detail.draft.version,
                         candidate: candidate,
                         resolvedState: resolvedState
                     )

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -163,7 +163,8 @@ struct WorkspaceView: View {
 
     private var documentReconciliationState: DocumentReconciliationToolbarState? {
         guard let state = store.documentReconciliationToolbarState,
-              state.itemId == store.currentItem?.id else { return nil }
+              let currentItem = store.currentItem,
+              state.sessionKey == store.documentSessionKey(for: currentItem) else { return nil }
         return state
     }
 
@@ -204,7 +205,7 @@ struct WorkspaceView: View {
                             Button {
                                 if let state = documentReconciliationState {
                                     store.pendingDocumentCommand = .closeReconciliation(
-                                        itemId: state.itemId
+                                        sessionKey: state.sessionKey
                                     )
                                 } else {
                                     store.goBack()
@@ -300,7 +301,7 @@ struct WorkspaceView: View {
                                 } else {
                                     Button {
                                         store.pendingDocumentCommand = .applyReconciliation(
-                                            itemId: state.itemId
+                                            sessionKey: state.sessionKey
                                         )
                                     } label: {
                                         Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
@@ -361,40 +362,48 @@ struct WorkspaceView: View {
                             .help("Document View")
                             .accessibilityLabel("Document View")
 
-                            Menu {
-                                if let draft = item.draft,
-                                   draft.status == .open,
-                                   WorkspaceStore.canRequestReview(draft) {
-                                    Button("Request Review") {
-                                        store.pendingDocumentCommand = .requestReview(
-                                            itemId: item.id,
-                                            draft: draft
-                                        )
+                            if hasDocumentActions(item) {
+                                Menu {
+                                    if canRequestDocumentReview(item),
+                                       let draft = item.draft,
+                                       let sessionKey = store.documentSessionKey(for: item) {
+                                        Button("Request Review") {
+                                            store.pendingDocumentCommand = .requestReview(
+                                                sessionKey: sessionKey,
+                                                draft: draft
+                                            )
+                                        }
+                                        Divider()
                                     }
-                                    Divider()
-                                }
-                                if let draft = item.draft {
-                                    Button("Discard Draft") {
-                                        store.pendingDocumentCommand = .discardDraft(
-                                            itemId: item.id,
-                                            draft: draft
-                                        )
+                                    if canDiscardDocumentDraft(item),
+                                       let draft = item.draft,
+                                       let sessionKey = store.documentSessionKey(for: item) {
+                                        Button("Discard Draft") {
+                                            store.pendingDocumentCommand = .discardDraft(
+                                                sessionKey: sessionKey,
+                                                draft: draft
+                                            )
+                                        }
                                     }
-                                }
-                                if store.canEditMemory(item)
-                                    && (item.resource != nil || item.draft?.targetId != nil)
-                                    && item.draft?.isDeletion != true {
-                                    Button("Move to Trash", role: .destructive) {
-                                        store.pendingDocumentCommand = .moveToTrash(itemId: item.id)
+                                    if canProposeOrganizationDeletion(item),
+                                       let sessionKey = store.documentSessionKey(for: item) {
+                                        Button(
+                                            "Propose Organization Deletion",
+                                            role: .destructive
+                                        ) {
+                                            store.pendingDocumentCommand = .moveToTrash(
+                                                sessionKey: sessionKey
+                                            )
+                                        }
                                     }
+                                } label: {
+                                    Image(systemName: "ellipsis")
                                 }
-                            } label: {
-                                Image(systemName: "ellipsis")
+                                .disabled(store.isSynchronizingDocument(item.id))
+                                .menuIndicator(.hidden)
+                                .help("Document Actions")
+                                .accessibilityLabel("Document Actions")
                             }
-                            .disabled(store.isSynchronizingDocument(item.id))
-                            .menuIndicator(.hidden)
-                            .help("Document Actions")
-                            .accessibilityLabel("Document Actions")
                         }
                     }
 
@@ -1152,6 +1161,34 @@ struct WorkspaceView: View {
         return store.currentItem?.supportsMarkdownPreview == true
             ? [.preview, .source, .diff]
             : [.source, .diff]
+    }
+
+    private func canRequestDocumentReview(_ item: MemoryListItem) -> Bool {
+        guard store.activeProjectId != nil,
+              let draft = item.draft else {
+            return false
+        }
+        return draft.status == .open
+            && draft.scope == .org
+            && WorkspaceStore.canRequestReview(draft)
+    }
+
+    private func canProposeOrganizationDeletion(_ item: MemoryListItem) -> Bool {
+        store.canEditMemory(item)
+            && MemoryFileTreeMenu.canProposeOrganizationDeletion(
+                item,
+                inOrgView: store.activeProjectId == nil
+            )
+    }
+
+    private func canDiscardDocumentDraft(_ item: MemoryListItem) -> Bool {
+        store.activeProjectId != nil && item.draft != nil
+    }
+
+    private func hasDocumentActions(_ item: MemoryListItem) -> Bool {
+        canRequestDocumentReview(item)
+            || canDiscardDocumentDraft(item)
+            || canProposeOrganizationDeletion(item)
     }
 
     private var documentMode: Binding<WorkbenchTabMode> {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -298,9 +298,9 @@ struct WorkspaceView: View {
                                     ProgressView()
                                         .controlSize(.small)
                                         .frame(width: 24, height: 24)
-                                        .help(state.isLoading ? "Reviewing changes" : "Updating draft")
+                                        .help(state.isLoading ? "Reviewing changes" : "Syncing")
                                         .accessibilityLabel(
-                                            state.isLoading ? "Reviewing changes" : "Updating draft"
+                                            state.isLoading ? "Reviewing changes" : "Syncing"
                                         )
                                 } else {
                                     Button {
@@ -311,21 +311,32 @@ struct WorkspaceView: View {
                                         Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
                                     }
                                     .disabled(!state.canUpdate)
-                                    .help("Update Draft")
-                                    .accessibilityLabel("Update Draft")
+                                    .help("Sync")
+                                    .accessibilityLabel("Sync")
                                 }
                             }
 
-                            if item.supportsMarkdownPreview {
-                                let mode = store.currentTabMode ?? .source
+                            if documentReconciliationState == nil, documentNeedsSync {
                                 Button {
-                                    store.open(item, mode: mode == .preview ? .source : .preview)
+                                    store.syncDocument(item)
                                 } label: {
-                                    Image(systemName: mode == .preview ? "doc.plaintext" : "eye")
+                                    Image(systemName: item.draft?.reconciliation == .conflicts
+                                        ? "exclamationmark.triangle"
+                                        : "arrow.trianglehead.2.clockwise.rotate.90")
                                 }
-                                .help(mode == .preview ? "Open Source" : "Open Preview")
-                                .accessibilityLabel(mode == .preview ? "Open Source" : "Open Preview")
+                                .help("Sync")
+                                .accessibilityLabel("Sync")
                             }
+
+                            Picker("Document View", selection: documentMode) {
+                                ForEach(availableDocumentModes, id: \.self) { mode in
+                                    Text(mode.title).tag(mode)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .disabled(documentReconciliationState != nil)
+                            .help("Document View")
+                            .accessibilityLabel("Document View")
 
                             Menu {
                                 if let draft = item.draft, draft.status == .open {
@@ -1113,6 +1124,29 @@ struct WorkspaceView: View {
                 .frame(minWidth: 120, maxWidth: 360, alignment: .leading)
                 .accessibilityLabel("Path: \(path)")
         }
+    }
+
+    private var availableDocumentModes: [WorkbenchTabMode] {
+        store.currentItem?.supportsMarkdownPreview == true
+            ? [.preview, .source, .diff]
+            : [.source, .diff]
+    }
+
+    private var documentMode: Binding<WorkbenchTabMode> {
+        Binding(
+            get: {
+                let mode = store.currentTabMode ?? .preview
+                return availableDocumentModes.contains(mode) ? mode : .source
+            },
+            set: { store.switchDocumentMode($0) }
+        )
+    }
+
+    private var documentNeedsSync: Bool {
+        guard let item = store.currentItem else { return false }
+        if item.draft?.freshness == .behind { return true }
+        return item.draft == nil
+            && item.resource.map { store.staleResourceIds.contains($0.id) } == true
     }
 
     private var searchResults: [SearchEntry] {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -222,21 +222,6 @@ struct WorkspaceView: View {
                         }
 
                         if #available(macOS 26.0, *) {
-                            ToolbarSpacer(.fixed)
-                        }
-
-                        if #available(macOS 26.0, *) {
-                            ToolbarItem {
-                                documentPath
-                            }
-                            .sharedBackgroundVisibility(.hidden)
-                        } else {
-                            ToolbarItem {
-                                documentPath
-                            }
-                        }
-
-                        if #available(macOS 26.0, *) {
                             ToolbarSpacer(.flexible)
                         }
                     }
@@ -1114,15 +1099,6 @@ struct WorkspaceView: View {
             EmptyView()
         case .reviews:
             EmptyView()
-        }
-    }
-
-    @ViewBuilder
-    private var documentPath: some View {
-        if let path = store.currentDocumentPath {
-            DocumentPathBreadcrumb(path: path)
-                .frame(minWidth: 120, maxWidth: 360, alignment: .leading)
-                .accessibilityLabel("Path: \(path)")
         }
     }
 

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -106,6 +106,13 @@ enum WorkspaceColumnLayout: Equatable {
     }
 }
 
+private enum DocumentSyncReadiness {
+    case ready
+    case pending
+    case failed
+    case unavailable
+}
+
 struct IssueBoardRoute: Hashable {
     let issueId: String
 }
@@ -205,7 +212,10 @@ struct WorkspaceView: View {
                             } label: {
                                 Image(systemName: "chevron.left")
                             }
-                            .disabled(documentReconciliationState == nil && !store.canGoBack)
+                            .disabled(
+                                documentReconciliationState?.isUpdating == true
+                                    || (documentReconciliationState == nil && !store.canGoBack)
+                            )
                             .help(documentReconciliationState == nil ? "Go Back" : "Back to Document")
                             .accessibilityLabel(
                                 documentReconciliationState == nil ? "Go Back" : "Back to Document"
@@ -302,15 +312,39 @@ struct WorkspaceView: View {
                             }
 
                             if documentReconciliationState == nil, documentNeedsSync {
-                                Button {
-                                    store.syncDocument(item)
-                                } label: {
-                                    Image(systemName: item.draft?.reconciliation == .conflicts
-                                        ? "exclamationmark.triangle"
-                                        : "arrow.trianglehead.2.clockwise.rotate.90")
+                                switch documentSyncReadiness {
+                                case .pending:
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .frame(width: 24, height: 24)
+                                        .help("Saving draft changes before sync")
+                                        .accessibilityLabel("Saving draft changes before sync")
+                                case .failed:
+                                    Button {
+                                        Task { await store.retrySync() }
+                                    } label: {
+                                        Image(systemName: "arrow.clockwise")
+                                    }
+                                    .help("Retry Draft Sync")
+                                    .accessibilityLabel("Retry Draft Sync")
+                                case .unavailable:
+                                    Button {} label: {
+                                        Image(systemName: "exclamationmark.triangle")
+                                    }
+                                    .disabled(true)
+                                    .help("Draft is not available on the server yet")
+                                    .accessibilityLabel("Draft is not available on the server yet")
+                                case .ready:
+                                    Button {
+                                        store.syncDocument(item)
+                                    } label: {
+                                        Image(systemName: item.draft?.reconciliation == .conflicts
+                                            ? "exclamationmark.triangle"
+                                            : "arrow.trianglehead.2.clockwise.rotate.90")
+                                    }
+                                    .help("Sync")
+                                    .accessibilityLabel("Sync")
                                 }
-                                .help("Sync")
-                                .accessibilityLabel("Sync")
                             }
 
                             Picker("Document View", selection: documentMode) {
@@ -319,12 +353,18 @@ struct WorkspaceView: View {
                                 }
                             }
                             .pickerStyle(.segmented)
-                            .disabled(documentReconciliationState != nil)
+                            .disabled(
+                                documentReconciliationState != nil
+                                    || availableDocumentModes.count < 2
+                                    || store.isSynchronizingDocument(item.id)
+                            )
                             .help("Document View")
                             .accessibilityLabel("Document View")
 
                             Menu {
-                                if let draft = item.draft, draft.status == .open {
+                                if let draft = item.draft,
+                                   draft.status == .open,
+                                   WorkspaceStore.canRequestReview(draft) {
                                     Button("Request Review") {
                                         store.pendingDocumentCommand = .requestReview(
                                             itemId: item.id,
@@ -341,7 +381,9 @@ struct WorkspaceView: View {
                                         )
                                     }
                                 }
-                                if !item.inherited {
+                                if store.canEditMemory(item)
+                                    && (item.resource != nil || item.draft?.targetId != nil)
+                                    && item.draft?.isDeletion != true {
                                     Button("Move to Trash", role: .destructive) {
                                         store.pendingDocumentCommand = .moveToTrash(itemId: item.id)
                                     }
@@ -349,6 +391,7 @@ struct WorkspaceView: View {
                             } label: {
                                 Image(systemName: "ellipsis")
                             }
+                            .disabled(store.isSynchronizingDocument(item.id))
                             .menuIndicator(.hidden)
                             .help("Document Actions")
                             .accessibilityLabel("Document Actions")
@@ -1103,7 +1146,10 @@ struct WorkspaceView: View {
     }
 
     private var availableDocumentModes: [WorkbenchTabMode] {
-        store.currentItem?.supportsMarkdownPreview == true
+        if store.currentItem?.draft?.documentBaselineAvailable == false {
+            return [.diff]
+        }
+        return store.currentItem?.supportsMarkdownPreview == true
             ? [.preview, .source, .diff]
             : [.source, .diff]
     }
@@ -1121,8 +1167,23 @@ struct WorkspaceView: View {
     private var documentNeedsSync: Bool {
         guard let item = store.currentItem else { return false }
         if item.draft?.freshness == .behind { return true }
-        return item.draft == nil
-            && item.resource.map { store.staleResourceIds.contains($0.id) } == true
+        return item.resource.map { store.staleResourceIds.contains($0.id) } == true
+    }
+
+    private var documentSyncReadiness: DocumentSyncReadiness {
+        guard let item = store.currentItem else { return .ready }
+        if store.isSynchronizingDocument(item.id) { return .pending }
+        guard let draft = item.draft else {
+            return .ready
+        }
+        switch draft.syncStatus {
+        case .queued, .syncing, .retrying:
+            return .pending
+        case .failed:
+            return .failed
+        case .synced:
+            return draft.serverId == nil ? .unavailable : .ready
+        }
     }
 
     private var searchResults: [SearchEntry] {
@@ -1131,12 +1192,7 @@ struct WorkspaceView: View {
         var entries: [SearchEntry] = []
         switch store.selectedSection {
         case .memory:
-            entries = memorySearchEntries(needle: needle) { item in
-                if item.scope == .org {
-                    return true
-                }
-                return item.projectId == store.activeProjectId
-            }
+            entries = memorySearchEntries(needle: needle)
         case .bundles:
             for bundle in store.bundles
             where "\(bundle.name) \(bundle.description)".localizedLowercase.contains(needle) {
@@ -1154,21 +1210,8 @@ struct WorkspaceView: View {
         return Array(entries.prefix(30))
     }
 
-    private func memorySearchEntries(
-        needle: String,
-        inScope: (MemoryListItem) -> Bool
-    ) -> [SearchEntry] {
-        let resourceItems = store.resources.map { resource -> MemoryListItem in
-            let draft = store.drafts.first {
-                $0.targetId == resource.id && $0.status != .discarded && $0.status != .merged
-            }
-            return .init(id: resource.id, resource: resource, draft: draft, inherited: false)
-        }
-        let newDrafts = store.drafts.filter { $0.targetId == nil }.map {
-            MemoryListItem(id: $0.id, resource: nil, draft: $0, inherited: false)
-        }
-        return (resourceItems + newDrafts)
-            .filter(inScope)
+    private func memorySearchEntries(needle: String) -> [SearchEntry] {
+        store.visibleMemoryItems
             .compactMap { item in
                 let document = item.document
                 let haystack = "\(document.title) \(document.path) \(document.body) \(item.kind.title)"
@@ -1244,10 +1287,10 @@ private struct MemoryProjectFilter: View {
     var body: some View {
         ToolbarFilterMenu(
             selectionTitle: store.activeProject?.name ?? "Org",
-            isLoading: store.loadingProjectId != nil
+            isLoading: store.isSwitchingMemoryContext
         ) {
             Button {
-                store.showOrgMemory()
+                Task { await store.showOrgMemory() }
             } label: {
                 if store.activeProjectId == nil {
                     Label("Org", systemImage: "checkmark")
@@ -1255,6 +1298,7 @@ private struct MemoryProjectFilter: View {
                     Label("Org", systemImage: "building.2")
                 }
             }
+            .disabled(store.isSwitchingMemoryContext)
 
             if !store.projects.isEmpty {
                 Divider()
@@ -1275,7 +1319,7 @@ private struct MemoryProjectFilter: View {
                             Text(project.name)
                         }
                     }
-                    .disabled(store.loadingProjectId != nil)
+                    .disabled(store.isSwitchingMemoryContext)
                 }
             }
         }

--- a/apps/macos/Sources/Infrastructure/ServerClient.swift
+++ b/apps/macos/Sources/Infrastructure/ServerClient.swift
@@ -89,10 +89,7 @@ struct ServerClient: Sendable {
                 .init(method: method, path: requestPath, headers: headers, body: body)
             )
         }
-        if response.headers.contains(where: {
-            $0.key.caseInsensitiveCompare("x-clumsies-cache") == .orderedSame
-                && $0.value.caseInsensitiveCompare("stale") == .orderedSame
-        }) {
+        if response.isStaleCache {
             dataSourceTracker.markStale()
         }
         return response
@@ -191,6 +188,15 @@ struct ServerClient: Sendable {
             return body.isEmpty ? "No error details were returned." : body
         }
         return message
+    }
+}
+
+extension DaemonServerResponse {
+    var isStaleCache: Bool {
+        headers.contains {
+            $0.key.caseInsensitiveCompare("x-clumsies-cache") == .orderedSame
+                && $0.value.caseInsensitiveCompare("stale") == .orderedSame
+        }
     }
 }
 

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -1469,7 +1469,7 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertFalse(firstProjectTab.isVisible(in: .memory, projectId: "project-2"))
     }
 
-    func testOrgWorkbenchTabsDoNotDependOnTheActiveProject() {
+    func testOrgAuthorityWorkbenchTabStaysInOrgViewContext() {
         let tab = WorkbenchTab(
             section: .memory,
             projectId: nil,
@@ -1478,8 +1478,9 @@ final class DaemonContractTests: XCTestCase {
             title: "Rule"
         )
 
-        XCTAssertTrue(tab.isVisible(in: .memory, projectId: "project-1"))
-        XCTAssertTrue(tab.isVisible(in: .memory, projectId: "project-2"))
+        XCTAssertTrue(tab.isVisible(in: .memory, projectId: nil))
+        XCTAssertFalse(tab.isVisible(in: .memory, projectId: "project-1"))
+        XCTAssertFalse(tab.isVisible(in: .memory, projectId: "project-2"))
     }
 
     func testReplacingMemoryPrimaryTextReplacesMarkdown() {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -716,7 +716,7 @@ final class DaemonContractTests: XCTestCase {
             hasUpstreamResourceChanges: true,
             reconciliation: .clean,
             reconciliationCandidateId: "candidate-1",
-            scope: .project,
+            scope: .org,
             kind: .context,
             targetId: "context-1",
             status: .open,

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -233,6 +233,28 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .deletedDraft)
     }
 
+    func testThreeWayLocalChangeShowsRemovalThenInsertion() {
+        let lines = ThreeWayDiff.lines(base: "a\nb", local: "a\nB", remote: "a\nb")
+        XCTAssertEqual(lines.map(\.kind), [.context, .removal, .insertion])
+    }
+
+    func testThreeWayRemoteChangeShowsGrayLines() {
+        let lines = ThreeWayDiff.lines(base: "a\nb", local: "a\nb", remote: "a\nB")
+        XCTAssertEqual(lines.map(\.kind), [.context, .remoteRemoval, .remoteInsertion])
+    }
+
+    func testThreeWayConflictShowsRemoteThenLocal() {
+        let lines = ThreeWayDiff.lines(base: "a", local: "L", remote: "R")
+        XCTAssertEqual(lines.map(\.kind), [.removal, .remoteInsertion, .insertion])
+    }
+
+    func testThreeWayUnchangedStreamYieldsNoBlocks() {
+        let presentation = UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
+            base: "a", local: "a", remote: "a"
+        ))
+        XCTAssertEqual(presentation.changedLineCount, 0)
+    }
+
     func testDraftToneTakesPrecedenceOverInherited() {
         let item = MemoryListItem(
             id: "res",

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -248,6 +248,16 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(lines.map(\.kind), [.removal, .remoteInsertion, .insertion])
     }
 
+    func testThreeWayEmptyBaseYieldsPureInsertions() {
+        let lines = ThreeWayDiff.lines(base: "", local: "a\nb", remote: "")
+        XCTAssertEqual(lines.map(\.kind), [.insertion, .insertion])
+    }
+
+    func testThreeWayEmptyBaseWithRemoteYieldsGrayFirst() {
+        let lines = ThreeWayDiff.lines(base: "", local: "a", remote: "b")
+        XCTAssertEqual(lines.map(\.kind), [.remoteInsertion, .insertion])
+    }
+
     func testThreeWayUnchangedStreamYieldsNoBlocks() {
         let presentation = UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
             base: "a", local: "a", remote: "a"

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -198,39 +198,45 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .primary)
     }
 
-    func testInheritedResourceUsesSecondaryTone() {
+    func testInheritedResourceWithoutDraftUsesPrimaryTone() {
         let item = MemoryListItem(id: "res", resource: nil, draft: nil, inherited: true)
-        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .secondary)
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .primary)
     }
 
-    func testNewDraftUsesGreenTone() {
-        let item = MemoryListItem(
-            id: "new",
-            resource: nil,
-            draft: draft(targetId: nil),
-            inherited: false
-        )
-        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .newDraft)
+    func testNewDraftUsesGreenToneRegardlessOfInheritance() {
+        for inherited in [false, true] {
+            let item = MemoryListItem(
+                id: "new",
+                resource: nil,
+                draft: draft(targetId: nil),
+                inherited: inherited
+            )
+            XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .newDraft)
+        }
     }
 
-    func testModifiedDraftUsesYellowTone() {
-        let item = MemoryListItem(
-            id: "res",
-            resource: nil,
-            draft: draft(targetId: "res"),
-            inherited: false
-        )
-        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .modifiedDraft)
+    func testModifiedDraftUsesYellowToneRegardlessOfInheritance() {
+        for inherited in [false, true] {
+            let item = MemoryListItem(
+                id: "res",
+                resource: nil,
+                draft: draft(targetId: "res"),
+                inherited: inherited
+            )
+            XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .modifiedDraft)
+        }
     }
 
-    func testDeletionDraftUsesRedTone() {
-        let item = MemoryListItem(
-            id: "res",
-            resource: nil,
-            draft: draft(targetId: "res", isDeletion: true),
-            inherited: false
-        )
-        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .deletedDraft)
+    func testDeletionDraftUsesRedToneRegardlessOfInheritance() {
+        for inherited in [false, true] {
+            let item = MemoryListItem(
+                id: "res",
+                resource: nil,
+                draft: draft(targetId: "res", isDeletion: true),
+                inherited: inherited
+            )
+            XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .deletedDraft)
+        }
     }
 
     func testThreeWayLocalChangeShowsRemovalThenInsertion() {
@@ -248,6 +254,74 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(lines.map(\.kind), [.removal, .remoteInsertion, .insertion])
     }
 
+    func testThreeWayIdenticalLocalAndRemoteReplacementIsEmittedOnce() {
+        let lines = ThreeWayDiff.lines(base: "a", local: "x", remote: "x")
+
+        XCTAssertEqual(lines.map(\.kind), [.removal, .insertion])
+        XCTAssertEqual(lines.map(\.text), ["a", "x"])
+        XCTAssertEqual(lines.map(\.oldLineNumber), [1, nil])
+        XCTAssertEqual(lines.map(\.newLineNumber), [nil, 1])
+        XCTAssertEqual(lines.map(\.remoteLineNumber), [nil, 1])
+    }
+
+    func testThreeWayMultiLineConflictKeepsRemoteAndLocalGroupsContiguous() {
+        let lines = ThreeWayDiff.lines(
+            base: "old 1\nold 2",
+            local: "local 1\nlocal 2",
+            remote: "remote 1\nremote 2"
+        )
+
+        XCTAssertEqual(lines.map(\.kind), [
+            .removal,
+            .removal,
+            .remoteInsertion,
+            .remoteInsertion,
+            .insertion,
+            .insertion,
+        ])
+        XCTAssertEqual(lines.map(\.text), [
+            "old 1",
+            "old 2",
+            "remote 1",
+            "remote 2",
+            "local 1",
+            "local 2",
+        ])
+        XCTAssertEqual(lines.compactMap(\.remoteLineNumber), [1, 2])
+        XCTAssertEqual(lines.compactMap(\.newLineNumber), [1, 2])
+    }
+
+    func testThreeWayConflictEmitsSharedPrefixAndSuffixOnce() {
+        let lines = ThreeWayDiff.lines(
+            base: "old prefix\nold middle\nold suffix",
+            local: "shared prefix\nlocal middle\nshared suffix",
+            remote: "shared prefix\nremote middle\nshared suffix"
+        )
+
+        XCTAssertEqual(lines.map(\.kind), [
+            .removal,
+            .removal,
+            .removal,
+            .insertion,
+            .remoteInsertion,
+            .insertion,
+            .insertion,
+        ])
+        XCTAssertEqual(lines.map(\.text), [
+            "old prefix",
+            "old middle",
+            "old suffix",
+            "shared prefix",
+            "remote middle",
+            "local middle",
+            "shared suffix",
+        ])
+        XCTAssertEqual(lines.compactMap(\.newLineNumber), [1, 2, 3])
+        XCTAssertEqual(lines.compactMap(\.remoteLineNumber), [1, 2, 3])
+        XCTAssertEqual(lines.filter { $0.text == "shared prefix" }.count, 1)
+        XCTAssertEqual(lines.filter { $0.text == "shared suffix" }.count, 1)
+    }
+
     func testThreeWayEmptyBaseYieldsPureInsertions() {
         let lines = ThreeWayDiff.lines(base: "", local: "a\nb", remote: "")
         XCTAssertEqual(lines.map(\.kind), [.insertion, .insertion])
@@ -258,21 +332,116 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(lines.map(\.kind), [.remoteInsertion, .insertion])
     }
 
+    func testThreeWayPureRemoteInsertionFromEmptyBaseUsesRemoteCoordinatesAndLabel() throws {
+        let lines = ThreeWayDiff.lines(base: "", local: "", remote: "remote 1\nremote 2")
+
+        XCTAssertEqual(lines.map(\.kind), [.remoteInsertion, .remoteInsertion])
+        XCTAssertEqual(lines.map(\.text), ["remote 1", "remote 2"])
+        XCTAssertEqual(lines.map(\.oldLineNumber), [nil, nil])
+        XCTAssertEqual(lines.map(\.newLineNumber), [nil, nil])
+        XCTAssertEqual(lines.map(\.remoteLineNumber), [1, 2])
+
+        let presentation = UnifiedDiffPresentation(lines: lines)
+        XCTAssertTrue(presentation.showsRemoteLineNumbers)
+        let block = try XCTUnwrap(presentation.blocks.first)
+        guard case .hunk(let label) = block.kind else {
+            return XCTFail("Expected a three-way hunk")
+        }
+        XCTAssertEqual(label, "@@ base 0,0 · local 0,0 · remote 1,2 @@")
+    }
+
+    func testThreeWayHunkLabelKeepsInsertionBoundaryForEmptyAxes() throws {
+        let lines = ThreeWayDiff.lines(
+            base: "a\nb\nc",
+            local: "a\nx\nb\nc",
+            remote: "a\nb\nc"
+        )
+
+        let presentation = UnifiedDiffPresentation(lines: lines, contextLineCount: 0)
+        let block = try XCTUnwrap(presentation.blocks.first { block in
+            if case .hunk = block.kind { return true }
+            return false
+        })
+        guard case .hunk(let label) = block.kind else {
+            return XCTFail("Expected a three-way hunk")
+        }
+        XCTAssertEqual(label, "@@ base 1,0 · local 2,1 · remote 1,0 @@")
+    }
+
+    func testThreeWayHunkLabelKeepsDeletionBoundaryForEmptyAxis() throws {
+        let lines = ThreeWayDiff.lines(
+            base: "a\nb\nc",
+            local: "a\nc",
+            remote: "a\nb\nc"
+        )
+
+        let presentation = UnifiedDiffPresentation(lines: lines, contextLineCount: 0)
+        let block = try XCTUnwrap(presentation.blocks.first { block in
+            if case .hunk = block.kind { return true }
+            return false
+        })
+        guard case .hunk(let label) = block.kind else {
+            return XCTFail("Expected a three-way hunk")
+        }
+        XCTAssertEqual(label, "@@ base 2,1 · local 1,0 · remote 2,1 @@")
+    }
+
+    func testThreeWayRemoteReplacementPreservesTextAndThreeCoordinateSpaces() throws {
+        let lines = ThreeWayDiff.lines(base: "a\nb", local: "a\nb", remote: "a\nB")
+
+        XCTAssertEqual(lines.map(\.text), ["a", "b", "B"])
+        XCTAssertEqual(lines.map(\.oldLineNumber), [1, 2, nil])
+        XCTAssertEqual(lines.map(\.newLineNumber), [1, 2, nil])
+        XCTAssertEqual(lines.map(\.remoteLineNumber), [1, nil, 2])
+
+        let presentation = UnifiedDiffPresentation(lines: lines)
+        let block = try XCTUnwrap(presentation.blocks.first)
+        guard case .hunk(let label) = block.kind else {
+            return XCTFail("Expected a three-way hunk")
+        }
+        XCTAssertEqual(label, "@@ base 1,2 · local 1,2 · remote 1,2 @@")
+    }
+
+    func testThreeWayDiffRetainsRepeatedBaseLines() {
+        let lines = ThreeWayDiff.lines(
+            base: "repeat\nrepeat\nend",
+            local: "repeat\nlocal\nrepeat\nend",
+            remote: "repeat\nremote\nrepeat\nend"
+        )
+        let context = lines.filter { $0.kind == .context }
+
+        XCTAssertEqual(context.map(\.text), ["repeat", "repeat", "end"])
+        XCTAssertEqual(context.compactMap(\.oldLineNumber), [1, 2, 3])
+        XCTAssertEqual(
+            lines.filter { $0.kind == .remoteInsertion }.map(\.text),
+            ["remote"]
+        )
+        XCTAssertEqual(
+            lines.filter { $0.kind == .insertion }.map(\.text),
+            ["local"]
+        )
+    }
+
+    func testTwoWayUnifiedPresentationKeepsStandardHeaderAndTwoCoordinates() throws {
+        let presentation = UnifiedDiffPresentation(model: SplitDiffModel.make(
+            original: "old",
+            modified: "new"
+        ))
+
+        XCTAssertFalse(presentation.showsRemoteLineNumbers)
+        let block = try XCTUnwrap(presentation.blocks.first)
+        guard case .hunk(let label) = block.kind else {
+            return XCTFail("Expected a two-way hunk")
+        }
+        XCTAssertEqual(label, "@@ -1,1 +1,1 @@")
+        XCTAssertTrue(block.lines.allSatisfy { $0.remoteLineNumber == nil })
+    }
+
     func testThreeWayUnchangedStreamYieldsNoBlocks() {
         let presentation = UnifiedDiffPresentation(lines: ThreeWayDiff.lines(
             base: "a", local: "a", remote: "a"
         ))
         XCTAssertEqual(presentation.changedLineCount, 0)
-    }
-
-    func testDraftToneTakesPrecedenceOverInherited() {
-        let item = MemoryListItem(
-            id: "res",
-            resource: nil,
-            draft: draft(targetId: "res"),
-            inherited: true
-        )
-        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .modifiedDraft)
     }
 
     private func draft(

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -119,14 +119,20 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(presentation.help, "The shared version of this file has changed")
     }
 
-    func testBehindDraftWithoutResourceChangesDoesNotShowFileAccessory() {
-        XCTAssertNil(
+    func testBehindDraftWithoutResourceChangesShowsBaseBehindAccessory() throws {
+        let presentation = try XCTUnwrap(
             SharedUpdateStatusPresentation.resolve(
                 freshness: .behind,
                 hasUpstreamResourceChanges: false,
                 reconciliation: .clean
             )
         )
+
+        XCTAssertEqual(
+            presentation.symbolName,
+            "arrow.trianglehead.2.clockwise.rotate.90"
+        )
+        XCTAssertEqual(presentation.help, "Draft base is behind the shared version")
     }
 
     func testConflictedBehindDraftShowsConflictAccessory() throws {
@@ -140,6 +146,87 @@ final class FileTreeSelectionTests: XCTestCase {
 
         XCTAssertEqual(presentation.symbolName, "exclamationmark.triangle")
         XCTAssertEqual(presentation.help, "Shared update has conflicts")
+    }
+
+    func testNilItemUsesPrimaryTone() {
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: nil), .primary)
+    }
+
+    func testSyncedResourceUsesPrimaryTone() {
+        let item = MemoryListItem(id: "res", resource: nil, draft: nil, inherited: false)
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .primary)
+    }
+
+    func testInheritedResourceUsesSecondaryTone() {
+        let item = MemoryListItem(id: "res", resource: nil, draft: nil, inherited: true)
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .secondary)
+    }
+
+    func testNewDraftUsesGreenTone() {
+        let item = MemoryListItem(
+            id: "new",
+            resource: nil,
+            draft: draft(targetId: nil),
+            inherited: false
+        )
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .newDraft)
+    }
+
+    func testModifiedDraftUsesYellowTone() {
+        let item = MemoryListItem(
+            id: "res",
+            resource: nil,
+            draft: draft(targetId: "res"),
+            inherited: false
+        )
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .modifiedDraft)
+    }
+
+    func testDeletionDraftUsesRedTone() {
+        let item = MemoryListItem(
+            id: "res",
+            resource: nil,
+            draft: draft(targetId: "res", isDeletion: true),
+            inherited: false
+        )
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .deletedDraft)
+    }
+
+    func testDraftToneTakesPrecedenceOverInherited() {
+        let item = MemoryListItem(
+            id: "res",
+            resource: nil,
+            draft: draft(targetId: "res"),
+            inherited: true
+        )
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .modifiedDraft)
+    }
+
+    private func draft(
+        targetId: String?,
+        isDeletion: Bool = false
+    ) -> LocalDraft {
+        LocalDraft(
+            id: "draft-\(targetId ?? "new")",
+            projectId: "project",
+            serverId: nil,
+            serverVersion: 0,
+            baseCommitId: "base",
+            currentCommitId: "base",
+            freshness: .current,
+            hasUpstreamResourceChanges: false,
+            reconciliation: .unknown,
+            reconciliationCandidateId: nil,
+            scope: .project,
+            kind: .context,
+            targetId: targetId,
+            status: .open,
+            origin: .desktop,
+            syncStatus: .synced,
+            updatedAt: "2026-08-05T00:00:00Z",
+            document: .init(title: "Untitled", path: "a.md", body: ""),
+            isDeletion: isDeletion
+        )
     }
 
     private func memoryItem(id: String, path: String) -> MemoryListItem {

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -239,6 +239,26 @@ final class FileTreeSelectionTests: XCTestCase {
         }
     }
 
+    func testLegacyProjectMemoryUsesReadOnlyLockWithoutChangingTitleTone() {
+        let item = memoryItem(
+            id: "legacy-project-memory",
+            path: "legacy.md",
+            scope: .project,
+            projectId: "project"
+        )
+
+        let accessory = MemoryFileTreeRowAccessory.resolve(item: item)
+        XCTAssertEqual(accessory, .legacyProjectReadOnly)
+        XCTAssertEqual(accessory.help, "Legacy Project memory — read-only")
+        XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: item), .primary)
+    }
+
+    func testOrgMemoryDoesNotUseLegacyReadOnlyLock() {
+        let item = memoryItem(id: "org-memory", path: "org.md")
+
+        XCTAssertEqual(MemoryFileTreeRowAccessory.resolve(item: item), .none)
+    }
+
     func testThreeWayLocalChangeShowsRemovalThenInsertion() {
         let lines = ThreeWayDiff.lines(base: "a\nb", local: "a\nB", remote: "a\nb")
         XCTAssertEqual(lines.map(\.kind), [.context, .removal, .insertion])
@@ -471,13 +491,18 @@ final class FileTreeSelectionTests: XCTestCase {
         )
     }
 
-    private func memoryItem(id: String, path: String) -> MemoryListItem {
+    private func memoryItem(
+        id: String,
+        path: String,
+        scope: MemoryScope = .org,
+        projectId: String? = nil
+    ) -> MemoryListItem {
         .init(
             id: id,
             resource: .init(
                 id: id,
-                scope: .org,
-                projectId: nil,
+                scope: scope,
+                projectId: projectId,
                 projectName: nil,
                 kind: .context,
                 contentHash: "sha256:\(id)",

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -148,6 +148,47 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(presentation.help, "Shared update has conflicts")
     }
 
+    func testStaleResourceWithoutDraftShowsSyncAccessory() throws {
+        let presentation = try XCTUnwrap(
+            SharedUpdateStatusPresentation.resolve(
+                freshness: nil,
+                hasUpstreamResourceChanges: false,
+                reconciliation: .unknown,
+                isStale: true
+            )
+        )
+
+        XCTAssertEqual(
+            presentation.symbolName,
+            "arrow.trianglehead.2.clockwise.rotate.90"
+        )
+        XCTAssertEqual(presentation.help, "A newer shared version is available")
+    }
+
+    func testSyncedResourceWithoutDraftShowsNoAccessory() {
+        XCTAssertNil(
+            SharedUpdateStatusPresentation.resolve(
+                freshness: nil,
+                hasUpstreamResourceChanges: false,
+                reconciliation: .unknown,
+                isStale: false
+            )
+        )
+    }
+
+    func testBehindDraftTakesPrecedenceOverStaleResource() throws {
+        let presentation = try XCTUnwrap(
+            SharedUpdateStatusPresentation.resolve(
+                freshness: .behind,
+                hasUpstreamResourceChanges: false,
+                reconciliation: .clean,
+                isStale: true
+            )
+        )
+
+        XCTAssertEqual(presentation.help, "Draft base is behind the shared version")
+    }
+
     func testNilItemUsesPrimaryTone() {
         XCTAssertEqual(MemoryFileTreeTitleTone.resolve(item: nil), .primary)
     }

--- a/apps/macos/Tests/LiveWorkspaceIntegrationTests.swift
+++ b/apps/macos/Tests/LiveWorkspaceIntegrationTests.swift
@@ -79,7 +79,7 @@ final class LiveWorkspaceIntegrationTests: XCTestCase {
     @MainActor
     private func exerciseDraft(kind: MemoryKind, store: WorkspaceStore) async throws {
         let originalDraftIds = Set(store.drafts.map(\.id))
-        await store.createMemory(kind: kind, scope: .project)
+        await store.createMemory(kind: kind, scope: .org)
         let createdDraft = try XCTUnwrap(store.drafts.first { !originalDraftIds.contains($0.id) })
 
         do {

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -2,7 +2,13 @@ import XCTest
 @testable import Clumsies
 
 final class MemoryFileTreeMenuTests: XCTestCase {
-    private func resourceItem(_ id: String, scope: MemoryScope, inherited: Bool, projectId: String? = nil) -> MemoryListItem {
+    private func resourceItem(
+        _ id: String,
+        scope: MemoryScope,
+        inherited: Bool,
+        projectId: String? = nil,
+        draft: LocalDraft? = nil
+    ) -> MemoryListItem {
         MemoryListItem(
             id: id,
             resource: MemoryResource(
@@ -17,36 +23,50 @@ final class MemoryFileTreeMenuTests: XCTestCase {
                 contentLoaded: false,
                 document: EditableMemoryDocument(title: id, path: "\(id).md", body: "")
             ),
-            draft: nil,
+            draft: draft,
             inherited: inherited
         )
     }
 
-    private func draftItem(_ id: String, scope: MemoryScope) -> MemoryListItem {
-        MemoryListItem(
+    private func localDraft(
+        _ id: String,
+        scope: MemoryScope,
+        targetId: String? = nil,
+        isDeletion: Bool = false
+    ) -> LocalDraft {
+        LocalDraft(
             id: id,
+            projectId: "p1",
+            serverId: nil,
+            serverVersion: 0,
+            baseCommitId: nil,
+            currentCommitId: nil,
+            freshness: .current,
+            hasUpstreamResourceChanges: false,
+            reconciliation: .clean,
+            reconciliationCandidateId: nil,
+            scope: scope,
+            kind: .context,
+            targetId: targetId,
+            status: .open,
+            origin: .desktop,
+            syncStatus: .queued,
+            updatedAt: "2026-01-01T00:00:00Z",
+            document: EditableMemoryDocument(title: id, path: "\(id).md", body: ""),
+            isDeletion: isDeletion
+        )
+    }
+
+    private func draftItem(
+        _ id: String,
+        scope: MemoryScope,
+        targetId: String? = nil,
+        isDeletion: Bool = false
+    ) -> MemoryListItem {
+        MemoryListItem(
+            id: targetId ?? id,
             resource: nil,
-            draft: LocalDraft(
-                id: id,
-                projectId: "p1",
-                serverId: nil,
-                serverVersion: 0,
-                baseCommitId: nil,
-                currentCommitId: nil,
-                freshness: .current,
-                hasUpstreamResourceChanges: false,
-                reconciliation: .clean,
-                reconciliationCandidateId: nil,
-                scope: scope,
-                kind: .context,
-                targetId: nil,
-                status: .open,
-                origin: .desktop,
-                syncStatus: .queued,
-                updatedAt: "2026-01-01T00:00:00Z",
-                document: EditableMemoryDocument(title: id, path: "\(id).md", body: ""),
-                isDeletion: false
-            ),
+            draft: localDraft(id, scope: scope, targetId: targetId, isDeletion: isDeletion),
             inherited: false
         )
     }
@@ -70,13 +90,20 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertTrue(MemoryFileTreeMenu.removable(items, inOrgView: true).isEmpty)
     }
 
-    func testOrgViewTrashableExcludesPureDrafts() {
+    func testOrgViewIsReadOnlyForAuthorityMutations() {
         let items = [
             resourceItem("org-a", scope: .org, inherited: false),
             draftItem("draft-a", scope: .org),
         ]
-        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: true).map(\.id), ["org-a"])
-        XCTAssertTrue(MemoryFileTreeMenu.isManageable(items[1], inOrgView: true))
+        XCTAssertTrue(MemoryFileTreeMenu.trashable(items, inOrgView: true).isEmpty)
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(items[0], inOrgView: true))
+        XCTAssertFalse(
+            MemoryFileTreeMenu.canProposeOrganizationDeletion(items[0], inOrgView: true)
+        )
+    }
+
+    func testOrgViewDoesNotOfferNewMemoryCreation() {
+        XCTAssertNil(MemoryFileTreeMenu.creationScope(inOrgView: true))
     }
 
     // MARK: - Project view
@@ -98,20 +125,79 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
     }
 
-    func testProjectViewManageableIncludesSelectedOrgDraftTargets() {
+    func testProjectViewAuthorityActionsOnlyIncludeSelectedOrgResources() {
         let items = [
             resourceItem("org-ref", scope: .org, inherited: true),
             resourceItem("org-unref", scope: .org, inherited: false),
             resourceItem("own-a", scope: .project, inherited: false, projectId: "p1"),
         ]
         XCTAssertEqual(
-            items.map { MemoryFileTreeMenu.isManageable($0, inOrgView: false) },
-            [true, false, true]
+            items.map { MemoryFileTreeMenu.canRename($0, inOrgView: false) },
+            [true, false, false]
         )
         XCTAssertEqual(
             MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id),
-            ["org-ref", "own-a"]
+            ["org-ref"]
         )
+    }
+
+    func testProjectViewCreatesProjectBoundOrgProposals() {
+        XCTAssertEqual(MemoryFileTreeMenu.creationScope(inOrgView: false), .org)
+    }
+
+    func testSelectedOrgAuthorityOffersExplicitMutationActionsInProjectView() {
+        let item = resourceItem("org-ref", scope: .org, inherited: true)
+
+        XCTAssertTrue(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertTrue(MemoryFileTreeMenu.canProposeOrganizationDeletion(item, inOrgView: false))
+        XCTAssertEqual(MemoryFileTreeMenu.trashable([item], inOrgView: false), [item])
+    }
+
+    func testUnselectedOrgAuthorityDoesNotOfferMutationActionsInProjectView() {
+        let item = resourceItem("org-unselected", scope: .org, inherited: false)
+
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canProposeOrganizationDeletion(item, inOrgView: false))
+        XCTAssertTrue(MemoryFileTreeMenu.trashable([item], inOrgView: false).isEmpty)
+    }
+
+    func testTargetBackedDraftOnlyRowDoesNotOfferAuthorityMutationActions() {
+        let item = draftItem("draft", scope: .org, targetId: "org-removed")
+
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canProposeOrganizationDeletion(item, inOrgView: false))
+        XCTAssertTrue(MemoryFileTreeMenu.trashable([item], inOrgView: false).isEmpty)
+    }
+
+    func testDeletionDraftDoesNotOfferDeletionAgain() {
+        let item = resourceItem(
+            "org-ref",
+            scope: .org,
+            inherited: true,
+            draft: localDraft(
+                "draft-delete",
+                scope: .org,
+                targetId: "org-ref",
+                isDeletion: true
+            )
+        )
+
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canProposeOrganizationDeletion(item, inOrgView: false))
+        XCTAssertTrue(MemoryFileTreeMenu.trashable([item], inOrgView: false).isEmpty)
+    }
+
+    func testLegacyProjectAuthorityDoesNotOfferOrganizationMutationActions() {
+        let item = resourceItem(
+            "legacy-project",
+            scope: .project,
+            inherited: false,
+            projectId: "p1"
+        )
+
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canProposeOrganizationDeletion(item, inOrgView: false))
+        XCTAssertTrue(MemoryFileTreeMenu.trashable([item], inOrgView: false).isEmpty)
     }
 
     // MARK: - Mixed selection stays predictable
@@ -125,7 +211,7 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
         XCTAssertEqual(
             MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id),
-            ["org-ref", "own-a"]
+            ["org-ref"]
         )
     }
 }

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -53,10 +53,11 @@ final class MemoryFileTreeMenuTests: XCTestCase {
 
     // MARK: - Org view
 
-    func testOrgViewAddableIncludesAllOrgItems() {
+    func testOrgViewAddableIncludesPublishedOrgItems() {
         let items = [
             resourceItem("org-a", scope: .org, inherited: false),
             resourceItem("org-b", scope: .org, inherited: false),
+            draftItem("draft-a", scope: .org),
         ]
         XCTAssertEqual(MemoryFileTreeMenu.addable(items, inOrgView: true).map(\.id), ["org-a", "org-b"])
     }
@@ -97,7 +98,7 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
     }
 
-    func testProjectViewManageableOnlyProjectOwned() {
+    func testProjectViewManageableIncludesSelectedOrgDraftTargets() {
         let items = [
             resourceItem("org-ref", scope: .org, inherited: true),
             resourceItem("org-unref", scope: .org, inherited: false),
@@ -105,9 +106,12 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         ]
         XCTAssertEqual(
             items.map { MemoryFileTreeMenu.isManageable($0, inOrgView: false) },
-            [false, false, true]
+            [true, false, true]
         )
-        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id), ["own-a"])
+        XCTAssertEqual(
+            MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id),
+            ["org-ref", "own-a"]
+        )
     }
 
     // MARK: - Mixed selection stays predictable
@@ -119,6 +123,9 @@ final class MemoryFileTreeMenuTests: XCTestCase {
             resourceItem("org-unref", scope: .org, inherited: false),
         ]
         XCTAssertEqual(MemoryFileTreeMenu.removable(items, inOrgView: false).map(\.id), ["org-ref"])
-        XCTAssertEqual(MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id), ["own-a"])
+        XCTAssertEqual(
+            MemoryFileTreeMenu.trashable(items, inOrgView: false).map(\.id),
+            ["org-ref", "own-a"]
+        )
     }
 }

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -288,6 +288,39 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(store.selectedItemId, secondLocalTab.itemId)
     }
 
+    func testProjectSelectionSideEffectsAreSerialized() async {
+        let gate = ProjectSelectionSideEffectGate()
+        let releaseFirst = WorkspaceNavigationTestLatch()
+        let firstEntered = expectation(description: "first selection entered daemon side effect")
+        let secondRequested = expectation(description: "second selection requested daemon side effect")
+        var events: [String] = []
+
+        let first = Task { @MainActor in
+            await gate.run {
+                events.append("first-start")
+                firstEntered.fulfill()
+                await releaseFirst.wait()
+                events.append("first-end")
+            }
+        }
+        await fulfillment(of: [firstEntered], timeout: 1)
+
+        let second = Task { @MainActor in
+            secondRequested.fulfill()
+            await gate.run {
+                events.append("second")
+            }
+        }
+        await fulfillment(of: [secondRequested], timeout: 1)
+        await Task.yield()
+        XCTAssertEqual(events, ["first-start"])
+
+        await releaseFirst.open()
+        await first.value
+        await second.value
+        XCTAssertEqual(events, ["first-start", "first-end", "second"])
+    }
+
     func testOpeningMarkdownDefaultsToPreview() {
         let store = WorkspaceStore()
 
@@ -302,6 +335,550 @@ final class WorkspaceNavigationTests: XCTestCase {
         store.open(item(path: "context/notes.txt"))
 
         XCTAssertEqual(store.activeVisibleTab?.mode, .source)
+    }
+
+    func testDocumentTabIdentityIsStableAcrossModes() {
+        var tab = WorkbenchTab(
+            section: .memory,
+            projectId: "project",
+            itemId: "memory",
+            mode: .preview,
+            title: "Memory"
+        )
+        let previewId = tab.id
+
+        tab.mode = .diff
+
+        XCTAssertEqual(tab.id, previewId)
+    }
+
+    func testOpeningAndSwitchingModesKeepsOneTabPerDocument() {
+        let store = WorkspaceStore()
+        let document = item(path: "context/architecture.md")
+
+        store.open(document)
+        let stableId = store.activeTabId
+        store.open(document, mode: .source)
+        store.open(document)
+
+        XCTAssertEqual(store.activeVisibleTab?.mode, .source)
+
+        store.switchDocumentMode(.diff)
+
+        XCTAssertEqual(store.tabs.count, 1)
+        XCTAssertEqual(store.activeTabId, stableId)
+        XCTAssertEqual(store.activeVisibleTab?.mode, .diff)
+    }
+
+    func testStaleResourcePlanRejectsAnOlderDaemonCheckout() {
+        let displayed = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "hash-new",
+            commitId: "commit-new"
+        )
+        let checkout = projectCheckout(
+            commitId: "commit-old",
+            resources: [checkoutResource(id: "memory", path: "memory.md", hash: "hash-old")]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [displayed],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-new",
+            authoritativeCommitId: "commit-new",
+            serverCursor: "commit-old",
+            checkout: checkout
+        )
+
+        XCTAssertNil(plan)
+    }
+
+    func testStaleCachedAuthoritativeRefCannotBuildRollbackPlan() {
+        let displayed = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "hash-new",
+            commitId: "commit-new"
+        )
+        let checkout = projectCheckout(
+            commitId: "commit-old",
+            resources: [checkoutResource(id: "memory", path: "memory.md", hash: "hash-old")]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [displayed],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-new",
+            authoritativeCommitId: "commit-old",
+            serverCursor: "commit-old",
+            checkout: checkout,
+            authoritativeResponseIsStale: true
+        )
+
+        XCTAssertNil(plan)
+    }
+
+    func testStaleCacheHeaderIsRecognizedCaseInsensitively() {
+        XCTAssertTrue(DaemonServerResponse(
+            status: 200,
+            headers: ["X-ClUmSiEs-CaChE": "StAlE"],
+            body: "{}"
+        ).isStaleCache)
+        XCTAssertFalse(DaemonServerResponse(
+            status: 200,
+            headers: ["x-clumsies-cache": "live"],
+            body: "{}"
+        ).isStaleCache)
+    }
+
+    func testStaleResourcePlanIsEmptyWhenDisplayedRefIsAuthoritative() {
+        let displayed = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "hash",
+            commitId: "commit-current"
+        )
+        let checkout = projectCheckout(
+            commitId: "commit-current",
+            resources: [checkoutResource(id: "memory", path: "memory.md", hash: "other-hash")]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [displayed],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-current",
+            authoritativeCommitId: "commit-current",
+            serverCursor: "commit-current",
+            checkout: checkout
+        )
+
+        XCTAssertEqual(plan, [:])
+    }
+
+    func testStaleResourcePlanCapturesStructuralChangesAndIgnoresPinnedOrgRows() {
+        let renamed = projectResource(id: "renamed", path: "old.md", hash: "same-hash")
+        let deleted = projectResource(id: "deleted", path: "deleted.md", hash: "deleted-hash")
+        let unchanged = projectResource(id: "unchanged", path: "same.md", hash: "same")
+        let org = MemoryResource(
+            id: "org-memory",
+            scope: .org,
+            projectId: nil,
+            projectName: nil,
+            kind: .context,
+            contentHash: "org-old",
+            updatedAt: "2026-08-19T00:00:00Z",
+            refCommitId: "org-commit",
+            contentLoaded: true,
+            document: .init(title: "Org", path: "org.md", body: "old org")
+        )
+        let checkout = projectCheckout(
+            commitId: "commit-new",
+            resources: [
+                checkoutResource(id: "renamed", path: "new.md", hash: "same-hash"),
+                checkoutResource(id: "unchanged", path: "same.md", hash: "same"),
+                checkoutResource(id: "added", path: "added.md", hash: "added-hash"),
+                checkoutResource(
+                    id: "org-memory",
+                    path: "org.md",
+                    hash: "org-new",
+                    scope: .org
+                ),
+            ]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [renamed, deleted, unchanged, org],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-old",
+            authoritativeCommitId: "commit-new",
+            serverCursor: "commit-new",
+            checkout: checkout,
+            authoritativeRefEtag: "\"server-commit-new\"",
+            generation: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        )
+
+        XCTAssertEqual(
+            Set(plan?.keys.map { $0 } ?? []),
+            ["renamed", "deleted", "added"]
+        )
+        XCTAssertEqual(plan?["renamed"]?.local?.document.path, "old.md")
+        XCTAssertEqual(plan?["renamed"]?.remote?.document.path, "new.md")
+        XCTAssertNotNil(plan?["deleted"]?.local)
+        XCTAssertNil(plan?["deleted"]?.remote)
+        XCTAssertNil(plan?["added"]?.local)
+        XCTAssertNotNil(plan?["added"]?.remote)
+        XCTAssertNil(plan?["org-memory"])
+        XCTAssertEqual(plan?["renamed"]?.authoritativeRefEtag, "\"server-commit-new\"")
+        XCTAssertNil(plan?["unchanged"])
+    }
+
+    func testStaleResourcePlanKeepsAProvisionalAdditionPending() {
+        let provisional = projectResource(
+            id: "added",
+            path: "added.md",
+            hash: "added-hash",
+            commitId: "commit-new"
+        )
+        let checkout = projectCheckout(
+            commitId: "commit-new",
+            resources: [checkoutResource(id: "added", path: "added.md", hash: "added-hash")]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [provisional],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-old",
+            authoritativeCommitId: "commit-new",
+            serverCursor: "commit-new",
+            checkout: checkout,
+            provisionalResourceIds: ["added"]
+        )
+
+        XCTAssertNil(plan?["added"]?.local)
+        XCTAssertNotNil(plan?["added"]?.remote)
+    }
+
+    func testEquivalentStalePlansIgnoreDetectionGeneration() {
+        let displayed = projectResource(id: "memory", path: "memory.md", hash: "old")
+        let checkout = projectCheckout(
+            commitId: "commit-new",
+            resources: [checkoutResource(id: "memory", path: "memory.md", hash: "new")]
+        )
+        let first = WorkspaceStore.staleResourcePlan(
+            displayedResources: [displayed],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-old",
+            authoritativeCommitId: "commit-new",
+            serverCursor: "commit-new",
+            checkout: checkout,
+            generation: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        ) ?? [:]
+        let second = WorkspaceStore.staleResourcePlan(
+            displayedResources: [displayed],
+            projectName: "Project",
+            observedProjectRefCommitId: "commit-old",
+            authoritativeCommitId: "commit-new",
+            serverCursor: "commit-new",
+            checkout: checkout,
+            generation: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        ) ?? [:]
+
+        XCTAssertNotEqual(first["memory"]?.generation, second["memory"]?.generation)
+        XCTAssertTrue(WorkspaceStore.staleResourcePlansMatch(first, second))
+    }
+
+    func testDocumentPathChangesAttributeRemoteRenameAndDeletionToShared() {
+        XCTAssertEqual(
+            WorkspaceStore.documentPathChanges(
+                basePath: "old.md",
+                localPath: "old.md",
+                remotePath: "new.md"
+            ),
+            [.init(source: .shared, from: "old.md", to: "new.md")]
+        )
+        XCTAssertEqual(
+            WorkspaceStore.documentPathChanges(
+                basePath: "old.md",
+                localPath: "old.md",
+                remotePath: nil
+            ),
+            [.init(source: .shared, from: "old.md", to: nil)]
+        )
+    }
+
+    func testDocumentPathChangesKeepDivergentDraftAndSharedRenamesSeparate() {
+        XCTAssertEqual(
+            WorkspaceStore.documentPathChanges(
+                basePath: "base.md",
+                localPath: "draft.md",
+                remotePath: "shared.md"
+            ),
+            [
+                .init(source: .draft, from: "base.md", to: "draft.md"),
+                .init(source: .shared, from: "base.md", to: "shared.md"),
+            ]
+        )
+    }
+
+    func testMemoryContentValidationRejectsStaleAndMismatchedBodies() throws {
+        let hash = "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        let resource = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: hash,
+            commitId: "commit-current"
+        )
+        let metadata = MemoryMetadata(
+            memoryId: "memory",
+            scope: "project",
+            projectId: "project",
+            path: "memory.md",
+            name: "Memory",
+            description: "",
+            contentHash: hash,
+            status: "active",
+            updatedAt: "2026-08-19T00:00:00Z"
+        )
+        let live = DaemonServerResponse(status: 200, headers: [:], body: "{}")
+
+        XCTAssertEqual(
+            try WorkspaceLoader.validatedMemoryContent(
+                for: resource,
+                detail: .init(memory: metadata, content: "hello", etag: "etag"),
+                response: live
+            ),
+            "hello"
+        )
+        XCTAssertThrowsError(try WorkspaceLoader.validatedMemoryContent(
+            for: resource,
+            detail: .init(memory: metadata, content: "wrong body", etag: "etag"),
+            response: live
+        ))
+        XCTAssertThrowsError(try WorkspaceLoader.validatedMemoryContent(
+            for: resource,
+            detail: .init(memory: metadata, content: "hello", etag: "etag"),
+            response: .init(
+                status: 200,
+                headers: ["x-clumsies-cache": "stale"],
+                body: "{}"
+            )
+        ))
+    }
+
+    func testResourceGenerationComparisonRejectsCommitAndHashChanges() {
+        let old = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "old",
+            commitId: "commit-old"
+        )
+        let current = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "new",
+            commitId: "commit-new"
+        )
+
+        XCTAssertFalse(WorkspaceStore.resourceGenerationMatches(old, current))
+        XCTAssertTrue(WorkspaceStore.resourceGenerationMatches(current, current))
+    }
+
+    func testRenameOnlyDraftDoesNotTreatAnUnloadedOrphanBaselineAsEditableContent() {
+        var unloaded = projectResource(
+            id: "removed-memory",
+            path: "old.md",
+            hash: "sha256:old",
+            commitId: "commit-old"
+        )
+        unloaded.contentLoaded = false
+        unloaded.document.body = ""
+        let summary = DaemonDraftSummary(
+            draftId: "draft",
+            projectId: "project",
+            serverDraftId: "server-draft",
+            serverVersion: 1,
+            baseCommitId: "commit-old",
+            currentCommitId: "commit-new",
+            freshness: .behind,
+            hasUpstreamResourceChanges: true,
+            reconciliation: .unknown,
+            reconciliationCandidateId: nil,
+            scope: .project,
+            resourceKind: .memory,
+            targetId: "removed-memory",
+            path: "old.md",
+            status: .open,
+            createdAt: "2026-08-19T00:00:00Z",
+            updatedAt: "2026-08-19T00:00:00Z",
+            pendingOperationCount: 0,
+            failedOperationCount: 0
+        )
+        let operation = DaemonLocalDraftOperation(
+            localOperationId: "operation",
+            resourceKind: .memory,
+            operation: .rename(
+                id: "removed-memory",
+                newPath: "renamed.md",
+                description: nil
+            ),
+            source: .desktop,
+            syncStatus: .synced,
+            lastError: nil,
+            createdAt: "2026-08-19T00:00:00Z",
+            updatedAt: "2026-08-19T00:00:00Z"
+        )
+
+        let mapped = WorkspaceLoader.mapDraft(
+            .init(draft: summary, operations: [operation]),
+            resources: [unloaded]
+        )
+
+        XCTAssertFalse(mapped.documentBaselineAvailable)
+        XCTAssertEqual(mapped.document.path, "renamed.md")
+    }
+
+    func testUnloadedResourceRenamePlanCarriesNoPlaceholderContent() {
+        var resource = projectResource(
+            id: "memory",
+            path: "old.md",
+            hash: "sha256:body"
+        )
+        resource.contentLoaded = false
+        resource.document.body = ""
+        let item = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: false
+        )
+
+        let plan = WorkspaceStore.documentRenamePlan(
+            for: item,
+            currentDraft: nil,
+            newPath: "renamed.md"
+        )
+
+        XCTAssertEqual(
+            plan,
+            .init(targetId: "memory", newPath: "renamed.md")
+        )
+        XCTAssertTrue(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+
+        let dirty = EditableMemoryDocument(
+            title: "old.md",
+            path: "old.md",
+            body: "unsaved body"
+        )
+        let retargeted = WorkspaceStore.documentByRetargetingPendingSave(
+            dirty,
+            to: "renamed.md"
+        )
+        XCTAssertEqual(retargeted.path, "renamed.md")
+        XCTAssertEqual(retargeted.body, "unsaved body")
+    }
+
+    func testPureCreateDraftDoesNotOfferATargetBackedRename() {
+        let draft = localDraft(id: "draft", targetId: nil)
+        let item = MemoryListItem(
+            id: draft.id,
+            resource: nil,
+            draft: draft,
+            inherited: false
+        )
+
+        XCTAssertNil(WorkspaceStore.documentRenamePlan(
+            for: item,
+            currentDraft: draft,
+            newPath: "renamed.md"
+        ))
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+    }
+
+    func testDraftUploadBarrierRequiresASettledServerDraft() {
+        XCTAssertEqual(
+            WorkspaceStore.draftUploadBarrierDecision(
+                serverDraftId: nil,
+                pendingOperationCount: 1,
+                failedOperationCount: 0,
+                operationStates: [.queued],
+                failureMessage: nil
+            ),
+            .wait
+        )
+        XCTAssertEqual(
+            WorkspaceStore.draftUploadBarrierDecision(
+                serverDraftId: "server-draft",
+                pendingOperationCount: 0,
+                failedOperationCount: 0,
+                operationStates: [.synced],
+                failureMessage: nil
+            ),
+            .ready
+        )
+        XCTAssertEqual(
+            WorkspaceStore.draftUploadBarrierDecision(
+                serverDraftId: "server-draft",
+                pendingOperationCount: 0,
+                failedOperationCount: 1,
+                operationStates: [.failed],
+                failureMessage: "upload failed"
+            ),
+            .failed("upload failed")
+        )
+    }
+
+    func testStaleDiffRefusesAnUnloadedHistoricalBaseline() {
+        var local = projectResource(id: "memory", path: "memory.md", hash: "old")
+        local.contentLoaded = false
+        local.document.body = ""
+        let remote = projectResource(
+            id: "memory",
+            path: "memory.md",
+            hash: "new",
+            commitId: "commit-new"
+        )
+        let snapshot = StaleResourceSyncSnapshot(
+            projectId: "project",
+            observedProjectRefCommitId: "commit-old",
+            observedSelectedOrgResourceIds: [],
+            observedOrgSelectionRevision: 1,
+            authoritativeCommitId: "commit-new",
+            authoritativeRefEtag: "\"commit-new\"",
+            selectedOrgResourceIds: [],
+            orgSelectionRevision: 1,
+            generation: UUID(),
+            local: local,
+            remote: remote
+        )
+
+        XCTAssertThrowsError(try WorkspaceStore.staleDocumentDiffTexts(snapshot)) { error in
+            XCTAssertEqual(error as? DocumentDiffError, .baselineUnavailable)
+        }
+    }
+
+    func testUnrepresentedDraftsKeepsTargetBackedDraftWhenAuthoritativeTargetIsMissing() {
+        let missingTarget = localDraft(
+            id: "draft-for-removed-resource",
+            targetId: "removed-resource"
+        )
+
+        let unrepresented = WorkspaceStore.unrepresentedDrafts(
+            [missingTarget],
+            authoritativeResourceIds: []
+        )
+
+        XCTAssertEqual(unrepresented.map(\.id), [missingTarget.id])
+    }
+
+    func testUnrepresentedDraftsFiltersDraftWithAnAuthoritativeTarget() {
+        let represented = localDraft(
+            id: "draft-for-current-resource",
+            targetId: "current-resource"
+        )
+
+        let unrepresented = WorkspaceStore.unrepresentedDrafts(
+            [represented],
+            authoritativeResourceIds: ["current-resource"]
+        )
+
+        XCTAssertTrue(unrepresented.isEmpty)
+    }
+
+    func testMissingTargetDraftUsesTargetIdAsItsStableItemIdentity() {
+        let missingTarget = localDraft(
+            id: "local-draft-id",
+            targetId: "removed-authoritative-resource"
+        )
+        let unrepresented = WorkspaceStore.unrepresentedDrafts(
+            [missingTarget],
+            authoritativeResourceIds: []
+        )
+
+        let itemIds = unrepresented.map { $0.targetId ?? $0.id }
+
+        XCTAssertEqual(itemIds, ["removed-authoritative-resource"])
+        XCTAssertNotEqual(itemIds.first, missingTarget.id)
     }
 
     func testCenteredTextViewUsesMinimumInsetInNarrowPane() {
@@ -329,6 +906,54 @@ final class WorkspaceNavigationTests: XCTestCase {
             DocumentSessionCommand.closeReconciliation(itemId: "document").itemId,
             "document"
         )
+    }
+
+    func testKeepFileAfterDeleteConflictUsesCurrentContentTemplate() {
+        let resource = ServerDraftResourceReference(
+            scope: "project",
+            id: "memory",
+            path: "memory.md"
+        )
+        let deleted = ReconciliationResourceState(
+            exists: false,
+            resource: resource,
+            content: nil
+        )
+        let candidate = DraftReconciliationCandidate(
+            candidateId: "candidate",
+            draftId: "draft",
+            draftVersion: 2,
+            baseCommitId: "base",
+            currentCommitId: "current",
+            status: .conflicts,
+            baseState: .init(
+                exists: true,
+                resource: resource,
+                content: .init(description: "base description", content: "Base body")
+            ),
+            currentState: .init(
+                exists: true,
+                resource: resource,
+                content: .init(description: "current description", content: "Remote body")
+            ),
+            draftState: deleted,
+            proposedState: deleted,
+            conflicts: [
+                .init(kind: "delete_modify", field: "exists", base: "true", current: "true", draft: "false")
+            ],
+            resultHash: nil,
+            valid: true,
+            createdAt: "2026-08-19T00:00:00Z",
+            invalidatedAt: nil
+        )
+
+        let template = DraftReconciliationView.resolutionContentTemplate(
+            for: candidate,
+            preferredState: deleted
+        )
+
+        XCTAssertEqual(template.primaryText, "Remote body")
+        XCTAssertEqual(template.description, "current description")
     }
 
     func testOpeningOrgScopedItemWithDraftStaysVisibleInOrgView() {
@@ -381,6 +1006,172 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertTrue(store.visibleTabs.contains { $0.id == store.activeTabId })
     }
 
+    func testMemoryTreeResourcesUseOrgCatalogInOrgView() {
+        let selectedOrg = orgResource(id: "selected-org")
+        let unselectedOrg = orgResource(id: "unselected-org")
+        let project = projectResource(id: "project", path: "project.md", hash: "project-hash")
+
+        let visible = WorkspaceStore.memoryTreeResources(
+            [selectedOrg, unselectedOrg, project],
+            activeProjectId: nil,
+            selectedOrgResourceIds: []
+        )
+
+        XCTAssertEqual(Set(visible.map(\.id)), ["selected-org", "unselected-org"])
+    }
+
+    func testMemoryTreeResourcesUseSelectedOrgAndCompatibilityProjectAuthority() {
+        let selectedOrg = orgResource(id: "selected-org")
+        let unselectedOrg = orgResource(id: "unselected-org")
+        let project = projectResource(id: "project", path: "project.md", hash: "project-hash")
+        let otherProject = projectResource(
+            id: "other-project",
+            path: "other.md",
+            hash: "other-hash",
+            projectId: "other"
+        )
+
+        let visible = WorkspaceStore.memoryTreeResources(
+            [selectedOrg, unselectedOrg, project, otherProject],
+            activeProjectId: "project",
+            selectedOrgResourceIds: ["selected-org"]
+        )
+
+        XCTAssertEqual(Set(visible.map(\.id)), ["selected-org", "project"])
+    }
+
+    func testMemoryTreeDraftsAreIsolatedByCarryingProject() {
+        let current = localDraft(id: "current", targetId: nil)
+        let other = localDraft(id: "other", targetId: nil, projectId: "other")
+        let org = localDraft(id: "org", targetId: nil, scope: .org)
+
+        XCTAssertEqual(
+            WorkspaceStore.memoryTreeDrafts(
+                [current, other, org],
+                activeProjectId: "project"
+            ).map(\.id),
+            ["current", "org"]
+        )
+        XCTAssertEqual(
+            WorkspaceStore.memoryTreeDrafts(
+                [current, other, org],
+                activeProjectId: nil
+            ).map(\.id),
+            ["org"]
+        )
+    }
+
+    func testMemoryTreePrefersTheNewestDraftForOneTarget() {
+        let older = localDraft(
+            id: "older",
+            targetId: "memory",
+            updatedAt: "2026-08-19T00:00:00Z"
+        )
+        let newer = localDraft(
+            id: "newer",
+            targetId: "memory",
+            updatedAt: "2026-08-20T00:00:00Z"
+        )
+
+        XCTAssertEqual(
+            WorkspaceStore.preferredMemoryTreeDrafts([newer, older]).map(\.id),
+            ["newer"]
+        )
+    }
+
+    func testSelectedOrgItemRetainsItsProjectDraftContext() {
+        let resource = orgResource(id: "org")
+        let item = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: true,
+            projectContextId: "project"
+        )
+
+        XCTAssertEqual(item.projectId, "project")
+    }
+
+    func testProjectLocalCreateCannotRequestReviewUntilOrgPublishingExists() {
+        let localCreate = localDraft(id: "local", targetId: nil)
+        let legacyProjectUpdate = localDraft(id: "legacy", targetId: "project-memory")
+        let orgCreate = localDraft(id: "org", targetId: nil, scope: .org)
+
+        XCTAssertFalse(WorkspaceStore.canRequestReview(localCreate))
+        XCTAssertTrue(WorkspaceStore.canRequestReview(legacyProjectUpdate))
+        XCTAssertTrue(WorkspaceStore.canRequestReview(orgCreate))
+    }
+
+    func testMemoryTabsAreScopedToTheProjectViewContext() {
+        let orgTab = tab(itemId: "shared", projectId: nil)
+        let projectTab = tab(itemId: "shared", projectId: "project")
+
+        XCTAssertTrue(orgTab.isVisible(in: .memory, projectId: nil))
+        XCTAssertFalse(orgTab.isVisible(in: .memory, projectId: "project"))
+        XCTAssertTrue(projectTab.isVisible(in: .memory, projectId: "project"))
+        XCTAssertFalse(projectTab.isVisible(in: .memory, projectId: nil))
+    }
+
+    func testProjectMemoryTabRequiresSelectionOrALocalDraft() {
+        let org = orgResource(id: "org")
+
+        XCTAssertFalse(WorkspaceStore.memoryTabIsAvailable(
+            itemId: org.id,
+            projectId: "project",
+            selectedOrgResourceIds: [],
+            resources: [org],
+            drafts: []
+        ))
+        XCTAssertTrue(WorkspaceStore.memoryTabIsAvailable(
+            itemId: org.id,
+            projectId: "project",
+            selectedOrgResourceIds: [org.id],
+            resources: [org],
+            drafts: []
+        ))
+        XCTAssertTrue(WorkspaceStore.memoryTabIsAvailable(
+            itemId: org.id,
+            projectId: "project",
+            selectedOrgResourceIds: [],
+            resources: [org],
+            drafts: [localDraft(id: "draft", targetId: org.id, scope: .org)]
+        ))
+
+        XCTAssertFalse(WorkspaceStore.memoryTabIsAvailable(
+            itemId: "discarded-create",
+            projectId: "project",
+            selectedOrgResourceIds: [],
+            resources: [],
+            drafts: []
+        ))
+        XCTAssertTrue(WorkspaceStore.memoryTabIsAvailable(
+            itemId: "still-loading",
+            projectId: "project",
+            selectedOrgResourceIds: [],
+            resources: [],
+            drafts: [],
+            allowsUnresolved: true
+        ))
+    }
+
+    func testOrgMemoryTabClosesAfterItsLocalCreateDisappears() {
+        XCTAssertFalse(WorkspaceStore.orgMemoryTabIsAvailable(
+            itemId: "discarded-create",
+            resources: [],
+            drafts: []
+        ))
+        XCTAssertTrue(WorkspaceStore.orgMemoryTabIsAvailable(
+            itemId: "org-resource",
+            resources: [orgResource(id: "org-resource")],
+            drafts: []
+        ))
+        XCTAssertTrue(WorkspaceStore.orgMemoryTabIsAvailable(
+            itemId: "org-draft",
+            resources: [],
+            drafts: [localDraft(id: "org-draft", targetId: nil, scope: .org)]
+        ))
+    }
+
     private func tab(
         itemId: String,
         section: WorkspaceSection = .memory,
@@ -409,6 +1200,105 @@ final class WorkspaceNavigationTests: XCTestCase {
             document: .init(title: URL(fileURLWithPath: path).lastPathComponent, path: path, body: "")
         )
         return MemoryListItem(id: resource.id, resource: resource, draft: nil, inherited: false)
+    }
+
+    private func projectResource(
+        id: String,
+        path: String,
+        hash: String,
+        commitId: String = "commit-old",
+        projectId: String = "project"
+    ) -> MemoryResource {
+        MemoryResource(
+            id: id,
+            scope: .project,
+            projectId: projectId,
+            projectName: "Project",
+            kind: .context,
+            contentHash: hash,
+            updatedAt: "2026-08-19T00:00:00Z",
+            refCommitId: commitId,
+            contentLoaded: true,
+            document: .init(title: path, path: path, body: "body-\(id)")
+        )
+    }
+
+    private func orgResource(id: String) -> MemoryResource {
+        MemoryResource(
+            id: id,
+            scope: .org,
+            projectId: nil,
+            projectName: nil,
+            kind: .context,
+            contentHash: "hash-\(id)",
+            updatedAt: "2026-08-19T00:00:00Z",
+            refCommitId: "org-commit",
+            contentLoaded: true,
+            document: .init(title: id, path: "\(id).md", body: "body-\(id)")
+        )
+    }
+
+    private func localDraft(
+        id: String,
+        targetId: String?,
+        projectId: String = "project",
+        scope: MemoryScope = .project,
+        updatedAt: String = "2026-08-19T00:00:00Z"
+    ) -> LocalDraft {
+        LocalDraft(
+            id: id,
+            projectId: projectId,
+            serverId: "server-\(id)",
+            serverVersion: 1,
+            baseCommitId: "commit-old",
+            currentCommitId: "commit-new",
+            freshness: .behind,
+            hasUpstreamResourceChanges: true,
+            reconciliation: .unknown,
+            reconciliationCandidateId: nil,
+            scope: scope,
+            kind: .context,
+            targetId: targetId,
+            status: .open,
+            origin: .desktop,
+            syncStatus: .synced,
+            updatedAt: updatedAt,
+            document: .init(title: "Memory", path: "memory.md", body: "draft body"),
+            isDeletion: false
+        )
+    }
+
+    private func projectCheckout(
+        commitId: String,
+        resources: [DaemonProjectCheckoutResource]
+    ) -> DaemonProjectCheckout {
+        DaemonProjectCheckout(
+            projectId: "project",
+            commitId: commitId,
+            refEtag: "\"\(commitId)\"",
+            commitCreatedAt: "2026-08-19T01:00:00Z",
+            orgSelectionRevision: 1,
+            selectedOrgResourceIds: resources.filter { $0.scope == .org }.map(\.resourceId),
+            resources: resources,
+            ready: true
+        )
+    }
+
+    private func checkoutResource(
+        id: String,
+        path: String,
+        hash: String,
+        scope: DaemonDraftScope = .project
+    ) -> DaemonProjectCheckoutResource {
+        DaemonProjectCheckoutResource(
+            resourceId: id,
+            scope: scope,
+            resourceKind: .memory,
+            projectId: scope == .project ? "project" : nil,
+            path: path,
+            contentHash: hash,
+            content: .init(description: nil, content: "remote-\(id)")
+        )
     }
 
     private func reviewRecord(
@@ -447,4 +1337,23 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
+}
+
+private actor WorkspaceNavigationTestLatch {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
 }

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -331,6 +331,56 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
+    func testOpeningOrgScopedItemWithDraftStaysVisibleInOrgView() {
+        let store = WorkspaceStore()
+        store.selectedSection = .memory
+        // activeProjectId defaults to nil (Org view).
+
+        let item = MemoryListItem(
+            id: "org-resource",
+            resource: MemoryResource(
+                id: "org-resource",
+                scope: .org,
+                projectId: nil,
+                projectName: nil,
+                kind: .context,
+                contentHash: "hash",
+                updatedAt: "2026-08-05T00:00:00Z",
+                refCommitId: "commit",
+                contentLoaded: true,
+                document: .init(title: "org.md", path: "org.md", body: "")
+            ),
+            draft: LocalDraft(
+                id: "org-draft",
+                projectId: "carrying-project",
+                serverId: nil,
+                serverVersion: 0,
+                baseCommitId: "commit",
+                currentCommitId: "commit",
+                freshness: .current,
+                hasUpstreamResourceChanges: false,
+                reconciliation: .unknown,
+                reconciliationCandidateId: nil,
+                scope: .org,
+                kind: .context,
+                targetId: "org-resource",
+                status: .open,
+                origin: .desktop,
+                syncStatus: .synced,
+                updatedAt: "2026-08-05T00:00:00Z",
+                document: .init(title: "org.md", path: "org.md", body: "body"),
+                isDeletion: false
+            ),
+            inherited: false
+        )
+
+        store.open(item)
+
+        XCTAssertEqual(store.activeTabId, store.activeVisibleTab?.id)
+        XCTAssertEqual(store.activeVisibleTab?.itemId, "org-resource")
+        XCTAssertTrue(store.visibleTabs.contains { $0.id == store.activeTabId })
+    }
+
     private func tab(
         itemId: String,
         section: WorkspaceSection = .memory,

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import XCTest
 @testable import Clumsies
 
@@ -432,6 +433,99 @@ final class WorkspaceNavigationTests: XCTestCase {
         ).isStaleCache)
     }
 
+    func testOrgAuthorityReconciliationPreservesOnlyProvenLoadedBodies() {
+        let unchangedBody = "unchanged body"
+        let unchangedHash = contentHash(unchangedBody)
+        let updatedBody = "old body"
+        let existing = [
+            orgResource(
+                id: "unchanged",
+                path: "unchanged.md",
+                body: unchangedBody,
+                hash: unchangedHash,
+                commitId: "org-commit-old"
+            ),
+            orgResource(
+                id: "updated",
+                path: "updated.md",
+                body: updatedBody,
+                hash: contentHash(updatedBody),
+                commitId: "org-commit-old"
+            ),
+            orgResource(
+                id: "deleted",
+                path: "deleted.md",
+                body: "deleted body",
+                hash: contentHash("deleted body"),
+                commitId: "org-commit-old"
+            ),
+        ]
+        let authoritative = [
+            orgResource(
+                id: "unchanged",
+                path: "unchanged.md",
+                body: "",
+                hash: unchangedHash,
+                commitId: "org-commit-new",
+                contentLoaded: false
+            ),
+            orgResource(
+                id: "updated",
+                path: "updated.md",
+                body: "",
+                hash: contentHash("new body"),
+                commitId: "org-commit-new",
+                contentLoaded: false
+            ),
+            orgResource(
+                id: "added",
+                path: "added.md",
+                body: "",
+                hash: contentHash("added body"),
+                commitId: "org-commit-new",
+                contentLoaded: false
+            ),
+        ]
+
+        let reconciled = WorkspaceStore.reconciledOrgResources(
+            existing: existing,
+            authoritative: authoritative
+        )
+        let byId = Dictionary(uniqueKeysWithValues: reconciled.map { ($0.id, $0) })
+
+        XCTAssertEqual(Set(byId.keys), ["unchanged", "updated", "added"])
+        XCTAssertEqual(byId["unchanged"]?.document.body, unchangedBody)
+        XCTAssertTrue(byId["unchanged"]?.contentLoaded == true)
+        XCTAssertEqual(byId["unchanged"]?.refCommitId, "org-commit-new")
+        XCTAssertEqual(byId["updated"]?.document.body, "")
+        XCTAssertFalse(byId["updated"]?.contentLoaded == true)
+        XCTAssertEqual(byId["updated"]?.contentHash, contentHash("new body"))
+        XCTAssertEqual(byId["added"]?.document.body, "")
+        XCTAssertFalse(byId["added"]?.contentLoaded == true)
+        XCTAssertNil(byId["deleted"])
+    }
+
+    func testOrgAuthoritySnapshotRejectsStaleCache() {
+        XCTAssertNil(WorkspaceStore.stableOrgAuthorityCommitId(
+            beforeCommitId: "org-commit-new",
+            afterCommitId: "org-commit-new",
+            responseIsStale: true
+        ))
+    }
+
+    func testOrgAuthoritySnapshotRejectsCommitChangeDuringListing() {
+        XCTAssertEqual(WorkspaceStore.stableOrgAuthorityCommitId(
+            beforeCommitId: "org-commit-new",
+            afterCommitId: "org-commit-new",
+            responseIsStale: false
+        ), "org-commit-new")
+        XCTAssertNil(WorkspaceStore.stableOrgAuthorityCommitId(
+            beforeCommitId: "org-commit-before",
+            afterCommitId: "org-commit-after",
+            responseIsStale: false
+        ))
+    }
+
     func testStaleResourcePlanIsEmptyWhenDisplayedRefIsAuthoritative() {
         let displayed = projectResource(
             id: "memory",
@@ -456,21 +550,25 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(plan, [:])
     }
 
-    func testStaleResourcePlanCapturesStructuralChangesAndIgnoresPinnedOrgRows() {
+    func testStaleResourcePlanCapturesProjectAndSelectedOrgChanges() {
         let renamed = projectResource(id: "renamed", path: "old.md", hash: "same-hash")
         let deleted = projectResource(id: "deleted", path: "deleted.md", hash: "deleted-hash")
         let unchanged = projectResource(id: "unchanged", path: "same.md", hash: "same")
-        let org = MemoryResource(
+        let org = orgResource(
             id: "org-memory",
-            scope: .org,
-            projectId: nil,
-            projectName: nil,
-            kind: .context,
-            contentHash: "org-old",
-            updatedAt: "2026-08-19T00:00:00Z",
-            refCommitId: "org-commit",
-            contentLoaded: true,
-            document: .init(title: "Org", path: "org.md", body: "old org")
+            path: "org.md",
+            body: "old org",
+            commitId: "org-commit-old"
+        )
+        let remoteOrgBody = "remote-org-memory"
+        let remoteOrgHash = contentHash(remoteOrgBody)
+        let authoritativeOrg = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: "",
+            hash: remoteOrgHash,
+            commitId: "org-commit-new",
+            contentLoaded: false
         )
         let checkout = projectCheckout(
             commitId: "commit-new",
@@ -481,8 +579,9 @@ final class WorkspaceNavigationTests: XCTestCase {
                 checkoutResource(
                     id: "org-memory",
                     path: "org.md",
-                    hash: "org-new",
-                    scope: .org
+                    hash: remoteOrgHash,
+                    scope: .org,
+                    body: remoteOrgBody
                 ),
             ]
         )
@@ -491,16 +590,19 @@ final class WorkspaceNavigationTests: XCTestCase {
             displayedResources: [renamed, deleted, unchanged, org],
             projectName: "Project",
             observedProjectRefCommitId: "commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
             authoritativeCommitId: "commit-new",
             serverCursor: "commit-new",
             checkout: checkout,
             authoritativeRefEtag: "\"server-commit-new\"",
+            authoritativeOrgResources: [authoritativeOrg],
+            authoritativeOrgRefCommitId: "org-commit-new",
             generation: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
         )
 
         XCTAssertEqual(
             Set(plan?.keys.map { $0 } ?? []),
-            ["renamed", "deleted", "added"]
+            ["renamed", "deleted", "added", "org-memory"]
         )
         XCTAssertEqual(plan?["renamed"]?.local?.document.path, "old.md")
         XCTAssertEqual(plan?["renamed"]?.remote?.document.path, "new.md")
@@ -508,9 +610,206 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertNil(plan?["deleted"]?.remote)
         XCTAssertNil(plan?["added"]?.local)
         XCTAssertNotNil(plan?["added"]?.remote)
-        XCTAssertNil(plan?["org-memory"])
+        XCTAssertEqual(plan?["org-memory"]?.local?.document.body, "old org")
+        XCTAssertEqual(plan?["org-memory"]?.remote?.document.body, remoteOrgBody)
+        XCTAssertEqual(plan?["org-memory"]?.remote?.refCommitId, "org-commit-new")
         XCTAssertEqual(plan?["renamed"]?.authoritativeRefEtag, "\"server-commit-new\"")
         XCTAssertNil(plan?["unchanged"])
+    }
+
+    func testSelectedOrgRenameBuildsAForwardPlan() {
+        let body = "same body"
+        let hash = contentHash(body)
+        let local = orgResource(
+            id: "org-memory",
+            path: "old.md",
+            body: body,
+            hash: hash,
+            commitId: "org-commit-old"
+        )
+        let authority = orgResource(
+            id: "org-memory",
+            path: "renamed.md",
+            body: "",
+            hash: hash,
+            commitId: "org-commit-new",
+            contentLoaded: false
+        )
+        let checkout = projectCheckout(
+            commitId: "project-commit-new",
+            resources: [checkoutResource(
+                id: "org-memory",
+                path: "renamed.md",
+                hash: hash,
+                scope: .org,
+                body: body
+            )]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [local],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: checkout,
+            authoritativeOrgResources: [authority],
+            authoritativeOrgRefCommitId: "org-commit-new"
+        )
+
+        XCTAssertEqual(plan?["org-memory"]?.local?.document.path, "old.md")
+        XCTAssertEqual(plan?["org-memory"]?.remote?.document.path, "renamed.md")
+        XCTAssertEqual(plan?["org-memory"]?.remote?.document.body, body)
+    }
+
+    func testSelectedOrgDeletionRequiresOrgAuthorityAndDoesNotDeleteADeselection() {
+        let local = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: "body",
+            commitId: "org-commit-old"
+        )
+        let checkout = projectCheckout(commitId: "project-commit-new", resources: [])
+
+        let deletion = WorkspaceStore.staleResourcePlan(
+            displayedResources: [local],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: checkout,
+            authoritativeOrgResources: [],
+            authoritativeOrgRefCommitId: "org-commit-new"
+        )
+        let deselection = WorkspaceStore.staleResourcePlan(
+            displayedResources: [local],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: checkout,
+            authoritativeOrgResources: [local],
+            authoritativeOrgRefCommitId: "org-commit-old"
+        )
+
+        XCTAssertNotNil(deletion?["org-memory"]?.local)
+        XCTAssertNil(deletion?["org-memory"]?.remote)
+        XCTAssertEqual(deselection, [:])
+    }
+
+    func testSelectedOrgPlanRejectsStaleOrMismatchedAuthority() {
+        let oldBody = "old body"
+        let oldHash = contentHash(oldBody)
+        let newBody = "new body"
+        let newHash = contentHash(newBody)
+        let local = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: newBody,
+            hash: newHash,
+            commitId: "org-commit-new"
+        )
+        let historicalAuthority = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: "",
+            hash: newHash,
+            commitId: "org-commit-new",
+            contentLoaded: false
+        )
+        let checkout = projectCheckout(
+            commitId: "project-commit-new",
+            resources: [checkoutResource(
+                id: "org-memory",
+                path: "org.md",
+                hash: oldHash,
+                scope: .org,
+                body: oldBody
+            )]
+        )
+        let currentCheckout = projectCheckout(
+            commitId: "project-commit-new",
+            resources: [checkoutResource(
+                id: "org-memory",
+                path: "org.md",
+                hash: newHash,
+                scope: .org,
+                body: newBody
+            )]
+        )
+
+        XCTAssertNil(WorkspaceStore.staleResourcePlan(
+            displayedResources: [local],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: checkout,
+            authoritativeOrgResources: [historicalAuthority],
+            authoritativeOrgRefCommitId: "org-commit-new"
+        ))
+        XCTAssertNil(WorkspaceStore.staleResourcePlan(
+            displayedResources: [local],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: currentCheckout,
+            authoritativeOrgResources: [historicalAuthority],
+            authoritativeOrgRefCommitId: "org-commit-new",
+            authoritativeOrgResponseIsStale: true
+        ))
+    }
+
+    func testSelectedOrgPlanRepairsAnOldBodyMislabeledAsTheCurrentGeneration() {
+        let oldBody = "old body"
+        let newBody = "new body"
+        let newHash = contentHash(newBody)
+        let mislabeledLocal = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: oldBody,
+            hash: newHash,
+            commitId: "org-commit-new"
+        )
+        let authority = orgResource(
+            id: "org-memory",
+            path: "org.md",
+            body: "",
+            hash: newHash,
+            commitId: "org-commit-new",
+            contentLoaded: false
+        )
+        let checkout = projectCheckout(
+            commitId: "project-commit-new",
+            resources: [checkoutResource(
+                id: "org-memory",
+                path: "org.md",
+                hash: newHash,
+                scope: .org,
+                body: newBody
+            )]
+        )
+
+        let plan = WorkspaceStore.staleResourcePlan(
+            displayedResources: [mislabeledLocal],
+            projectName: "Project",
+            observedProjectRefCommitId: "project-commit-old",
+            observedSelectedOrgResourceIds: ["org-memory"],
+            authoritativeCommitId: "project-commit-new",
+            serverCursor: "project-commit-new",
+            checkout: checkout,
+            authoritativeOrgResources: [authority],
+            authoritativeOrgRefCommitId: "org-commit-new"
+        )
+
+        XCTAssertEqual(plan?["org-memory"]?.local?.document.body, oldBody)
+        XCTAssertEqual(plan?["org-memory"]?.remote?.document.body, newBody)
     }
 
     func testStaleResourcePlanKeepsAProvisionalAdditionPending() {
@@ -743,7 +1042,7 @@ final class WorkspaceNavigationTests: XCTestCase {
             plan,
             .init(targetId: "memory", newPath: "renamed.md")
         )
-        XCTAssertTrue(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
 
         let dirty = EditableMemoryDocument(
             title: "old.md",
@@ -898,13 +1197,28 @@ final class WorkspaceNavigationTests: XCTestCase {
     }
 
     func testReconciliationToolbarCommandsRemainBoundToDocument() {
+        let projectP = MemoryDocumentSessionKey(projectId: "project-p", itemId: "document")
+        let projectQ = MemoryDocumentSessionKey(projectId: "project-q", itemId: "document")
         XCTAssertEqual(
-            DocumentSessionCommand.applyReconciliation(itemId: "document").itemId,
-            "document"
+            DocumentSessionCommand.applyReconciliation(sessionKey: projectP).sessionKey,
+            projectP
         )
         XCTAssertEqual(
-            DocumentSessionCommand.closeReconciliation(itemId: "document").itemId,
-            "document"
+            DocumentSessionCommand.closeReconciliation(sessionKey: projectP).sessionKey,
+            projectP
+        )
+        XCTAssertNotEqual(
+            DocumentSessionCommand.applyReconciliation(sessionKey: projectP).sessionKey,
+            projectQ
+        )
+        XCTAssertNotEqual(
+            DocumentReconciliationToolbarState(
+                sessionKey: projectP,
+                isLoading: false,
+                canUpdate: true,
+                isUpdating: false
+            ).sessionKey,
+            projectQ
         )
     }
 
@@ -956,11 +1270,7 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(template.description, "current description")
     }
 
-    func testOpeningOrgScopedItemWithDraftStaysVisibleInOrgView() {
-        let store = WorkspaceStore()
-        store.selectedSection = .memory
-        // activeProjectId defaults to nil (Org view).
-
+    func testOrgViewPresentationStripsProjectCarriedDraft() {
         let item = MemoryListItem(
             id: "org-resource",
             resource: MemoryResource(
@@ -999,11 +1309,14 @@ final class WorkspaceNavigationTests: XCTestCase {
             inherited: false
         )
 
-        store.open(item)
+        let presented = WorkspaceStore.memoryItemForViewContext(
+            item,
+            activeProjectId: nil
+        )
 
-        XCTAssertEqual(store.activeTabId, store.activeVisibleTab?.id)
-        XCTAssertEqual(store.activeVisibleTab?.itemId, "org-resource")
-        XCTAssertTrue(store.visibleTabs.contains { $0.id == store.activeTabId })
+        XCTAssertEqual(presented?.resource?.id, "org-resource")
+        XCTAssertNil(presented?.draft)
+        XCTAssertNil(presented?.projectContextId)
     }
 
     func testMemoryTreeResourcesUseOrgCatalogInOrgView() {
@@ -1057,8 +1370,41 @@ final class WorkspaceNavigationTests: XCTestCase {
                 [current, other, org],
                 activeProjectId: nil
             ).map(\.id),
-            ["org"]
+            []
         )
+    }
+
+    func testMemoryTabDraftNeverUsesAnotherProjectOrAnOrgTab() {
+        let projectP = localDraft(
+            id: "draft-p",
+            targetId: "memory",
+            projectId: "project-p",
+            scope: .org,
+            updatedAt: "2026-08-19T00:00:00Z"
+        )
+        let newerProjectQ = localDraft(
+            id: "draft-q",
+            targetId: "memory",
+            projectId: "project-q",
+            scope: .org,
+            updatedAt: "2026-08-20T00:00:00Z"
+        )
+
+        XCTAssertEqual(WorkspaceStore.memoryTabDraft(
+            itemId: "memory",
+            projectId: "project-p",
+            drafts: [projectP, newerProjectQ]
+        )?.id, "draft-p")
+        XCTAssertEqual(WorkspaceStore.memoryTabDraft(
+            itemId: "memory",
+            projectId: "project-q",
+            drafts: [projectP, newerProjectQ]
+        )?.id, "draft-q")
+        XCTAssertNil(WorkspaceStore.memoryTabDraft(
+            itemId: "memory",
+            projectId: nil,
+            drafts: [projectP, newerProjectQ]
+        ))
     }
 
     func testMemoryTreePrefersTheNewestDraftForOneTarget() {
@@ -1092,13 +1438,38 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(item.projectId, "project")
     }
 
-    func testProjectLocalCreateCannotRequestReviewUntilOrgPublishingExists() {
+    func testSameOrgTargetHasDistinctDocumentSessionsPerProject() throws {
+        let resource = orgResource(id: "org")
+        let projectP = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: true,
+            projectContextId: "project-p"
+        )
+        let projectQ = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: true,
+            projectContextId: "project-q"
+        )
+
+        let keyP = try XCTUnwrap(WorkspaceStore.memoryDocumentSessionKey(for: projectP))
+        let keyQ = try XCTUnwrap(WorkspaceStore.memoryDocumentSessionKey(for: projectQ))
+        XCTAssertNotEqual(keyP, keyQ)
+        XCTAssertEqual(keyP.itemId, keyQ.itemId)
+        XCTAssertEqual(keyP.projectId, "project-p")
+        XCTAssertEqual(keyQ.projectId, "project-q")
+    }
+
+    func testOnlyOrganizationDraftsCanRequestReview() {
         let localCreate = localDraft(id: "local", targetId: nil)
         let legacyProjectUpdate = localDraft(id: "legacy", targetId: "project-memory")
         let orgCreate = localDraft(id: "org", targetId: nil, scope: .org)
 
         XCTAssertFalse(WorkspaceStore.canRequestReview(localCreate))
-        XCTAssertTrue(WorkspaceStore.canRequestReview(legacyProjectUpdate))
+        XCTAssertFalse(WorkspaceStore.canRequestReview(legacyProjectUpdate))
         XCTAssertTrue(WorkspaceStore.canRequestReview(orgCreate))
     }
 
@@ -1157,18 +1528,181 @@ final class WorkspaceNavigationTests: XCTestCase {
     func testOrgMemoryTabClosesAfterItsLocalCreateDisappears() {
         XCTAssertFalse(WorkspaceStore.orgMemoryTabIsAvailable(
             itemId: "discarded-create",
-            resources: [],
-            drafts: []
+            resources: []
         ))
         XCTAssertTrue(WorkspaceStore.orgMemoryTabIsAvailable(
             itemId: "org-resource",
-            resources: [orgResource(id: "org-resource")],
-            drafts: []
+            resources: [orgResource(id: "org-resource")]
         ))
-        XCTAssertTrue(WorkspaceStore.orgMemoryTabIsAvailable(
+        XCTAssertFalse(WorkspaceStore.orgMemoryTabIsAvailable(
             itemId: "org-draft",
-            resources: [],
-            drafts: [localDraft(id: "org-draft", targetId: nil, scope: .org)]
+            resources: []
+        ))
+    }
+
+    func testDocumentSynchronizationAdmissionIsProjectContextScoped() {
+        XCTAssertTrue(WorkspaceStore.canStartDocumentSynchronization(
+            isSwitchingMemoryContext: false,
+            activeProjectId: "project-p",
+            itemProjectContextId: "project-p"
+        ))
+        XCTAssertFalse(WorkspaceStore.canStartDocumentSynchronization(
+            isSwitchingMemoryContext: true,
+            activeProjectId: "project-p",
+            itemProjectContextId: "project-p"
+        ))
+        XCTAssertFalse(WorkspaceStore.canStartDocumentSynchronization(
+            isSwitchingMemoryContext: false,
+            activeProjectId: "project-q",
+            itemProjectContextId: "project-p"
+        ))
+        XCTAssertFalse(WorkspaceStore.canStartDocumentSynchronization(
+            isSwitchingMemoryContext: false,
+            activeProjectId: nil,
+            itemProjectContextId: nil
+        ))
+    }
+
+    func testCapturedProjectOperationStopsAfterContextChanges() {
+        XCTAssertTrue(WorkspaceStore.projectContextIsCurrent(
+            isSwitchingMemoryContext: false,
+            activeProjectId: "project-p",
+            expectedProjectId: "project-p"
+        ))
+        XCTAssertFalse(WorkspaceStore.projectContextIsCurrent(
+            isSwitchingMemoryContext: true,
+            activeProjectId: "project-p",
+            expectedProjectId: "project-p"
+        ))
+        XCTAssertFalse(WorkspaceStore.projectContextIsCurrent(
+            isSwitchingMemoryContext: false,
+            activeProjectId: "project-q",
+            expectedProjectId: "project-p"
+        ))
+    }
+
+    func testContextSwitchCommitWaitsForEveryReconciliationActivity() {
+        XCTAssertTrue(WorkspaceStore.canCommitMemoryContextSwitch(
+            hasDocumentSynchronization: false,
+            hasApplyingDocumentReconciliation: false,
+            hasStandaloneReconciliationActivity: false
+        ))
+        XCTAssertFalse(WorkspaceStore.canCommitMemoryContextSwitch(
+            hasDocumentSynchronization: true,
+            hasApplyingDocumentReconciliation: false,
+            hasStandaloneReconciliationActivity: false
+        ))
+        XCTAssertFalse(WorkspaceStore.canCommitMemoryContextSwitch(
+            hasDocumentSynchronization: false,
+            hasApplyingDocumentReconciliation: false,
+            hasStandaloneReconciliationActivity: true
+        ))
+    }
+
+    func testRemovingCleanProjectMemoryPrunesItsTabButDraftRetainsIt() {
+        let resource = orgResource(id: "org")
+        let tab = tab(itemId: resource.id, projectId: "project-p")
+        let projectWithoutSelection = ProjectState(
+            id: "project-p",
+            name: "Project P",
+            refCommitId: "commit",
+            refEtag: "etag",
+            selectedOrgResourceIds: [],
+            orgSelectionRevision: 2,
+            isLoaded: true
+        )
+        let projectWithSelection = ProjectState(
+            id: "project-p",
+            name: "Project P",
+            refCommitId: "commit",
+            refEtag: "etag",
+            selectedOrgResourceIds: [resource.id],
+            orgSelectionRevision: 3,
+            isLoaded: true
+        )
+
+        let afterRemoval = WorkspaceStore.retainedMemoryTabs(
+            [tab],
+            projects: [projectWithoutSelection],
+            resources: [resource],
+            drafts: []
+        )
+        XCTAssertTrue(afterRemoval.isEmpty)
+        XCTAssertTrue(WorkspaceStore.retainedMemoryTabs(
+            afterRemoval,
+            projects: [projectWithSelection],
+            resources: [resource],
+            drafts: []
+        ).isEmpty)
+        XCTAssertEqual(WorkspaceStore.retainedMemoryTabs(
+            [tab],
+            projects: [projectWithoutSelection],
+            resources: [resource],
+            drafts: [localDraft(
+                id: "draft-p",
+                targetId: resource.id,
+                projectId: "project-p",
+                scope: .org
+            )]
+        ), [tab])
+        XCTAssertTrue(WorkspaceStore.retainedMemoryTabs(
+            [tab],
+            projects: [projectWithoutSelection],
+            resources: [resource],
+            drafts: [localDraft(
+                id: "draft-q",
+                targetId: resource.id,
+                projectId: "project-q",
+                scope: .org
+            )]
+        ).isEmpty)
+    }
+
+    func testNewContextDraftStartsWithValidNonemptyContent() {
+        XCTAssertEqual(
+            WorkspaceStore.defaultDocument(kind: .context, path: "context/untitled.md").body,
+            "# Untitled\n"
+        )
+    }
+
+    func testNewDraftPathSkipsFreshOrganizationAndLocalDraftCollisions() {
+        XCTAssertEqual(
+            WorkspaceStore.uniqueDefaultPath(
+                base: "untitled.md",
+                occupiedPaths: ["untitled.md", "untitled-2.md"]
+            ),
+            "untitled-3.md"
+        )
+        XCTAssertEqual(
+            WorkspaceStore.uniqueDefaultPath(
+                base: "workflow/untitled.md",
+                occupiedPaths: []
+            ),
+            "workflow/untitled.md"
+        )
+    }
+
+    func testProjectSelectionRemovalIsBlockedByItsActiveTargetDraft() {
+        let resourceIds: Set<String> = ["org-memory"]
+        XCTAssertTrue(WorkspaceStore.hasActiveDraft(
+            in: "project-p",
+            targetingAny: resourceIds,
+            drafts: [localDraft(
+                id: "draft-p",
+                targetId: "org-memory",
+                projectId: "project-p",
+                scope: .org
+            )]
+        ))
+        XCTAssertFalse(WorkspaceStore.hasActiveDraft(
+            in: "project-p",
+            targetingAny: resourceIds,
+            drafts: [localDraft(
+                id: "draft-q",
+                targetId: "org-memory",
+                projectId: "project-q",
+                scope: .org
+            )]
         ))
     }
 
@@ -1223,18 +1757,26 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
-    private func orgResource(id: String) -> MemoryResource {
-        MemoryResource(
+    private func orgResource(
+        id: String,
+        path: String? = nil,
+        body: String? = nil,
+        hash: String? = nil,
+        commitId: String = "org-commit",
+        contentLoaded: Bool = true
+    ) -> MemoryResource {
+        let body = body ?? "body-\(id)"
+        return MemoryResource(
             id: id,
             scope: .org,
             projectId: nil,
             projectName: nil,
             kind: .context,
-            contentHash: "hash-\(id)",
+            contentHash: hash ?? "hash-\(id)",
             updatedAt: "2026-08-19T00:00:00Z",
-            refCommitId: "org-commit",
-            contentLoaded: true,
-            document: .init(title: id, path: "\(id).md", body: "body-\(id)")
+            refCommitId: commitId,
+            contentLoaded: contentLoaded,
+            document: .init(title: id, path: path ?? "\(id).md", body: body)
         )
     }
 
@@ -1288,7 +1830,8 @@ final class WorkspaceNavigationTests: XCTestCase {
         id: String,
         path: String,
         hash: String,
-        scope: DaemonDraftScope = .project
+        scope: DaemonDraftScope = .project,
+        body: String? = nil
     ) -> DaemonProjectCheckoutResource {
         DaemonProjectCheckoutResource(
             resourceId: id,
@@ -1297,8 +1840,13 @@ final class WorkspaceNavigationTests: XCTestCase {
             projectId: scope == .project ? "project" : nil,
             path: path,
             contentHash: hash,
-            content: .init(description: nil, content: "remote-\(id)")
+            content: .init(description: nil, content: body ?? "remote-\(id)")
         )
+    }
+
+    private func contentHash(_ content: String) -> String {
+        let digest = SHA256.hash(data: Data(content.utf8))
+        return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
     }
 
     private func reviewRecord(

--- a/crates/daemon/src/agent_runtime/mcp_contract.rs
+++ b/crates/daemon/src/agent_runtime/mcp_contract.rs
@@ -389,7 +389,11 @@ impl StoreInput {
             draft_id: None,
             base_commit_id: None,
             project_id: project_id.to_owned(),
-            scope: DaemonDraftScope::Project,
+            // Project Memory is an overlay on Organization authority. The
+            // Project id carries the LocalDraft; the Draft itself targets the
+            // Organization Ref so an eventual Review cannot create a second
+            // Project-owned authority.
+            scope: DaemonDraftScope::Org,
             resource,
             op: operation,
             source: Some(DaemonDraftOperationSource::McpStore),
@@ -1481,7 +1485,7 @@ mod tests {
         let AgentRuntimeRequest::Store(request) = request else {
             panic!("unexpected request variant");
         };
-        assert_eq!(request.scope, DaemonDraftScope::Project);
+        assert_eq!(request.scope, DaemonDraftScope::Org);
         assert_eq!(request.resource, DaemonDraftResourceKind::Memory);
         assert_eq!(request.source, Some(DaemonDraftOperationSource::McpStore));
         assert!(request.op.create.is_some());

--- a/crates/daemon/src/draft.rs
+++ b/crates/daemon/src/draft.rs
@@ -57,11 +57,15 @@ pub(crate) async fn resolve_local_draft(
         .fetch_optional(&mut **tx)
         .await?
         .ok_or_else(|| DaemonError::NotFound(format!("local draft not found: {draft_id}")))?;
+        let stored_scope: String = row.try_get("resource_scope")?;
         let stored_kind: String = row.try_get("resource_kind")?;
         let stored_project_id: String = row.try_get("project_id")?;
-        if stored_project_id != project_id || stored_kind != resource.as_str() {
+        if stored_project_id != project_id
+            || stored_scope != scope.as_str()
+            || stored_kind != resource.as_str()
+        {
             return Err(DaemonError::InvalidRequest(format!(
-                "local draft {draft_id} belongs to a different project or resource kind"
+                "local draft {draft_id} belongs to a different project, scope, or resource kind"
             )));
         }
         let stored_base_commit_id: Option<String> = row.try_get("base_commit_id")?;
@@ -119,11 +123,17 @@ pub(crate) async fn resolve_local_draft(
         "SELECT draft_id, project_id, resource_scope, resource_kind, base_commit_id
          FROM local_drafts
          WHERE (draft_id = $1 OR target_id = $1)
+           AND project_id = $2
+           AND resource_scope = $3
+           AND resource_kind = $4
            AND status IN ('open', 'submitted')
          ORDER BY updated_at DESC
          LIMIT 1",
     )
     .bind(target_id)
+    .bind(project_id)
+    .bind(scope.as_str())
+    .bind(resource.as_str())
     .fetch_optional(&mut **tx)
     .await?
     {

--- a/crates/daemon/src/search/index.rs
+++ b/crates/daemon/src/search/index.rs
@@ -1296,8 +1296,10 @@ pub(super) fn decode_vector(bytes: &[u8], dimensions: usize) -> Result<Vec<f32>,
         )));
     }
     let vector = bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|chunk| f32::from_le_bytes(*chunk))
         .collect::<Vec<_>>();
     if !valid_normalized_vector(&vector) {
         return Err(SearchFailure::vector(

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -1803,7 +1803,7 @@ mod tests {
                     delete: None,
                     discard: None,
                 },
-                source: Some(DaemonDraftOperationSource::McpStore),
+                source: Some(DaemonDraftOperationSource::Desktop),
             })
             .await
             .unwrap();
@@ -2248,12 +2248,21 @@ mod tests {
     #[tokio::test]
     async fn mcp_text_replacements_are_atomic_and_persist_as_complete_content() {
         let (_temp, state) = test_state().await;
+        sqlx::query(
+            "INSERT INTO cached_refs (
+                ref_key, name, scope, org_id, project_id, commit_id, etag, server_updated_at
+             ) VALUES ('org:org_test', 'refs/heads/main', 'org', 'org_test', NULL,
+                       'commit_test', '\"commit_test\"', '2026-07-21T00:00:00Z')",
+        )
+        .execute(&state.inner.pool)
+        .await
+        .unwrap();
         let central_pool = state.inner.pool.clone();
         let service = DaemonIpcService::new(state);
         let original = service
             .load_memory(LoadMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                ids: vec!["ctx_retrieval".to_owned()],
+                ids: vec!["rule_testing".to_owned()],
                 known_hashes: BTreeMap::new(),
             })
             .await
@@ -2272,16 +2281,16 @@ mod tests {
                     "resource": "memory",
                     "op": {
                         "update": {
-                            "id": "ctx_retrieval",
+                            "id": "rule_testing",
                             "expected_hash": original.content_hash,
                             "replacements": [
                                 {
-                                    "old_text": "Hybrid search",
-                                    "new_text": "Memory activation"
+                                    "old_text": "Apply when changing retrieval.",
+                                    "new_text": "Apply when changing retrieval behavior."
                                 },
                                 {
-                                    "old_text": "dense vectors",
-                                    "new_text": "vector retrieval"
+                                    "old_text": "Run integration tests.",
+                                    "new_text": "Run integration and regression tests."
                                 }
                             ]
                         }
@@ -2301,14 +2310,16 @@ mod tests {
         let loaded = service
             .load_memory(LoadMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                ids: vec!["ctx_retrieval".to_owned()],
+                ids: vec!["rule_testing".to_owned()],
                 known_hashes: BTreeMap::new(),
             })
             .await
             .unwrap();
         assert_eq!(
             loaded.resources[0].content.as_deref(),
-            Some("# Retrieval\n\nMemory activation combines BM25 and vector retrieval.")
+            Some(
+                "# Testing\n\nApply when changing retrieval behavior.\n\nRun integration and regression tests.\n\nTags: testing"
+            )
         );
         let updated_hash = loaded.resources[0].content_hash.clone();
 
@@ -2329,11 +2340,11 @@ mod tests {
                         "resource": "memory",
                         "op": {
                             "update": {
-                                "id": "ctx_retrieval",
+                                "id": "rule_testing",
                                 "expected_hash": updated_hash,
                                 "replacements": [{
-                                    "old_text": "Memory activation",
-                                    "new_text": "Agent memory activation"
+                                    "old_text": "Run integration and regression tests.",
+                                    "new_text": "Run integration, regression, and smoke tests."
                                 }]
                             }
                         },
@@ -2363,10 +2374,10 @@ mod tests {
                     "resource": "memory",
                     "op": {
                         "update": {
-                            "id": "ctx_retrieval",
+                            "id": "rule_testing",
                             "expected_hash": original.content_hash,
                             "replacements": [{
-                                "old_text": "Memory activation",
+                                "old_text": "Run integration and regression tests.",
                                 "new_text": "stale write"
                             }]
                         }
@@ -2396,11 +2407,186 @@ mod tests {
             update.content,
             DaemonDraftContent {
                 description: None,
-                content:
-                    "# Retrieval\n\nAgent memory activation combines BM25 and vector retrieval."
-                        .to_owned()
+                content: "# Testing\n\nApply when changing retrieval behavior.\n\nRun integration, regression, and smoke tests.\n\nTags: testing"
+                    .to_owned()
             }
         );
+    }
+
+    #[tokio::test]
+    async fn mcp_target_mutations_reject_legacy_project_authority_without_local_pollution() {
+        let (_temp, state) = test_state().await;
+        let pool = state.inner.pool.clone();
+        let service = DaemonIpcService::new(state);
+        let original = service
+            .load_memory(LoadMemoryRequest {
+                project_id: "prj_test".to_owned(),
+                ids: vec!["ctx_retrieval".to_owned()],
+                known_hashes: BTreeMap::new(),
+            })
+            .await
+            .unwrap()
+            .resources
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let requests = [
+            json!({
+                "update": {
+                    "id": "ctx_retrieval",
+                    "expected_hash": original.content_hash,
+                    "replacements": [{
+                        "old_text": "Hybrid search",
+                        "new_text": "Forbidden update"
+                    }]
+                }
+            }),
+            json!({
+                "rename": {
+                    "id": "ctx_retrieval",
+                    "new_path": "architecture/renamed.md"
+                }
+            }),
+            json!({
+                "delete": {
+                    "id": "ctx_retrieval"
+                }
+            }),
+        ];
+        for op in requests {
+            let response = service
+                .dispatch(DaemonIpcRequest::new(
+                    "store_draft_operation",
+                    json!({
+                        "project_id": "prj_test",
+                        "scope": "org",
+                        "resource": "memory",
+                        "op": op,
+                        "source": "mcp_store"
+                    }),
+                ))
+                .await;
+            assert!(!response.ok);
+            let error = response
+                .error
+                .expect("legacy mutation must return an error");
+            assert_eq!(error.code, "invalid_request");
+            assert!(
+                error
+                    .message
+                    .contains("legacy Project Memory ctx_retrieval")
+            );
+            assert!(error.message.contains("read-only"));
+        }
+
+        let draft_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let operation_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM local_draft_operations")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(draft_count, 0);
+        assert_eq!(operation_count, 0);
+
+        let unchanged = service
+            .load_memory(LoadMemoryRequest {
+                project_id: "prj_test".to_owned(),
+                ids: vec!["ctx_retrieval".to_owned()],
+                known_hashes: BTreeMap::new(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(unchanged.resources[0].path, original.path);
+        assert_eq!(
+            unchanged.resources[0].content.as_deref(),
+            original.content.as_deref()
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_discard_resolves_existing_legacy_draft_scope_without_fabricating_a_draft() {
+        let (_temp, state) = test_state().await;
+        let pool = state.inner.pool.clone();
+        let service = DaemonIpcService::new(state);
+        let draft = service
+            .store_draft_operation(DaemonDraftOperationRequest {
+                draft_id: None,
+                base_commit_id: None,
+                project_id: "prj_test".to_owned(),
+                scope: crate::DaemonDraftScope::Project,
+                resource: crate::DaemonDraftResourceKind::Memory,
+                op: DaemonDraftOperation {
+                    create: None,
+                    update: Some(DaemonUpdateDraftOperation::Content(
+                        DaemonContentDraftUpdate {
+                            id: "ctx_retrieval".to_owned(),
+                            content: DaemonDraftContent {
+                                description: None,
+                                content: "# Legacy draft\n\nCleanup only.".to_owned(),
+                            },
+                            description: None,
+                        },
+                    )),
+                    rename: None,
+                    delete: None,
+                    discard: None,
+                },
+                source: Some(DaemonDraftOperationSource::Desktop),
+            })
+            .await
+            .unwrap();
+
+        let discarded = service
+            .dispatch(DaemonIpcRequest::new(
+                "store_draft_operation",
+                json!({
+                    "project_id": "prj_test",
+                    "scope": "org",
+                    "resource": "memory",
+                    "op": {"discard": {"id": draft.draft_id}},
+                    "source": "mcp_store"
+                }),
+            ))
+            .await;
+        assert!(discarded.ok, "discard failed: {:?}", discarded.error);
+        let response: DaemonDraftOperationResponse =
+            serde_json::from_value(discarded.payload).unwrap();
+        assert_eq!(response.draft_id, draft.draft_id);
+        let detail = service.get_draft(&draft.draft_id).await.unwrap();
+        assert_eq!(detail.draft.scope, crate::DaemonDraftScope::Project);
+        assert_eq!(
+            detail.draft.status,
+            crate::DaemonLocalDraftStatus::Discarded
+        );
+        let draft_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(draft_count, 1);
+
+        let missing = service
+            .dispatch(DaemonIpcRequest::new(
+                "store_draft_operation",
+                json!({
+                    "project_id": "prj_test",
+                    "scope": "org",
+                    "resource": "memory",
+                    "op": {"discard": {"id": "draft_missing"}},
+                    "source": "mcp_store"
+                }),
+            ))
+            .await;
+        assert!(!missing.ok);
+        assert_eq!(missing.error.unwrap().code, "not_found");
+        let final_draft_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(final_draft_count, 1);
     }
 
     #[tokio::test]
@@ -2481,11 +2667,11 @@ mod tests {
                 "store_draft_operation",
                 json!({
                     "project_id": "prj_test",
-                    "scope": "project",
+                    "scope": "org",
                     "resource": "memory",
                     "op": {
                         "discard": {
-                            "id": "rule_testing"
+                            "id": stored.draft_id
                         }
                     },
                     "source": "mcp_store"
@@ -2494,7 +2680,7 @@ mod tests {
             .await;
         assert!(
             discarded.ok,
-            "daemon rejected discarding an org draft with project scope: {:?}",
+            "daemon rejected discarding an org draft: {:?}",
             discarded.error
         );
         let detail = service.get_draft(&stored.draft_id).await.unwrap();

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -4,16 +4,23 @@ use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
 use serde::de::DeserializeOwned;
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
 use tokio::sync::{Mutex, Notify, Semaphore};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use super::*;
+use crate::draft::daemon_draft_scope_from_str;
 
 const STARTUP_CREDENTIAL_LOAD_TIMEOUT: Duration = Duration::from_secs(10);
 const LAZY_CREDENTIAL_LOAD_TIMEOUT: Duration = Duration::from_secs(5);
 const CREDENTIAL_RECOVERY_COOLDOWN: Duration = Duration::from_secs(10);
+
+fn legacy_project_memory_read_only_error(resource_id: &str) -> DaemonError {
+    DaemonError::InvalidRequest(format!(
+        "legacy Project Memory {resource_id} is read-only; MCP mutations may target only selected Organization Memory"
+    ))
+}
 
 #[derive(Default)]
 pub(crate) struct CredentialRecovery {
@@ -1161,20 +1168,113 @@ impl DaemonState {
         request: DaemonDraftOperationRequest,
     ) -> Result<DaemonDraftOperationResponse, DaemonError> {
         request.op.validate(request.resource)?;
-        if request.op.has_text_update() {
+        let has_text_update = request.op.has_text_update();
+        let is_mcp_target_mutation = request.source == Some(DaemonDraftOperationSource::McpStore)
+            && request.op.discard.is_none()
+            && (request.op.update.is_some()
+                || request.op.rename.is_some()
+                || request.op.delete.is_some());
+        if has_text_update || is_mcp_target_mutation {
             let _sync_guard = self.inner.sync_lock.lock().await;
             let _mutation_guard = self.inner.draft_mutation_lock.lock().await;
-            let request = self.materialize_text_update(request).await?;
+            let request = if has_text_update {
+                self.materialize_text_update(request).await?
+            } else {
+                self.normalize_mcp_target_mutation(request).await?
+            };
             return self.persist_draft_operation(request).await;
         }
         if request.op.delete.is_some() || request.op.discard.is_some() {
             let _sync_guard = self.inner.sync_lock.lock().await;
             let _mutation_guard = self.inner.draft_mutation_lock.lock().await;
+            let request = if request.source == Some(DaemonDraftOperationSource::McpStore)
+                && request.op.discard.is_some()
+            {
+                self.normalize_mcp_discard(request).await?
+            } else {
+                request
+            };
             return self.persist_draft_operation(request).await;
         }
 
         let _mutation_guard = self.inner.draft_mutation_lock.lock().await;
         self.persist_draft_operation(request).await
+    }
+
+    async fn normalize_mcp_target_mutation(
+        &self,
+        mut request: DaemonDraftOperationRequest,
+    ) -> Result<DaemonDraftOperationRequest, DaemonError> {
+        let target_id = request.op.target_id().ok_or_else(|| {
+            DaemonError::InvalidRequest(
+                "target-backed MCP mutation requires a stable Memory resource id".to_owned(),
+            )
+        })?;
+        // A create Draft is itself the effective resource until publication.
+        // Resolve that local identity before consulting the materialized
+        // Project index: delete must become Discard even when no Project Ref
+        // has been activated yet, and rename must keep the Draft's real scope.
+        if let Some(local) = sqlx::query(
+            "SELECT draft_id, resource_scope
+             FROM local_drafts
+             WHERE draft_id = $1
+               AND project_id = $2
+               AND resource_kind = $3
+               AND target_id IS NULL
+               AND status IN ('open', 'submitted')",
+        )
+        .bind(target_id)
+        .bind(&request.project_id)
+        .bind(request.resource.as_str())
+        .fetch_optional(&self.inner.pool)
+        .await?
+        {
+            request.draft_id = Some(local.try_get("draft_id")?);
+            request.scope = daemon_draft_scope_from_str(
+                local.try_get::<String, _>("resource_scope")?.as_str(),
+            )?;
+            return Ok(request);
+        }
+        let resource = self
+            .load_stable_mutation_target(&request, target_id)
+            .await?;
+        request.scope = match resource.scope {
+            SourceScope::Org => DaemonDraftScope::Org,
+            SourceScope::Project => {
+                return Err(legacy_project_memory_read_only_error(&resource.resource_id));
+            }
+        };
+        Ok(request)
+    }
+
+    async fn load_stable_mutation_target(
+        &self,
+        request: &DaemonDraftOperationRequest,
+        target_id: &str,
+    ) -> Result<LoadedMemoryResource, DaemonError> {
+        let loaded = search::load_memory(
+            self,
+            LoadMemoryRequest {
+                project_id: request.project_id.clone(),
+                ids: vec![target_id.to_owned()],
+                known_hashes: BTreeMap::new(),
+            },
+        )
+        .await?;
+        let resource = loaded.resources.into_iter().next().ok_or_else(|| {
+            DaemonError::NotFound(format!("memory resource {target_id} is not available"))
+        })?;
+        if resource.resource_id != target_id {
+            return Err(DaemonError::InvalidRequest(
+                "draft mutation id must be a stable resource id, not a path".to_owned(),
+            ));
+        }
+        if !memory_kind_matches_resource(resource.kind, request.resource) {
+            return Err(DaemonError::InvalidRequest(
+                "draft mutation resource kind does not match its target".to_owned(),
+            ));
+        }
+        Ok(resource)
     }
 
     async fn materialize_text_update(
@@ -1191,27 +1291,17 @@ impl DaemonState {
                     "draft operation does not contain a text replacement update".to_owned(),
                 )
             })?;
-        let loaded = search::load_memory(
-            self,
-            LoadMemoryRequest {
-                project_id: request.project_id.clone(),
-                ids: vec![update.id.clone()],
-                known_hashes: BTreeMap::new(),
-            },
-        )
-        .await?;
-        let resource = loaded.resources.into_iter().next().ok_or_else(|| {
-            DaemonError::NotFound(format!("memory resource {} is not available", update.id))
-        })?;
-        if resource.resource_id != update.id {
-            return Err(DaemonError::InvalidRequest(
-                "text replacement update id must be a stable resource id, not a path".to_owned(),
-            ));
-        }
-        if !memory_kind_matches_resource(resource.kind, request.resource) {
-            return Err(DaemonError::InvalidRequest(
-                "text replacement resource kind does not match its target".to_owned(),
-            ));
+        let resource = self
+            .load_stable_mutation_target(&request, &update.id)
+            .await?;
+        match resource.scope {
+            SourceScope::Org => request.scope = DaemonDraftScope::Org,
+            SourceScope::Project
+                if request.source == Some(DaemonDraftOperationSource::McpStore) =>
+            {
+                return Err(legacy_project_memory_read_only_error(&resource.resource_id));
+            }
+            SourceScope::Project => request.scope = DaemonDraftScope::Project,
         }
         if resource.content_hash != update.expected_hash {
             return Err(DaemonError::State {
@@ -1221,13 +1311,6 @@ impl DaemonState {
                     update.id, update.expected_hash, resource.content_hash
                 ),
             });
-        }
-        let resolved_scope = match resource.scope {
-            SourceScope::Org => DaemonDraftScope::Org,
-            SourceScope::Project => DaemonDraftScope::Project,
-        };
-        if request.scope != resolved_scope {
-            request.scope = resolved_scope;
         }
         let content = resource.content.ok_or_else(|| DaemonError::State {
             code: "memory_content_unavailable",
@@ -1245,6 +1328,39 @@ impl DaemonState {
             },
         ));
         request.op.validate(request.resource)?;
+        Ok(request)
+    }
+
+    async fn normalize_mcp_discard(
+        &self,
+        mut request: DaemonDraftOperationRequest,
+    ) -> Result<DaemonDraftOperationRequest, DaemonError> {
+        let draft_id = request
+            .op
+            .discard
+            .as_ref()
+            .map(|discard| discard.id.as_str())
+            .ok_or_else(|| {
+                DaemonError::InvalidRequest(
+                    "MCP discard requires an existing local Draft id".to_owned(),
+                )
+            })?;
+        let row = sqlx::query(
+            "SELECT draft_id, resource_scope
+             FROM local_drafts
+             WHERE draft_id = $1
+               AND project_id = $2
+               AND resource_kind = $3",
+        )
+        .bind(draft_id)
+        .bind(&request.project_id)
+        .bind(request.resource.as_str())
+        .fetch_optional(&self.inner.pool)
+        .await?
+        .ok_or_else(|| DaemonError::NotFound(format!("local draft not found: {draft_id}")))?;
+        request.draft_id = Some(row.try_get("draft_id")?);
+        request.scope =
+            daemon_draft_scope_from_str(row.try_get::<String, _>("resource_scope")?.as_str())?;
         Ok(request)
     }
 

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -2285,7 +2285,7 @@ async fn deleting_a_draft_created_resource_discards_the_draft() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2308,7 +2308,7 @@ async fn deleting_a_draft_created_resource_discards_the_draft() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -2097,6 +2097,187 @@ async fn draft_operation_service_method_writes_local_queue_without_http() {
 }
 
 #[tokio::test]
+async fn same_org_target_can_have_active_drafts_in_multiple_projects() {
+    let (_root, _state, service) = common::test_daemon().await;
+    let target_id = "mem_shared_org";
+    let project_p = "prj_p";
+    let project_q = "prj_q";
+
+    let q_write = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: None,
+            base_commit_id: None,
+            project_id: project_q.to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("Q overlay"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await
+        .unwrap();
+
+    let p_write = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: None,
+            base_commit_id: None,
+            project_id: project_p.to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("P overlay"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await
+        .unwrap();
+
+    assert_ne!(q_write.draft_id, p_write.draft_id);
+
+    let p_second_write = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: None,
+            base_commit_id: None,
+            project_id: project_p.to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("P overlay again"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(p_second_write.draft_id, p_write.draft_id);
+
+    let q_detail = service.get_draft(&q_write.draft_id).await.unwrap();
+    let p_detail = service.get_draft(&p_write.draft_id).await.unwrap();
+    let q_summary = &q_detail.draft;
+    let p_summary = &p_detail.draft;
+
+    assert_eq!(q_summary.project_id, project_q);
+    assert_eq!(q_summary.scope, DaemonDraftScope::Org);
+    assert_eq!(q_summary.target_id.as_deref(), Some(target_id));
+    assert_eq!(p_summary.project_id, project_p);
+    assert_eq!(p_summary.scope, DaemonDraftScope::Org);
+    assert_eq!(p_summary.target_id.as_deref(), Some(target_id));
+    assert_eq!(q_detail.operations.len(), 1);
+    assert_eq!(p_detail.operations.len(), 2);
+}
+
+#[tokio::test]
+async fn explicit_draft_id_rejects_a_different_project_or_scope() {
+    let (_root, _state, service) = common::test_daemon().await;
+    let target_id = "mem_explicit_identity";
+    let created = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: None,
+            base_commit_id: None,
+            project_id: "prj_p".to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("P overlay"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await
+        .unwrap();
+
+    let wrong_project = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: Some(created.draft_id.clone()),
+            base_commit_id: None,
+            project_id: "prj_q".to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("Wrong project"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await;
+    assert!(matches!(wrong_project, Err(DaemonError::InvalidRequest(_))));
+
+    let wrong_scope = service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: Some(created.draft_id),
+            base_commit_id: None,
+            project_id: "prj_p".to_owned(),
+            scope: DaemonDraftScope::Project,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: None,
+                update: Some(DaemonUpdateDraftOperation::Content(
+                    DaemonContentDraftUpdate {
+                        id: target_id.to_owned(),
+                        content: context_content("Wrong scope"),
+                        description: None,
+                    },
+                )),
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await;
+    assert!(matches!(wrong_scope, Err(DaemonError::InvalidRequest(_))));
+}
+
+#[tokio::test]
 async fn deleting_a_draft_created_resource_discards_the_draft() {
     let (_root, _state, service) = common::test_daemon().await;
     let created = service

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -330,6 +330,16 @@ async fn cache_root_for_commit(
     std::path::PathBuf::from(cache.active_generation_path.unwrap())
 }
 
+async fn current_project_commit_id(repository: &ServerRepository, project_id: &str) -> String {
+    repository
+        .get_project_commit_state(project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap()
+}
+
 #[tokio::test]
 async fn project_creation_proxy_preserves_idempotency_and_replays_the_result() {
     let postgres = common::start_postgres().await;
@@ -479,7 +489,7 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -597,7 +607,7 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
             draft_id: Some(local_draft.draft_id.clone()),
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -674,14 +684,14 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
                 title: "Seed context".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/original.md".to_owned()),
                 },
                 operations: vec![DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/original.md".to_owned()),
                     },
@@ -702,9 +712,9 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         None,
     )
     .await;
-    let seed_commit_id = seed_merge.commit_id.unwrap();
+    let seed_org_commit_id = seed_merge.commit_id.unwrap();
     let context_id = repository
-        .list_project_memories(&bootstrap.project_id)
+        .list_org_memories(&bootstrap.org_id)
         .await
         .unwrap()
         .items
@@ -790,7 +800,7 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -814,7 +824,7 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
             draft_id: Some(update_draft.draft_id.clone()),
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -842,10 +852,10 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         &repository,
         update_projection.draft.server_draft_id.as_deref().unwrap(),
         update_projection.draft.server_version,
-        Some(&seed_commit_id),
+        Some(&seed_org_commit_id),
     )
     .await;
-    let update_commit_id = update_merge.commit_id.unwrap();
+    let update_org_commit_id = update_merge.commit_id.unwrap();
     service
         .retry_sync(DaemonSyncRetryRequest {
             channel: SyncRetryChannel::All,
@@ -854,6 +864,14 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         .unwrap();
     let merged_update = service.get_draft(&update_draft.draft_id).await.unwrap();
     assert_eq!(merged_update.draft.status, DaemonLocalDraftStatus::Merged);
+    let update_project_commit_id = repository
+        .get_project_commit_state(&bootstrap.project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap();
+    assert_ne!(update_project_commit_id, update_org_commit_id);
     let cache = service
         .memory_cache(DaemonMemoryCacheRequest {
             project_id: bootstrap.project_id.clone(),
@@ -886,14 +904,14 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
                 update: None,
                 rename: None,
                 delete: Some(DaemonDeleteDraftOperation {
-                    id: context_id,
+                    id: context_id.clone(),
                     description: None,
                 }),
                 discard: None,
@@ -914,10 +932,10 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         &repository,
         delete_projection.draft.server_draft_id.as_deref().unwrap(),
         delete_projection.draft.server_version,
-        Some(&update_commit_id),
+        Some(&update_org_commit_id),
     )
     .await;
-    let delete_commit_id = delete_merge.commit_id.unwrap();
+    let delete_org_commit_id = delete_merge.commit_id.unwrap();
     service
         .retry_sync(DaemonSyncRetryRequest {
             channel: SyncRetryChannel::All,
@@ -926,6 +944,14 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         .unwrap();
     let merged_delete = service.get_draft(&delete_draft.draft_id).await.unwrap();
     assert_eq!(merged_delete.draft.status, DaemonLocalDraftStatus::Merged);
+    let delete_project_commit_id = repository
+        .get_project_commit_state(&bootstrap.project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap();
+    assert_ne!(delete_project_commit_id, delete_org_commit_id);
     let deleted_cache = service
         .memory_cache(DaemonMemoryCacheRequest {
             project_id: bootstrap.project_id.clone(),
@@ -934,7 +960,7 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
         .unwrap();
     assert_eq!(
         deleted_cache.commit_id.as_deref(),
-        Some(delete_commit_id.as_str())
+        Some(delete_project_commit_id.as_str())
     );
     let deleted_cache_root =
         std::path::PathBuf::from(deleted_cache.active_generation_path.unwrap());
@@ -945,14 +971,12 @@ async fn merged_context_drafts_are_terminal_across_update_rename_and_delete() {
             .join("cache/memory/context/renamed.md")
             .exists()
     );
-    assert!(
+    assert!(matches!(
         repository
-            .list_project_memories(&bootstrap.project_id)
-            .await
-            .unwrap()
-            .items
-            .is_empty()
-    );
+            .get_org_memory(&bootstrap.org_id, &context_id)
+            .await,
+        Err(server::repository::ServerError::NotFound { .. })
+    ));
 
     server_task.abort();
 }
@@ -978,14 +1002,14 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
                 title: "Seed conflict base".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/base.md".to_owned()),
                 },
                 operations: vec![DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/base.md".to_owned()),
                     },
@@ -1069,7 +1093,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -1116,14 +1140,14 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
                 title: "Advance the remote Ref".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/remote-change.md".to_owned()),
                 },
                 operations: vec![DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/remote-change.md".to_owned()),
                     },
@@ -1241,7 +1265,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             draft_id: Some(local_draft.draft_id.clone()),
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -1500,13 +1524,24 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
         .unwrap();
     let merged = service.get_draft(&local_draft.draft_id).await.unwrap();
     assert_eq!(merged.draft.status, DaemonLocalDraftStatus::Merged);
+    let final_project_commit_id = repository
+        .get_project_commit_state(&bootstrap.project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap();
+    assert_ne!(final_project_commit_id, final_commit_id);
     let cache = service
         .memory_cache(DaemonMemoryCacheRequest {
             project_id: bootstrap.project_id,
         })
         .await
         .unwrap();
-    assert_eq!(cache.commit_id.as_deref(), Some(final_commit_id.as_str()));
+    assert_eq!(
+        cache.commit_id.as_deref(),
+        Some(final_project_commit_id.as_str())
+    );
     let cache_root = std::path::PathBuf::from(cache.active_generation_path.unwrap());
     assert_eq!(
         std::fs::read_to_string(cache_root.join("cache/memory/context/offline-conflict.md"))
@@ -1574,7 +1609,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let create_rule = create_resource_draft(
         &service,
         &bootstrap.project_id,
-        DaemonDraftScope::Project,
+        DaemonDraftScope::Org,
         DaemonDraftResourceKind::Memory,
         "rules/memory-review",
         rule_content(
@@ -1583,10 +1618,10 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         DaemonDraftOperationSource::Desktop,
     )
     .await;
-    let rule_create_commit =
+    let rule_create_org_commit =
         sync_local_draft_and_merge(&service, &repository, &create_rule, None).await;
     let rule_meta = repository
-        .list_project_memories(&bootstrap.project_id)
+        .list_org_memories(&bootstrap.org_id)
         .await
         .unwrap()
         .items
@@ -1595,7 +1630,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         .unwrap();
     let rule_id = rule_meta.memory_id;
     let created_rule = repository
-        .get_project_memory(&bootstrap.project_id, &rule_id)
+        .get_org_memory(&bootstrap.org_id, &rule_id)
         .await
         .unwrap();
     assert_eq!(created_rule.memory.name, "memory-review");
@@ -1603,8 +1638,11 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         created_rule.content,
         "# Memory review discipline\n\nApply when publishing durable memory.\n\nReview every memory change before merge.\n\nTags: memory, review"
     );
+    let rule_create_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(rule_create_project_commit, rule_create_org_commit);
     let rule_create_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &rule_create_commit).await;
+        cache_root_for_commit(&service, &bootstrap.project_id, &rule_create_project_commit).await;
     assert_eq!(
         std::fs::read_to_string(rule_create_root.join("cache/memory/rules/memory-review")).unwrap(),
         created_rule.content
@@ -1613,7 +1651,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let create_workflow = create_resource_draft(
         &service,
         &bootstrap.project_id,
-        DaemonDraftScope::Project,
+        DaemonDraftScope::Org,
         DaemonDraftResourceKind::Memory,
         "workflow/memory-publication",
         workflow_content(&format!(
@@ -1622,15 +1660,15 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         DaemonDraftOperationSource::Desktop,
     )
     .await;
-    let workflow_create_commit = sync_local_draft_and_merge(
+    let workflow_create_org_commit = sync_local_draft_and_merge(
         &service,
         &repository,
         &create_workflow,
-        Some(&rule_create_commit),
+        Some(&rule_create_org_commit),
     )
     .await;
     let workflow_meta = repository
-        .list_project_memories(&bootstrap.project_id)
+        .list_org_memories(&bootstrap.org_id)
         .await
         .unwrap()
         .items
@@ -1639,7 +1677,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         .unwrap();
     let workflow_id = workflow_meta.memory_id;
     let created_workflow = repository
-        .get_project_memory(&bootstrap.project_id, &workflow_id)
+        .get_org_memory(&bootstrap.org_id, &workflow_id)
         .await
         .unwrap();
     assert_eq!(
@@ -1648,8 +1686,15 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
             "# Memory publication\n\nPublish durable memory safely.\n\n1. Apply rule `{rule_id}`.\n2. Verify the materialized generation."
         )
     );
-    let workflow_create_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &workflow_create_commit).await;
+    let workflow_create_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(workflow_create_project_commit, workflow_create_org_commit);
+    let workflow_create_root = cache_root_for_commit(
+        &service,
+        &bootstrap.project_id,
+        &workflow_create_project_commit,
+    )
+    .await;
     assert_eq!(
         std::fs::read_to_string(
             workflow_create_root.join("cache/memory/workflow/memory-publication")
@@ -1663,7 +1708,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let update_rule = update_and_rename_resource_draft(
         &service,
         &bootstrap.project_id,
-        (DaemonDraftScope::Project, DaemonDraftResourceKind::Memory),
+        (DaemonDraftScope::Org, DaemonDraftResourceKind::Memory),
         &rule_id,
         rule_content(
             "# Memory review discipline\n\nApply when publishing durable memory.\n\nReview the change and its materialized result before merge.\n\nTags: memory, review, verification",
@@ -1672,15 +1717,15 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         DaemonDraftOperationSource::McpStore,
     )
     .await;
-    let rule_update_commit = sync_local_draft_and_merge(
+    let rule_update_org_commit = sync_local_draft_and_merge(
         &service,
         &repository,
         &update_rule,
-        Some(&workflow_create_commit),
+        Some(&workflow_create_org_commit),
     )
     .await;
     let updated_rule = repository
-        .get_project_memory(&bootstrap.project_id, &rule_id)
+        .get_org_memory(&bootstrap.org_id, &rule_id)
         .await
         .unwrap();
     assert_eq!(updated_rule.memory.path, "rules/memory-review-policy");
@@ -1688,8 +1733,11 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         updated_rule.content,
         "# Memory review discipline\n\nApply when publishing durable memory.\n\nReview the change and its materialized result before merge.\n\nTags: memory, review, verification"
     );
+    let rule_update_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(rule_update_project_commit, rule_update_org_commit);
     let rule_update_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &rule_update_commit).await;
+        cache_root_for_commit(&service, &bootstrap.project_id, &rule_update_project_commit).await;
     assert!(
         !rule_update_root
             .join("cache/memory/rules/memory-review")
@@ -1709,7 +1757,7 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let update_workflow = update_and_rename_resource_draft(
         &service,
         &bootstrap.project_id,
-        (DaemonDraftScope::Project, DaemonDraftResourceKind::Memory),
+        (DaemonDraftScope::Org, DaemonDraftResourceKind::Memory),
         &workflow_id,
         workflow_content(&format!(
             "# Memory publication\n\nPublish and verify durable memory.\n\n1. Verify the materialized generation.\n2. Apply rule `{rule_id}`."
@@ -1718,15 +1766,15 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
         DaemonDraftOperationSource::Desktop,
     )
     .await;
-    let workflow_update_commit = sync_local_draft_and_merge(
+    let workflow_update_org_commit = sync_local_draft_and_merge(
         &service,
         &repository,
         &update_workflow,
-        Some(&rule_update_commit),
+        Some(&rule_update_org_commit),
     )
     .await;
     let updated_workflow = repository
-        .get_project_memory(&bootstrap.project_id, &workflow_id)
+        .get_org_memory(&bootstrap.org_id, &workflow_id)
         .await
         .unwrap();
     assert_eq!(updated_workflow.memory.path, "workflow/memory-publish");
@@ -1736,8 +1784,15 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
             "# Memory publication\n\nPublish and verify durable memory.\n\n1. Verify the materialized generation.\n2. Apply rule `{rule_id}`."
         )
     );
-    let workflow_update_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &workflow_update_commit).await;
+    let workflow_update_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(workflow_update_project_commit, workflow_update_org_commit);
+    let workflow_update_root = cache_root_for_commit(
+        &service,
+        &bootstrap.project_id,
+        &workflow_update_project_commit,
+    )
+    .await;
     assert!(
         !workflow_update_root
             .join("cache/memory/workflow/memory-publication")
@@ -1759,26 +1814,33 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let delete_workflow = delete_resource_draft(
         &service,
         &bootstrap.project_id,
-        DaemonDraftScope::Project,
+        DaemonDraftScope::Org,
         DaemonDraftResourceKind::Memory,
         &workflow_id,
     )
     .await;
-    let workflow_delete_commit = sync_local_draft_and_merge(
+    let workflow_delete_org_commit = sync_local_draft_and_merge(
         &service,
         &repository,
         &delete_workflow,
-        Some(&workflow_update_commit),
+        Some(&workflow_update_org_commit),
     )
     .await;
     assert!(matches!(
         repository
-            .get_project_memory(&bootstrap.project_id, &workflow_id)
+            .get_org_memory(&bootstrap.org_id, &workflow_id)
             .await,
         Err(server::repository::ServerError::NotFound { .. })
     ));
-    let workflow_delete_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &workflow_delete_commit).await;
+    let workflow_delete_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(workflow_delete_project_commit, workflow_delete_org_commit);
+    let workflow_delete_root = cache_root_for_commit(
+        &service,
+        &bootstrap.project_id,
+        &workflow_delete_project_commit,
+    )
+    .await;
     assert!(
         !workflow_delete_root
             .join("cache/memory/workflow/memory-publish")
@@ -1793,26 +1855,27 @@ async fn rule_and_workflow_crud_preserve_materialized_markdown() {
     let delete_rule = delete_resource_draft(
         &service,
         &bootstrap.project_id,
-        DaemonDraftScope::Project,
+        DaemonDraftScope::Org,
         DaemonDraftResourceKind::Memory,
         &rule_id,
     )
     .await;
-    let rule_delete_commit = sync_local_draft_and_merge(
+    let rule_delete_org_commit = sync_local_draft_and_merge(
         &service,
         &repository,
         &delete_rule,
-        Some(&workflow_delete_commit),
+        Some(&workflow_delete_org_commit),
     )
     .await;
     assert!(matches!(
-        repository
-            .get_project_memory(&bootstrap.project_id, &rule_id)
-            .await,
+        repository.get_org_memory(&bootstrap.org_id, &rule_id).await,
         Err(server::repository::ServerError::NotFound { .. })
     ));
+    let rule_delete_project_commit =
+        current_project_commit_id(&repository, &bootstrap.project_id).await;
+    assert_ne!(rule_delete_project_commit, rule_delete_org_commit);
     let rule_delete_root =
-        cache_root_for_commit(&service, &bootstrap.project_id, &rule_delete_commit).await;
+        cache_root_for_commit(&service, &bootstrap.project_id, &rule_delete_project_commit).await;
     assert!(
         !rule_delete_root
             .join("cache/memory/rules/memory-review-policy")
@@ -1936,15 +1999,23 @@ async fn selected_hub_rule_and_workflow_changes_converge_without_reselection() {
     let workflow_id = workflow.memory_id;
 
     let selection = repository
-        .replace_project_org_selection(
-            &bootstrap.project_id,
-            0,
-            ReplaceProjectOrgSelectionRequest {
-                resource_ids: vec![rule_id.clone(), workflow_id.clone()],
-            },
-        )
+        .get_project_org_selection(&bootstrap.project_id)
         .await
         .unwrap();
+    assert_eq!(selection.revision, 2);
+    assert_eq!(selection.memories.len(), 2);
+    assert!(
+        selection
+            .memories
+            .iter()
+            .any(|memory| memory.memory_id == rule_id)
+    );
+    assert!(
+        selection
+            .memories
+            .iter()
+            .any(|memory| memory.memory_id == workflow_id)
+    );
     service
         .retry_sync(DaemonSyncRetryRequest {
             channel: SyncRetryChannel::Commits,
@@ -2527,14 +2598,14 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
                 title: "Add synchronized context".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/commit-sync.md".to_owned()),
                 },
                 operations: vec![DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/commit-sync.md".to_owned()),
                     },
@@ -2585,7 +2656,23 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
         )
         .await
         .unwrap();
-    let project_commit_id = merge.commit_id.unwrap();
+    let org_commit_id = merge.commit_id.unwrap();
+    let commit_sync_id = repository
+        .list_org_memories(&bootstrap.org_id)
+        .await
+        .unwrap()
+        .items
+        .into_iter()
+        .find(|memory| memory.path == "context/commit-sync.md")
+        .unwrap()
+        .memory_id;
+    let initial_selection = repository
+        .get_project_org_selection(&bootstrap.project_id)
+        .await
+        .unwrap();
+    assert_eq!(initial_selection.revision, 1);
+    assert_eq!(initial_selection.memories.len(), 1);
+    assert_eq!(initial_selection.memories[0].memory_id, commit_sync_id);
     let org_context_id = repository
         .create_org_context(
             &bootstrap.org_id,
@@ -2594,12 +2681,12 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
         )
         .await
         .unwrap();
-    repository
+    let selection = repository
         .replace_project_org_selection(
             &bootstrap.project_id,
-            0,
+            initial_selection.revision,
             ReplaceProjectOrgSelectionRequest {
-                resource_ids: vec![org_context_id.clone()],
+                resource_ids: vec![commit_sync_id.clone(), org_context_id.clone()],
             },
         )
         .await
@@ -2611,7 +2698,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
         .reference
         .commit_id
         .unwrap();
-    assert_ne!(commit_id, project_commit_id);
+    assert_ne!(commit_id, org_commit_id);
 
     let mut roots = Vec::new();
     for service in [&service_a, &service_b] {
@@ -2653,13 +2740,12 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
             .unwrap();
         assert!(checkout.ready);
         assert_eq!(checkout.commit_id.as_deref(), Some(commit_id.as_str()));
-        assert_eq!(checkout.org_selection_revision, 1);
-        assert_eq!(
-            checkout.selected_org_resource_ids,
-            vec![org_context_id.clone()]
-        );
+        assert_eq!(checkout.org_selection_revision, selection.revision);
+        assert_eq!(checkout.selected_org_resource_ids.len(), 2);
+        assert!(checkout.selected_org_resource_ids.contains(&commit_sync_id));
+        assert!(checkout.selected_org_resource_ids.contains(&org_context_id));
         assert!(checkout.resources.iter().any(|resource| {
-            resource.scope == DaemonDraftScope::Project
+            resource.scope == DaemonDraftScope::Org
                 && resource.path == "context/commit-sync.md"
                 && resource.content
                     == context_content("# Commit sync\n\nInstalled from an immutable Commit.")

--- a/crates/server/migrations/20260820000100_add_draft_operation_ordinals.sql
+++ b/crates/server/migrations/20260820000100_add_draft_operation_ordinals.sql
@@ -1,0 +1,48 @@
+ALTER TABLE draft_operations
+    ADD COLUMN ordinal BIGINT;
+
+-- Freeze the ordering used by existing deployments before making it part of
+-- the write contract. operation_id is retained only as the legacy tie-breaker
+-- for rows that share PostgreSQL's transaction timestamp.
+WITH ranked_operations AS (
+    SELECT
+        operation_id,
+        ROW_NUMBER() OVER (
+            PARTITION BY draft_id
+            ORDER BY created_at, operation_id
+        ) AS ordinal
+    FROM draft_operations
+)
+UPDATE draft_operations AS operation
+SET ordinal = ranked.ordinal
+FROM ranked_operations AS ranked
+WHERE ranked.operation_id = operation.operation_id;
+
+ALTER TABLE draft_operations
+    ALTER COLUMN ordinal SET NOT NULL,
+    ADD CONSTRAINT draft_operations_ordinal_positive CHECK (ordinal > 0),
+    ADD CONSTRAINT draft_operations_draft_ordinal_unique UNIQUE (draft_id, ordinal);
+
+-- Existing daemon projections may have consumed operations in the legacy
+-- tie-break order. Wake every active Draft so it reloads the now-canonical
+-- ordinal projection without changing the Draft's content version.
+INSERT INTO draft_events (
+    event_id,
+    draft_id,
+    project_id,
+    event_type,
+    version,
+    daemon_installation_id,
+    created_at
+)
+SELECT
+    'evt_projection_refresh_' || md5('20260820000100:' || draft.draft_id),
+    draft.draft_id,
+    draft.project_id,
+    'updated',
+    draft.version,
+    NULL,
+    now()
+FROM drafts AS draft
+WHERE draft.status IN ('open', 'submitted')
+ON CONFLICT (event_id) DO NOTHING;

--- a/crates/server/migrations/20260820000200_invalidate_path_only_org_candidates.sql
+++ b/crates/server/migrations/20260820000200_invalidate_path_only_org_candidates.sql
@@ -1,0 +1,44 @@
+-- Candidates created before path-only Organization Draft targets were
+-- canonicalized may have reconciled against a different resource after a
+-- rename or path reuse. Invalidate those cached projections so both server
+-- and daemon callers must rebuild them with stable resource identity.
+WITH invalidated_drafts AS (
+    UPDATE draft_reconciliation_candidates AS candidate
+    SET invalidated_at = now()
+    FROM drafts AS draft
+    WHERE candidate.draft_id = draft.draft_id
+      AND candidate.invalidated_at IS NULL
+      AND draft.resource_scope = 'org'
+      AND draft.status IN ('open', 'submitted')
+      AND draft.target_id IS NULL
+      AND draft.path IS NOT NULL
+      AND NOT COALESCE((
+            SELECT operation.action = 'create'
+            FROM draft_operations AS operation
+            WHERE operation.draft_id = draft.draft_id
+            ORDER BY operation.ordinal
+            LIMIT 1
+      ), FALSE)
+    RETURNING draft.draft_id
+)
+INSERT INTO draft_events (
+    event_id,
+    draft_id,
+    project_id,
+    event_type,
+    version,
+    daemon_installation_id,
+    created_at
+)
+SELECT
+    'evt_path_identity_refresh_' || md5('20260820000200:' || draft.draft_id),
+    draft.draft_id,
+    draft.project_id,
+    'updated',
+    draft.version,
+    NULL,
+    now()
+FROM drafts AS draft
+JOIN (SELECT DISTINCT draft_id FROM invalidated_drafts) AS invalidated
+  ON invalidated.draft_id = draft.draft_id
+ON CONFLICT (event_id) DO NOTHING;

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -23,9 +23,9 @@ use crate::api::{
     CreateReviewRequest, CreateReviewSubmissionRequest, CreateSetupSessionRequest,
     DraftOperationBatchRequest, DraftOperationInput, OidcAuthorizationRequest, OidcCallbackRequest,
     OrgRole, PersonalBundleRequest, PersonalBundleUpdateRequest, ProjectRole,
-    ReplaceProjectOrgSelectionRequest, ReplaceSetupConfigurationRequest, ResourceScope,
-    SetupOidcAuthorization, SetupOidcAuthorizationRequest, TokenRequest, UpdateAdminOrgRequest,
-    UpdateDraftRequest, UpdateMemberRequest, UpdateProjectMemberRequest, UpdateProjectRequest,
+    ReplaceProjectOrgSelectionRequest, ReplaceSetupConfigurationRequest, SetupOidcAuthorization,
+    SetupOidcAuthorizationRequest, TokenRequest, UpdateAdminOrgRequest, UpdateDraftRequest,
+    UpdateMemberRequest, UpdateProjectMemberRequest, UpdateProjectRequest,
 };
 use crate::auth::{AuthError, AuthPrincipal, AuthService, CredentialKind};
 use crate::db::current_schema_migration;
@@ -1192,9 +1192,6 @@ async fn create_draft(
     Extension(principal): Extension<AuthPrincipal>,
     Json(request): Json<CreateDraftRequest>,
 ) -> Result<Json<crate::api::DraftDetail>, HttpError> {
-    if request.resource.scope == ResourceScope::Org {
-        require_org_admin(&principal)?;
-    }
     state
         .repository
         .ensure_project_member(&principal, &request.project_id)

--- a/crates/server/src/repository.rs
+++ b/crates/server/src/repository.rs
@@ -970,7 +970,7 @@ impl ServerRepository {
                         target_id, path, new_path, content
                  FROM draft_operations
                  WHERE draft_id = $1
-                 ORDER BY operation_id",
+                 ORDER BY ordinal",
             )
             .bind(&draft_id)
             .fetch_all(&self.pool)
@@ -1384,6 +1384,7 @@ impl ServerRepository {
         request: ReplaceProjectOrgSelectionRequest,
     ) -> Result<ProjectOrgSelection, ServerError> {
         let mut tx = self.pool.begin().await?;
+        lock_org_draft_selection_coordination_for_project(&mut tx, project_id).await?;
         let org_id = project_org_id(&mut tx, project_id).await?;
         lock_org_ref_for_project_projection(&mut tx, &org_id).await?;
         let parent_commit_id = current_project_ref(&mut tx, project_id).await?;
@@ -1395,6 +1396,12 @@ impl ServerRepository {
                 current_revision,
             ));
         }
+        ensure_removed_org_resources_have_no_active_drafts(
+            &mut tx,
+            project_id,
+            &request.resource_ids,
+        )
+        .await?;
         let next_revision = current_revision + 1;
         sqlx::query("DELETE FROM project_org_resource_selections WHERE project_id = $1")
             .bind(project_id)
@@ -1622,9 +1629,12 @@ impl ServerRepository {
     pub async fn create_draft(
         &self,
         author_user_id: &str,
-        request: CreateDraftRequest,
+        mut request: CreateDraftRequest,
     ) -> Result<DraftDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
+        if request.resource.scope == ResourceScope::Org {
+            lock_org_draft_selection_coordination_for_project(&mut tx, &request.project_id).await?;
+        }
         let org_id = project_org_id(&mut tx, &request.project_id).await?;
         user_ref(&mut tx, author_user_id).await?;
         if let Some(base_commit_id) = request.base_commit_id.as_deref() {
@@ -1640,6 +1650,17 @@ impl ServerRepository {
             validate_draft_operation_resource(&request.resource, operation)?;
         }
         validate_new_resource_draft_operations(&request.operations)?;
+        if request.resource.scope == ResourceScope::Org {
+            canonicalize_org_draft_targets_are_selected(
+                &mut tx,
+                &request.project_id,
+                &org_id,
+                request.base_commit_id.as_deref(),
+                &mut request.resource,
+                &mut request.operations,
+            )
+            .await?;
+        }
 
         let draft_id = prefixed_id("drf");
         sqlx::query(
@@ -1735,8 +1756,15 @@ impl ServerRepository {
         operation: DraftOperationInput,
     ) -> Result<DraftDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
-        append_draft_operation_in_tx(&mut tx, draft_id, expected_draft_version, operation, None)
-            .await?;
+        append_draft_operation_in_tx(
+            &mut tx,
+            draft_id,
+            expected_draft_version,
+            operation,
+            None,
+            false,
+        )
+        .await?;
         tx.commit().await?;
         self.get_draft(draft_id).await
     }
@@ -1917,6 +1945,26 @@ impl ServerRepository {
             ));
         }
         let mut tx = self.pool.begin().await?;
+        let draft_ids = request
+            .operations
+            .iter()
+            .map(|item| item.draft_id.clone())
+            .collect::<Vec<_>>();
+        let rows = sqlx::query(
+            "SELECT DISTINCT project.org_id
+             FROM drafts AS draft
+             JOIN projects AS project ON project.project_id = draft.project_id
+             WHERE draft.draft_id = ANY($1)
+               AND draft.resource_scope = 'org'
+             ORDER BY project.org_id",
+        )
+        .bind(&draft_ids)
+        .fetch_all(&mut *tx)
+        .await?;
+        for row in rows {
+            lock_org_draft_selection_coordination(&mut tx, &row.try_get::<String, _>("org_id")?)
+                .await?;
+        }
         let mut accepted_operations = Vec::new();
         let mut cursor = None;
         let daemon_installation_id = request.daemon_installation_id;
@@ -1928,6 +1976,7 @@ impl ServerRepository {
                     item.expected_draft_version,
                     item.operation,
                     Some(&daemon_installation_id),
+                    true,
                 )
                 .await?,
             );
@@ -2048,6 +2097,7 @@ impl ServerRepository {
         }
         let project_id: String = row.try_get("project_id")?;
         let scope = resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?;
+        ensure_publishable_draft_scope(scope)?;
         let current_ref = target_ref_for_draft(&mut tx, &project_id, scope).await?;
         if current_ref.as_deref() != expected_ref {
             return Err(ServerError::precondition_failed(
@@ -2104,13 +2154,22 @@ impl ServerRepository {
                 "submitted",
             ));
         }
-        if load_draft_operations(&mut tx, &request.draft_id)
-            .await?
-            .is_empty()
-        {
+        let operations = load_draft_operations(&mut tx, &request.draft_id).await?;
+        if operations.is_empty() {
             return Err(ServerError::InvalidRequest(
                 "a review draft must contain at least one operation".to_owned(),
             ));
+        }
+        if scope == ResourceScope::Org {
+            let org_id = project_org_id(&mut tx, &project_id).await?;
+            validate_stored_org_draft_operations_are_selected(
+                &mut tx,
+                &project_id,
+                &org_id,
+                current_ref.as_deref(),
+                &operations,
+            )
+            .await?;
         }
 
         let review_id = prefixed_id("rev");
@@ -2500,6 +2559,7 @@ impl ServerRepository {
         let draft_id: String = row.try_get("draft_id")?;
         let project_id: String = row.try_get("project_id")?;
         let scope = resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?;
+        ensure_publishable_draft_scope(scope)?;
         let current_ref = target_ref_for_draft(&mut tx, &project_id, scope).await?;
         if current_ref.as_deref() != expected_ref {
             return Err(ServerError::precondition_failed(
@@ -2540,10 +2600,22 @@ impl ServerRepository {
                 "a current draft must not submit reconciliation data".to_owned(),
             ));
         }
-        if load_draft_operations(&mut tx, &draft_id).await?.is_empty() {
+        let operations = load_draft_operations(&mut tx, &draft_id).await?;
+        if operations.is_empty() {
             return Err(ServerError::InvalidRequest(
                 "a review draft must contain at least one operation".to_owned(),
             ));
+        }
+        if scope == ResourceScope::Org {
+            let org_id = project_org_id(&mut tx, &project_id).await?;
+            validate_stored_org_draft_operations_are_selected(
+                &mut tx,
+                &project_id,
+                &org_id,
+                current_ref.as_deref(),
+                &operations,
+            )
+            .await?;
         }
         let next_draft_version: i64 = sqlx::query_scalar(
             "UPDATE drafts
@@ -2591,6 +2663,28 @@ impl ServerRepository {
         request: CreateReviewMergeRequest,
     ) -> Result<ReviewMergeResult, ServerError> {
         let mut tx = self.pool.begin().await?;
+        let coordination = sqlx::query(
+            "SELECT draft.project_id, draft.resource_scope
+             FROM reviews AS review
+             JOIN drafts AS draft ON draft.draft_id = review.draft_id
+             WHERE review.review_id = $1",
+        )
+        .bind(review_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some(coordination) = coordination
+            && resource_scope(
+                coordination
+                    .try_get::<String, _>("resource_scope")?
+                    .as_str(),
+            )? == ResourceScope::Org
+        {
+            lock_org_draft_selection_coordination_for_project(
+                &mut tx,
+                &coordination.try_get::<String, _>("project_id")?,
+            )
+            .await?;
+        }
         let row = sqlx::query(
             "SELECT r.review_id, r.draft_id, r.project_id, r.status, r.version,
                     r.approved_result_hash,
@@ -2623,6 +2717,7 @@ impl ServerRepository {
         let draft_id: String = row.try_get("draft_id")?;
         let org_id = project_org_id(&mut tx, &project_id).await?;
         let resource_scope = resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?;
+        ensure_publishable_draft_scope(resource_scope)?;
         let current_head = match resource_scope {
             ResourceScope::Org => current_org_ref(&mut tx, &org_id).await?,
             ResourceScope::Project => {
@@ -2665,14 +2760,29 @@ impl ServerRepository {
 
         let operations = load_draft_operations(&mut tx, &draft_id).await?;
         let materialized_operations = materialize_draft_operations(&operations)?;
+        if resource_scope == ResourceScope::Org {
+            validate_org_draft_operation_inputs_are_selected(
+                &mut tx,
+                &project_id,
+                &org_id,
+                current_head.as_deref(),
+                &materialized_operations,
+            )
+            .await?;
+        }
         let org_resource_impact = match resource_scope {
             ResourceScope::Org => {
                 resolve_org_resource_impact(&mut tx, &org_id, &materialized_operations).await?
             }
             ResourceScope::Project => OrgResourceImpact::default(),
         };
+        let mut created_resource_ids = Vec::new();
         for operation in &materialized_operations {
-            apply_operation(&mut tx, &project_id, resource_scope, operation).await?;
+            if let Some(resource_id) =
+                apply_operation(&mut tx, &project_id, resource_scope, operation).await?
+            {
+                created_resource_ids.push(resource_id);
+            }
         }
 
         let commit_id = match resource_scope {
@@ -2682,6 +2792,15 @@ impl ServerRepository {
                 advance_org_ref(&mut tx, &org_id, &commit_id).await?;
                 refresh_projects_for_org_resource_changes(&mut tx, &org_id, &org_resource_impact)
                     .await?;
+                if !created_resource_ids.is_empty() {
+                    select_created_org_resources_for_project(
+                        &mut tx,
+                        &project_id,
+                        &org_id,
+                        &created_resource_ids,
+                    )
+                    .await?;
+                }
                 commit_id
             }
             ResourceScope::Project => {
@@ -2979,6 +3098,286 @@ fn validate_draft_operation_resource(
     }
 }
 
+fn ensure_publishable_draft_scope(scope: ResourceScope) -> Result<(), ServerError> {
+    if scope == ResourceScope::Project {
+        return Err(ServerError::InvalidRequest(
+            "project-scoped Memory authority is read-only; publish an Organization-scoped Draft"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+async fn canonicalize_org_draft_targets_are_selected(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    draft_resource: &mut DraftResourceRef,
+    operations: &mut [DraftOperationInput],
+) -> Result<(), ServerError> {
+    if operations
+        .first()
+        .is_some_and(|operation| operation.action == DraftOperationAction::Create)
+    {
+        return Ok(());
+    }
+    if draft_resource.id.is_some() {
+        canonicalize_org_draft_target_is_selected(
+            tx,
+            project_id,
+            org_id,
+            base_commit_id,
+            draft_resource,
+        )
+        .await?;
+    } else if draft_resource.path.is_some()
+        && let Some(resource_id) = resolve_org_draft_target_id(
+            tx,
+            org_id,
+            base_commit_id,
+            draft_resource,
+            !operations.is_empty(),
+        )
+        .await?
+    {
+        draft_resource.id = Some(resource_id);
+        validate_org_draft_target_is_selected(tx, project_id, org_id, draft_resource).await?;
+    }
+    for operation in operations {
+        if operation.action != DraftOperationAction::Create {
+            canonicalize_org_draft_target_is_selected(
+                tx,
+                project_id,
+                org_id,
+                base_commit_id,
+                &mut operation.resource,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn validate_org_draft_operation_inputs_are_selected(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    operations: &[DraftOperationInput],
+) -> Result<(), ServerError> {
+    if operations
+        .first()
+        .is_some_and(|operation| operation.action == DraftOperationAction::Create)
+    {
+        return Ok(());
+    }
+    for operation in operations {
+        if operation.action != DraftOperationAction::Create {
+            validate_org_draft_target_is_selected_at_base(
+                tx,
+                project_id,
+                org_id,
+                base_commit_id,
+                &operation.resource,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn validate_stored_org_draft_operations_are_selected(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    operations: &[DraftOperation],
+) -> Result<(), ServerError> {
+    if operations
+        .first()
+        .is_some_and(|operation| operation.input.action == DraftOperationAction::Create)
+    {
+        return Ok(());
+    }
+    for operation in operations {
+        if operation.input.action != DraftOperationAction::Create {
+            validate_org_draft_target_is_selected_at_base(
+                tx,
+                project_id,
+                org_id,
+                base_commit_id,
+                &operation.input.resource,
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn canonicalize_org_draft_target_is_selected(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    resource: &mut DraftResourceRef,
+) -> Result<(), ServerError> {
+    if resource.id.is_none() {
+        resource.id =
+            resolve_org_draft_target_id(tx, org_id, base_commit_id, resource, true).await?;
+    }
+    validate_org_draft_target_is_selected(tx, project_id, org_id, resource).await
+}
+
+async fn validate_org_draft_target_is_selected_at_base(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    resource: &DraftResourceRef,
+) -> Result<(), ServerError> {
+    let mut canonical = resource.clone();
+    canonicalize_org_draft_target_is_selected(
+        tx,
+        project_id,
+        org_id,
+        base_commit_id,
+        &mut canonical,
+    )
+    .await
+}
+
+async fn resolve_org_draft_target_id(
+    tx: &mut Transaction<'_, Postgres>,
+    org_id: &str,
+    base_commit_id: Option<&str>,
+    resource: &DraftResourceRef,
+    allow_historical_lookup: bool,
+) -> Result<Option<String>, ServerError> {
+    if let Some(resource_id) = resource.id.as_ref() {
+        return Ok(Some(resource_id.clone()));
+    }
+    let Some(path) = resource.path.as_deref() else {
+        return Ok(None);
+    };
+
+    if let Some(base_commit_id) = base_commit_id {
+        let resource_id = sqlx::query_scalar::<_, String>(
+            "SELECT entry.item_id
+             FROM commits AS commit
+             JOIN tree_entries AS entry ON entry.tree_id = commit.tree_id
+             WHERE commit.commit_id = $1
+               AND commit.org_id = $2
+               AND commit.scope = 'org'
+               AND entry.scope = 'org'
+               AND entry.resource_kind = 'memory'
+               AND entry.path = $3",
+        )
+        .bind(base_commit_id)
+        .bind(org_id)
+        .bind(path)
+        .fetch_optional(&mut **tx)
+        .await?;
+        if resource_id.is_some() {
+            return Ok(resource_id);
+        }
+    }
+
+    let current_resource_id = sqlx::query_scalar::<_, String>(
+        "SELECT resource_id
+         FROM resources
+         WHERE org_id = $1
+           AND scope = 'org'
+           AND status = 'active'
+           AND path = $2",
+    )
+    .bind(org_id)
+    .bind(path)
+    .fetch_optional(&mut **tx)
+    .await?;
+    if current_resource_id.is_some() || !allow_historical_lookup {
+        return Ok(current_resource_id);
+    }
+
+    let resource_ids = sqlx::query_scalar::<_, String>(
+        "SELECT DISTINCT entry.item_id
+         FROM commits AS commit
+         JOIN tree_entries AS entry ON entry.tree_id = commit.tree_id
+         WHERE commit.org_id = $1
+           AND commit.scope = 'org'
+           AND entry.scope = 'org'
+           AND entry.resource_kind = 'memory'
+           AND entry.path = $2
+         ORDER BY entry.item_id
+         LIMIT 2",
+    )
+    .bind(org_id)
+    .bind(path)
+    .fetch_all(&mut **tx)
+    .await?;
+    match resource_ids.as_slice() {
+        [] => Ok(None),
+        [resource_id] => Ok(Some(resource_id.clone())),
+        _ => Err(ServerError::InvalidRequest(format!(
+            "Organization Memory path {path} has referred to multiple resources; target it by resource id"
+        ))),
+    }
+}
+
+async fn validate_org_draft_target_is_selected(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    resource: &DraftResourceRef,
+) -> Result<(), ServerError> {
+    let selected = if let Some(resource_id) = resource.id.as_deref() {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM project_org_resource_selections s
+                JOIN resources r ON r.resource_id = s.resource_id
+                WHERE s.project_id = $1
+                  AND r.resource_id = $2
+                  AND r.org_id = $3
+                  AND r.scope = 'org'
+                  AND r.status = 'active'
+             )",
+        )
+        .bind(project_id)
+        .bind(resource_id)
+        .bind(org_id)
+        .fetch_one(&mut **tx)
+        .await?
+    } else if let Some(path) = resource.path.as_deref() {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (
+                SELECT 1
+                FROM project_org_resource_selections s
+                JOIN resources r ON r.resource_id = s.resource_id
+                WHERE s.project_id = $1
+                  AND r.org_id = $2
+                  AND r.scope = 'org'
+                  AND r.path = $3
+                  AND r.status = 'active'
+             )",
+        )
+        .bind(project_id)
+        .bind(org_id)
+        .bind(path)
+        .fetch_one(&mut **tx)
+        .await?
+    } else {
+        false
+    };
+    if selected {
+        return Ok(());
+    }
+    Err(ServerError::InvalidRequest(
+        "an Organization Memory Draft may target only Memory currently selected by its carrying Project"
+            .to_owned(),
+    ))
+}
+
 fn validate_new_resource_draft_operations(
     operations: &[DraftOperationInput],
 ) -> Result<(), ServerError> {
@@ -3099,12 +3498,22 @@ async fn insert_draft_operation(
     input: DraftOperationInput,
 ) -> Result<String, ServerError> {
     let operation_id = prefixed_id("dop");
+    // Serialize every allocator, including future call sites that do not
+    // already hold the draft row lock. A per-draft MAX is safe once this lock
+    // is held and keeps replacement operation sets densely ordered.
+    sqlx::query("SELECT draft_id FROM drafts WHERE draft_id = $1 FOR UPDATE")
+        .bind(draft_id)
+        .fetch_one(&mut **tx)
+        .await?;
     sqlx::query(
         "INSERT INTO draft_operations (
             operation_id, draft_id, action, resource_scope, resource_kind, target_id, path,
-            new_path, content
+            new_path, content, ordinal
          )
-         VALUES ($1, $2, $3, $4, 'memory', $5, $6, $7, $8)",
+         SELECT $1, $2, $3, $4, 'memory', $5, $6, $7, $8,
+                COALESCE(MAX(ordinal), 0) + 1
+         FROM draft_operations
+         WHERE draft_id = $2",
     )
     .bind(&operation_id)
     .bind(draft_id)
@@ -3123,17 +3532,37 @@ async fn append_draft_operation_in_tx(
     tx: &mut Transaction<'_, Postgres>,
     draft_id: &str,
     expected_draft_version: i64,
-    operation: DraftOperationInput,
+    mut operation: DraftOperationInput,
     event_daemon_installation_id: Option<&str>,
+    org_coordination_already_locked: bool,
 ) -> Result<i64, ServerError> {
+    let identity = sqlx::query(
+        "SELECT project_id, resource_scope
+         FROM drafts
+         WHERE draft_id = $1",
+    )
+    .bind(draft_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    .ok_or_else(|| ServerError::not_found("draft", draft_id))?;
+    let identity_scope = resource_scope(identity.try_get::<String, _>("resource_scope")?.as_str())?;
+    if identity_scope == ResourceScope::Org && !org_coordination_already_locked {
+        lock_org_draft_selection_coordination_for_project(
+            tx,
+            &identity.try_get::<String, _>("project_id")?,
+        )
+        .await?;
+    }
     let row = sqlx::query(
-        "SELECT d.status, d.version, d.resource_scope, d.resource_kind,
-                EXISTS (
-                    SELECT 1
+        "SELECT d.status, d.version, d.project_id, d.resource_scope, d.resource_kind,
+                d.base_commit_id,
+                COALESCE((
+                    SELECT operation.action = 'create'
                     FROM draft_operations AS operation
                     WHERE operation.draft_id = d.draft_id
-                      AND operation.action = 'create'
-                ) AS creates_resource
+                    ORDER BY operation.ordinal
+                    LIMIT 1
+                ), FALSE) AS creates_resource
          FROM drafts AS d
          WHERE d.draft_id = $1
          FOR UPDATE",
@@ -3144,8 +3573,9 @@ async fn append_draft_operation_in_tx(
     .ok_or_else(|| ServerError::not_found("draft", draft_id))?;
     let status: String = row.try_get("status")?;
     let version: i64 = row.try_get("version")?;
+    let scope = resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?;
     let draft_resource = DraftResourceRef {
-        scope: resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?,
+        scope,
         id: None,
         path: None,
     };
@@ -3167,6 +3597,22 @@ async fn append_draft_operation_in_tx(
         ));
     }
     validate_draft_operation_resource(&draft_resource, &operation)?;
+    if scope == ResourceScope::Org
+        && !creates_resource
+        && operation.action != DraftOperationAction::Create
+    {
+        let project_id: String = row.try_get("project_id")?;
+        let org_id = project_org_id(tx, &project_id).await?;
+        let base_commit_id: Option<String> = row.try_get("base_commit_id")?;
+        canonicalize_org_draft_target_is_selected(
+            tx,
+            &project_id,
+            &org_id,
+            base_commit_id.as_deref(),
+            &mut operation.resource,
+        )
+        .await?;
+    }
 
     insert_draft_operation(tx, draft_id, operation).await?;
     let updated = sqlx::query(
@@ -3337,6 +3783,131 @@ async fn current_project_org_selection_revision(
     .fetch_optional(&mut **tx)
     .await?
     .ok_or_else(|| ServerError::not_found("project_org_selection", project_id))
+}
+
+/// Serializes transitions that can change the relationship between Project
+/// selections and active Organization Drafts: replacing a selection,
+/// creating/appending a Draft, and merging Organization authority. The lock
+/// is Organization-scoped because one delete merge projects into every
+/// selecting Project. It is acquired before Draft/ref/selection rows, works
+/// across server instances, and therefore avoids opposing row-lock orders.
+async fn lock_org_draft_selection_coordination(
+    tx: &mut Transaction<'_, Postgres>,
+    org_id: &str,
+) -> Result<(), ServerError> {
+    sqlx::query(
+        "SELECT pg_advisory_xact_lock(
+            hashtextextended('org_draft_selection:' || $1, 0)
+         )",
+    )
+    .bind(org_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn lock_org_draft_selection_coordination_for_project(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+) -> Result<(), ServerError> {
+    let org_id = project_org_id(tx, project_id).await?;
+    lock_org_draft_selection_coordination(tx, &org_id).await
+}
+
+async fn ensure_removed_org_resources_have_no_active_drafts(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    retained_resource_ids: &[String],
+) -> Result<(), ServerError> {
+    let blocked = sqlx::query(
+        "WITH removed AS (
+            SELECT selection.resource_id, resource.org_id
+            FROM project_org_resource_selections AS selection
+            JOIN resources AS resource
+              ON resource.resource_id = selection.resource_id
+            WHERE selection.project_id = $1
+              AND NOT (selection.resource_id = ANY($2))
+         ), active_drafts AS (
+            SELECT draft.draft_id, draft.base_commit_id, draft.created_at,
+                   draft.target_id, draft.path
+            FROM drafts AS draft
+            WHERE draft.project_id = $1
+              AND draft.resource_scope = 'org'
+              AND draft.status IN ('open', 'submitted')
+              AND NOT COALESCE((
+                    SELECT operation.action = 'create'
+                    FROM draft_operations AS operation
+                    WHERE operation.draft_id = draft.draft_id
+                    ORDER BY operation.ordinal
+                    LIMIT 1
+              ), FALSE)
+         ), targets AS (
+            SELECT draft_id, base_commit_id, created_at, target_id, path
+            FROM active_drafts
+            UNION ALL
+            SELECT draft.draft_id, draft.base_commit_id, draft.created_at,
+                   operation.target_id, operation.path
+            FROM active_drafts AS draft
+            JOIN draft_operations AS operation
+              ON operation.draft_id = draft.draft_id
+            WHERE operation.resource_scope = 'org'
+              AND operation.action <> 'create'
+         )
+         SELECT removed.resource_id, target.draft_id
+         FROM removed
+         JOIN targets AS target
+           ON COALESCE(
+                target.target_id,
+                (
+                    SELECT base_entry.item_id
+                    FROM commits AS base_commit
+                    JOIN tree_entries AS base_entry
+                      ON base_entry.tree_id = base_commit.tree_id
+                    WHERE base_commit.commit_id = target.base_commit_id
+                      AND base_commit.org_id = removed.org_id
+                      AND base_commit.scope = 'org'
+                      AND base_entry.scope = 'org'
+                      AND base_entry.resource_kind = 'memory'
+                      AND base_entry.path = target.path
+                ),
+                (
+                    SELECT resource.resource_id
+                    FROM resources AS resource
+                    WHERE resource.org_id = removed.org_id
+                      AND resource.scope = 'org'
+                      AND resource.status = 'active'
+                      AND resource.path = target.path
+                ),
+                (
+                    SELECT CASE
+                        WHEN COUNT(DISTINCT historical_entry.item_id) = 1
+                        THEN MIN(historical_entry.item_id)
+                    END
+                    FROM commits AS historical_commit
+                    JOIN tree_entries AS historical_entry
+                      ON historical_entry.tree_id = historical_commit.tree_id
+                    WHERE historical_commit.org_id = removed.org_id
+                      AND historical_commit.scope = 'org'
+                      AND historical_entry.scope = 'org'
+                      AND historical_entry.resource_kind = 'memory'
+                      AND historical_entry.path = target.path
+                )
+              ) = removed.resource_id
+         ORDER BY removed.resource_id, target.created_at, target.draft_id
+         LIMIT 1",
+    )
+    .bind(project_id)
+    .bind(retained_resource_ids)
+    .fetch_optional(&mut **tx)
+    .await?;
+    let Some(blocked) = blocked else {
+        return Ok(());
+    };
+    let resource_id: String = blocked.try_get("resource_id")?;
+    let draft_id: String = blocked.try_get("draft_id")?;
+    Err(ServerError::InvalidRequest(format!(
+        "cannot remove Organization Memory {resource_id} from this Project while active Organization Draft {draft_id} targets it; discard or finish the Draft first"
+    )))
 }
 
 async fn update_project_org_selection_revision(
@@ -3804,7 +4375,7 @@ async fn load_draft_operations(
                 new_path, content, created_at
          FROM draft_operations
          WHERE draft_id = $1
-         ORDER BY created_at, operation_id",
+         ORDER BY ordinal",
     )
     .bind(draft_id)
     .fetch_all(&mut **tx)
@@ -4275,7 +4846,7 @@ async fn create_reconciliation_candidate_in_tx(
     }
 
     invalidate_draft_candidates(tx, draft_id).await?;
-    let resource = DraftResourceRef {
+    let mut resource = DraftResourceRef {
         scope,
         id: row.try_get("target_id")?,
         path: row.try_get("path")?,
@@ -4284,6 +4855,12 @@ async fn create_reconciliation_candidate_in_tx(
     let allow_path_lookup = operations
         .first()
         .is_none_or(|operation| operation.input.action != DraftOperationAction::Create);
+    if scope == ResourceScope::Org && resource.id.is_none() && allow_path_lookup {
+        let org_id = project_org_id(tx, &project_id).await?;
+        resource.id =
+            resolve_org_draft_target_id(tx, &org_id, base_commit_id.as_deref(), &resource, true)
+                .await?;
+    }
     let base_state =
         resource_state_at_commit(tx, base_commit_id.as_deref(), &resource, allow_path_lookup)
             .await?;
@@ -4754,7 +5331,7 @@ async fn apply_operation(
     project_id: &str,
     scope: ResourceScope,
     operation: &DraftOperationInput,
-) -> Result<(), ServerError> {
+) -> Result<Option<String>, ServerError> {
     if operation.resource.scope != scope {
         return Err(ServerError::InvalidRequest(
             "draft operation scope does not match its draft".to_owned(),
@@ -4813,7 +5390,7 @@ async fn apply_resource_operation(
     project_id: &str,
     scope: ResourceScope,
     operation: &DraftOperationInput,
-) -> Result<(), ServerError> {
+) -> Result<Option<String>, ServerError> {
     let org_id = project_org_id(tx, project_id).await?;
     let resource_project_id = (scope == ResourceScope::Project).then_some(project_id);
     match operation.action {
@@ -4843,6 +5420,7 @@ async fn apply_resource_operation(
             .bind(&prepared.body)
             .execute(&mut **tx)
             .await?;
+            return Ok(Some(resource_id));
         }
         DraftOperationAction::Update => {
             let resource =
@@ -4897,6 +5475,39 @@ async fn apply_resource_operation(
             .await?;
         }
     }
+    Ok(None)
+}
+
+/// A new Organization Memory proposed from a Project becomes part of that
+/// Project's effective Memory when the Review merges. Existing Organization
+/// resources keep their explicit Add/Remove membership semantics.
+async fn select_created_org_resources_for_project(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    org_id: &str,
+    resource_ids: &[String],
+) -> Result<(), ServerError> {
+    let parent_commit_id = current_project_ref(tx, project_id).await?;
+    let current_revision = current_project_org_selection_revision(tx, project_id).await?;
+    let next_revision = current_revision + 1;
+    for resource_id in resource_ids {
+        sqlx::query(
+            "INSERT INTO project_org_resource_selections (project_id, resource_id, revision)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (project_id, resource_id)
+             DO UPDATE SET revision = EXCLUDED.revision,
+                           updated_at = now()",
+        )
+        .bind(project_id)
+        .bind(resource_id)
+        .bind(next_revision)
+        .execute(&mut **tx)
+        .await?;
+    }
+    validate_project_effective_memory(tx, project_id, org_id).await?;
+    update_project_org_selection_revision(tx, project_id, next_revision).await?;
+    let commit_id = create_project_commit(tx, project_id, parent_commit_id.as_deref()).await?;
+    advance_project_ref(tx, project_id, &commit_id).await?;
     Ok(())
 }
 

--- a/crates/server/tests/admin_api.rs
+++ b/crates/server/tests/admin_api.rs
@@ -659,15 +659,15 @@ async fn memory_export_contains_verifiable_full_state() {
     sqlx::query(
         "INSERT INTO draft_operations (
             operation_id, draft_id, action, resource_scope, resource_kind, target_id,
-            path, new_path, content
+            path, new_path, content, ordinal
          )
          VALUES
-            ('op_export_1', 'draft_export_1', 'create', 'project', 'memory',
+            ('op_export_z_create', 'draft_export_1', 'create', 'project', 'memory',
              NULL, 'rules/new.md', NULL,
-             '{\"description\": \"New memory\", \"content\": \"# New\"}'::jsonb),
-            ('op_export_2', 'draft_export_1', 'update', 'project', 'memory',
+             '{\"description\": \"New memory\", \"content\": \"# New\"}'::jsonb, 1),
+            ('op_export_a_update', 'draft_export_1', 'update', 'project', 'memory',
              'rul_legacy_project_rule', 'rules/project-rule.md', NULL,
-             '{\"content\": \"# Updated\"}'::jsonb)",
+             '{\"content\": \"# Updated\"}'::jsonb, 2)",
     )
     .execute(&postgres.pool)
     .await

--- a/crates/server/tests/authorization_boundaries.rs
+++ b/crates/server/tests/authorization_boundaries.rs
@@ -42,6 +42,17 @@ async fn bearer_identity_enforces_personal_and_project_boundaries() {
         .create_project(&bootstrap.org_id, "Owner Only", "")
         .await
         .unwrap();
+    let selected_org_memory_id = repo
+        .create_org_context(&bootstrap.org_id, "context/selected.md", "# Selected")
+        .await
+        .unwrap();
+    let unselected_org_memory_id = repo
+        .create_org_context(&bootstrap.org_id, "context/unselected.md", "# Unselected")
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&bootstrap.project_id, &selected_org_memory_id)
+        .await
+        .unwrap();
 
     let (owner_app, _) = common::authenticated_router(postgres.pool.clone()).await;
     let draft_response = owner_app
@@ -134,7 +145,7 @@ async fn bearer_identity_enforces_personal_and_project_boundaries() {
                         daemon_installation_id: "daemon_member".to_owned(),
                         project_id: bootstrap.project_id.clone(),
                         base_commit_id: None,
-                        title: "Forbidden org draft".to_owned(),
+                        title: "New organization memory proposal".to_owned(),
                         description: None,
                         resource: DraftResourceRef {
                             scope: ResourceScope::Org,
@@ -149,7 +160,65 @@ async fn bearer_identity_enforces_personal_and_project_boundaries() {
         )
         .await
         .unwrap();
-    assert_eq!(org_draft.status(), StatusCode::FORBIDDEN);
+    assert_eq!(org_draft.status(), StatusCode::OK);
+
+    let selected_org_draft = member_app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/drafts")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&CreateDraftRequest {
+                        daemon_installation_id: "daemon_member".to_owned(),
+                        project_id: bootstrap.project_id.clone(),
+                        base_commit_id: None,
+                        title: "Selected organization memory proposal".to_owned(),
+                        description: None,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: Some(selected_org_memory_id),
+                            path: None,
+                        },
+                        operations: Vec::new(),
+                    })
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(selected_org_draft.status(), StatusCode::OK);
+
+    let unselected_org_draft = member_app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/drafts")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&CreateDraftRequest {
+                        daemon_installation_id: "daemon_member".to_owned(),
+                        project_id: bootstrap.project_id.clone(),
+                        base_commit_id: None,
+                        title: "Unselected organization memory proposal".to_owned(),
+                        description: None,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: Some(unselected_org_memory_id),
+                            path: None,
+                        },
+                        operations: Vec::new(),
+                    })
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unselected_org_draft.status(), StatusCode::BAD_REQUEST);
 
     let create_project = member_app
         .clone()

--- a/crates/server/tests/draft_operation_ordering.rs
+++ b/crates/server/tests/draft_operation_ordering.rs
@@ -1,0 +1,370 @@
+mod common;
+
+use server::api::{
+    CreateDraftRequest, CreateReviewDecisionRequest, CreateReviewMergeRequest, CreateReviewRequest,
+    DraftOperationAction, DraftOperationBatchItem, DraftOperationBatchRequest, DraftOperationInput,
+    DraftResourceContent, DraftResourceRef, ResourceScope, ReviewDecision,
+};
+use server::repository::ServerRepository;
+
+fn memory_content(content: &str) -> Option<DraftResourceContent> {
+    Some(DraftResourceContent {
+        description: None,
+        content: content.to_owned(),
+    })
+}
+
+async fn approve_and_merge(
+    repo: &ServerRepository,
+    user_id: &str,
+    expected_ref: Option<&str>,
+    draft_id: &str,
+    expected_draft_version: i64,
+) {
+    let review = repo
+        .create_review(
+            user_id,
+            expected_ref,
+            CreateReviewRequest {
+                draft_id: draft_id.to_owned(),
+                expected_draft_version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approved = repo
+        .create_review_decision(
+            &review.review.review_id,
+            user_id,
+            CreateReviewDecisionRequest {
+                decision: ReviewDecision::Approved,
+                expected_review_version: review.review.version,
+                body: None,
+            },
+        )
+        .await
+        .unwrap();
+    repo.create_review_merge(
+        &approved.review.review_id,
+        expected_ref,
+        CreateReviewMergeRequest {
+            expected_review_version: approved.review.version,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn create_request_preserves_create_update_rename_order_through_review_and_merge() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Operation Ordering",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Create Request Ordering",
+    )
+    .await;
+    let head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+    let initial_path = "context/created-in-order.md";
+    let final_path = "context/created-in-final-order.md";
+
+    let draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_create_ordering".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: head.clone(),
+                title: "Create and refine in one request".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some(initial_path.to_owned()),
+                },
+                operations: vec![
+                    DraftOperationInput {
+                        action: DraftOperationAction::Create,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: None,
+                            path: Some(initial_path.to_owned()),
+                        },
+                        content: memory_content("# Initial"),
+                        new_path: None,
+                    },
+                    DraftOperationInput {
+                        action: DraftOperationAction::Update,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: None,
+                            path: Some(initial_path.to_owned()),
+                        },
+                        content: memory_content("# Refined"),
+                        new_path: None,
+                    },
+                    DraftOperationInput {
+                        action: DraftOperationAction::Rename,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: None,
+                            path: Some(initial_path.to_owned()),
+                        },
+                        content: None,
+                        new_path: Some(final_path.to_owned()),
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+    // Make every legacy tie-breaker disagree with request order. Stable reads
+    // must continue to follow ordinal, not timestamp or generated ID.
+    sqlx::query(
+        "UPDATE draft_operations
+         SET operation_id = CASE action
+                WHEN 'create' THEN 'dop_z_create'
+                WHEN 'update' THEN 'dop_m_update'
+                WHEN 'rename' THEN 'dop_a_rename'
+                ELSE operation_id
+             END,
+             created_at = '2026-08-20T00:00:00Z'
+         WHERE draft_id = $1",
+    )
+    .bind(&draft.draft.draft_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
+    let stored: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT action, ordinal FROM draft_operations
+         WHERE draft_id = $1 ORDER BY ordinal",
+    )
+    .bind(&draft.draft.draft_id)
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        stored,
+        vec![
+            ("create".to_owned(), 1),
+            ("update".to_owned(), 2),
+            ("rename".to_owned(), 3),
+        ]
+    );
+
+    let detail = repo.get_draft(&draft.draft.draft_id).await.unwrap();
+    assert_eq!(
+        detail
+            .operations
+            .iter()
+            .map(|operation| operation.input.action)
+            .collect::<Vec<_>>(),
+        vec![
+            DraftOperationAction::Create,
+            DraftOperationAction::Update,
+            DraftOperationAction::Rename,
+        ]
+    );
+    approve_and_merge(
+        &repo,
+        &bootstrap.user_id,
+        head.as_deref(),
+        &detail.draft.draft_id,
+        detail.draft.version,
+    )
+    .await;
+
+    let created = repo
+        .list_org_memories(&bootstrap.org_id)
+        .await
+        .unwrap()
+        .items
+        .into_iter()
+        .find(|memory| memory.path == final_path)
+        .expect("ordered operations should materialize the final path");
+    assert_eq!(
+        repo.get_org_memory(&bootstrap.org_id, &created.memory_id)
+            .await
+            .unwrap()
+            .content,
+        "# Refined"
+    );
+}
+
+#[tokio::test]
+async fn batch_preserves_multiple_operations_and_their_event_versions() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Operation Ordering",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Batch Ordering",
+    )
+    .await;
+    let resource_id = repo
+        .create_org_context(&bootstrap.org_id, "context/batch-order.md", "# Authority")
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&bootstrap.project_id, &resource_id)
+        .await
+        .unwrap();
+    let head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+    let target = DraftResourceRef {
+        scope: ResourceScope::Org,
+        id: Some(resource_id.clone()),
+        path: None,
+    };
+    let draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_batch_ordering".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: head.clone(),
+                title: "Apply ordered batch".to_owned(),
+                description: None,
+                resource: target.clone(),
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let batch = repo
+        .create_draft_operation_batch(DraftOperationBatchRequest {
+            daemon_installation_id: "daemon_batch_ordering".to_owned(),
+            operations: vec![
+                DraftOperationBatchItem {
+                    local_operation_id: "local_first".to_owned(),
+                    draft_id: draft.draft.draft_id.clone(),
+                    expected_draft_version: 1,
+                    operation: DraftOperationInput {
+                        action: DraftOperationAction::Update,
+                        resource: target.clone(),
+                        content: memory_content("# First"),
+                        new_path: None,
+                    },
+                },
+                DraftOperationBatchItem {
+                    local_operation_id: "local_final".to_owned(),
+                    draft_id: draft.draft.draft_id.clone(),
+                    expected_draft_version: 2,
+                    operation: DraftOperationInput {
+                        action: DraftOperationAction::Update,
+                        resource: target,
+                        content: memory_content("# Final"),
+                        new_path: None,
+                    },
+                },
+            ],
+        })
+        .await
+        .unwrap();
+    assert_eq!(batch.accepted_operations, ["local_first", "local_final"]);
+
+    sqlx::query(
+        "UPDATE draft_operations
+         SET operation_id = CASE content->>'content'
+                WHEN '# First' THEN 'dop_z_batch_first'
+                WHEN '# Final' THEN 'dop_a_batch_final'
+                ELSE operation_id
+             END,
+             created_at = '2026-08-20T00:00:00Z'
+         WHERE draft_id = $1",
+    )
+    .bind(&draft.draft.draft_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
+    let stored: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT content->>'content', ordinal
+         FROM draft_operations
+         WHERE draft_id = $1
+         ORDER BY ordinal",
+    )
+    .bind(&draft.draft.draft_id)
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        stored,
+        vec![("# First".to_owned(), 1), ("# Final".to_owned(), 2)]
+    );
+
+    let detail = repo.get_draft(&draft.draft.draft_id).await.unwrap();
+    assert_eq!(
+        detail
+            .operations
+            .iter()
+            .map(|operation| {
+                (
+                    operation.input.content.as_ref().unwrap().content.as_str(),
+                    operation.operation_id.as_str(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            ("# First", "dop_z_batch_first"),
+            ("# Final", "dop_a_batch_final"),
+        ]
+    );
+    assert_eq!(detail.draft.version, 3);
+
+    let events = repo
+        .list_draft_events(&bootstrap.user_id, None, None)
+        .await
+        .unwrap()
+        .events
+        .into_iter()
+        .filter(|event| event.draft_id == draft.draft.draft_id)
+        .map(|event| (event.event_type, event.version))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        events,
+        vec![
+            (server::api::DraftEventType::Created, 1),
+            (server::api::DraftEventType::OperationAppended, 2),
+            (server::api::DraftEventType::OperationAppended, 3),
+        ]
+    );
+
+    approve_and_merge(
+        &repo,
+        &bootstrap.user_id,
+        head.as_deref(),
+        &detail.draft.draft_id,
+        detail.draft.version,
+    )
+    .await;
+    assert_eq!(
+        repo.get_org_memory(&bootstrap.org_id, &resource_id)
+            .await
+            .unwrap()
+            .content,
+        "# Final"
+    );
+}

--- a/crates/server/tests/draft_operation_ordinal_migration.rs
+++ b/crates/server/tests/draft_operation_ordinal_migration.rs
@@ -1,0 +1,111 @@
+mod common;
+
+use sqlx::Executor;
+
+#[tokio::test]
+async fn draft_operation_ordinal_migration_freezes_legacy_order_per_draft() {
+    let postgres = common::postgres_without_migrations().await;
+    postgres
+        .pool
+        .execute(
+            r#"
+            CREATE TABLE drafts (
+                draft_id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                version BIGINT NOT NULL
+            );
+            CREATE TABLE draft_operations (
+                operation_id TEXT PRIMARY KEY,
+                draft_id TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+            CREATE TABLE draft_events (
+                server_sequence BIGSERIAL NOT NULL UNIQUE,
+                event_id TEXT PRIMARY KEY,
+                draft_id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                version BIGINT NOT NULL,
+                daemon_installation_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+            INSERT INTO drafts (draft_id, project_id, status, version) VALUES
+                ('draft_a', 'project_a', 'open', 7),
+                ('draft_b', 'project_b', 'merged', 4);
+            INSERT INTO draft_operations (operation_id, draft_id, created_at) VALUES
+                ('dop_middle', 'draft_a', '2026-08-19T23:59:59Z'),
+                ('dop_z', 'draft_a', '2026-08-20T00:00:00Z'),
+                ('dop_a', 'draft_a', '2026-08-20T00:00:00Z'),
+                ('dop_other', 'draft_b', '2026-08-20T00:00:00Z');
+            "#,
+        )
+        .await
+        .unwrap();
+
+    postgres
+        .pool
+        .execute(include_str!(
+            "../migrations/20260820000100_add_draft_operation_ordinals.sql"
+        ))
+        .await
+        .unwrap();
+
+    let operations: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT draft_id, operation_id, ordinal
+         FROM draft_operations
+         ORDER BY draft_id, ordinal",
+    )
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        operations,
+        vec![
+            ("draft_a".to_owned(), "dop_middle".to_owned(), 1),
+            ("draft_a".to_owned(), "dop_a".to_owned(), 2),
+            ("draft_a".to_owned(), "dop_z".to_owned(), 3),
+            ("draft_b".to_owned(), "dop_other".to_owned(), 1),
+        ]
+    );
+
+    let refresh_events: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT draft_id, event_type, version
+         FROM draft_events
+         ORDER BY server_sequence",
+    )
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        refresh_events,
+        vec![("draft_a".to_owned(), "updated".to_owned(), 7)],
+        "active Draft projections must reload the canonical ordinal order"
+    );
+
+    let duplicate = sqlx::query(
+        "INSERT INTO draft_operations (operation_id, draft_id, ordinal)
+         VALUES ('dop_duplicate', 'draft_a', 1)",
+    )
+    .execute(&postgres.pool)
+    .await
+    .unwrap_err();
+    assert!(
+        duplicate
+            .to_string()
+            .contains("draft_operations_draft_ordinal_unique"),
+        "unexpected duplicate-ordinal error: {duplicate}"
+    );
+
+    let missing = sqlx::query(
+        "INSERT INTO draft_operations (operation_id, draft_id)
+         VALUES ('dop_missing', 'draft_c')",
+    )
+    .execute(&postgres.pool)
+    .await
+    .unwrap_err();
+    assert!(
+        missing.to_string().contains("ordinal"),
+        "unexpected missing-ordinal error: {missing}"
+    );
+}

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -113,7 +113,151 @@ async fn draft_created_resource_must_be_discarded_instead_of_deleted() {
 }
 
 #[tokio::test]
-async fn draft_review_merge_produces_project_commit() {
+async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Legacy Project Memory",
+    )
+    .await;
+    let legacy_resource = DraftResourceRef {
+        scope: ResourceScope::Project,
+        id: None,
+        path: Some("context/legacy.md".to_owned()),
+    };
+    let legacy_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_legacy".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Legacy Project draft".to_owned(),
+                description: None,
+                resource: legacy_resource.clone(),
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let create_review_error = repo
+        .create_review(
+            &bootstrap.user_id,
+            None,
+            CreateReviewRequest {
+                draft_id: legacy_draft.draft.draft_id.clone(),
+                expected_draft_version: legacy_draft.draft.version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        create_review_error
+            .to_string()
+            .contains("project-scoped Memory authority is read-only")
+    );
+
+    let rejected_review_id = "rev_legacy_rejected";
+    sqlx::query(
+        "INSERT INTO reviews (
+            review_id, draft_id, project_id, author_user_id,
+            title, description, status, version
+         )
+         VALUES ($1, $2, $3, $4, 'Legacy rejected Review', '', 'rejected', 1)",
+    )
+    .bind(rejected_review_id)
+    .bind(&legacy_draft.draft.draft_id)
+    .bind(&bootstrap.project_id)
+    .bind(&bootstrap.user_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    let resubmit_error = repo
+        .create_review_submission(
+            rejected_review_id,
+            &bootstrap.user_id,
+            None,
+            CreateReviewSubmissionRequest {
+                expected_review_version: 1,
+                expected_draft_version: legacy_draft.draft.version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        resubmit_error
+            .to_string()
+            .contains("project-scoped Memory authority is read-only")
+    );
+
+    let approved_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_legacy".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Legacy approved Project draft".to_owned(),
+                description: None,
+                resource: legacy_resource,
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE drafts SET status = 'submitted' WHERE draft_id = $1")
+        .bind(&approved_draft.draft.draft_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    let approved_review_id = "rev_legacy_approved";
+    sqlx::query(
+        "INSERT INTO reviews (
+            review_id, draft_id, project_id, author_user_id,
+            title, description, status, version, approved_result_hash
+         )
+         VALUES ($1, $2, $3, $4, 'Legacy approved Review', '', 'approved', 1, 'legacy')",
+    )
+    .bind(approved_review_id)
+    .bind(&approved_draft.draft.draft_id)
+    .bind(&bootstrap.project_id)
+    .bind(&bootstrap.user_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    let merge_error = repo
+        .create_review_merge(
+            approved_review_id,
+            None,
+            CreateReviewMergeRequest {
+                expected_review_version: 1,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        merge_error
+            .to_string()
+            .contains("project-scoped Memory authority is read-only")
+    );
+}
+
+#[tokio::test]
+async fn draft_review_merge_produces_org_and_carrier_project_commits() {
     let postgres = common::migrated_postgres().await;
     let repo = ServerRepository::new(postgres.pool.clone());
     let bootstrap = common::initialize_installation(
@@ -165,6 +309,7 @@ async fn draft_review_merge_produces_project_commit() {
     assert_eq!(org_commit_state.reference.org_id, org_id);
     assert!(org_commit_state.latest.is_some());
     assert_ne!(org_ref_etag, "\"ref-none\"");
+    let org_base_commit_id = org_commit_state.latest.unwrap().commit_id;
     let org_commits: CommitListResponse = get_json(app.clone(), "/api/v1/org/commits").await;
     assert_eq!(org_commits.items.len(), 2);
 
@@ -286,11 +431,11 @@ async fn draft_review_merge_produces_project_commit() {
         &CreateDraftRequest {
             daemon_installation_id: "daemon_test".to_owned(),
             project_id: project_id.clone(),
-            base_commit_id: Some(initial_commit_id.clone()),
-            title: "Add project context".to_owned(),
-            description: Some("First project context entry".to_owned()),
+            base_commit_id: Some(org_base_commit_id.clone()),
+            title: "Add organization context".to_owned(),
+            description: Some("Organization context proposed from a Project".to_owned()),
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context/intro.md".to_owned()),
             },
@@ -321,7 +466,7 @@ async fn draft_review_merge_produces_project_commit() {
         &DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context/intro.md".to_owned()),
             },
@@ -340,7 +485,7 @@ async fn draft_review_merge_produces_project_commit() {
         &DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context/intro.md".to_owned()),
             },
@@ -370,11 +515,11 @@ async fn draft_review_merge_produces_project_commit() {
         &CreateDraftRequest {
             daemon_installation_id: "daemon_batch_origin".to_owned(),
             project_id: project_id.clone(),
-            base_commit_id: Some(initial_commit_id.clone()),
+            base_commit_id: Some(org_base_commit_id.clone()),
             title: "Batch draft".to_owned(),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context/batch.md".to_owned()),
             },
@@ -394,7 +539,7 @@ async fn draft_review_merge_produces_project_commit() {
                 operation: DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/batch.md".to_owned()),
                     },
@@ -500,7 +645,7 @@ async fn draft_review_merge_produces_project_commit() {
     let merge: ReviewMergeResult = post_json_with_etag(
         app.clone(),
         &format!("/api/v1/reviews/{}/merges", review.review_id),
-        &initial_head_etag,
+        &org_ref_etag,
         &CreateReviewMergeRequest {
             expected_review_version: 2,
         },
@@ -521,33 +666,55 @@ async fn draft_review_merge_produces_project_commit() {
 
     let project: Project = get_json(app.clone(), &format!("/api/v1/projects/{project_id}")).await;
     assert_eq!(project.revision, 0);
-    let (commit_state, merged_head_etag): (CommitStateResponse, String) = get_json_with_etag(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/commit-state?local_commit_id={initial_commit_id}"),
-    )
-    .await;
-    assert!(commit_state.update_available);
+    let (org_commit_state, merged_org_head_etag): (CommitStateResponse, String) =
+        get_json_with_etag(
+            app.clone(),
+            &format!("/api/v1/org/commit-state?local_commit_id={org_base_commit_id}"),
+        )
+        .await;
+    assert!(org_commit_state.update_available);
     assert_eq!(
-        commit_state
+        org_commit_state
             .latest
             .as_ref()
             .map(|commit| commit.commit_id.as_str()),
         Some(commit_id.as_str())
     );
-    assert_eq!(merged_head_etag, format!("\"{commit_id}\""));
-    let (current_commit_state, _): (CommitStateResponse, String) = get_json_with_etag(
+    assert_eq!(merged_org_head_etag, format!("\"{commit_id}\""));
+    let (current_org_commit_state, _): (CommitStateResponse, String) = get_json_with_etag(
         app.clone(),
-        &format!("/api/v1/projects/{project_id}/commit-state?local_commit_id={commit_id}"),
+        &format!("/api/v1/org/commit-state?local_commit_id={commit_id}"),
     )
     .await;
-    assert!(!current_commit_state.update_available);
+    assert!(!current_org_commit_state.update_available);
+
+    let (project_commit_state, _): (CommitStateResponse, String) = get_json_with_etag(
+        app.clone(),
+        &format!("/api/v1/projects/{project_id}/commit-state?local_commit_id={initial_commit_id}"),
+    )
+    .await;
+    assert!(project_commit_state.update_available);
+    let project_commit_id = project_commit_state
+        .latest
+        .expect("auto-selection should create a carrier Project commit")
+        .commit_id;
+    assert_ne!(project_commit_id, commit_id);
 
     let project_context_page: MemoryListResponse = get_json(
         app.clone(),
         &format!("/api/v1/projects/{project_id}/memories"),
     )
     .await;
-    assert_eq!(project_context_page.items.len(), 1);
+    assert!(project_context_page.items.is_empty());
+
+    let org_memory_page: MemoryListResponse = get_json(app.clone(), "/api/v1/org/memories").await;
+    let created_org_memory_id = org_memory_page
+        .items
+        .iter()
+        .find(|memory| memory.path == "context/intro.md")
+        .expect("merged create should materialize Org authority")
+        .memory_id
+        .clone();
 
     let invalid_bundle = post_response(
         app.clone(),
@@ -555,7 +722,7 @@ async fn draft_review_merge_produces_project_commit() {
         &PersonalBundleRequest {
             name: "Invalid project memory".to_owned(),
             description: None,
-            resource_ids: vec![project_context_page.items[0].memory_id.clone()],
+            resource_ids: vec!["mem_missing".to_owned()],
         },
     )
     .await;
@@ -675,7 +842,7 @@ async fn draft_review_merge_produces_project_commit() {
     let current_selection: ProjectOrgSelection = put_json_with_if_match(
         app.clone(),
         &format!("/api/v1/projects/{project_id}/org-selections"),
-        2,
+        3,
         &ReplaceProjectOrgSelectionRequest {
             resource_ids: vec![org_context_id.clone()],
         },
@@ -683,7 +850,8 @@ async fn draft_review_merge_produces_project_commit() {
     .await;
     assert_eq!(current_selection.memories.len(), 1);
 
-    let commit: CommitPayload = get_json(app, &format!("/api/v1/commits/{commit_id}")).await;
+    let commit: CommitPayload =
+        get_json(app, &format!("/api/v1/commits/{project_commit_id}")).await;
     assert_eq!(
         commit.commit.project_id.as_deref(),
         Some(project_id.as_str())
@@ -707,13 +875,24 @@ async fn draft_review_merge_produces_project_commit() {
     let selection = commit
         .project_org_selection
         .expect("project commit should include org selection");
-    assert_eq!(selection.memories.len(), 2);
-    assert_eq!(selection.memories[0].memory_id, org_context_id);
-    assert_eq!(selection.memories[1].memory_id, org_reference_id);
+    assert_eq!(selection.memories.len(), 3);
+    let selected_ids = selection
+        .memories
+        .iter()
+        .map(|memory| memory.memory_id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        selected_ids,
+        std::collections::BTreeSet::from([
+            org_context_id.as_str(),
+            org_reference_id.as_str(),
+            created_org_memory_id.as_str(),
+        ])
+    );
 }
 
 #[tokio::test]
-async fn org_draft_review_merge_advances_only_the_org_ref() {
+async fn org_draft_review_merge_advances_org_and_selected_project_refs() {
     let postgres = common::migrated_postgres().await;
     let repo = ServerRepository::new(postgres.pool.clone());
     let bootstrap = common::initialize_installation(
@@ -733,6 +912,15 @@ async fn org_draft_review_merge_advances_only_the_org_ref() {
         )
         .await
         .unwrap();
+    repo.select_org_resource_for_project(&bootstrap.project_id, &context_id)
+        .await
+        .unwrap();
+    let project_head_before = repo
+        .get_project_commit_state(&bootstrap.project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
     let (app, _) = common::authenticated_router(postgres.pool.clone()).await;
     let (org_state, org_ref_etag): (CommitStateResponse, String) =
         get_json_with_etag(app.clone(), "/api/v1/org/commit-state").await;
@@ -802,7 +990,112 @@ async fn org_draft_review_merge_advances_only_the_org_ref() {
         &format!("/api/v1/projects/{}/commit-state", bootstrap.project_id),
     )
     .await;
-    assert_eq!(project_state.reference.commit_id, None);
+    assert_ne!(project_state.reference.commit_id, project_head_before);
+}
+
+#[tokio::test]
+async fn org_create_review_merge_selects_the_new_memory_for_its_project() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Project Memory",
+    )
+    .await;
+    let secondary_project_id = repo
+        .create_project(&bootstrap.org_id, "Secondary Project", "")
+        .await
+        .unwrap();
+    let secondary_state_before = repo
+        .get_project_commit_state(&secondary_project_id, None)
+        .await
+        .unwrap();
+    let secondary_selection_before = repo
+        .get_project_org_selection(&secondary_project_id)
+        .await
+        .unwrap();
+    let (app, _) = common::authenticated_router(postgres.pool.clone()).await;
+    let (org_before, org_etag): (CommitStateResponse, String) =
+        get_json_with_etag(app.clone(), "/api/v1/org/commit-state").await;
+
+    let approved = create_approved_review(
+        app.clone(),
+        CreateDraftRequest {
+            daemon_installation_id: "daemon_org_create".to_owned(),
+            project_id: bootstrap.project_id.clone(),
+            base_commit_id: org_before.reference.commit_id,
+            title: "Create shared project memory".to_owned(),
+            description: None,
+            resource: DraftResourceRef {
+                scope: ResourceScope::Org,
+                id: None,
+                path: Some("context/project-created.md".to_owned()),
+            },
+            operations: vec![DraftOperationInput {
+                action: DraftOperationAction::Create,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some("context/project-created.md".to_owned()),
+                },
+                content: context_draft_content("# Project-created\n\nShared after review."),
+                new_path: None,
+            }],
+        },
+    )
+    .await;
+    let _: ReviewMergeResult = post_json_with_etag(
+        app.clone(),
+        &format!("/api/v1/reviews/{}/merges", approved.review_id),
+        &org_etag,
+        &CreateReviewMergeRequest {
+            expected_review_version: approved.version,
+        },
+    )
+    .await;
+
+    let org_memories: MemoryListResponse = get_json(app.clone(), "/api/v1/org/memories").await;
+    let created = org_memories
+        .items
+        .iter()
+        .find(|memory| memory.path == "context/project-created.md")
+        .expect("merged Org create should materialize an Organization Memory");
+    let selection: ProjectOrgSelection = get_json(
+        app.clone(),
+        &format!("/api/v1/projects/{}/org-selections", bootstrap.project_id),
+    )
+    .await;
+    assert!(
+        selection
+            .memories
+            .iter()
+            .any(|memory| memory.memory_id == created.memory_id)
+    );
+    assert_eq!(selection.revision, 1);
+    let project_state: CommitStateResponse = get_json(
+        app,
+        &format!("/api/v1/projects/{}/commit-state", bootstrap.project_id),
+    )
+    .await;
+    assert!(project_state.reference.commit_id.is_some());
+
+    let secondary_state_after = repo
+        .get_project_commit_state(&secondary_project_id, None)
+        .await
+        .unwrap();
+    let secondary_selection_after = repo
+        .get_project_org_selection(&secondary_project_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        secondary_state_after.reference.commit_id,
+        secondary_state_before.reference.commit_id
+    );
+    assert_eq!(secondary_selection_after, secondary_selection_before);
 }
 
 #[tokio::test]
@@ -1065,74 +1358,23 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
     .await
     .unwrap();
 
-    let initial_project_head = repo
-        .get_project_commit_state(&bootstrap.project_id, None)
-        .await
-        .unwrap()
-        .reference
-        .commit_id;
-    let project_draft = repo
-        .create_draft(
-            &bootstrap.user_id,
-            CreateDraftRequest {
-                daemon_installation_id: "daemon_projection_rollback".to_owned(),
-                project_id: bootstrap.project_id.clone(),
-                base_commit_id: initial_project_head.clone(),
-                title: "Create colliding project context".to_owned(),
-                description: None,
-                resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
-                    id: None,
-                    path: Some("context/collision.md".to_owned()),
-                },
-                operations: vec![DraftOperationInput {
-                    action: DraftOperationAction::Create,
-                    resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
-                        id: None,
-                        path: Some("context/collision.md".to_owned()),
-                    },
-                    content: context_draft_content("# Project context"),
-                    new_path: None,
-                }],
-            },
-        )
-        .await
-        .unwrap();
-    let project_review = repo
-        .create_review(
-            &bootstrap.user_id,
-            initial_project_head.as_deref(),
-            CreateReviewRequest {
-                draft_id: project_draft.draft.draft_id,
-                expected_draft_version: project_draft.draft.version,
-                title: None,
-                description: None,
-                candidate_id: None,
-                resolved_state: None,
-            },
-        )
-        .await
-        .unwrap();
-    let project_review = repo
-        .create_review_decision(
-            &project_review.review.review_id,
-            &project_review.review.author.user_id,
-            CreateReviewDecisionRequest {
-                decision: ReviewDecision::Approved,
-                expected_review_version: project_review.review.version,
-                body: None,
-            },
-        )
-        .await
-        .unwrap();
-    repo.create_review_merge(
-        &project_review.review.review_id,
-        initial_project_head.as_deref(),
-        CreateReviewMergeRequest {
-            expected_review_version: project_review.review.version,
-        },
+    // Compatibility fixture: releases before Org-only authority could leave
+    // Project-owned rows behind. They remain readable but no Review may
+    // create or mutate them after this cutover.
+    sqlx::query(
+        "INSERT INTO resources (
+            resource_id, org_id, project_id, scope, resource_kind, path, name,
+            status, revision, content_hash, body, description
+         )
+         VALUES (
+            'mem_legacy_collision', $1, $2, 'project', 'memory',
+            'context/collision.md', 'collision', 'active', 1,
+            'sha256:legacy', '# Legacy Project context', ''
+         )",
     )
+    .bind(&bootstrap.org_id)
+    .bind(&bootstrap.project_id)
+    .execute(&postgres.pool)
     .await
     .unwrap();
 
@@ -1298,14 +1540,14 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             title: "Create review lifecycle context".to_owned(),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context/review-lifecycle.md".to_owned()),
             },
             operations: vec![DraftOperationInput {
                 action: DraftOperationAction::Create,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/review-lifecycle.md".to_owned()),
                 },
@@ -1627,7 +1869,7 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
 }
 
 #[tokio::test]
-async fn stale_draft_cannot_overwrite_a_new_project_ref() {
+async fn stale_draft_cannot_overwrite_a_new_org_ref() {
     let postgres = common::migrated_postgres().await;
     let bootstrap = common::initialize_installation(
         postgres.pool.clone(),
@@ -1880,18 +2122,10 @@ async fn stale_draft_cannot_overwrite_a_new_project_ref() {
         event.draft_id == stale.draft_id && event.event_type == DraftEventType::Rebased
     }));
 
-    let context: MemoryListResponse = get_json(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/memories"),
-    )
-    .await;
+    let context: MemoryListResponse = get_json(app.clone(), "/api/v1/org/memories").await;
     assert_eq!(context.items.len(), 1);
     assert_eq!(context.items[0].path, "context/first.md");
-    let commits: CommitListResponse = get_json(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/commits"),
-    )
-    .await;
+    let commits: CommitListResponse = get_json(app.clone(), "/api/v1/org/commits").await;
     assert_eq!(commits.items.len(), 1);
     assert_eq!(commits.items[0].commit_id, first_commit_id);
 
@@ -2003,8 +2237,7 @@ async fn stale_draft_cannot_overwrite_a_new_project_ref() {
     )
     .await;
     assert!(merge.commit_id.is_some());
-    let context: MemoryListResponse =
-        get_json(app, &format!("/api/v1/projects/{project_id}/memories")).await;
+    let context: MemoryListResponse = get_json(app, "/api/v1/org/memories").await;
     assert_eq!(context.items.len(), 3);
 }
 
@@ -2023,7 +2256,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     .await;
 
     let resource = DraftResourceRef {
-        scope: ResourceScope::Project,
+        scope: ResourceScope::Org,
         id: None,
         path: Some("context/coordination.md".to_owned()),
     };
@@ -2098,7 +2331,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
         .id
         .clone();
     let existing_resource = DraftResourceRef {
-        scope: ResourceScope::Project,
+        scope: ResourceScope::Org,
         id: Some(resource_id.clone()),
         path: None,
     };
@@ -2518,6 +2751,971 @@ async fn project_org_selection_rejects_foreign_and_colliding_resources_atomicall
 }
 
 #[tokio::test]
+async fn project_org_selection_preserves_every_active_org_draft_target() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Active Draft Selection",
+    )
+    .await;
+    let mut resource_ids = Vec::new();
+    for name in ["open", "submitted", "operation", "discarded", "merged"] {
+        resource_ids.push(
+            repo.create_org_context(
+                &bootstrap.org_id,
+                &format!("context/{name}.md"),
+                &format!("# {name}"),
+            )
+            .await
+            .unwrap(),
+        );
+    }
+    let [open_id, submitted_id, operation_id, discarded_id, merged_id] =
+        resource_ids.clone().try_into().unwrap();
+    let mut selection = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            0,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: resource_ids.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let open_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_selection_open".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Open target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(open_id.clone()),
+                    path: None,
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    let submitted_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_selection_submitted".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Submitted path target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some("context/submitted.md".to_owned()),
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE drafts SET status = 'submitted' WHERE draft_id = $1")
+        .bind(&submitted_draft.draft.draft_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    let operation_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_selection_operation".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Operation target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(open_id.clone()),
+                    path: None,
+                },
+                operations: vec![DraftOperationInput {
+                    action: DraftOperationAction::Update,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: Some(operation_id.clone()),
+                        path: None,
+                    },
+                    content: context_draft_content("# operation draft"),
+                    new_path: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+    let discarded_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_selection_discarded".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Discarded target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(discarded_id.clone()),
+                    path: None,
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    repo.discard_draft(
+        &discarded_draft.draft.draft_id,
+        &bootstrap.user_id,
+        discarded_draft.draft.version,
+    )
+    .await
+    .unwrap();
+    let merged_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_selection_merged".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Merged target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(merged_id.clone()),
+                    path: None,
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    sqlx::query("UPDATE drafts SET status = 'merged' WHERE draft_id = $1")
+        .bind(&merged_draft.draft.draft_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+
+    let added_id = repo
+        .create_org_context(&bootstrap.org_id, "context/added.md", "# added")
+        .await
+        .unwrap();
+    let mut with_addition = resource_ids.clone();
+    with_addition.push(added_id.clone());
+    selection = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            selection.revision,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: with_addition.clone(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        selection
+            .memories
+            .iter()
+            .any(|memory| memory.memory_id == added_id)
+    );
+
+    for (blocked_id, draft_id) in [
+        (&open_id, &open_draft.draft.draft_id),
+        (&submitted_id, &submitted_draft.draft.draft_id),
+        (&operation_id, &operation_draft.draft.draft_id),
+    ] {
+        let error = repo
+            .replace_project_org_selection(
+                &bootstrap.project_id,
+                selection.revision,
+                ReplaceProjectOrgSelectionRequest {
+                    resource_ids: with_addition
+                        .iter()
+                        .filter(|resource_id| *resource_id != blocked_id)
+                        .cloned()
+                        .collect(),
+                },
+            )
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains(blocked_id));
+        assert!(message.contains(draft_id));
+        assert!(message.contains("active Organization Draft"));
+    }
+
+    let without_discarded = with_addition
+        .iter()
+        .filter(|resource_id| *resource_id != &discarded_id)
+        .cloned()
+        .collect::<Vec<_>>();
+    selection = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            selection.revision,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: without_discarded.clone(),
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        selection
+            .memories
+            .iter()
+            .all(|memory| memory.memory_id != discarded_id)
+    );
+
+    let without_terminal = without_discarded
+        .into_iter()
+        .filter(|resource_id| resource_id != &merged_id)
+        .collect::<Vec<_>>();
+    selection = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            selection.revision,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: without_terminal,
+            },
+        )
+        .await
+        .unwrap();
+    assert!(
+        selection
+            .memories
+            .iter()
+            .all(|memory| memory.memory_id != merged_id)
+    );
+}
+
+#[tokio::test]
+async fn project_org_selection_resolves_legacy_path_only_draft_after_authority_rename() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Legacy Path Draft Selection",
+    )
+    .await;
+    let old_path = "context/path-only-target.md";
+    let new_path = "context/path-only-target-renamed.md";
+    let resource_id = repo
+        .create_org_context(&bootstrap.org_id, old_path, "# Shared target")
+        .await
+        .unwrap();
+    let selection = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            0,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: vec![resource_id.clone()],
+            },
+        )
+        .await
+        .unwrap();
+    let base_commit_id = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+
+    let path_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_path_identity".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: base_commit_id.clone(),
+                title: "Update by path".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some(old_path.to_owned()),
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        path_draft.draft.resource.id.as_deref(),
+        Some(resource_id.as_str())
+    );
+    let path_draft = repo
+        .append_draft_operation(
+            &path_draft.draft.draft_id,
+            path_draft.draft.version,
+            DraftOperationInput {
+                action: DraftOperationAction::Update,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some(old_path.to_owned()),
+                },
+                content: context_draft_content("# Local update"),
+                new_path: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        path_draft.operations[0].input.resource.id.as_deref(),
+        Some(resource_id.as_str())
+    );
+
+    // Compatibility fixture: old clients persisted only paths and some old
+    // Draft shells had no base commit. The historical Org tree must still map
+    // that path to the stable resource identity after an authority rename.
+    sqlx::query("UPDATE drafts SET target_id = NULL, base_commit_id = NULL WHERE draft_id = $1")
+        .bind(&path_draft.draft.draft_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE draft_operations SET target_id = NULL WHERE draft_id = $1")
+        .bind(&path_draft.draft.draft_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+
+    let rename_project_id = repo
+        .create_project(&bootstrap.org_id, "Authority Rename Carrier", "")
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&rename_project_id, &resource_id)
+        .await
+        .unwrap();
+    let rename_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_authority_rename".to_owned(),
+                project_id: rename_project_id.clone(),
+                base_commit_id: base_commit_id.clone(),
+                title: "Rename authority target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(resource_id.clone()),
+                    path: None,
+                },
+                operations: vec![DraftOperationInput {
+                    action: DraftOperationAction::Rename,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: Some(resource_id.clone()),
+                        path: None,
+                    },
+                    content: None,
+                    new_path: Some(new_path.to_owned()),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+    let review = repo
+        .create_review(
+            &bootstrap.user_id,
+            base_commit_id.as_deref(),
+            CreateReviewRequest {
+                draft_id: rename_draft.draft.draft_id,
+                expected_draft_version: rename_draft.draft.version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approved = repo
+        .create_review_decision(
+            &review.review.review_id,
+            &bootstrap.user_id,
+            CreateReviewDecisionRequest {
+                decision: ReviewDecision::Approved,
+                expected_review_version: review.review.version,
+                body: None,
+            },
+        )
+        .await
+        .unwrap();
+    repo.create_review_merge(
+        &approved.review.review_id,
+        base_commit_id.as_deref(),
+        CreateReviewMergeRequest {
+            expected_review_version: approved.review.version,
+        },
+    )
+    .await
+    .unwrap();
+
+    let renamed_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+    let replacement = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_reuse_historical_path".to_owned(),
+                project_id: rename_project_id,
+                base_commit_id: renamed_head,
+                title: "Reuse the freed path".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some(old_path.to_owned()),
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(replacement.draft.resource.id, None);
+    let replacement = repo
+        .append_draft_operation(
+            &replacement.draft.draft_id,
+            replacement.draft.version,
+            DraftOperationInput {
+                action: DraftOperationAction::Create,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some(old_path.to_owned()),
+                },
+                content: context_draft_content("# Replacement"),
+                new_path: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        replacement.operations[0].input.action,
+        DraftOperationAction::Create
+    );
+
+    let error = repo
+        .replace_project_org_selection(
+            &bootstrap.project_id,
+            selection.revision,
+            ReplaceProjectOrgSelectionRequest {
+                resource_ids: Vec::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains(&resource_id));
+    assert!(message.contains(&path_draft.draft.draft_id));
+    assert!(message.contains("active Organization Draft"));
+
+    let replacement_resource_id = repo
+        .create_org_context(&bootstrap.org_id, old_path, "# Authority replacement")
+        .await
+        .unwrap();
+    assert_ne!(replacement_resource_id, resource_id);
+    sqlx::query("UPDATE drafts SET base_commit_id = $2 WHERE draft_id = $1")
+        .bind(&path_draft.draft.draft_id)
+        .bind(&base_commit_id)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    let candidate = repo
+        .create_draft_reconciliation_candidate(
+            &path_draft.draft.draft_id,
+            server::api::CreateDraftReconciliationCandidateRequest {
+                expected_draft_version: path_draft.draft.version,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(candidate.status, ReconciliationCandidateStatus::Clean);
+    assert_eq!(
+        candidate.base_state.resource.id.as_deref(),
+        Some(resource_id.as_str())
+    );
+    assert_eq!(
+        candidate.base_state.resource.path.as_deref(),
+        Some(old_path)
+    );
+    assert_eq!(
+        candidate.current_state.resource.id.as_deref(),
+        Some(resource_id.as_str())
+    );
+    assert_eq!(
+        candidate.current_state.resource.path.as_deref(),
+        Some(new_path)
+    );
+    assert_eq!(
+        candidate.draft_state.resource.id.as_deref(),
+        Some(resource_id.as_str())
+    );
+    assert_eq!(
+        candidate.draft_state.resource.path.as_deref(),
+        Some(old_path)
+    );
+    let proposed = candidate.proposed_state.as_ref().unwrap();
+    assert_eq!(proposed.resource.id.as_deref(), Some(resource_id.as_str()));
+    assert_eq!(proposed.resource.path.as_deref(), Some(new_path));
+    assert_eq!(
+        proposed.content.as_ref().map(content_text_for_test),
+        Some("# Local update")
+    );
+}
+
+#[tokio::test]
+async fn org_draft_target_validation_serializes_with_project_selection_changes() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Draft Selection Serialization",
+    )
+    .await;
+    let create_target_id = repo
+        .create_org_context(&bootstrap.org_id, "context/create-target.md", "# create")
+        .await
+        .unwrap();
+    let append_target_id = repo
+        .create_org_context(&bootstrap.org_id, "context/append-target.md", "# append")
+        .await
+        .unwrap();
+    repo.replace_project_org_selection(
+        &bootstrap.project_id,
+        0,
+        ReplaceProjectOrgSelectionRequest {
+            resource_ids: vec![create_target_id.clone(), append_target_id.clone()],
+        },
+    )
+    .await
+    .unwrap();
+
+    let mut selection_tx = postgres.pool.begin().await.unwrap();
+    sqlx::query(
+        "SELECT pg_advisory_xact_lock(
+            hashtextextended('org_draft_selection:' || $1, 0)
+         )",
+    )
+    .bind(&bootstrap.org_id)
+    .execute(&mut *selection_tx)
+    .await
+    .unwrap();
+    sqlx::query(
+        "DELETE FROM project_org_resource_selections
+         WHERE project_id = $1 AND resource_id = $2",
+    )
+    .bind(&bootstrap.project_id)
+    .bind(&create_target_id)
+    .execute(&mut *selection_tx)
+    .await
+    .unwrap();
+    let create_repo = repo.clone();
+    let create_user_id = bootstrap.user_id.clone();
+    let create_project_id = bootstrap.project_id.clone();
+    let create_target = create_target_id.clone();
+    let create_task = tokio::spawn(async move {
+        create_repo
+            .create_draft(
+                &create_user_id,
+                CreateDraftRequest {
+                    daemon_installation_id: "daemon_concurrent_create".to_owned(),
+                    project_id: create_project_id,
+                    base_commit_id: None,
+                    title: "Concurrent create".to_owned(),
+                    description: None,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: Some(create_target),
+                        path: None,
+                    },
+                    operations: Vec::new(),
+                },
+            )
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    assert!(!create_task.is_finished());
+    selection_tx.commit().await.unwrap();
+    let create_error = create_task.await.unwrap().unwrap_err();
+    assert!(create_error.to_string().contains("currently selected"));
+
+    let carrier = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_concurrent_append".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: None,
+                title: "Concurrent append".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(append_target_id.clone()),
+                    path: None,
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    let mut append_selection_tx = postgres.pool.begin().await.unwrap();
+    sqlx::query(
+        "SELECT pg_advisory_xact_lock(
+            hashtextextended('org_draft_selection:' || $1, 0)
+         )",
+    )
+    .bind(&bootstrap.org_id)
+    .execute(&mut *append_selection_tx)
+    .await
+    .unwrap();
+    sqlx::query(
+        "DELETE FROM project_org_resource_selections
+         WHERE project_id = $1 AND resource_id = $2",
+    )
+    .bind(&bootstrap.project_id)
+    .bind(&append_target_id)
+    .execute(&mut *append_selection_tx)
+    .await
+    .unwrap();
+    let append_repo = repo.clone();
+    let append_draft_id = carrier.draft.draft_id.clone();
+    let append_version = carrier.draft.version;
+    let append_target = append_target_id.clone();
+    let append_task = tokio::spawn(async move {
+        append_repo
+            .append_draft_operation(
+                &append_draft_id,
+                append_version,
+                DraftOperationInput {
+                    action: DraftOperationAction::Update,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: Some(append_target),
+                        path: None,
+                    },
+                    content: context_draft_content("# concurrent append"),
+                    new_path: None,
+                },
+            )
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    assert!(!append_task.is_finished());
+    append_selection_tx.commit().await.unwrap();
+    let append_error = append_task.await.unwrap().unwrap_err();
+    assert!(append_error.to_string().contains("currently selected"));
+}
+
+#[tokio::test]
+async fn created_org_draft_materializes_local_identity_updates_and_renames() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Created Draft Materialization",
+    )
+    .await;
+    let current_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+    let draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_created_materialization".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: current_head.clone(),
+                title: "Create then refine Organization Memory".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: None,
+                    path: Some("context/local-created.md".to_owned()),
+                },
+                operations: vec![DraftOperationInput {
+                    action: DraftOperationAction::Create,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: None,
+                        path: Some("context/local-created.md".to_owned()),
+                    },
+                    content: context_draft_content("# Initial"),
+                    new_path: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+    let draft = repo
+        .append_draft_operation(
+            &draft.draft.draft_id,
+            draft.draft.version,
+            DraftOperationInput {
+                action: DraftOperationAction::Update,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some("draft_local_created_identity".to_owned()),
+                    path: None,
+                },
+                content: context_draft_content("# Refined"),
+                new_path: None,
+            },
+        )
+        .await
+        .unwrap();
+    let draft = repo
+        .append_draft_operation(
+            &draft.draft.draft_id,
+            draft.draft.version,
+            DraftOperationInput {
+                action: DraftOperationAction::Rename,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some("draft_local_created_identity".to_owned()),
+                    path: None,
+                },
+                content: None,
+                new_path: Some("context/refined-created.md".to_owned()),
+            },
+        )
+        .await
+        .unwrap();
+    let review = repo
+        .create_review(
+            &bootstrap.user_id,
+            current_head.as_deref(),
+            CreateReviewRequest {
+                draft_id: draft.draft.draft_id,
+                expected_draft_version: draft.draft.version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approved = repo
+        .create_review_decision(
+            &review.review.review_id,
+            &bootstrap.user_id,
+            CreateReviewDecisionRequest {
+                decision: ReviewDecision::Approved,
+                expected_review_version: review.review.version,
+                body: None,
+            },
+        )
+        .await
+        .unwrap();
+    repo.create_review_merge(
+        &approved.review.review_id,
+        current_head.as_deref(),
+        CreateReviewMergeRequest {
+            expected_review_version: approved.review.version,
+        },
+    )
+    .await
+    .unwrap();
+
+    let created = repo
+        .list_org_memories(&bootstrap.org_id)
+        .await
+        .unwrap()
+        .items
+        .into_iter()
+        .find(|memory| memory.path == "context/refined-created.md")
+        .expect("materialized create should use the latest local path");
+    assert_eq!(
+        repo.get_org_memory(&bootstrap.org_id, &created.memory_id)
+            .await
+            .unwrap()
+            .content,
+        "# Refined"
+    );
+}
+
+#[tokio::test]
+async fn org_delete_merge_advances_authority_past_other_projects_active_drafts() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Acme Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Delete Merge Draft Coordination",
+    )
+    .await;
+    let resource_id = repo
+        .create_org_context(
+            &bootstrap.org_id,
+            "context/shared-target.md",
+            "# Shared target",
+        )
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&bootstrap.project_id, &resource_id)
+        .await
+        .unwrap();
+    let other_project_id = repo
+        .create_project(&bootstrap.org_id, "Other Project", "")
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&other_project_id, &resource_id)
+        .await
+        .unwrap();
+    let current_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+
+    let blocking_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_other_project".to_owned(),
+                project_id: other_project_id.clone(),
+                base_commit_id: current_head.clone(),
+                title: "Update shared target elsewhere".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(resource_id.clone()),
+                    path: None,
+                },
+                operations: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+    let deletion_draft = repo
+        .create_draft(
+            &bootstrap.user_id,
+            CreateDraftRequest {
+                daemon_installation_id: "daemon_delete_merge".to_owned(),
+                project_id: bootstrap.project_id.clone(),
+                base_commit_id: current_head.clone(),
+                title: "Delete shared target".to_owned(),
+                description: None,
+                resource: DraftResourceRef {
+                    scope: ResourceScope::Org,
+                    id: Some(resource_id.clone()),
+                    path: None,
+                },
+                operations: vec![DraftOperationInput {
+                    action: DraftOperationAction::Delete,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: Some(resource_id.clone()),
+                        path: None,
+                    },
+                    content: None,
+                    new_path: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+    let review = repo
+        .create_review(
+            &bootstrap.user_id,
+            current_head.as_deref(),
+            CreateReviewRequest {
+                draft_id: deletion_draft.draft.draft_id,
+                expected_draft_version: deletion_draft.draft.version,
+                title: None,
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap();
+    let approved = repo
+        .create_review_decision(
+            &review.review.review_id,
+            &bootstrap.user_id,
+            CreateReviewDecisionRequest {
+                decision: ReviewDecision::Approved,
+                expected_review_version: review.review.version,
+                body: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    repo.create_review_merge(
+        &approved.review.review_id,
+        current_head.as_deref(),
+        CreateReviewMergeRequest {
+            expected_review_version: approved.review.version,
+        },
+    )
+    .await
+    .unwrap();
+    let blocking_draft = repo
+        .get_draft(&blocking_draft.draft.draft_id)
+        .await
+        .unwrap();
+    assert_eq!(blocking_draft.draft.status, DraftStatus::Open);
+    assert_eq!(
+        blocking_draft.draft.coordination.freshness,
+        DraftFreshness::Behind
+    );
+    assert!(
+        repo.get_project_org_selection(&bootstrap.project_id)
+            .await
+            .unwrap()
+            .memories
+            .is_empty()
+    );
+    assert!(
+        repo.get_project_org_selection(&other_project_id)
+            .await
+            .unwrap()
+            .memories
+            .is_empty()
+    );
+}
+
+#[tokio::test]
 async fn invalid_memory_paths_and_rule_shapes_are_rejected_before_draft_storage() {
     let postgres = common::migrated_postgres().await;
     let bootstrap = common::initialize_installation(
@@ -2683,11 +3881,8 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
     .await;
     let project_id = bootstrap.project_id;
     let (app, _token) = common::authenticated_router(postgres.pool.clone()).await;
-    let (initial_state, initial_etag): (CommitStateResponse, String) = get_json_with_etag(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/commit-state"),
-    )
-    .await;
+    let (initial_state, initial_etag): (CommitStateResponse, String) =
+        get_json_with_etag(app.clone(), "/api/v1/org/commit-state").await;
 
     let rule_draft: DraftDetail = post_json(
         app.clone(),
@@ -2699,14 +3894,14 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
             title: "Add coding rule".to_owned(),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("rules/coding".to_owned()),
             },
             operations: vec![DraftOperationInput {
                 action: DraftOperationAction::Create,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("rules/coding".to_owned()),
                 },
@@ -2751,11 +3946,8 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
         .find(|entry| entry.path.as_deref() == Some("rules/coding"))
         .expect("rule Commit should contain the Rule");
     let rule_id = rule_entry.id.clone();
-    let rule: MemoryDetail = get_json(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/memories/{rule_id}"),
-    )
-    .await;
+    let rule: MemoryDetail =
+        get_json(app.clone(), &format!("/api/v1/org/memories/{rule_id}")).await;
     assert_eq!(rule.memory.name, "coding");
     assert_eq!(
         rule.content,
@@ -2768,11 +3960,8 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
         .expect("rule Blob should be present");
     assert_eq!(rule_blob.content, rule.content);
 
-    let (_, rule_ref_etag): (CommitStateResponse, String) = get_json_with_etag(
-        app.clone(),
-        &format!("/api/v1/projects/{project_id}/commit-state"),
-    )
-    .await;
+    let (_, rule_ref_etag): (CommitStateResponse, String) =
+        get_json_with_etag(app.clone(), "/api/v1/org/commit-state").await;
     let workflow_draft: DraftDetail = post_json(
         app.clone(),
         "/api/v1/drafts",
@@ -2783,14 +3972,14 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
             title: "Add coding workflow".to_owned(),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("workflow/coding".to_owned()),
             },
             operations: vec![DraftOperationInput {
                 action: DraftOperationAction::Create,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("workflow/coding".to_owned()),
                 },
@@ -2844,14 +4033,8 @@ async fn markdown_rule_and_workflow_survive_draft_review_and_commit_round_trip()
         .iter()
         .find(|entry| entry.path.as_deref() == Some("workflow/coding"))
         .expect("workflow Commit should contain the Workflow");
-    let workflow: MemoryDetail = get_json(
-        app,
-        &format!(
-            "/api/v1/projects/{project_id}/memories/{}",
-            workflow_entry.id
-        ),
-    )
-    .await;
+    let workflow: MemoryDetail =
+        get_json(app, &format!("/api/v1/org/memories/{}", workflow_entry.id)).await;
     assert_eq!(workflow.memory.name, "coding");
     assert_eq!(
         workflow.content,
@@ -2935,14 +4118,14 @@ async fn create_approved_context_review(
             title: format!("Create {path}"),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some(path.to_owned()),
             },
             operations: vec![DraftOperationInput {
                 action: DraftOperationAction::Create,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some(path.to_owned()),
                 },
@@ -3291,14 +4474,14 @@ async fn review_comments_support_line_anchors() {
             title: "Anchored comment draft".to_owned(),
             description: None,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: Some(resource_id.clone()),
                 path: None,
             },
             operations: vec![DraftOperationInput {
                 action: DraftOperationAction::Rename,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: Some(resource_id),
                     path: None,
                 },

--- a/crates/server/tests/path_identity_candidate_migration.rs
+++ b/crates/server/tests/path_identity_candidate_migration.rs
@@ -1,0 +1,122 @@
+mod common;
+
+use sqlx::Executor;
+
+#[tokio::test]
+async fn path_identity_migration_invalidates_only_active_legacy_org_candidates() {
+    let postgres = common::postgres_without_migrations().await;
+    postgres
+        .pool
+        .execute(
+            r#"
+            CREATE TABLE drafts (
+                draft_id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                resource_scope TEXT NOT NULL,
+                target_id TEXT,
+                path TEXT,
+                status TEXT NOT NULL,
+                version BIGINT NOT NULL
+            );
+            CREATE TABLE draft_operations (
+                operation_id TEXT PRIMARY KEY,
+                draft_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                ordinal BIGINT NOT NULL
+            );
+            CREATE TABLE draft_reconciliation_candidates (
+                candidate_id TEXT PRIMARY KEY,
+                draft_id TEXT NOT NULL,
+                invalidated_at TIMESTAMPTZ
+            );
+            CREATE TABLE draft_events (
+                server_sequence BIGSERIAL NOT NULL UNIQUE,
+                event_id TEXT PRIMARY KEY,
+                draft_id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                version BIGINT NOT NULL,
+                daemon_installation_id TEXT,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+
+            INSERT INTO drafts (
+                draft_id, project_id, resource_scope, target_id, path, status, version
+            ) VALUES
+                ('legacy_open', 'project_a', 'org', NULL, 'context/old.md', 'open', 7),
+                ('legacy_submitted', 'project_a', 'org', NULL, 'context/submitted.md', 'submitted', 8),
+                ('create_first', 'project_a', 'org', NULL, 'context/new.md', 'open', 2),
+                ('stable_id', 'project_a', 'org', 'mem_stable', 'context/stable.md', 'open', 3),
+                ('project_scope', 'project_a', 'project', NULL, 'context/project.md', 'open', 4),
+                ('terminal', 'project_a', 'org', NULL, 'context/terminal.md', 'merged', 5),
+                ('already_invalid', 'project_a', 'org', NULL, 'context/invalid.md', 'open', 6);
+
+            INSERT INTO draft_operations (operation_id, draft_id, action, ordinal) VALUES
+                ('op_legacy_open', 'legacy_open', 'update', 1),
+                ('op_legacy_submitted', 'legacy_submitted', 'rename', 1),
+                ('op_create_first', 'create_first', 'create', 1),
+                ('op_stable_id', 'stable_id', 'update', 1),
+                ('op_project_scope', 'project_scope', 'update', 1),
+                ('op_terminal', 'terminal', 'update', 1),
+                ('op_already_invalid', 'already_invalid', 'update', 1);
+
+            INSERT INTO draft_reconciliation_candidates (
+                candidate_id, draft_id, invalidated_at
+            ) VALUES
+                ('candidate_legacy_open', 'legacy_open', NULL),
+                ('candidate_legacy_submitted', 'legacy_submitted', NULL),
+                ('candidate_create_first', 'create_first', NULL),
+                ('candidate_stable_id', 'stable_id', NULL),
+                ('candidate_project_scope', 'project_scope', NULL),
+                ('candidate_terminal', 'terminal', NULL),
+                ('candidate_already_invalid', 'already_invalid', '2026-08-19T00:00:00Z');
+            "#,
+        )
+        .await
+        .unwrap();
+
+    postgres
+        .pool
+        .execute(include_str!(
+            "../migrations/20260820000200_invalidate_path_only_org_candidates.sql"
+        ))
+        .await
+        .unwrap();
+
+    let candidates: Vec<(String, bool)> = sqlx::query_as(
+        "SELECT candidate_id, invalidated_at IS NOT NULL
+         FROM draft_reconciliation_candidates
+         ORDER BY candidate_id",
+    )
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        candidates,
+        vec![
+            ("candidate_already_invalid".to_owned(), true),
+            ("candidate_create_first".to_owned(), false),
+            ("candidate_legacy_open".to_owned(), true),
+            ("candidate_legacy_submitted".to_owned(), true),
+            ("candidate_project_scope".to_owned(), false),
+            ("candidate_stable_id".to_owned(), false),
+            ("candidate_terminal".to_owned(), false),
+        ]
+    );
+
+    let refresh_events: Vec<(String, String, i64)> = sqlx::query_as(
+        "SELECT draft_id, event_type, version
+         FROM draft_events
+         ORDER BY draft_id",
+    )
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        refresh_events,
+        vec![
+            ("legacy_open".to_owned(), "updated".to_owned(), 7),
+            ("legacy_submitted".to_owned(), "updated".to_owned(), 8),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary

Git-style status colors and a three-way unified diff view for the macOS Memory file tree.

### File tree status
- New drafts (create) render green; modified drafts amber; deletion drafts red; inherited memories stay secondary.
- The right-side sync indicator now covers every local-behind-remote case: a behind draft shows it even when only its base commit changed upstream, conflicts show an orange warning, and non-draft resources whose shared version moved forward (detected against the daemon's synced checkout) show a sync icon and can be synced.

### Document views and Sync
- Documents switch between Preview / Source / Diff via a segmented toolbar control (in-place mode switch, single tab).
- Diff reuses the Reviews unified diff component (`UnifiedDiffView`) and renders a three-way stream: local changes (base -> draft) in green/red, remote changes (base -> latest shared) in gray, conflicts as gray + colored lines. Data comes from the existing `DraftReconciliationCandidate` (`baseState`/`currentState`) for behind drafts, or from the synced checkout for stale non-draft resources.
- A Sync toolbar tool reviews shared changes for behind drafts and refreshes stale resources; the menu wording "Update Draft" was replaced with "Sync".
- Rename-only drafts show a path-change banner (a pure rename has no content diff).
- Removed the document path breadcrumb from the toolbar.

### Bug fixes
- Org-scoped documents with drafts open correctly: the tab no longer leaks the draft's carrying project, so the document is visible outside that project.
- Diff crash on drafts with an empty base (newly created drafts) fixed.

## Known issues (handed off)
- The document Diff pane does not reliably fill the pane height: when the diff content is short the whole VStack (including the tab strip) gets vertically centered. Attempts so far: an outer vertical `ScrollView` wrapper, and a `maxHeight: .infinity` frame on the unified view. The current code gives `documentDiff` a greedy `ScrollView([.vertical])` root (the same pane contract Preview uses). Needs verification on screen; the unified view is kept as a content-sized fragment, matching its Reviews usage.

## Testing
- `xcodebuild test` for the Clumsies scheme passes (daemon build skipped), including new unit tests for the three-way diff builder, the status presentation, and title tones.

## Design note
- The visual model is documented in Memory Space at `工程文档/详细设计/文件树状态颜色与同步指示.md`.