### PR TITLE
agent adapters: remove managed root Stop hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 - **Memory as a Team Asset (Git-Semantic Context)**: Rules, workflows, and project context live as first-class Markdown-backed Memory objects in Org and Project scopes. Changes are proposed as Drafts, verified through Peer Reviews, and merged atomically into immutable Commit history.
 - **Hybrid Retrieval & Precise Activation**: Combines SQLite FTS5 BM25 text search, local dense vector embeddings, Reciprocal Rank Fusion (RRF), and Cross-Encoder reranking. Agents retrieve task-relevant fragments on demand without exhausting token budgets.
 - **Agent-Native Asynchronous Kanban**: Agents autonomously claim tasks (`begin_work`), build dependency DAGs, evaluate blocking predicates, and record structured verification steps. Human approval gates (`approve_closure`) ensure only verified work transitions to Done.
-- **Pure MCP & Lifecycle Hooks**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`) with zero thin-skill pollution.
+- **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.
 - **Self-Hosted Authority**: Run the Rust Server and PostgreSQL in your own infrastructure with organization OIDC, while the local resident daemon owns fast local state and XPC transport.
 
 ---
@@ -47,11 +47,11 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 
 | Agent Host | Protocol Surface | Managed Files | Supported Lifecycle |
 | :--- | :--- | :--- | :--- |
-| **Google Antigravity** | MCP + Lifecycle Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`, `Stop` (Decision Probe) |
-| **Claude Code** | MCP + Lifecycle Hook | `.mcp.json`, `.claude/hooks.json` | `PreInvocation`, `PostInvocation` |
-| **OpenAI Codex** | MCP + Config Hook | `codex.json`, `.codex/hooks/` | Pre/Post Execution |
-| **opencode** | MCP Server | `.opencode/mcp.json` | Task Dispatch |
-| **DeepSeek Harness (dsh)**| Hook Bridge | `.dsh/hooks/` | Run Telemetry & Session Binding |
+| **Google Antigravity** | MCP + Lifecycle Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`; no root `Stop` |
+| **Claude Code** | MCP + Lifecycle Hook | `.mcp.json`, `.claude/settings.json` | Prompt, subagent, failure, and session events; no root `Stop` |
+| **OpenAI Codex** | MCP + Config Hook | `.codex/config.toml`, `.codex/hooks.json` | Prompt, subagent, and session events; no root `Stop` |
+| **opencode** | MCP + Plugin | `opencode.json`, `.opencode/plugins/clumsies.ts` | Prompt, failure, and session events; no normal root `Stop` |
+| **DeepSeek Harness (dsh)** | MCP + Hook Bridge | `.dsh/clumsies.json` | Prompt, failure, and session events; no normal root `Stop` |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 - **记忆即团队资产（Git 语义上下文管理）**：将架构规则、工作流规范与项目上下文收敛为统一的 Markdown 记忆对象，具备精准语义摘要与 Org / Project 命名空间。任何修改通过本地 Draft 提交并经过团队 Review 合并，杜绝静默覆盖。
 - **混合检索与按需精准激活**：深度融合 SQLite FTS5 BM25 全文检索、本地向量嵌入、倒数排名融合（RRF）与交叉编码器（Cross-Encoder）重排。Agent 通过 `activate` 按需动态召回最相关切片，避免上下文窗口浪费。
 - **面向 Agent 的原生异步看板（Issue DAG）**：Agent 通过类型化 MCP 操作自主认领任务（`begin_work`）、构建有向无环依赖图、评估阻塞谓词并沉淀验证步骤。最终必须由人类通过审批关卡（`approve_closure`）验收完成。
-- **纯净 MCP + 生命周期 Hook**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供高性能代理，不注入废弃技能文件。
+- **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。
 - **私有化权威部署**：在自有基础设施中运行 Rust Server 与 PostgreSQL（支持组织 OIDC 鉴权），本地守护进程独立管理高速本地缓存与 XPC 通信。
 
 ---
@@ -47,11 +47,11 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 
 | 智能体宿主 | 协议表面 | 纳管文件 | 支持的生命周期 |
 | :--- | :--- | :--- | :--- |
-| **Google Antigravity** | MCP + 生命周期 Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`, `Stop` (决策探测) |
-| **Claude Code** | MCP + 生命周期 Hook | `.mcp.json`, `.claude/hooks.json` | `PreInvocation`, `PostInvocation` |
-| **OpenAI Codex** | MCP + 配置 Hook | `codex.json`, `.codex/hooks/` | Pre/Post 执行感知 |
-| **opencode** | MCP 服务 | `.opencode/mcp.json` | 任务调度分发 |
-| **DeepSeek Harness (dsh)**| Hook 桥接 | `.dsh/hooks/` | 执行遥测与会话绑定 |
+| **Google Antigravity** | MCP + 生命周期 Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`；无根 `Stop` |
+| **Claude Code** | MCP + 生命周期 Hook | `.mcp.json`, `.claude/settings.json` | prompt、subagent、失败与会话事件；无根 `Stop` |
+| **OpenAI Codex** | MCP + 配置 Hook | `.codex/config.toml`, `.codex/hooks.json` | prompt、subagent 与会话事件；无根 `Stop` |
+| **opencode** | MCP + Plugin | `opencode.json`, `.opencode/plugins/clumsies.ts` | prompt、失败与会话事件；不转发正常根 `Stop` |
+| **DeepSeek Harness (dsh)** | MCP + Hook 桥接 | `.dsh/clumsies.json` | prompt、失败与会话事件；不转发正常根 `Stop` |
 
 ---
 

--- a/apps/macos/Sources/Features/IssueBoardView.swift
+++ b/apps/macos/Sources/Features/IssueBoardView.swift
@@ -1191,13 +1191,13 @@ struct IssueWorkflowHelpPopover: View {
                         workflowStep("kanban.create", detail: "Capture durable work as a native Todo Issue.")
                         workflowStep("kanban.update", detail: "Maintain structured Issue meaning from user feedback.")
                         workflowStep("kanban.begin_work", detail: "Link the hook-provided run_id to an Issue after a semantic decision.")
-                        workflowStep("kanban.request_closure", detail: "Ask for closure only after judging the acceptance criteria satisfied.")
+                        workflowStep("kanban.request_closure", detail: "Call explicitly from a skill or maintained workflow after judging the acceptance criteria satisfied.")
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 Label(
-                    "A Stop hook ends an AgentRun; it never requests, approves, or closes an Issue by itself.",
+                    "Managed adapters do not install normal root Stop hooks. Lifecycle telemetry never requests, approves, or closes an Issue.",
                     systemImage: "exclamationmark.shield"
                 )
                 .font(.callout)

--- a/assets/adapters/opencode/runtime/plugin.ts
+++ b/assets/adapters/opencode/runtime/plugin.ts
@@ -5,7 +5,7 @@ import type { Plugin, PluginInput } from "@opencode-ai/plugin"
  *
  * opencode has no config-file-level hook surface; its lifecycle observation
  * surface is the plugin event bus. This plugin subscribes to session and
- * message events, normalizes them into the same daemon contract that the
+ * message events, normalizes the non-intrusive lifecycle signals that the
  * codex / claude-code shell hooks produce, and forwards each event to
  * `clumsiesd _agent issue-run-event --host opencode` over stdio.
  *
@@ -126,15 +126,15 @@ export const ClumsiesOpencode: Plugin = async (input) => {
         if (info.role === "assistant") {
           state.roles.set(info.id, "assistant")
           if (info.parentID) state.parents.set(info.id, info.parentID)
+          if (!info.error) return
           const time = (info as unknown as { time?: { completed?: number } }).time
           const isFinished = typeof time?.completed === "number"
           if (!isFinished) return
           const parent = info.parentID ?? null
           const rootMessageID = parent ? rootUserMessageID(state, parent) : null
           if (!rootMessageID) return
-          const hasError = !!info.error
           await forward(input.$, cwd, {
-            hook_event_name: hasError ? "StopFailure" : "Stop",
+            hook_event_name: "StopFailure",
             session_id: sessionID,
             message_id: rootMessageID,
           })

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -198,7 +198,10 @@ impl<'de> Deserialize<'de> for ManagedFile {
         let stored = StoredManagedFile::deserialize(deserializer)?;
         if let Some(declared) = &stored.owned_fragments {
             let expected = managed_file_owned_fragments(stored.kind);
-            if declared.iter().map(String::as_str).collect::<Vec<_>>() != expected {
+            let legacy = legacy_managed_file_owned_fragments(stored.kind);
+            if !owned_fragments_match(declared, expected)
+                && !legacy.is_some_and(|legacy| owned_fragments_match(declared, legacy))
+            {
                 return Err(serde::de::Error::custom(
                     "managed adapter manifest declares unexpected owned fragments",
                 ));
@@ -219,7 +222,6 @@ fn managed_file_owned_fragments(kind: ManagedFileKind) -> &'static [&'static str
         }
         ManagedFileKind::CodexHooks | ManagedFileKind::ClaudeSettings => &[
             "hooks.UserPromptSubmit[clumsies-issue-run-event]",
-            "hooks.Stop[clumsies-issue-run-event]",
             "hooks.StopFailure[clumsies-issue-run-event]",
         ],
         ManagedFileKind::ClaudeMcp => &["mcpServers.clumsies"],
@@ -227,12 +229,31 @@ fn managed_file_owned_fragments(kind: ManagedFileKind) -> &'static [&'static str
             &["mcp.clumsies", "plugin[./.opencode/plugins/clumsies.ts]"]
         }
         ManagedFileKind::DshConfig => &["$file"],
-        ManagedFileKind::AntigravityHooks => &[
-            "clumsies-issue-run-event.PreInvocation",
-            "clumsies-issue-run-event.Stop",
-        ],
+        ManagedFileKind::AntigravityHooks => &["clumsies-issue-run-event.PreInvocation"],
         ManagedFileKind::Exclusive => &["$file"],
     }
+}
+
+fn legacy_managed_file_owned_fragments(kind: ManagedFileKind) -> Option<&'static [&'static str]> {
+    match kind {
+        ManagedFileKind::CodexHooks | ManagedFileKind::ClaudeSettings => Some(&[
+            "hooks.UserPromptSubmit[clumsies-issue-run-event]",
+            "hooks.Stop[clumsies-issue-run-event]",
+            "hooks.StopFailure[clumsies-issue-run-event]",
+        ]),
+        ManagedFileKind::AntigravityHooks => Some(&[
+            "clumsies-issue-run-event.PreInvocation",
+            "clumsies-issue-run-event.Stop",
+        ]),
+        _ => None,
+    }
+}
+
+fn owned_fragments_match(declared: &[String], expected: &[&str]) -> bool {
+    declared
+        .iter()
+        .map(String::as_str)
+        .eq(expected.iter().copied())
 }
 
 #[derive(Clone, Debug)]
@@ -2714,7 +2735,17 @@ fn legacy_hook_is_proven_managed(
     }))
 }
 
-const BASE_AGENT_RUN_HOOKS: [(&str, u64); 5] = [
+const BASE_AGENT_RUN_HOOKS: [(&str, u64); 4] = [
+    ("UserPromptSubmit", 5),
+    ("SubagentStart", 5),
+    ("SubagentStop", 5),
+    ("SessionEnd", 3),
+];
+
+// Stop is intentionally absent from fresh installs, but remains in the cleanup
+// set so an update or remove can retire an exact handler owned by an older
+// adapter without touching another tool's Stop hook.
+const REMOVABLE_AGENT_RUN_HOOKS: [(&str, u64); 5] = [
     ("UserPromptSubmit", 5),
     ("Stop", 5),
     ("SubagentStart", 5),
@@ -2793,6 +2824,7 @@ fn render_hook_registry(
         .as_object_mut()
         .ok_or_else(|| adapter_conflict("The hook registry `hooks` value must be an object."))?;
 
+    retire_hook_handler(hooks, "Stop", 5, script_path, ownership)?;
     for &(event, timeout) in &BASE_AGENT_RUN_HOOKS {
         install_hook_handler(hooks, event, timeout, script_path, ownership)?;
     }
@@ -2830,6 +2862,28 @@ fn install_hook_handler(
     Ok(())
 }
 
+fn retire_hook_handler(
+    hooks: &mut Map<String, Value>,
+    event: &str,
+    timeout: u64,
+    script_path: &Path,
+    ownership: HookOwnership,
+) -> Result<(), DaemonError> {
+    let Some(value) = hooks.get_mut(event) else {
+        return Ok(());
+    };
+    let groups = value.as_array_mut().ok_or_else(|| {
+        adapter_conflict(&format!(
+            "The hook registry `{event}` value must be an array."
+        ))
+    })?;
+    remove_owned_hook_handlers(groups, script_path, timeout, ownership)?;
+    if groups.is_empty() {
+        hooks.remove(event);
+    }
+    Ok(())
+}
+
 fn remove_hook_registry(
     content: &[u8],
     script_path: &Path,
@@ -2844,7 +2898,7 @@ fn remove_hook_registry(
         return Ok(Some(content.to_vec()));
     };
 
-    let mut events = BASE_AGENT_RUN_HOOKS
+    let mut events = REMOVABLE_AGENT_RUN_HOOKS
         .iter()
         .map(|(event, _)| *event)
         .collect::<Vec<_>>();
@@ -2878,7 +2932,7 @@ fn remove_hook_registry(
 }
 
 fn timeout_for_event(event: &str) -> u64 {
-    BASE_AGENT_RUN_HOOKS
+    REMOVABLE_AGENT_RUN_HOOKS
         .iter()
         .find_map(|(candidate, timeout)| (*candidate == event).then_some(*timeout))
         .unwrap_or(5)
@@ -3105,45 +3159,29 @@ fn render_antigravity_hooks(
         .as_object_mut()
         .ok_or_else(|| adapter_conflict("The Antigravity hook registry must be a JSON object."))?;
 
-    if let Some(existing_entry) = root_object.get("clumsies-issue-run-event")
-        && !ownership.lifecycle
-        && !antigravity_hook_entry_matches(existing_entry, script_path)
-    {
-        return Err(adapter_conflict(
-            "The Antigravity `clumsies-issue-run-event` hook entry is already registered but is not owned by this Clumsies integration.",
-        ));
+    if let Some(existing_entry) = root_object.get("clumsies-issue-run-event") {
+        if !ownership.lifecycle {
+            return Err(adapter_conflict(
+                "The Antigravity `clumsies-issue-run-event` hook entry is already registered but is not owned by this Clumsies integration.",
+            ));
+        }
+        if !antigravity_hook_entry_matches(existing_entry, script_path) {
+            return Err(adapter_conflict(
+                "The managed Antigravity `clumsies-issue-run-event` hook entry changed after installation.",
+            ));
+        }
     }
 
-    let hook_entry = root_object
-        .entry("clumsies-issue-run-event")
-        .or_insert_with(|| Value::Object(Map::new()))
-        .as_object_mut()
-        .ok_or_else(|| {
-            adapter_conflict(
-                "The Antigravity `clumsies-issue-run-event` entry must be a JSON object.",
-            )
-        })?;
-
     let hook_cmd = hook_command(script_path);
-    hook_entry.insert(
-        "PreInvocation".to_owned(),
-        json!([
-            {
+    root_object.insert(
+        "clumsies-issue-run-event".to_owned(),
+        json!({
+            "PreInvocation": [{
                 "type": "command",
                 "command": hook_cmd,
                 "timeout": 5
-            }
-        ]),
-    );
-    hook_entry.insert(
-        "Stop".to_owned(),
-        json!([
-            {
-                "type": "command",
-                "command": hook_cmd,
-                "timeout": 5
-            }
-        ]),
+            }]
+        }),
     );
 
     render_json(&root)
@@ -3176,18 +3214,33 @@ fn remove_antigravity_hooks(
 }
 
 fn antigravity_hook_entry_matches(entry: &Value, script_path: &Path) -> bool {
+    antigravity_current_hook_entry_matches(entry, script_path)
+        || antigravity_legacy_hook_entry_matches(entry, script_path)
+}
+
+fn antigravity_current_hook_entry_matches(entry: &Value, script_path: &Path) -> bool {
     let Some(object) = entry.as_object() else {
         return false;
     };
-    let pre_matches = object
-        .get("PreInvocation")
-        .and_then(Value::as_array)
-        .is_some_and(|arr| arr.len() == 1 && is_exact_command_handler(&arr[0], script_path, 5));
+    object.len() == 1 && antigravity_pre_invocation_matches(object, script_path)
+}
+
+fn antigravity_legacy_hook_entry_matches(entry: &Value, script_path: &Path) -> bool {
+    let Some(object) = entry.as_object() else {
+        return false;
+    };
     let stop_matches = object
         .get("Stop")
         .and_then(Value::as_array)
         .is_some_and(|arr| arr.len() == 1 && is_exact_command_handler(&arr[0], script_path, 5));
-    pre_matches && stop_matches
+    object.len() == 2 && antigravity_pre_invocation_matches(object, script_path) && stop_matches
+}
+
+fn antigravity_pre_invocation_matches(object: &Map<String, Value>, script_path: &Path) -> bool {
+    object
+        .get("PreInvocation")
+        .and_then(Value::as_array)
+        .is_some_and(|arr| arr.len() == 1 && is_exact_command_handler(&arr[0], script_path, 5))
 }
 
 fn render_codex_config(
@@ -4339,6 +4392,7 @@ mod tests {
         assert!(prompt_commands.contains(&foreign_same_host.as_str()));
         assert!(prompt_commands.contains(&"echo foreign"));
         let stop_commands = hook_commands(&rendered, "Stop");
+        assert!(!stop_commands.contains(&current_command.as_str()));
         assert!(stop_commands.contains(&foreign_lifecycle.as_str()));
         assert!(stop_commands.contains(&"echo stop foreign"));
         if include_stop_failure {
@@ -4465,6 +4519,87 @@ mod tests {
             serde_json::from_value::<AdapterManifest>(serialized).unwrap(),
             manifest
         );
+    }
+
+    #[test]
+    fn hook_manifests_omit_stop_and_accept_only_the_exact_legacy_fragment_sets() {
+        let cases: [(ManagedFileKind, &str, &[&str], &[&str]); 3] = [
+            (
+                ManagedFileKind::CodexHooks,
+                "codex_hooks",
+                &[
+                    "hooks.UserPromptSubmit[clumsies-issue-run-event]",
+                    "hooks.StopFailure[clumsies-issue-run-event]",
+                ],
+                &[
+                    "hooks.UserPromptSubmit[clumsies-issue-run-event]",
+                    "hooks.Stop[clumsies-issue-run-event]",
+                    "hooks.StopFailure[clumsies-issue-run-event]",
+                ],
+            ),
+            (
+                ManagedFileKind::ClaudeSettings,
+                "claude_settings",
+                &[
+                    "hooks.UserPromptSubmit[clumsies-issue-run-event]",
+                    "hooks.StopFailure[clumsies-issue-run-event]",
+                ],
+                &[
+                    "hooks.UserPromptSubmit[clumsies-issue-run-event]",
+                    "hooks.Stop[clumsies-issue-run-event]",
+                    "hooks.StopFailure[clumsies-issue-run-event]",
+                ],
+            ),
+            (
+                ManagedFileKind::AntigravityHooks,
+                "antigravity_hooks",
+                &["clumsies-issue-run-event.PreInvocation"],
+                &[
+                    "clumsies-issue-run-event.PreInvocation",
+                    "clumsies-issue-run-event.Stop",
+                ],
+            ),
+        ];
+
+        for (kind, wire_kind, expected, legacy) in cases {
+            let managed = ManagedFile {
+                path: "/tmp/workspace/hooks.json".to_owned(),
+                kind,
+                installed_hash: "installed-hash".to_owned(),
+            };
+            let serialized = serde_json::to_value(&managed).unwrap();
+            assert_eq!(serialized["owned_fragments"], json!(expected));
+            assert!(
+                serialized["owned_fragments"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|fragment| !fragment.as_str().unwrap().ends_with(".Stop")
+                        && !fragment.as_str().unwrap().starts_with("hooks.Stop["))
+            );
+            assert_eq!(
+                serde_json::from_value::<ManagedFile>(serialized).unwrap(),
+                managed
+            );
+
+            let legacy_manifest = json!({
+                "path": "/tmp/workspace/hooks.json",
+                "kind": wire_kind,
+                "installed_hash": "installed-hash",
+                "owned_fragments": legacy,
+            });
+            assert_eq!(
+                serde_json::from_value::<ManagedFile>(legacy_manifest.clone()).unwrap(),
+                managed
+            );
+
+            let mut forged = legacy_manifest;
+            forged["owned_fragments"]
+                .as_array_mut()
+                .unwrap()
+                .push(Value::String("foreign.fragment".to_owned()));
+            assert!(serde_json::from_value::<ManagedFile>(forged).is_err());
+        }
     }
 
     #[cfg(unix)]
@@ -4821,6 +4956,81 @@ mod tests {
     }
 
     #[test]
+    fn fresh_hook_install_rejects_an_unowned_local_stop_handler() {
+        for (script, include_stop_failure) in [
+            (
+                Path::new("/tmp/workspace/.codex/hooks/issue-run-event.sh"),
+                false,
+            ),
+            (
+                Path::new("/tmp/workspace/.claude/hooks/issue-run-event.sh"),
+                true,
+            ),
+        ] {
+            let existing = render_json(&json!({
+                "hooks": {
+                    "Stop": [{
+                        "hooks": [{
+                            "type": "command",
+                            "command": hook_command(script),
+                            "timeout": 5
+                        }]
+                    }]
+                }
+            }))
+            .unwrap();
+            let error = render_hook_registry(
+                Some(&existing),
+                script,
+                include_stop_failure,
+                HookOwnership::default(),
+            )
+            .unwrap_err();
+            assert!(matches!(
+                error,
+                DaemonError::State {
+                    code: "project_agent_adapter_conflict",
+                    ..
+                }
+            ));
+        }
+    }
+
+    #[test]
+    fn remove_hook_registry_still_retires_an_old_managed_stop_handler() {
+        let script = Path::new("/tmp/workspace/.codex/hooks/issue-run-event.sh");
+        let existing = render_json(&json!({
+            "theme": "dark",
+            "hooks": {
+                "Stop": [
+                    {
+                        "hooks": [{
+                            "type": "command",
+                            "command": hook_command(script),
+                            "timeout": 5
+                        }]
+                    },
+                    {
+                        "hooks": [{
+                            "type": "command",
+                            "command": "echo foreign",
+                            "timeout": 5
+                        }]
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+
+        let removed = remove_hook_registry(&existing, script, false)
+            .unwrap()
+            .unwrap();
+        let removed: Value = serde_json::from_slice(&removed).unwrap();
+        assert_eq!(removed["theme"], "dark");
+        assert_eq!(hook_commands(&removed, "Stop"), vec!["echo foreign"]);
+    }
+
+    #[test]
     fn managed_hook_and_resolver_pin_the_bundled_daemon_runtime() {
         let runtime = "/Applications/Clumsies App.app/Contents/Resources/clumsiesd";
         let rendered =
@@ -4858,6 +5068,16 @@ mod tests {
         assert!(codex.iter().any(|change| {
             change.path.ends_with(".codex/hooks/issue-run-event.sh") && change.mode == 0o755
         }));
+        let codex_registry: Value = serde_json::from_slice(
+            codex
+                .iter()
+                .find(|change| change.path.ends_with(".codex/hooks.json"))
+                .and_then(|change| change.desired.as_deref())
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(codex_registry["hooks"].get("Stop").is_none());
+        assert!(codex_registry["hooks"].get("StopFailure").is_none());
 
         let claude = install_plan(
             ProjectAgentAdapterKind::ClaudeCode,
@@ -4873,6 +5093,16 @@ mod tests {
         assert!(claude.iter().any(|change| {
             change.path.ends_with(".claude/hooks/issue-run-event.sh") && change.mode == 0o755
         }));
+        let claude_registry: Value = serde_json::from_slice(
+            claude
+                .iter()
+                .find(|change| change.path.ends_with(".claude/settings.json"))
+                .and_then(|change| change.desired.as_deref())
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(claude_registry["hooks"].get("Stop").is_none());
+        assert_eq!(hook_commands(&claude_registry, "StopFailure").len(), 1);
     }
 
     #[test]
@@ -5049,6 +5279,9 @@ mod tests {
                 .contains("return \"/Applications/Clumsies App.app/Contents/Resources/clumsiesd\"")
         );
         assert!(!rendered.contains("process.env.CLUMSIES_BINARY"));
+        assert!(rendered.contains(r#"hook_event_name: "StopFailure""#));
+        assert!(!rendered.contains(r#"hook_event_name: "Stop""#));
+        assert!(!rendered.contains(r#"hasError ? "StopFailure" : "Stop""#));
     }
 
     #[test]
@@ -5376,7 +5609,7 @@ name: legacy
 
         let hooks_json: Value = serde_json::from_slice(&fs::read(&hooks_path).unwrap()).unwrap();
         assert!(hooks_json["clumsies-issue-run-event"]["PreInvocation"].is_array());
-        assert!(hooks_json["clumsies-issue-run-event"]["Stop"].is_array());
+        assert!(hooks_json["clumsies-issue-run-event"].get("Stop").is_none());
 
         let manifest = manifest_for_changes(&changes, helper, "helper-hash".to_owned());
         let removals = remove_plan(&manifest, workspace.path()).unwrap();
@@ -5388,6 +5621,132 @@ name: legacy
         assert!(!hook_path.exists());
         cleanup_empty_adapter_directories(&removals, workspace.path());
         assert!(!workspace.path().join(".agents").exists());
+    }
+
+    #[test]
+    fn antigravity_update_retires_legacy_stop_and_preserves_foreign_entries() {
+        let script = Path::new("/tmp/workspace/.agents/hooks/issue-run-event.sh");
+        let command = hook_command(script);
+        let legacy = render_json(&json!({
+            "lint-checker": {
+                "PostToolUse": [{"type": "command", "command": "./lint.sh"}]
+            },
+            "clumsies-issue-run-event": {
+                "PreInvocation": [{
+                    "type": "command",
+                    "command": command,
+                    "timeout": 5
+                }],
+                "Stop": [{
+                    "type": "command",
+                    "command": command,
+                    "timeout": 5
+                }]
+            }
+        }))
+        .unwrap();
+
+        let migrated = render_antigravity_hooks(
+            Some(&legacy),
+            script,
+            HookOwnership {
+                lifecycle: true,
+                legacy_prompt: false,
+            },
+        )
+        .unwrap();
+        let migrated_value: Value = serde_json::from_slice(&migrated).unwrap();
+        assert!(migrated_value.get("lint-checker").is_some());
+        assert!(migrated_value["clumsies-issue-run-event"]["PreInvocation"].is_array());
+        assert!(
+            migrated_value["clumsies-issue-run-event"]
+                .get("Stop")
+                .is_none()
+        );
+        assert_eq!(
+            render_antigravity_hooks(
+                Some(&migrated),
+                script,
+                HookOwnership {
+                    lifecycle: true,
+                    legacy_prompt: false,
+                },
+            )
+            .unwrap(),
+            migrated
+        );
+
+        let removed = remove_antigravity_hooks(&migrated, script)
+            .unwrap()
+            .unwrap();
+        let removed: Value = serde_json::from_slice(&removed).unwrap();
+        assert!(removed.get("lint-checker").is_some());
+        assert!(removed.get("clumsies-issue-run-event").is_none());
+    }
+
+    #[test]
+    fn antigravity_update_rejects_drifted_or_foreign_named_entries() {
+        let script = Path::new("/tmp/workspace/.agents/hooks/issue-run-event.sh");
+        let drifted = render_json(&json!({
+            "clumsies-issue-run-event": {
+                "PreInvocation": [{
+                    "type": "command",
+                    "command": hook_command(script),
+                    "timeout": 9
+                }],
+                "Stop": [{
+                    "type": "command",
+                    "command": hook_command(script),
+                    "timeout": 5
+                }]
+            }
+        }))
+        .unwrap();
+        assert!(
+            render_antigravity_hooks(
+                Some(&drifted),
+                script,
+                HookOwnership {
+                    lifecycle: true,
+                    legacy_prompt: false,
+                },
+            )
+            .is_err()
+        );
+
+        let unowned_legacy = render_json(&json!({
+            "clumsies-issue-run-event": {
+                "PreInvocation": [{
+                    "type": "command",
+                    "command": hook_command(script),
+                    "timeout": 5
+                }],
+                "Stop": [{
+                    "type": "command",
+                    "command": hook_command(script),
+                    "timeout": 5
+                }]
+            }
+        }))
+        .unwrap();
+        assert!(
+            render_antigravity_hooks(Some(&unowned_legacy), script, HookOwnership::default(),)
+                .is_err()
+        );
+
+        let foreign = render_json(&json!({
+            "clumsies-issue-run-event": {
+                "PreInvocation": [{
+                    "type": "command",
+                    "command": "./foreign.sh",
+                    "timeout": 5
+                }]
+            }
+        }))
+        .unwrap();
+        assert!(
+            render_antigravity_hooks(Some(&foreign), script, HookOwnership::default(),).is_err()
+        );
     }
 
     #[test]

--- a/crates/daemon/src/agent_runtime/hook.rs
+++ b/crates/daemon/src/agent_runtime/hook.rs
@@ -59,7 +59,7 @@ impl HookHost {
             Self::ClaudeCode => "prompt_id",
             Self::Opencode => "message_id",
             // The dsh plugin mints one turn id per user prompt and reuses it
-            // for the matching Stop event, mirroring the codex turn model.
+            // for a matching failure event, mirroring the codex turn model.
             Self::Dsh => "turn_id",
             Self::Antigravity => "turn_id",
         }
@@ -114,7 +114,6 @@ pub struct NormalizedHookEvent {
     outcome: Option<AgentRunOutcome>,
     display_label: Option<String>,
     workspace_path: Option<String>,
-    stop_hook_active: bool,
 }
 
 impl NormalizedHookEvent {
@@ -160,10 +159,6 @@ impl NormalizedHookEvent {
         self.workspace_path.as_deref()
     }
 
-    pub fn stop_hook_active(&self) -> bool {
-        self.stop_hook_active
-    }
-
     pub fn to_record_request(&self, project_id: impl Into<String>) -> RecordAgentRunEventRequest {
         RecordAgentRunEventRequest {
             event_id: self.event_id.clone(),
@@ -182,29 +177,6 @@ impl NormalizedHookEvent {
             summary: None,
             occurred_at: None,
         }
-    }
-
-    /// Turn the first supported Stop into a durable, non-terminal decision
-    /// probe. The host's follow-up Stop keeps the original event id and ends
-    /// the run, so transport replay cannot emit the continuation twice.
-    pub fn to_stop_probe_request(
-        &self,
-        project_id: impl Into<String>,
-    ) -> Option<RecordAgentRunEventRequest> {
-        if self.hook_event_name != HookEventName::Stop
-            || self.stop_hook_active
-            || !matches!(
-                self.host,
-                HookHost::Codex | HookHost::ClaudeCode | HookHost::Antigravity
-            )
-        {
-            return None;
-        }
-        let mut request = self.to_record_request(project_id);
-        request.event_id.push_str("_probe");
-        request.event_type = AgentRunEventType::Heartbeat;
-        request.outcome = None;
-        Some(request)
     }
 }
 
@@ -262,6 +234,8 @@ fn normalize_object(
             host_run_key = Some(root_run_key(host, object)?);
             AgentRunEventType::Started
         }
+        // Kept as an input compatibility path for existing/manual bridges.
+        // Managed adapters no longer register a normal root Stop hook.
         HookEventName::Stop => {
             kind = Some(AgentRunKind::Root);
             host_run_key = Some(root_run_key(host, object)?);
@@ -317,7 +291,6 @@ fn normalize_object(
         outcome,
         display_label,
         workspace_path,
-        stop_hook_active: bool_field(object, "stop_hook_active").unwrap_or(false),
     })
 }
 
@@ -409,10 +382,6 @@ fn bounded_display_label(value: &str) -> Option<String> {
 
 fn string_field<'a>(object: &'a Map<String, Value>, name: &str) -> Option<&'a str> {
     object.get(name)?.as_str()
-}
-
-fn bool_field(object: &Map<String, Value>, name: &str) -> Option<bool> {
-    object.get(name)?.as_bool()
 }
 
 #[cfg(test)]
@@ -592,17 +561,15 @@ mod tests {
     }
 
     #[test]
-    fn first_supported_stop_has_a_distinct_non_terminal_probe() {
+    fn legacy_root_stop_is_terminal_without_a_decision_probe() {
         let event = normalize_hook_event(
             HookHost::Codex,
-            br#"{"session_id":"thr_1","turn_id":"turn_7","hook_event_name":"Stop","stop_hook_active":false}"#,
+            br#"{"session_id":"thr_1","turn_id":"turn_7","hook_event_name":"Stop"}"#,
         )
         .unwrap();
-        let probe = event.to_stop_probe_request("prj_test").unwrap();
-        let final_event = event.to_record_request("prj_test");
-        assert_eq!(probe.event_type, AgentRunEventType::Heartbeat);
-        assert_eq!(final_event.event_type, AgentRunEventType::Ended);
-        assert_ne!(probe.event_id, final_event.event_id);
+        let request = event.to_record_request("prj_test");
+        assert_eq!(request.event_type, AgentRunEventType::Ended);
+        assert!(!request.event_id.ends_with("_probe"));
     }
 
     #[test]
@@ -645,8 +612,5 @@ mod tests {
         .unwrap();
         assert_eq!(failure.host_run_key(), Some("root:turn_43"));
         assert_eq!(failure.outcome(), Some(AgentRunOutcome::Failed));
-
-        let probe = stopped.to_stop_probe_request("prj_test").unwrap();
-        assert_eq!(probe.event_type, AgentRunEventType::Heartbeat);
     }
 }

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -163,19 +163,6 @@ fn run_hook_proxy(host: HookHost) -> Result<(), Box<dyn std::error::Error>> {
     verify_agent_runtime(&client)?;
     let binding =
         client.resolve_project_binding(DaemonProjectBindingResolveRequest { workspace_path })?;
-    if should_offer_stop_decision(host, &event) {
-        let probe = event
-            .to_stop_probe_request(&binding.project_id)
-            .ok_or("Stop event did not produce a decision probe")?;
-        let response = client.record_agent_run_event(probe)?;
-        if !response.duplicate {
-            write_hook_output(&json!({
-                "decision": "block",
-                "reason": "Before stopping, make the explicit semantic Issue decision now. If the current root task is linked to an In Progress Issue and its acceptance criteria are satisfied, call kanban.request_closure with the current run_id and AgentRun revision. Otherwise leave it In Progress. Stop itself never completes or advances an Issue."
-            }))?;
-        }
-        return Ok(());
-    }
     let response = client.record_agent_run_event(event.to_record_request(&binding.project_id))?;
     if response.duplicate {
         return Ok(());
@@ -263,14 +250,6 @@ fn agent_runtime_matches(resident: &daemon::AgentRuntimeIdentity) -> bool {
         && resident.build_id == daemon::agent_runtime::AGENT_RUNTIME_BUILD_ID
 }
 
-fn should_offer_stop_decision(host: HookHost, event: &NormalizedHookEvent) -> bool {
-    matches!(host, HookHost::Codex | HookHost::ClaudeCode)
-        && event.hook_event_name() == HookEventName::Stop
-        && !event.stop_hook_active()
-        && std::env::var_os("CLUMSIES_HOOK_FORCE_FINAL_STOP").as_deref()
-            != Some(std::ffi::OsStr::new("1"))
-}
-
 fn hook_context(
     client: &DaemonIpcClient,
     project_id: &str,
@@ -307,11 +286,11 @@ fn hook_context(
         .unwrap_or_else(|| "This run is not bound to any Issue yet. ".to_owned());
     let context = match run.kind {
         AgentRunKind::Root => format!(
-            "Clumsies current root AgentRun: run_id={}, revision={}. {}Decide semantically whether this prompt continues an existing native Issue, creates a new durable Issue, or should not become an Issue; never infer that from text matching. Use kanban.list to inspect existing Issues and kanban.create to capture a new one. Before calling kanban.begin_work, check the Issue's active_runs via kanban.get: another AgentRun may already hold it, so claim only the Issue this run is actually working. Call kanban.begin_work with this run_id and revision only when the Issue is the active line of work. Before finishing, call kanban.request_closure only when the linked Issue's acceptance criteria are satisfied; otherwise leave it In Progress. AgentRun Stop never advances, approves, or closes an Issue.",
+            "Clumsies current root AgentRun: run_id={}, revision={}. {}Decide semantically whether this prompt continues an existing native Issue, creates a new durable Issue, or should not become an Issue; never infer that from text matching. Use kanban.list to inspect existing Issues and kanban.create to capture a new one. Before calling kanban.begin_work, check the Issue's active_runs via kanban.get: another AgentRun may already hold it, so claim only the Issue this run is actually working. Call kanban.begin_work with this run_id and revision only when the Issue is the active line of work.",
             run.run_id, run.revision, binding
         ),
         AgentRunKind::Subagent => format!(
-            "Clumsies current subagent AgentRun: run_id={}, revision={}. {}Call kanban.begin_work only when this subagent is explicitly working an existing native Issue. Subagents must not request Issue closure; report findings to the root Agent. AgentRun Stop never advances or closes an Issue.",
+            "Clumsies current subagent AgentRun: run_id={}, revision={}. {}Call kanban.begin_work only when this subagent is explicitly working an existing native Issue. Subagents must not request Issue closure; report findings to the root Agent.",
             run.run_id, run.revision, binding
         ),
     };

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -1080,6 +1080,25 @@ pub(crate) async fn record_agent_run_event(
             existing.run_id, existing.kind
         )));
     }
+    let mut affected_runs = if request.source == AgentRunEventSource::Hook
+        && request.event_type == AgentRunEventType::Started
+        && kind == AgentRunKind::Root
+        && existing.is_none()
+        && let Some(host_session_id) = request.host_session_id.as_deref()
+    {
+        recover_prior_root_runs_for_new_hook_turn(
+            &mut tx,
+            &request.project_id,
+            request.host,
+            host_session_id,
+            host_run_key,
+            &received_at,
+            &occurred_at,
+        )
+        .await?
+    } else {
+        Vec::new()
+    };
     let parent = resolve_parent_run(&mut tx, &request, kind).await?;
     let explicit_issue_number = request
         .issue_key
@@ -1190,11 +1209,71 @@ pub(crate) async fn record_agent_run_event(
     .await?;
     tx.commit().await?;
     let response_run = run.clone();
+    affected_runs.push(run);
     Ok(RecordAgentRunEventResponse {
         run: Some(response_run),
-        affected_runs: vec![run],
+        affected_runs,
         duplicate: false,
     })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn recover_prior_root_runs_for_new_hook_turn(
+    tx: &mut Transaction<'_, Sqlite>,
+    project_id: &str,
+    host: AgentRunHost,
+    host_session_id: &str,
+    new_host_run_key: &str,
+    received_at: &str,
+    occurred_at: &str,
+) -> Result<Vec<AgentRun>, DaemonError> {
+    let rows = sqlx::query(
+        "SELECT run_id, project_id, issue_number, host, host_run_key, host_session_id,
+                parent_run_id, kind, phase, outcome, end_reason, display_label, summary,
+                revision, started_at, last_seen_at, lease_expires_at, ended_at
+         FROM agent_runs
+         WHERE project_id = $1 AND host = $2 AND host_session_id = $3
+           AND host_run_key <> $4 AND kind = 'root' AND phase = 'running'
+         ORDER BY last_seen_at DESC, run_id DESC",
+    )
+    .bind(project_id)
+    .bind(host.as_str())
+    .bind(host_session_id)
+    .bind(new_host_run_key)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut recovered = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut run = agent_run_from_row(&row)?;
+        run.phase = AgentRunPhase::Ended;
+        if run.end_reason.as_deref() != Some(AGENT_REPORT_REASON) {
+            run.outcome = Some(AgentRunOutcome::Unknown);
+            run.end_reason = Some(RECOVERED_END_REASON.to_owned());
+        }
+        run.revision += 1;
+        run.last_seen_at = received_at.to_owned();
+        if run.ended_at.is_none() {
+            run.ended_at = Some(occurred_at.to_owned());
+        }
+        update_run(tx, &run).await?;
+        insert_event(
+            tx,
+            &format!("arevt_{}", Uuid::new_v4().simple()),
+            None,
+            Some(&run.run_id),
+            run.host_session_id.as_deref(),
+            AgentRunEventType::Ended,
+            AgentRunEventSource::Recovery,
+            run.issue_number,
+            run.outcome,
+            None,
+            occurred_at,
+        )
+        .await?;
+        recovered.push(run);
+    }
+    Ok(recovered)
 }
 
 pub(crate) async fn start_issue_work(
@@ -4857,6 +4936,179 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn new_hook_root_turn_recovers_previous_bound_root_and_can_take_over_issue() {
+        let pool = run_pool().await;
+        native_issue(&pool, "project-1", 3).await;
+
+        let first = record_agent_run_event(
+            &pool,
+            lifecycle_request(
+                "hook_turn_one_start",
+                Some("root:turn-one"),
+                AgentRunEventType::Started,
+            ),
+        )
+        .await
+        .unwrap()
+        .run
+        .unwrap();
+        let first = start_issue_work(
+            &pool,
+            StartIssueWorkRequest {
+                project_id: "project-1".to_owned(),
+                run_id: Some(first.run_id),
+                issue_key: "ISSUE-003".to_owned(),
+                expected_revision: Some(first.revision),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap()
+        .run
+        .unwrap();
+
+        let second_request = lifecycle_request(
+            "hook_turn_two_start",
+            Some("root:turn-two"),
+            AgentRunEventType::Started,
+        );
+        let second_response = record_agent_run_event(&pool, second_request.clone())
+            .await
+            .unwrap();
+        let second = second_response.run.unwrap();
+        assert_eq!(second.phase, AgentRunPhase::Running);
+        assert_eq!(second.issue_number, None);
+        assert_eq!(second_response.affected_runs.len(), 2);
+        let recovered = &second_response.affected_runs[0];
+        assert_eq!(recovered.run_id, first.run_id);
+        assert_eq!(recovered.phase, AgentRunPhase::Ended);
+        assert_eq!(recovered.outcome, Some(AgentRunOutcome::Unknown));
+        assert_eq!(recovered.end_reason.as_deref(), Some(RECOVERED_END_REASON));
+        assert_eq!(recovered.revision, first.revision + 1);
+        assert_eq!(second_response.affected_runs[1].run_id, second.run_id);
+
+        let duplicate = record_agent_run_event(&pool, second_request).await.unwrap();
+        assert!(duplicate.duplicate);
+        assert_eq!(duplicate.affected_runs.len(), 1);
+        assert_eq!(duplicate.affected_runs[0].run_id, second.run_id);
+        assert_eq!(
+            load_agent_run(&pool, &first.run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .revision,
+            recovered.revision
+        );
+        let recovery_events: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM agent_run_events
+             WHERE run_id = $1 AND event_type = 'ended' AND source = 'recovery'",
+        )
+        .bind(&first.run_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(recovery_events, 1);
+
+        let taken_over = start_issue_work(
+            &pool,
+            StartIssueWorkRequest {
+                project_id: "project-1".to_owned(),
+                run_id: Some(second.run_id.clone()),
+                issue_key: "ISSUE-003".to_owned(),
+                expected_revision: Some(second.revision),
+                session_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(taken_over.board_state, IssueBoardState::InProgress);
+        assert_eq!(
+            taken_over.run.as_ref().map(|run| run.run_id.as_str()),
+            Some(second.run_id.as_str())
+        );
+        assert_eq!(taken_over.run.unwrap().issue_number, Some(3));
+    }
+
+    #[tokio::test]
+    async fn same_key_subagent_and_mcp_manual_starts_do_not_recover_root_runs() {
+        let pool = run_pool().await;
+        let root_request = lifecycle_request(
+            "hook_same_key_start",
+            Some("root:same-key"),
+            AgentRunEventType::Started,
+        );
+        let root = record_agent_run_event(&pool, root_request)
+            .await
+            .unwrap()
+            .run
+            .unwrap();
+
+        let same_key = record_agent_run_event(
+            &pool,
+            lifecycle_request(
+                "hook_same_key_heartbeat",
+                Some("root:same-key"),
+                AgentRunEventType::Started,
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(same_key.affected_runs.len(), 1);
+        assert_eq!(same_key.run.as_ref().unwrap().run_id, root.run_id);
+        assert_eq!(same_key.run.as_ref().unwrap().phase, AgentRunPhase::Running);
+
+        let mut child_request = lifecycle_request(
+            "hook_child_new_key",
+            Some("subagent:session-1:new-child"),
+            AgentRunEventType::Started,
+        );
+        child_request.kind = Some(AgentRunKind::Subagent);
+        child_request.parent_host_run_key = Some("root:same-key".to_owned());
+        let child = record_agent_run_event(&pool, child_request).await.unwrap();
+        assert_eq!(child.affected_runs.len(), 1);
+        assert_eq!(
+            load_agent_run(&pool, &root.run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .phase,
+            AgentRunPhase::Running
+        );
+
+        let mut first_manual = lifecycle_request(
+            "mcp_manual_one_start",
+            Some("manual:turn-one"),
+            AgentRunEventType::Started,
+        );
+        first_manual.host = AgentRunHost::Manual;
+        first_manual.source = AgentRunEventSource::Mcp;
+        first_manual.host_session_id = Some("manual-session".to_owned());
+        let first_manual = record_agent_run_event(&pool, first_manual)
+            .await
+            .unwrap()
+            .run
+            .unwrap();
+        let mut second_manual = lifecycle_request(
+            "mcp_manual_two_start",
+            Some("manual:turn-two"),
+            AgentRunEventType::Started,
+        );
+        second_manual.host = AgentRunHost::Manual;
+        second_manual.source = AgentRunEventSource::Mcp;
+        second_manual.host_session_id = Some("manual-session".to_owned());
+        let second_manual = record_agent_run_event(&pool, second_manual).await.unwrap();
+        assert_eq!(second_manual.affected_runs.len(), 1);
+        assert_eq!(
+            load_agent_run(&pool, &first_manual.run_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .phase,
+            AgentRunPhase::Running
+        );
+    }
+
+    #[tokio::test]
     async fn event_id_requires_an_identical_full_request_fingerprint() {
         let pool = run_pool().await;
         let request = lifecycle_request(
@@ -5382,8 +5634,18 @@ mod tests {
         .unwrap();
         assert_eq!(started.board_state, IssueBoardState::InProgress);
 
-        // The same session cannot start the second Issue while the first is In Progress.
-        let run_a2 = session_hook_start(&pool, "session_a_2", "root:a2", "session-a").await;
+        // A non-Hook run in the same session cannot start the second Issue
+        // while the first is In Progress. Hook root turns use rollover
+        // recovery; MCP/manual starts deliberately do not.
+        let mut run_a2_request =
+            lifecycle_request("session_a_2", Some("root:a2"), AgentRunEventType::Started);
+        run_a2_request.source = AgentRunEventSource::Mcp;
+        run_a2_request.host_session_id = Some("session-a".to_owned());
+        let run_a2 = record_agent_run_event(&pool, run_a2_request)
+            .await
+            .unwrap()
+            .run
+            .unwrap();
         let conflict = start_issue_work(
             &pool,
             StartIssueWorkRequest {
@@ -6898,26 +7160,16 @@ mod tests {
             }
         ));
 
-        // A second hook run cannot claim another Issue while the session
-        // holds an In Progress one.
-        let second = record_agent_run_event(
-            &pool,
-            lifecycle_request(
-                "hook_claim_start_2",
-                Some("root:claim-2"),
-                AgentRunEventType::Started,
-            ),
-        )
-        .await
-        .unwrap()
-        .run
-        .unwrap();
+        // A hook run from another session cannot claim the same Issue while
+        // the first run remains active.
+        let second =
+            session_hook_start(&pool, "hook_claim_start_2", "root:claim-2", "session-2").await;
         let error = start_issue_work(
             &pool,
             StartIssueWorkRequest {
                 project_id: "project-1".to_owned(),
                 run_id: Some(second.run_id),
-                issue_key: "ISSUE-004".to_owned(),
+                issue_key: "ISSUE-003".to_owned(),
                 expected_revision: Some(second.revision),
                 session_id: None,
             },
@@ -7524,18 +7776,13 @@ mod tests {
         .await
         .unwrap();
         // Another run whose Issue is closed while it is still running.
-        let closed = record_agent_run_event(
+        let closed = session_hook_start(
             &pool,
-            lifecycle_request(
-                "hook_reaper_closed",
-                Some("root:closed"),
-                AgentRunEventType::Started,
-            ),
+            "hook_reaper_closed",
+            "root:closed",
+            "reaper-closed-session",
         )
-        .await
-        .unwrap()
-        .run
-        .unwrap();
+        .await;
         start_issue_work(
             &pool,
             StartIssueWorkRequest {

--- a/dev/dsh/clumsies-hook.mjs
+++ b/dev/dsh/clumsies-hook.mjs
@@ -1,9 +1,8 @@
 // DSH → Clumsies hook bridge.
 //
 // Forwards web-session lifecycle events to the local Clumsies daemon so it
-// can issue and end `dsh` AgentRuns (kanban.begin_work / request_closure
-// require a hook-issued run). Fail-open: a missing daemon or a failed
-// forward never blocks the session.
+// can issue `dsh` AgentRuns and end them on failure or session disposal.
+// Fail-open: a missing daemon or a failed forward never blocks the session.
 //
 // Install: copy to ~/.dsh/profiles/web/clumsies-hook.mjs and add to
 // cordis.patch.yml:
@@ -27,10 +26,6 @@
 // - The payload must reach the hook proxy via stdin, so we use spawn() and
 //   write the JSON ourselves — async execFile() has no input option and the
 //   child would block on stdin forever.
-// - A turn interrupted by the next prompt may never emit turn/end (dsh does
-//   not close cancelled turns). The plugin tracks the open turn per session
-//   and, on the next turn/start, first closes the stale run with a Stop so
-//   no dsh run stays 'running' until the daemon's lease reaper.
 // - Diagnostics are opt-in via CLUMSIES_HOOK_LOG (default: off).
 
 import { spawn } from 'node:child_process'
@@ -77,32 +72,69 @@ function log(line) {
 }
 
 function forward(payload, runtime) {
-  const bin = runtime || process.env.CLUMSIES_BIN || DEFAULT_BIN
-  const input = JSON.stringify(payload)
-  log('forward ' + input.slice(0, 140))
-  const child = spawn(bin, ['_agent', 'issue-run-event', '--host', 'dsh'], {
-    stdio: ['pipe', 'ignore', 'pipe'],
-    windowsHide: true,
+  return new Promise((resolve) => {
+    const bin = runtime || process.env.CLUMSIES_BIN || DEFAULT_BIN
+    const input = JSON.stringify(payload)
+    log('forward ' + input.slice(0, 140))
+    let child
+    try {
+      child = spawn(bin, ['_agent', 'issue-run-event', '--host', 'dsh'], {
+        stdio: ['pipe', 'ignore', 'pipe'],
+        windowsHide: true,
+      })
+    } catch (err) {
+      log('forward spawn error: ' + (err.message || err).slice(0, 200))
+      resolve()
+      return
+    }
+    let stderr = ''
+    let settled = false
+    let watchdog
+    const settle = () => {
+      if (settled) return
+      settled = true
+      if (watchdog) clearTimeout(watchdog)
+      resolve()
+    }
+    child.stderr?.on('data', (chunk) => { stderr += chunk })
+    child.once('error', (err) => {
+      log('forward error: ' + (err.message || err).slice(0, 200))
+      settle()
+    })
+    child.once('close', (code, signal) => {
+      log('forward close code=' + code + ' signal=' + signal + (stderr ? ' stderr=' + stderr.slice(0, 120) : ''))
+      settle()
+    })
+    child.stdin.on('error', () => { /* EPIPE when the child exits early */ })
+    child.stdin.end(input)
+    // Fail-open watchdog: release the per-session queue even if a child does
+    // not report its SIGKILL promptly.
+    watchdog = setTimeout(() => {
+      child.kill('SIGKILL')
+      settle()
+    }, 5000)
   })
-  let stderr = ''
-  child.stderr?.on('data', (chunk) => { stderr += chunk })
-  child.on('error', (err) => log('forward error: ' + (err.message || err).slice(0, 200)))
-  child.on('close', (code, signal) => {
-    log('forward close code=' + code + ' signal=' + signal + (stderr ? ' stderr=' + stderr.slice(0, 120) : ''))
-  })
-  child.stdin.on('error', () => { /* EPIPE when the child exits early */ })
-  child.stdin.end(input)
-  // Fail-open watchdog: never let a stuck hook block the session's resources.
-  const watchdog = setTimeout(() => { child.kill('SIGKILL') }, 5000)
-  child.on('close', () => clearTimeout(watchdog))
 }
 
 export default {
   name: 'clumsies-hook',
   apply(ctx) {
     log('plugin loaded, bin=' + (process.env.CLUMSIES_BIN || DEFAULT_BIN))
-    /** Open (unclosed) turn id per root session, for interrupted-turn repair. */
-    const openTurns = new Map()
+
+    // Preserve lifecycle order within one dsh session. Each forward remains
+    // fail-open, while unrelated sessions can still make progress in parallel.
+    const forwarding = new Map()
+    const enqueue = (sessionId, payload, runtime) => {
+      const previous = forwarding.get(sessionId) ?? Promise.resolve()
+      const current = previous
+        .catch((err) => log('forward queue error: ' + (err.message || err).slice(0, 200)))
+        .then(() => forward(payload, runtime))
+        .catch((err) => log('forward queue error: ' + (err.message || err).slice(0, 200)))
+      forwarding.set(sessionId, current)
+      void current.then(() => {
+        if (forwarding.get(sessionId) === current) forwarding.delete(sessionId)
+      })
+    }
 
     const emit = (session, event) => {
       const header = session?.header ?? session
@@ -122,13 +154,7 @@ export default {
         case 'turn/start': {
           const turn = event.data?.turn ?? '?'
           const turnId = sessionId + ':t' + turn
-          const stale = openTurns.get(sessionId)
-          if (stale && stale !== turnId) {
-            log('repair stale turn ' + stale)
-            forward({ hook_event_name: 'Stop', session_id: sessionId, turn_id: stale, cwd }, runtime)
-          }
-          openTurns.set(sessionId, turnId)
-          forward({
+          enqueue(sessionId, {
             hook_event_name: 'UserPromptSubmit',
             session_id: sessionId,
             turn_id: turnId,
@@ -139,15 +165,16 @@ export default {
         case 'turn/end': {
           const turn = event.data?.turn ?? '?'
           const turnId = sessionId + ':t' + turn
-          openTurns.delete(sessionId)
           const failed = event.data?.reason?.kind === 'error'
-          forward({
-            hook_event_name: failed ? 'StopFailure' : 'Stop',
-            session_id: sessionId,
-            turn_id: turnId,
-            cwd,
-            ...(failed ? { error: 'turn-failed' } : {}),
-          }, runtime)
+          if (failed) {
+            enqueue(sessionId, {
+              hook_event_name: 'StopFailure',
+              session_id: sessionId,
+              turn_id: turnId,
+              cwd,
+              error: 'turn-failed',
+            }, runtime)
+          }
           break
         }
       }
@@ -163,18 +190,7 @@ export default {
       const resolved = resolveWorkspace(header.cwd ?? FALLBACK_CWD)
       const cwd = resolved ? resolved.workspace : (header.cwd ?? FALLBACK_CWD)
       const runtime = resolved ? resolved.runtime : undefined
-      const stale = openTurns.get(sessionId)
-      if (stale) {
-        log('session disposed with open turn ' + stale)
-        forward({
-          hook_event_name: 'Stop',
-          session_id: sessionId,
-          turn_id: stale,
-          cwd,
-        }, runtime)
-        openTurns.delete(sessionId)
-      }
-      forward({
+      enqueue(sessionId, {
         hook_event_name: 'SessionEnd',
         session_id: sessionId,
         cwd,

--- a/dev/dsh/issue-run-event.sh
+++ b/dev/dsh/issue-run-event.sh
@@ -3,7 +3,7 @@
 # Best effort only: lifecycle observation must never block the dsh session.
 #
 # Usage:  printf '%s' "$PAYLOAD" | issue-run-event.sh
-# Payload: {"hook_event_name":"UserPromptSubmit|Stop|StopFailure|SubagentStart|SubagentStop|SessionEnd",
+# Payload: {"hook_event_name":"UserPromptSubmit|StopFailure|SubagentStart|SubagentStop|SessionEnd",
 #           "session_id":"...","turn_id":"...","agent_id":"...","agent_type":"...","cwd":"/path"}
 #
 # Resolves the App-bundled clumsiesd from the nearest .dsh/clumsies.json

--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -1,9 +1,10 @@
 # Adapter
 
 Adapter is the daemon-owned integration layer that makes the Clumsies Agent
-runtime usable inside Codex, Claude Code, opencode, and Antigravity. It installs each host's
-MCP registration, lifecycle bridge, and necessary configuration without creating a second
-memory or runtime implementation.
+runtime usable inside Codex, Claude Code, opencode, dsh, and Antigravity. It
+installs each host's MCP registration, non-blocking lifecycle bridge, and
+necessary configuration without creating a second memory or runtime
+implementation.
 
 ## Runtime boundary
 
@@ -19,7 +20,7 @@ one of two short-lived proxy modes:
 
 ```text
 clumsiesd mcp serve
-clumsiesd _agent issue-run-event --host codex|claude-code|opencode|antigravity
+clumsiesd _agent issue-run-event --host codex|claude-code|opencode|dsh|antigravity
 ```
 
 The installer requires an executable whose canonical path ends in
@@ -44,6 +45,7 @@ workspace root, and host.
 | Codex | `.codex/config.toml` → `mcp_servers.clumsies` | `.codex/hooks.json`, `hooks/resolve-binary.sh`, `hooks/issue-run-event.sh` |
 | Claude Code | `.mcp.json` → `mcpServers.clumsies` | `.claude/settings.json`, `hooks/resolve-binary.sh`, `hooks/issue-run-event.sh` |
 | opencode | `opencode.json` → `mcp.clumsies` | `.opencode/plugins/clumsies.ts` |
+| dsh | profile-managed MCP registration | `.dsh/clumsies.json` routes the separately installed client bridge |
 | Antigravity | `.mcp.json` → `mcpServers.clumsies` | `.agents/hooks.json`, `.agents/hooks/resolve-binary.sh`, `.agents/hooks/issue-run-event.sh` |
 
 Every host consumes the MCP tools directly; the thin host-native skills that
@@ -58,9 +60,13 @@ array. The opencode plugin embeds the same pinned path for lifecycle events.
 
 ## Lifecycle bridge
 
-Codex and Claude Code register one managed `issue-run-event.sh` for the common
-event set. Claude Code additionally registers `StopFailure`. opencode maps the
-events its plugin API actually exposes.
+Codex and Claude Code register one managed `issue-run-event.sh` for prompt,
+subagent, and session lifecycle. Claude Code additionally registers
+`StopFailure`. Antigravity registers `PreInvocation`. None of these adapters
+registers a normal root `Stop`. The opencode plugin forwards user messages,
+failed assistant completions, and session deletion, but does not turn a normal
+assistant completion into `Stop`. The dsh client bridge follows the same
+non-blocking boundary.
 
 ```text
 host event
@@ -77,15 +83,20 @@ Lifecycle observation is fail-open: an unavailable runtime or daemon must not
 prevent the Agent host from continuing.
 
 Successful root and subagent starts return bounded context containing the
-current `run_id`, revision, binding status, and semantic Kanban instructions.
-Hooks observe and remind; only an explicit `kanban` tool call changes an Issue.
-For Codex and Claude Code, the first root Stop is stored as a non-terminal
-decision probe and asks the Agent to judge whether `request_closure` is
-appropriate. A follow-up Stop ends the run. Stop itself never advances an
-Issue.
+current `run_id`, revision, binding status, and the information needed for
+explicit Kanban work. Lifecycle integration never creates a stop-blocking
+closure prompt. Acceptance-criteria judgment and `kanban.request_closure`
+belong to an opt-in skill or a manually maintained Agent workflow.
+
+The private bridge continues to accept a legacy or manually forwarded root
+`Stop` so older installations fail open while they are cleaned up. Such an
+event is only a non-blocking AgentRun observation: it cannot call `kanban`,
+block the host, or advance an Issue. `StopFailure`, `SubagentStop`, and
+`SessionEnd` remain available because they do not create a root completion
+decision point.
 
 See [AgentRun lifecycle](/guides/agent-run-injection) for the event mapping and
-decision semantics.
+authority boundary.
 
 ## Safe install, update, and remove
 

--- a/docs/guides/agent-run-injection.md
+++ b/docs/guides/agent-run-injection.md
@@ -41,14 +41,20 @@ unbound, and one active Issue cannot be claimed by a second active run.
 
 | Host | Observed events | Integration surface |
 | --- | --- | --- |
-| Codex | `UserPromptSubmit`, `Stop`, `SubagentStart`, `SubagentStop`, `SessionEnd` | `.codex/hooks.json` → managed shell Hook |
-| Claude Code | the common set plus `StopFailure` | `.claude/settings.json` → managed shell Hook |
-| opencode | user message, completed/failed assistant message, deleted session | managed plugin maps them to `UserPromptSubmit`, `Stop`/`StopFailure`, and `SessionEnd` |
-| dsh | the same hook vocabulary (`UserPromptSubmit`, `Stop`/`StopFailure`, `SubagentStart`/`SubagentStop`, `SessionEnd`) | dsh client plugin pipes events to `clumsiesd _agent issue-run-event --host dsh` |
+| Codex | `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `SessionEnd` | `.codex/hooks.json` → managed shell Hook; no root `Stop` registration |
+| Claude Code | the Codex set plus `StopFailure` | `.claude/settings.json` → managed shell Hook; no root `Stop` registration |
+| Antigravity | `PreInvocation` | `.agents/hooks.json` → managed shell Hook; no root `Stop` registration |
+| opencode | user message, failed assistant message, deleted session | managed plugin maps them to `UserPromptSubmit`, `StopFailure`, and `SessionEnd`; successful completion emits no `Stop` |
+| dsh | turn start, failed turn, session disposal | dsh client plugin forwards non-blocking root events to `clumsiesd _agent issue-run-event --host dsh`; successful completion emits no `Stop` |
 
 The resident daemon upserts a run by Project, host, and host run key. Stable
 event IDs make delivery idempotent; replaying the same event is a no-op, while
 reusing an ID with different content is rejected.
+
+When a new root turn starts in the same host session, the daemon recovery-ends
+any still-running prior root turn before creating the new run. This rollover is
+only lifecycle bookkeeping: it does not advance the prior Issue or decide that
+the new turn continues it. `SessionEnd` closes the final outstanding turn.
 
 ## Injected context
 
@@ -61,26 +67,28 @@ Root context tells the Agent to:
 1. use `kanban.list` or `kanban.get` to inspect real board state;
 2. create durable work only when appropriate;
 3. call `kanban.begin_work` only for the active line of work and only when no
-   other run already holds the Issue;
-4. call `kanban.request_closure` only after judging acceptance criteria;
-5. otherwise leave the Issue In Progress.
+   other run already holds the Issue.
+
+Closure policy is not injected by a lifecycle callback. An opt-in skill or a
+manually maintained workflow decides when acceptance criteria are satisfied
+and explicitly calls `kanban.request_closure`; otherwise the Issue stays In
+Progress.
 
 Subagent context allows explicit work binding but forbids requesting closure;
 the subagent reports findings to the root Agent instead.
 
-## Stop is a reminder, not a decision
+## Normal root Stop is not managed
 
-For Codex and Claude Code, the first root Stop becomes a distinct non-terminal
-heartbeat probe. The proxy asks the host to continue once so the Agent can make
-the semantic Kanban decision itself. If the Issue is ready, the Agent calls
-`kanban.request_closure`; if it is not ready, the Agent makes no state change.
+Managed integrations do not register or synthesize a normal root `Stop` and
+the proxy never asks a host to continue so that it can inject a closure
+reminder. This avoids making lifecycle telemetry part of the Agent's control
+flow. `StopFailure` records a failed root outcome, `SubagentStop` ends a
+subagent observation, and `SessionEnd` ends remaining runs for the session.
 
-The follow-up Stop records the run end. A duplicate probe does not ask again.
-`StopFailure` records a failed outcome, and `SessionEnd` ends remaining runs for
-the session. No Stop event advances, approves, or closes an Issue.
-
-opencode forwards the lifecycle events exposed by its plugin API but does not
-synthesize an unsupported stop-blocking exchange.
+For cleanup compatibility, the private bridge still accepts `Stop` from an
+older installation or a manually maintained hook. It records a terminal
+AgentRun observation without returning a block decision, calling `kanban`, or
+advancing an Issue. New adapters do not produce that input.
 
 ## Privacy and failure behavior
 
@@ -99,8 +107,8 @@ mismatch, and IPC failure must not prevent the Agent host from continuing.
 The two paths are deliberately separate:
 
 ```text
-Hook lifecycle event -> record_agent_run_event -> AgentRun observation
-Agent judgment       -> MCP kanban operation   -> Issue transition
+Hook lifecycle event        -> record_agent_run_event -> AgentRun observation
+Skill/manual Agent judgment -> MCP kanban operation   -> Issue transition
 ```
 
 The private bridge is not an MCP tool. Conversely, `kanban.begin_work`, pause,
@@ -111,7 +119,7 @@ events. This keeps transport telemetry from becoming product intent.
 
 | Concern | Active path |
 | --- | --- |
-| Proxy dispatch, runtime identity gate, and injected context | `crates/daemon/src/main.rs` |
+| Proxy dispatch, runtime identity gate, and injected run context | `crates/daemon/src/main.rs` |
 | Host payload normalization | `crates/daemon/src/agent_runtime/hook.rs` |
 | AgentRun persistence and Issue transitions | `crates/daemon/src/work_tracking.rs` |
 | Adapter rendering and migration | `crates/daemon/src/agent_adapter.rs` |

--- a/docs/guides/dsh-integration.md
+++ b/docs/guides/dsh-integration.md
@@ -5,10 +5,11 @@ Agent host ("dsh"). This guide covers both halves of the integration:
 
 1. **MCP access** — the dsh web profile connects to the Clumsies MCP server,
    which gives the model `mcp__clumsies__activate / load / store / kanban`.
-2. **AgentRun lifecycle** — a dsh-side client plugin forwards session/turn
-   events to the daemon's hook proxy, which issues and ends `dsh` AgentRuns.
-   With a live run the model can `kanban.begin_work` and
-   `kanban.request_closure` exactly like codex or Claude Code sessions.
+2. **AgentRun lifecycle** — a dsh-side client plugin forwards non-blocking
+   session/turn events to the daemon's hook proxy, which issues `dsh`
+   AgentRuns and records failure or session boundaries. With a live run the
+   model can use `kanban.begin_work`; an opt-in skill or manually maintained
+   workflow may explicitly call `kanban.request_closure`.
 
 ## MCP access (read + mutate content)
 
@@ -87,9 +88,9 @@ printf '%s' "$PAYLOAD" | clumsiesd _agent issue-run-event --host dsh
 
 | Field | Required | Meaning |
 |---|---|---|
-| `hook_event_name` | yes | `UserPromptSubmit`, `Stop`, `StopFailure`, `SubagentStart`, `SubagentStop`, `SessionEnd` |
+| `hook_event_name` | yes | New integrations send `UserPromptSubmit`, `StopFailure`, `SubagentStart`, `SubagentStop`, or `SessionEnd`; `Stop` is accepted only for legacy/manual compatibility |
 | `session_id` | yes | dsh session id (e.g. `session-…`); deduplicates events |
-| `turn_id` | root events | one id per user prompt, reused by the matching `Stop`/`StopFailure` |
+| `turn_id` | root events | one id per user prompt, reused by a matching `StopFailure` or legacy/manual `Stop` |
 | `agent_id` | subagent events | subagent id (`subagent:…`) |
 | `agent_type` | subagent events | display label for the subagent run |
 | `cwd` | no | workspace path; resolves the project binding when present |
@@ -99,7 +100,6 @@ Example turn lifecycle:
 
 ```json
 {"hook_event_name":"UserPromptSubmit","session_id":"session-abc","turn_id":"turn-001","cwd":"/work/repo"}
-{"hook_event_name":"Stop","session_id":"session-abc","turn_id":"turn-001"}
 {"hook_event_name":"SubagentStart","session_id":"session-abc","turn_id":"turn-001","agent_id":"sub-1","agent_type":"reviewer"}
 {"hook_event_name":"SubagentStop","session_id":"session-abc","turn_id":"turn-001","agent_id":"sub-1","agent_type":"reviewer"}
 {"hook_event_name":"SessionEnd","session_id":"session-abc"}
@@ -121,15 +121,18 @@ export function apply(ctx: Context) {
   const forward = (payload: object) => {
     try { execFileSync('clumsiesd', ['_agent', 'issue-run-event', '--host', 'dsh'], { input: JSON.stringify(payload), stdio: 'pipe' }) } catch { /* fail-open */ }
   }
-  // ctx.on('session/…', …) — session start/end, turn start/stop, subagent start/stop
+  // ctx.on('session/…', …) — turn start/failure, session end, subagent start/stop
 }
 ```
 
 The shipped plugin (`dev/dsh/clumsies-hook.mjs`) also resolves the
 `.dsh/clumsies.json` marker described above; a shell wrapper
 (`dev/dsh/issue-run-event.sh`) drives the same contract from any event
-source. The invariant to preserve: **one `turn_id` per user prompt, reused
-for the matching `Stop`**, and **no event ever blocks the session**.
+source. A normal successful turn does not emit root `Stop`. The invariant to
+preserve is **one `turn_id` per user prompt, reused for a failure event**, and
+**no event ever blocks the session**. If an older or manually maintained
+integration still sends `Stop`, the bridge records telemetry only and returns
+no stop-blocking decision.
 
 ## Daemon-side changes (landed)
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,7 +11,7 @@ The point of this section is not to restate the architecture. It is to tell a re
 | bring up Server and the database for a team | [Deployment](/guides/deploy-for-an-org) | covers local self-hosted bring-up, bootstrap identity, and what still remains manual |
 | use clumsies inside a repo as a normal member | [Member workflow](/guides/how-to-use-clumsies) | starts from Desktop, then follows the Draft, Review, and Commit workflow |
 | wire an agent host into the local runtime | [Agent runtime](/guides/agent-runtime) | covers `clumsiesd mcp serve`, the private Hook proxy, daemon XPC, and release identity |
-| understand run injection and Stop behavior | [AgentRun lifecycle](/guides/agent-run-injection) | separates lifecycle observation from explicit `kanban` decisions |
+| understand run injection and lifecycle authority | [AgentRun lifecycle](/guides/agent-run-injection) | explains why managed adapters omit normal root Stop and keep `kanban` decisions explicit |
 | connect the DeepSeek Harness web app | [DSH integration](/guides/dsh-integration) | registers the MCP server and forwards session/turn events as `dsh` AgentRuns |
 | work on the clumsies repository itself | [Development workflow](/guides/development-workflow) | worktree + kanban loop used by the project's own agents |
 | learn where effective Memory comes from | [Memory storage boundary](/guides/rule-store-unification) | Server Commit generations, Draft overlays, and the MCP proxy read path |

--- a/docs/issue-board-design.md
+++ b/docs/issue-board-design.md
@@ -225,14 +225,20 @@ UserPromptSubmit records/upserts the root AgentRun and injects its exact identit
 plus instructions to choose existing/new/no Issue. The instruction names
 `kanban.create`; it never tells the Agent to create a Memory document.
 
-Before root Stop, the host-specific hook reminds the Agent to request closure
-only after a semantic acceptance-criteria check. Normal Stop ends telemetry
-without an outcome-based Issue transition. Subagent Stop records telemetry only.
+Adapter-managed lifecycle integration does not install or synthesize a normal
+root Stop and never blocks the host to create a closure decision point. An
+opt-in skill or manually maintained Agent workflow performs the semantic
+acceptance-criteria check and explicitly calls `kanban.request_closure`.
+
+The private bridge accepts a legacy or manually forwarded normal Stop only for
+cleanup compatibility. It records AgentRun telemetry without returning a block
+decision or changing Issue state. Subagent Stop records telemetry only.
 
 Codex and Claude Code use managed shell Hooks; opencode uses its plugin API;
 the DeepSeek Harness (dsh) forwards the same lifecycle vocabulary through
-`clumsiesd _agent issue-run-event --host dsh`. StopFailure records a failed
-outcome; SessionEnd ends remaining runs for the session.
+`clumsiesd _agent issue-run-event --host dsh`. New integrations omit normal
+root Stop forwarding. StopFailure records a failed outcome; SessionEnd ends
+remaining runs for the session.
 
 ## 7. macOS composition
 

--- a/docs/issue-board-requirements.md
+++ b/docs/issue-board-requirements.md
@@ -121,14 +121,15 @@ For (1), call `kanban.begin_work`. For (2), call `kanban.create`, then call
 unrelated problem is discovered while doing other work, call `kanban.create`
 without `begin_work`; this is the primary source of Todo cards.
 
-### Before stopping
+### Before handing off completed work
 
 The root Agent calls `kanban.request_closure` only after it judges every
 acceptance criterion satisfied. When the Issue's `verification_level` requires
 human verification (`human_required` or `mixed`), the Agent must first attach
 the human `verification_steps` with `kanban.update`; `request_closure` is
 rejected while they are missing. Otherwise it makes no lifecycle mutation.
-Hooks create this decision point but never make the decision themselves.
+Skills or a manually maintained workflow create this decision point; lifecycle
+hooks neither create it nor make the decision.
 
 Subagents may bind to an existing Issue when explicitly assigned its work, but
 cannot request closure.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -330,20 +330,24 @@ validates the tagged input and forwards the operation.
 
 Lifecycle hooks do not call the agent-facing `kanban` tool. Adapter-managed
 scripts pipe the host event to the private command
-`clumsiesd _agent issue-run-event --host codex|claude-code|opencode`. The
+`clumsiesd _agent issue-run-event --host codex|claude-code|opencode|dsh|antigravity`. The
 short-lived Rust proxy resolves the repository's daemon Project binding,
 reduces the host payload to bounded identifiers and lifecycle fields, and
 calls `record_agent_run_event`. It emits a bounded current-run context
-containing `run_id`, revision, and the semantic decision instruction after a
-successful root or subagent start. For Codex and Claude Code, the first root
-Stop is a non-terminal decision probe; a follow-up Stop records the end. All
-parsing, binding, IPC, and daemon failures remain fail-open.
+containing `run_id`, revision, and binding state after a successful root or
+subagent start. Managed adapters neither install nor synthesize a normal root
+`Stop`, and the proxy never blocks a host to force a closure decision.
+`StopFailure`, `SubagentStop`, and `SessionEnd` remain non-blocking lifecycle
+observations. All parsing, binding, IPC, and daemon failures remain fail-open.
 
 The private bridge does not persist raw hook JSON, prompts, transcripts, tool
 payloads, or assistant messages. `record_agent_run_event` is not exposed as an
 MCP tool; agents use `kanban.begin_work` and `kanban.request_closure` for explicit
-semantic updates. Prompt text is not matched to an Issue automatically, and a
-normal Stop records no semantic outcome.
+semantic updates. Closure judgment is supplied by an opt-in skill or a
+manually maintained workflow, not by a lifecycle callback. Prompt text is not
+matched to an Issue automatically. The bridge accepts a legacy or manually
+forwarded normal `Stop` for compatibility, but records only AgentRun telemetry
+and never blocks or mutates an Issue.
 
 Every valid `activate_memory` call also writes one local Retrieval Run from the
 same ranked candidate trace used for the response. This does not add fields to

--- a/docs/zh/guides/agent-run-injection.md
+++ b/docs/zh/guides/agent-run-injection.md
@@ -5,10 +5,17 @@
 一个 session 同时只能持有一个 In Progress Issue；换 Issue 前先 pause
 或 request_closure。
 
-Codex 与 Claude Code 的第一次根 Stop 只记录非终态 decision probe，并让
-Agent 自己判断是否应调用 `request_closure`；后续 Stop 才结束 AgentRun。
-opencode 使用 plugin API 转发同一组事件，dsh 使用相同的 lifecycle 词汇。
-Stop 本身不会推进、批准或关闭 Issue。Hook 输入会缩减为有限的 lifecycle
-标识，prompt、transcript 和 tool payload 不进入 daemon。
+纳管适配器不再安装或自动转发正常根 `Stop`，proxy 也不会阻断宿主来注入
+closure 提醒。是否满足验收条件、何时调用 `request_closure`，由可选 skill
+或人工维护的 Agent 工作流显式决定；否则 Issue 保持 In Progress。
+
+`StopFailure`、`SubagentStop` 与 `SessionEnd` 等非侵入性生命周期仍会记录。
+同一宿主 session 开始新的根 turn 时，daemon 会先以 recovery 结束仍在运行的
+旧根 turn；这只维护生命周期，不推进旧 Issue，也不推断新 turn 继续该 Issue。
+`SessionEnd` 会结束最后尚未结束的 turn。
+为清理旧安装，bridge 继续兼容旧 Hook 或手动发送的 `Stop`，但只把它作为
+AgentRun 遥测：不会返回 block、调用 `kanban`，也不会推进、批准或关闭
+Issue。Hook 输入会缩减为有限的 lifecycle 标识，prompt、transcript 和
+tool payload 不进入 daemon。
 
 （中文文档持续翻译中；英文为准。）


### PR DESCRIPTION
## Problem

Managed adapters currently make a successful root completion pass through
Clumsies. Codex and Claude Code Stop hooks can block host shutdown to inject
an Issue closure reminder, while opencode and dsh synthesize equivalent Stop
events. This couples Issue semantics to lifecycle callbacks and makes the
integration too invasive.

## Changes

Remove normal root Stop from fresh Codex, Claude Code, and Antigravity
registries. Keep exact cleanup and manifest compatibility for older managed
installations while preserving foreign Stop handlers. Successful opencode and
dsh completions no longer forward Stop; failure, subagent, and session signals
remain.

Remove the proxy's Stop decision probe and closure reminder. A legacy or
manually forwarded Stop remains a non-blocking terminal observation. On the
next prompt, the daemon recovery-ends an older root turn in the same session,
so turn-scoped AgentRuns do not remain active without a completion hook. dsh
forwards lifecycle events serially per session to preserve ordering.

Document Issue closure as an opt-in skill or manually maintained workflow,
and clean generated Stop handlers from the current project.

## Verification

- `cargo test -p daemon --lib` (220 passed, 2 ignored)
- `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture`
- `cargo clippy -p daemon --lib --bins --no-deps -- -D warnings`
- `bun run test:macos`
- `bun run build`
- JavaScript, shell, JSON, formatting, and diff checks
