### PR TITLE
reviews: support atomic multi-draft changes

### DIFF
--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -203,6 +203,11 @@ struct ReviewChangeSources: Sendable {
     let operationLabels: [String]
 }
 
+struct ReviewFileChange: Sendable {
+    let detail: ReviewDraftDetail
+    let sources: ReviewChangeSources
+}
+
 struct ProjectState: Identifiable, Hashable, Sendable {
     let id: String
     let name: String

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -92,6 +92,8 @@ enum ReviewRequestError: LocalizedError, Sendable {
     case draftNotSynchronized
     case legacyProjectDraftCannotBePublished
     case reconciliationRequired
+    case reconcileDirectoryDrafts
+    case mixedProjects
 
     var errorDescription: String? {
         switch self {
@@ -101,6 +103,10 @@ enum ReviewRequestError: LocalizedError, Sendable {
             "Legacy Project-scoped drafts are read-only and cannot be published."
         case .reconciliationRequired:
             "Merge the latest shared version before requesting a review."
+        case .reconcileDirectoryDrafts:
+            "Sync every changed file in this directory before requesting one review."
+        case .mixedProjects:
+            "All drafts in a review must belong to the same Project."
         }
     }
 }
@@ -3674,12 +3680,72 @@ final class WorkspaceStore: ObservableObject {
             path: "/api/v1/reviews",
             headers: ["If-Match": Self.refETag(candidate?.currentCommitId ?? draft.currentCommitId)],
             body: CreateReviewRequest(
-                draftId: serverId,
-                expectedDraftVersion: candidate?.draftVersion ?? draft.serverVersion,
+                drafts: [ReviewDraftRequest(
+                    draftId: serverId,
+                    expectedDraftVersion: candidate?.draftVersion ?? draft.serverVersion
+                )],
                 title: title,
                 description: description,
                 candidateId: candidate?.candidateId,
                 resolvedState: resolvedState
+            )
+        )
+        let record = WorkspaceLoader.mapReview(detail)
+        reviews.insert(record, at: 0)
+        selectedReviewId = record.id
+        selectedSection = .reviews
+    }
+
+    func requestReview(
+        for drafts: [LocalDraft],
+        title: String,
+        description: String
+    ) async throws {
+        let selectedDrafts = drafts.sorted {
+            $0.document.path.localizedStandardCompare($1.document.path) == .orderedAscending
+        }
+        guard let selectedPrimary = selectedDrafts.first else { return }
+        guard selectedDrafts.allSatisfy({ $0.projectId == selectedPrimary.projectId }) else {
+            throw ReviewRequestError.mixedProjects
+        }
+        guard selectedDrafts.allSatisfy(Self.canRequestReview) else {
+            throw ReviewRequestError.legacyProjectDraftCannotBePublished
+        }
+        guard selectedDrafts.allSatisfy({ synchronizationItemId(for: $0) == nil }) else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        var drafts = [LocalDraft]()
+        drafts.reserveCapacity(selectedDrafts.count)
+        for draft in selectedDrafts {
+            drafts.append(
+                try await synchronizedDraftForReconciliation(
+                    itemId: draft.targetId ?? draft.id,
+                    draft: draft
+                )
+            )
+        }
+        guard let primary = drafts.first else { return }
+        guard drafts.allSatisfy({ $0.freshness == .current }) else {
+            throw ReviewRequestError.reconcileDirectoryDrafts
+        }
+        guard drafts.allSatisfy({ $0.serverId != nil }) else {
+            throw ReviewRequestError.draftNotSynchronized
+        }
+        let detail: ReviewDetail = try await server.send(
+            method: "POST",
+            path: "/api/v1/reviews",
+            headers: ["If-Match": Self.refETag(primary.currentCommitId)],
+            body: CreateReviewRequest(
+                drafts: drafts.map {
+                    ReviewDraftRequest(
+                        draftId: $0.serverId!,
+                        expectedDraftVersion: $0.serverVersion
+                    )
+                },
+                title: title,
+                description: description,
+                candidateId: nil,
+                resolvedState: nil
             )
         )
         let record = WorkspaceLoader.mapReview(detail)
@@ -3713,7 +3779,16 @@ final class WorkspaceStore: ObservableObject {
             ],
             body: CreateReviewSubmissionRequest(
                 expectedReviewVersion: review.version,
-                expectedDraftVersion: candidate?.draftVersion ?? detail.draft.version,
+                drafts: (detail.drafts ?? [
+                    ReviewDraftDetail(draft: detail.draft, operations: detail.operations)
+                ]).map {
+                    ReviewDraftRequest(
+                        draftId: $0.draft.draftId,
+                        expectedDraftVersion: $0.draft.draftId == detail.draft.draftId
+                            ? candidate?.draftVersion ?? $0.draft.version
+                            : $0.draft.version
+                    )
+                },
                 title: review.title,
                 description: review.description,
                 candidateId: candidate?.candidateId,
@@ -3723,11 +3798,31 @@ final class WorkspaceStore: ObservableObject {
         replaceReview(with: WorkspaceLoader.mapReview(updated))
     }
 
-    func reviewChangeSources(for detail: ReviewDetail) async throws -> ReviewChangeSources {
-        async let baseRequest: CommitPayload? = loadCommit(detail.draft.baseCommitId)
-        async let currentRequest: CommitPayload? = loadCommit(detail.draft.coordination.currentCommitId)
-        let (base, current) = try await (baseRequest, currentRequest)
-        return try WorkspaceLoader.mapReviewChangeSources(detail: detail, base: base, current: current)
+    func reviewFileChanges(for detail: ReviewDetail) async throws -> [ReviewFileChange] {
+        let draftDetails = detail.drafts ?? [
+            ReviewDraftDetail(draft: detail.draft, operations: detail.operations)
+        ]
+        var changes = [ReviewFileChange]()
+        changes.reserveCapacity(draftDetails.count)
+        for draftDetail in draftDetails {
+            async let baseRequest: CommitPayload? = loadCommit(draftDetail.draft.baseCommitId)
+            async let currentRequest: CommitPayload? = loadCommit(
+                draftDetail.draft.coordination.currentCommitId
+            )
+            let (base, current) = try await (baseRequest, currentRequest)
+            changes.append(
+                ReviewFileChange(
+                    detail: draftDetail,
+                    sources: try WorkspaceLoader.mapReviewChangeSources(
+                        draft: draftDetail.draft,
+                        operations: draftDetail.operations,
+                        base: base,
+                        current: current
+                    )
+                )
+            )
+        }
+        return changes
     }
 
     func reconciliationCandidate(for draft: LocalDraft) async throws -> DraftReconciliationCandidate {
@@ -3774,6 +3869,14 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func reconciliationCandidate(for detail: ReviewDetail) async throws -> DraftReconciliationCandidate {
+        try await reconciliationCandidate(
+            for: ReviewDraftDetail(draft: detail.draft, operations: detail.operations)
+        )
+    }
+
+    func reconciliationCandidate(
+        for detail: ReviewDraftDetail
+    ) async throws -> DraftReconciliationCandidate {
         guard !isSwitchingMemoryContext else {
             throw DocumentSyncError.mutationWhileSynchronizing
         }
@@ -4983,21 +5086,35 @@ struct WorkspaceLoader: Sendable {
         base: CommitPayload?,
         current: CommitPayload?
     ) throws -> ReviewChangeSources {
-        let terminalOperation = detail.operations.last
+        try mapReviewChangeSources(
+            draft: detail.draft,
+            operations: detail.operations,
+            base: base,
+            current: current
+        )
+    }
+
+    static func mapReviewChangeSources(
+        draft: ServerDraft,
+        operations: [ServerDraftOperation],
+        base: CommitPayload?,
+        current: CommitPayload?
+    ) throws -> ReviewChangeSources {
+        let terminalOperation = operations.last
         let draftContent: String?
         let resolutionContent: String?
         if terminalOperation?.action == "delete" {
             draftContent = nil
             resolutionContent = nil
         } else {
-            let content = detail.operations.reversed().first {
+            let content = operations.reversed().first {
                 ($0.action == "create" || $0.action == "update") && $0.content != nil
             }?.content
             draftContent = content?.renderedText
             resolutionContent = content?.primaryText
         }
-        let initialPath = detail.operations.first?.resource.path ?? detail.draft.resource.path
-        let finalPath = detail.operations.reduce(initialPath) { path, operation in
+        let initialPath = operations.first?.resource.path ?? draft.resource.path
+        let finalPath = operations.reduce(initialPath) { path, operation in
             if let newPath = operation.newPath { return newPath }
             if operation.action == "create", let createdPath = operation.resource.path { return createdPath }
             return path
@@ -5005,7 +5122,7 @@ struct WorkspaceLoader: Sendable {
         let operationLabels: [String]
         if terminalOperation?.action == "delete" {
             operationLabels = ["Delete \(finalPath ?? "the selected memory")"]
-        } else if detail.operations.first?.action == "create" {
+        } else if operations.first?.action == "create" {
             operationLabels = ["Create \(finalPath ?? "memory")"]
         } else if finalPath != initialPath, let finalPath {
             operationLabels = ["Rename to \(finalPath)"]
@@ -5013,8 +5130,8 @@ struct WorkspaceLoader: Sendable {
             operationLabels = []
         }
         return try .init(
-            baseContent: commitResourceText(base, resource: detail.draft.resource),
-            currentContent: commitResourceText(current, resource: detail.draft.resource),
+            baseContent: commitResourceText(base, resource: draft.resource),
+            currentContent: commitResourceText(current, resource: draft.resource),
             draftContent: draftContent,
             resolutionContent: resolutionContent,
             proposedPath: finalPath,

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -171,6 +171,12 @@ private struct PendingOrganizationDeletion: Identifiable {
     }
 }
 
+private struct PendingDirectoryReview: Identifiable {
+    let id = UUID()
+    let drafts: [LocalDraft]
+    let initialTitle: String
+}
+
 private struct FileTreeView: View {
     @ObservedObject var store: WorkspaceStore
     let items: [MemoryListItem]
@@ -181,6 +187,7 @@ private struct FileTreeView: View {
     @State private var itemToRename: MemoryListItem?
     @State private var proposedName = ""
     @State private var pendingOrganizationDeletion: PendingOrganizationDeletion?
+    @State private var pendingDirectoryReview: PendingDirectoryReview?
 
     private var roots: [FileTreeNode] {
         FileTreeNode.build(items)
@@ -237,6 +244,7 @@ private struct FileTreeView: View {
             itemToRename = nil
             proposedName = ""
             pendingOrganizationDeletion = nil
+            pendingDirectoryReview = nil
         }
         .alert(
             "Propose Organization Rename",
@@ -273,6 +281,18 @@ private struct FileTreeView: View {
                 },
                 secondaryButton: .cancel()
             )
+        }
+        .sheet(item: $pendingDirectoryReview) { request in
+            ReviewRequestSheet(
+                initialTitle: request.initialTitle,
+                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
+            ) { title, description, _, _ in
+                try await store.requestReview(
+                    for: request.drafts,
+                    title: title,
+                    description: description
+                )
+            }
         }
     }
 
@@ -395,9 +415,16 @@ private struct FileTreeView: View {
         let trashSelectionContainsSynchronizingDocument = trashableItems.contains {
             store.isSynchronizingDocument($0.id)
         }
+        let reviewDrafts = MemoryFileTreeMenu.reviewableDrafts(
+            targetItems,
+            inOrgView: isOrgView
+        )
+        let reviewSelectionIsReady = !reviewDrafts.isEmpty && reviewDrafts.allSatisfy {
+            $0.syncStatus == .synced && $0.serverId != nil && $0.freshness == .current
+        }
         let hasDraftAction = !isOrgView && singleItem?.draft != nil
         let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
-            || hasDraftAction || singleStale
+            || hasDraftAction || !reviewDrafts.isEmpty || singleStale
 
         // ---- generic document operations (standard macOS conventions) ----
         if let singleItem {
@@ -453,6 +480,15 @@ private struct FileTreeView: View {
                 removeFromProject(removableItems)
             }
             .disabled(!store.canManageOrgSelection || selectionContainsSynchronizingDocument)
+        }
+        if !isOrgView, !reviewDrafts.isEmpty {
+            Button(reviewRequestTitle(count: reviewDrafts.count)) {
+                pendingDirectoryReview = .init(
+                    drafts: reviewDrafts,
+                    initialTitle: directoryReviewTitle(for: nodeIds, draftCount: reviewDrafts.count)
+                )
+            }
+            .disabled(!reviewSelectionIsReady || selectionContainsSynchronizingDocument)
         }
         if let singleItem {
             let resourceIsStale = singleItem.resource.map {
@@ -522,6 +558,20 @@ private struct FileTreeView: View {
         count == 1
             ? "Propose Organization Deletion"
             : "Propose \(count) Organization Deletions"
+    }
+
+    private func reviewRequestTitle(count: Int) -> String {
+        count == 1 ? "Request Review…" : "Request Review for \(count) Changes…"
+    }
+
+    private func directoryReviewTitle(for nodeIds: Set<String>, draftCount: Int) -> String {
+        if nodeIds.count == 1,
+           let nodeId = nodeIds.first,
+           let node = FileTreeNode.node(withId: nodeId, in: roots),
+           node.item == nil {
+            return "Update \(node.name)"
+        }
+        return draftCount == 1 ? "Update memory" : "Update \(draftCount) memories"
     }
 
     private func proposeOrganizationDeletion(_ items: [MemoryListItem]) {
@@ -1712,6 +1762,18 @@ private struct ReviewRequestSheet: View {
 /// only in the read-only Org view; Draft proposals and Remove from Project
 /// exist only inside an explicit Project context.
 enum MemoryFileTreeMenu {
+    /// One directory Review contains every open Organization Draft below the
+    /// selection. Unchanged files and legacy Project authority are excluded.
+    static func reviewableDrafts(
+        _ items: [MemoryListItem],
+        inOrgView: Bool
+    ) -> [LocalDraft] {
+        guard !inOrgView else { return [] }
+        return items.compactMap(\.draft).filter {
+            $0.status == .open && WorkspaceStore.canRequestReview($0)
+        }
+    }
+
     /// Rename is an organization-authority proposal. Project views only
     /// expose it for Org resources that are still selected by that project.
     /// The Org overview is authority-only/read-only because it has no

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -500,11 +500,11 @@ struct ReviewFileDescriptor: Identifiable, Hashable, Sendable {
 
     static func resolve(
         reviewId: String,
-        detail: ReviewDetail,
+        detail: ReviewDraftDetail,
         sources: ReviewChangeSources
     ) -> ReviewFileDescriptor {
         let path = sources.proposedPath ?? detail.draft.resource.path ?? "Untitled"
-        let id = detail.draft.resource.id ?? "review-file:\(reviewId):\(path)"
+        let id = detail.draft.resource.id ?? "review-file:\(reviewId):\(detail.draft.draftId)"
         return .init(id: id, path: path)
     }
 }
@@ -515,6 +515,7 @@ struct ReviewDetailPage: View {
     let loadsRemoteContent: Bool
 
     @State private var detail: ReviewDetail?
+    @State private var fileChanges: [ReviewFileChange] = []
     @State private var changeSources: ReviewChangeSources?
     @State private var diffModel: SplitDiffModel?
     @State private var loading = true
@@ -544,6 +545,27 @@ struct ReviewDetailPage: View {
 
     private var storedReviewDecisionSignature: ReviewDecisionReadiness? {
         store.reviews.first { $0.id == reviewId }.map(ReviewDecisionReadiness.init)
+    }
+
+    private var fileDescriptors: [ReviewFileDescriptor] {
+        fileChanges.map {
+            ReviewFileDescriptor.resolve(
+                reviewId: reviewId,
+                detail: $0.detail,
+                sources: $0.sources
+            )
+        }
+    }
+
+    private var selectedFileChange: ReviewFileChange? {
+        guard let selectedFileId else { return fileChanges.first }
+        return fileChanges.first {
+            ReviewFileDescriptor.resolve(
+                reviewId: reviewId,
+                detail: $0.detail,
+                sources: $0.sources
+            ).id == selectedFileId
+        }
     }
 
     private var commentPlacement: ReviewCommentPlacement {
@@ -585,11 +607,8 @@ struct ReviewDetailPage: View {
                         Task { await refreshDetail() }
                     }
                 ) { resolvedState in
-                    guard let detail else {
-                        throw ServerClientError.invalidResponse("Review detail is unavailable.")
-                    }
                     try await store.applyReconciliation(
-                        draftId: detail.draft.draftId,
+                        draftId: candidate.draftId,
                         candidate: candidate,
                         resolvedState: resolvedState
                     )
@@ -607,8 +626,8 @@ struct ReviewDetailPage: View {
                         Task { await load() }
                     }
                 }
-            } else if let review, let detail, let changeSources {
-                content(review, detail: detail, sources: changeSources)
+            } else if let review, let detail, !fileChanges.isEmpty {
+                content(review, detail: detail)
             } else {
                 ContentUnavailableView(
                     "Review Unavailable",
@@ -631,6 +650,9 @@ struct ReviewDetailPage: View {
         .onChange(of: store.pendingReviewReconciliationId) { _, reviewId in
             handlePendingReconciliation(reviewId)
         }
+        .onChange(of: selectedFileId) { _, _ in
+            selectCurrentFile()
+        }
         .onChange(of: storedReviewDecisionSignature) { _, signature in
             guard let signature,
                   detail.map({ ReviewDecisionReadiness(review: WorkspaceLoader.mapReview($0.review)) })
@@ -642,36 +664,33 @@ struct ReviewDetailPage: View {
 
     private func content(
         _ review: ReviewRecord,
-        detail: ReviewDetail,
-        sources: ReviewChangeSources
+        detail: ReviewDetail
     ) -> some View {
-        let file = ReviewFileDescriptor.resolve(
-            reviewId: reviewId,
-            detail: detail,
-            sources: sources
-        )
         return HSplitView {
             ReviewFileNavigator(
-                files: [file],
+                files: fileDescriptors,
                 selection: $selectedFileId
             )
             .frame(minWidth: 180, idealWidth: 220, maxWidth: 280)
 
             Group {
-                if selectedFileId == nil || selectedFileId == file.id {
+                if let selectedFileChange {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 20) {
                             reviewHeader(review)
 
                             if review.freshness == .behind {
-                                readinessChip(review, detail: detail)
+                                readinessChip(
+                                    review,
+                                    detail: selectedFileChange.detail
+                                )
                             }
 
                             if showsGeneralComments {
                                 generalCommentsPanel
                             }
 
-                            diffPanel(detail: detail)
+                            diffPanel(detail: selectedFileChange.detail)
                         }
                         .frame(maxWidth: 1180, alignment: .leading)
                         .frame(maxWidth: .infinity, alignment: .top)
@@ -692,7 +711,7 @@ struct ReviewDetailPage: View {
         }
         .onAppear {
             if selectedFileId == nil {
-                selectedFileId = file.id
+                selectedFileId = fileDescriptors.first?.id
             }
         }
     }
@@ -755,7 +774,7 @@ struct ReviewDetailPage: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private func readinessChip(_ review: ReviewRecord, detail: ReviewDetail) -> some View {
+    private func readinessChip(_ review: ReviewRecord, detail: ReviewDraftDetail) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Label(
                 review.reconciliation == .conflicts
@@ -899,7 +918,7 @@ struct ReviewDetailPage: View {
     }
 
     @ViewBuilder
-    private func diffPanel(detail: ReviewDetail) -> some View {
+    private func diffPanel(detail: ReviewDraftDetail) -> some View {
         if detail.operations.last?.action == "delete" {
             Label {
                 Text("This Review deletes the selected memory. There is no proposed file to render.")
@@ -956,6 +975,7 @@ struct ReviewDetailPage: View {
         loading = true
         loadError = nil
         detail = nil
+        fileChanges = []
         changeSources = nil
         diffModel = nil
         composing = nil
@@ -969,10 +989,10 @@ struct ReviewDetailPage: View {
         }
         do {
             let loadedDetail = try await store.reviewDetail(reviewId)
-            let loadedSources = try await store.reviewChangeSources(for: loadedDetail)
+            let loadedChanges = try await store.reviewFileChanges(for: loadedDetail)
             applyLoadedDetail(
                 loadedDetail,
-                sources: loadedSources,
+                changes: loadedChanges,
                 request: request
             )
         } catch {
@@ -988,10 +1008,10 @@ struct ReviewDetailPage: View {
         let request = beginDetailRequest()
         do {
             let loadedDetail = try await store.reviewDetail(reviewId)
-            let loadedSources = try await store.reviewChangeSources(for: loadedDetail)
+            let loadedChanges = try await store.reviewFileChanges(for: loadedDetail)
             applyLoadedDetail(
                 loadedDetail,
-                sources: loadedSources,
+                changes: loadedChanges,
                 request: request
             )
         } catch {
@@ -1029,7 +1049,7 @@ struct ReviewDetailPage: View {
 
     private func applyLoadedDetail(
         _ loadedDetail: ReviewDetail,
-        sources loadedSources: ReviewChangeSources,
+        changes loadedChanges: [ReviewFileChange],
         request: DetailRequest
     ) {
         guard !Task.isCancelled,
@@ -1045,17 +1065,23 @@ struct ReviewDetailPage: View {
         }
 
         detail = loadedDetail
-        changeSources = loadedSources
-        diffModel = makeDiffModel(from: loadedSources)
+        fileChanges = loadedChanges
         loading = false
         loadError = nil
-        selectedFileId = ReviewFileDescriptor.resolve(
-            reviewId: reviewId,
-            detail: loadedDetail,
-            sources: loadedSources
-        ).id
+        let availableIds = Set(fileDescriptors.map(\.id))
+        if selectedFileId == nil || !availableIds.contains(selectedFileId!) {
+            selectedFileId = fileDescriptors.first?.id
+        }
+        selectCurrentFile()
         store.replaceReview(with: loadedReview)
         store.reviewDecisionReadiness = loadedSignature
+    }
+
+    private func selectCurrentFile() {
+        changeSources = selectedFileChange?.sources
+        diffModel = selectedFileChange.flatMap { makeDiffModel(from: $0.sources) }
+        composing = nil
+        commentDraft = ""
     }
 
     private func markCurrentDetailDecisionReady() {
@@ -1104,7 +1130,7 @@ struct ReviewDetailPage: View {
         }
     }
 
-    private func loadReconciliation(detail: ReviewDetail?) {
+    private func loadReconciliation(detail: ReviewDraftDetail?) {
         guard let detail, !loadsReconciliation else { return }
         clearDecisionReadiness()
         loadsReconciliation = true
@@ -1120,7 +1146,7 @@ struct ReviewDetailPage: View {
     }
 
     private func handlePendingReconciliation(_ reviewId: String?) {
-        guard reviewId == self.reviewId, let detail else { return }
+        guard reviewId == self.reviewId, let detail = selectedFileChange?.detail else { return }
         store.pendingReviewReconciliationId = nil
         loadReconciliation(detail: detail)
     }

--- a/apps/macos/Sources/Infrastructure/ServerModels.swift
+++ b/apps/macos/Sources/Infrastructure/ServerModels.swift
@@ -194,6 +194,7 @@ struct ReviewMetadata: Codable, Identifiable, Hashable, Sendable {
     let reviewId: String
     let projectId: String
     let draftId: String
+    var draftIds: [String]? = nil
     let author: UserReference
     let title: String
     let description: String
@@ -257,7 +258,13 @@ struct ReviewDetail: Codable, Sendable {
     let review: ReviewMetadata
     let draft: ServerDraft
     let operations: [ServerDraftOperation]
+    var drafts: [ReviewDraftDetail]? = nil
     let comments: [ReviewComment]
+}
+
+struct ReviewDraftDetail: Codable, Sendable {
+    let draft: ServerDraft
+    let operations: [ServerDraftOperation]
 }
 
 struct DraftCoordination: Codable, Hashable, Sendable {
@@ -337,8 +344,7 @@ struct ServerDraftSyncState: Codable, Sendable {
 }
 
 struct CreateReviewRequest: Codable, Sendable {
-    let draftId: String
-    let expectedDraftVersion: Int
+    let drafts: [ReviewDraftRequest]
     let title: String
     let description: String
     let candidateId: String?
@@ -347,11 +353,16 @@ struct CreateReviewRequest: Codable, Sendable {
 
 struct CreateReviewSubmissionRequest: Codable, Sendable {
     let expectedReviewVersion: Int
-    let expectedDraftVersion: Int
+    let drafts: [ReviewDraftRequest]
     let title: String
     let description: String
     let candidateId: String?
     let resolvedState: ReconciliationResourceState?
+}
+
+struct ReviewDraftRequest: Codable, Sendable {
+    let draftId: String
+    let expectedDraftVersion: Int
 }
 
 struct CreateReviewCommentRequest: Codable, Sendable {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -736,6 +736,25 @@ final class DaemonContractTests: XCTestCase {
         }
     }
 
+    func testReviewRequestUsesRequiredDraftArray() throws {
+        let request = CreateReviewRequest(
+            drafts: [
+                .init(draftId: "draft-1", expectedDraftVersion: 1),
+                .init(draftId: "draft-2", expectedDraftVersion: 2),
+            ],
+            title: "Directory update",
+            description: "",
+            candidateId: nil,
+            resolvedState: nil
+        )
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONCoding.encoder().encode(request))
+                as? [String: Any]
+        )
+        XCTAssertEqual((object["drafts"] as? [[String: Any]])?.count, 2)
+        XCTAssertNil(object["draft_id"])
+    }
+
     func testReconciliationCandidateAndRebaseWireContract() throws {
         let json = """
         {
@@ -806,7 +825,10 @@ final class DaemonContractTests: XCTestCase {
 
         let submission = CreateReviewSubmissionRequest(
             expectedReviewVersion: 4,
-            expectedDraftVersion: candidate.draftVersion,
+            drafts: [.init(
+                draftId: candidate.draftId,
+                expectedDraftVersion: candidate.draftVersion
+            )],
             title: "Guide",
             description: "",
             candidateId: candidate.candidateId,
@@ -818,7 +840,8 @@ final class DaemonContractTests: XCTestCase {
         )
         XCTAssertEqual(submissionObject["candidate_id"] as? String, "candidate-1")
         XCTAssertEqual(submissionObject["expected_review_version"] as? Int, 4)
-        XCTAssertEqual(submissionObject["expected_draft_version"] as? Int, 7)
+        let submissionDrafts = try XCTUnwrap(submissionObject["drafts"] as? [[String: Any]])
+        XCTAssertEqual(submissionDrafts.first?["expected_draft_version"] as? Int, 7)
     }
 
     func testDraftProjectionPreservesMarkdown() {

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -32,7 +32,8 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         _ id: String,
         scope: MemoryScope,
         targetId: String? = nil,
-        isDeletion: Bool = false
+        isDeletion: Bool = false,
+        status: DaemonLocalDraftStatus = .open
     ) -> LocalDraft {
         LocalDraft(
             id: id,
@@ -48,7 +49,7 @@ final class MemoryFileTreeMenuTests: XCTestCase {
             scope: scope,
             kind: .context,
             targetId: targetId,
-            status: .open,
+            status: status,
             origin: .desktop,
             syncStatus: .queued,
             updatedAt: "2026-01-01T00:00:00Z",
@@ -143,6 +144,38 @@ final class MemoryFileTreeMenuTests: XCTestCase {
 
     func testProjectViewCreatesProjectBoundOrgProposals() {
         XCTAssertEqual(MemoryFileTreeMenu.creationScope(inOrgView: false), .org)
+    }
+
+    func testDirectoryReviewIncludesOnlyOpenOrganizationDraftsInProjectView() {
+        let openOrg = resourceItem(
+            "org-open",
+            scope: .org,
+            inherited: true,
+            draft: localDraft("draft-open", scope: .org, targetId: "org-open")
+        )
+        let submittedOrg = resourceItem(
+            "org-submitted",
+            scope: .org,
+            inherited: true,
+            draft: localDraft(
+                "draft-submitted",
+                scope: .org,
+                targetId: "org-submitted",
+                status: .submitted
+            )
+        )
+        let project = draftItem("project-draft", scope: .project)
+
+        XCTAssertEqual(
+            MemoryFileTreeMenu.reviewableDrafts(
+                [openOrg, submittedOrg, project],
+                inOrgView: false
+            ).map(\.id),
+            ["draft-open"]
+        )
+        XCTAssertTrue(
+            MemoryFileTreeMenu.reviewableDrafts([openOrg], inOrgView: true).isEmpty
+        )
     }
 
     func testSelectedOrgAuthorityOffersExplicitMutationActionsInProjectView() {

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -18,7 +18,7 @@ use server::api::{
     CreateReviewDecisionRequest, CreateReviewMergeRequest, CreateReviewRequest,
     CreateReviewSubmissionRequest, DraftOperationAction, DraftOperationInput, DraftResourceContent,
     DraftResourceRef, Project, ReconciliationCandidateStatus, ReplaceProjectOrgSelectionRequest,
-    ResourceScope, ReviewDecision, ReviewMergeResult,
+    ResourceScope, ReviewDecision, ReviewDraftRequest, ReviewMergeResult,
 };
 use server::repository::ServerRepository;
 use sha2::{Digest, Sha256};
@@ -117,8 +117,10 @@ async fn approve_and_merge(
             &detail.draft.author.user_id,
             expected_ref,
             CreateReviewRequest {
-                draft_id: draft_id.to_owned(),
-                expected_draft_version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: draft_id.to_owned(),
+                    expected_draft_version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -560,8 +562,10 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
             &bootstrap.user_id,
             None,
             CreateReviewRequest {
-                draft_id: draft.draft.draft_id.clone(),
-                expected_draft_version: draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: draft.draft.draft_id.clone(),
+                    expected_draft_version: draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -641,7 +645,10 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
             rejected.draft.coordination.current_commit_id.as_deref(),
             CreateReviewSubmissionRequest {
                 expected_review_version: rejected.review.version,
-                expected_draft_version: edited.draft.server_version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: rejected.draft.draft_id.clone(),
+                    expected_draft_version: edited.draft.server_version,
+                }],
                 title: Some("Revised daemon context".to_owned()),
                 description: None,
                 candidate_id: None,
@@ -1375,8 +1382,10 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             &bootstrap.user_id,
             Some(&current_commit_id),
             CreateReviewRequest {
-                draft_id: server_behind.draft.draft_id.clone(),
-                expected_draft_version: server_behind.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: server_behind.draft.draft_id.clone(),
+                    expected_draft_version: server_behind.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -1481,8 +1490,10 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
             &bootstrap.user_id,
             Some(&current_commit_id),
             CreateReviewRequest {
-                draft_id: rebased.draft.draft.draft_id.clone(),
-                expected_draft_version: rebased.draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: rebased.draft.draft.draft_id.clone(),
+                    expected_draft_version: rebased.draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -2624,8 +2635,10 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
             &bootstrap.user_id,
             None,
             CreateReviewRequest {
-                draft_id: draft.draft.draft_id,
-                expected_draft_version: draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: draft.draft.draft_id,
+                    expected_draft_version: draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,

--- a/crates/server/migrations/20260821000100_add_review_drafts.sql
+++ b/crates/server/migrations/20260821000100_add_review_drafts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE review_drafts (
+    review_id TEXT NOT NULL REFERENCES reviews(review_id) ON DELETE CASCADE,
+    draft_id TEXT NOT NULL UNIQUE REFERENCES drafts(draft_id) ON DELETE RESTRICT,
+    ordinal INTEGER NOT NULL CHECK (ordinal >= 0),
+    PRIMARY KEY (review_id, draft_id),
+    UNIQUE (review_id, ordinal)
+);
+
+INSERT INTO review_drafts (review_id, draft_id, ordinal)
+SELECT review_id, draft_id, 0
+FROM reviews;

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -796,9 +796,14 @@ pub struct DraftOperationBatchResponse {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CreateReviewRequest {
+pub struct ReviewDraftRequest {
     pub draft_id: String,
     pub expected_draft_version: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateReviewRequest {
+    pub drafts: Vec<ReviewDraftRequest>,
     pub title: Option<String>,
     pub description: Option<String>,
     pub candidate_id: Option<String>,
@@ -808,7 +813,7 @@ pub struct CreateReviewRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateReviewSubmissionRequest {
     pub expected_review_version: i64,
-    pub expected_draft_version: i64,
+    pub drafts: Vec<ReviewDraftRequest>,
     pub title: Option<String>,
     pub description: Option<String>,
     pub candidate_id: Option<String>,
@@ -829,6 +834,7 @@ pub struct Review {
     pub review_id: String,
     pub project_id: String,
     pub draft_id: String,
+    pub draft_ids: Vec<String>,
     pub author: UserRef,
     pub title: String,
     pub description: String,
@@ -851,7 +857,14 @@ pub struct ReviewDetail {
     pub review: Review,
     pub draft: Draft,
     pub operations: Vec<DraftOperation>,
+    pub drafts: Vec<ReviewDraftDetail>,
     pub comments: Vec<ReviewComment>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReviewDraftDetail {
+    pub draft: Draft,
+    pub operations: Vec<DraftOperation>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1570,10 +1570,12 @@ async fn create_review(
     headers: HeaderMap,
     Json(request): Json<CreateReviewRequest>,
 ) -> Result<Json<crate::api::ReviewDetail>, HttpError> {
-    state
-        .repository
-        .ensure_draft_owner(&principal, &request.draft_id)
-        .await?;
+    for draft in &request.drafts {
+        state
+            .repository
+            .ensure_draft_owner(&principal, &draft.draft_id)
+            .await?;
+    }
     let expected_ref = parse_ref_if_match(&headers)?;
     Ok(Json(
         state

--- a/crates/server/src/repository.rs
+++ b/crates/server/src/repository.rs
@@ -25,10 +25,10 @@ use crate::api::{
     ProjectMemberListResponse, ProjectOrgSelection, ProjectRef, ProjectRole,
     ReconciliationCandidateStatus, ReconciliationConflict, ReconciliationConflictKind,
     ReconciliationResourceState, Ref, ReplaceProjectOrgSelectionRequest, ResourceScope, Review,
-    ReviewComment, ReviewCommentListResponse, ReviewDecision, ReviewDetail, ReviewListResponse,
-    ReviewMergeResult, ReviewStatus, Tree, TreeEntry, TreeEntryKind, TreeEntryScope,
-    TreeEntrySource, UpdateAdminOrgRequest, UpdateDraftRequest, UpdateMemberRequest,
-    UpdateProjectMemberRequest, UpdateProjectRequest, UserRef,
+    ReviewComment, ReviewCommentListResponse, ReviewDecision, ReviewDetail, ReviewDraftDetail,
+    ReviewListResponse, ReviewMergeResult, ReviewStatus, Tree, TreeEntry, TreeEntryKind,
+    TreeEntryScope, TreeEntrySource, UpdateAdminOrgRequest, UpdateDraftRequest,
+    UpdateMemberRequest, UpdateProjectMemberRequest, UpdateProjectRequest, UserRef,
 };
 use crate::auth::{AuthPrincipal, user_capabilities};
 
@@ -2062,6 +2062,33 @@ impl ServerRepository {
         request: CreateReviewRequest,
     ) -> Result<ReviewDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
+        let requested_drafts = request
+            .drafts
+            .iter()
+            .map(|draft| (draft.draft_id.clone(), draft.expected_draft_version))
+            .collect::<Vec<_>>();
+        let Some((primary_draft_id, primary_expected_version)) = requested_drafts.first().cloned()
+        else {
+            return Err(ServerError::InvalidRequest(
+                "a review must contain at least one draft".to_owned(),
+            ));
+        };
+        let distinct_draft_ids = requested_drafts
+            .iter()
+            .map(|(draft_id, _)| draft_id)
+            .collect::<BTreeSet<_>>();
+        if distinct_draft_ids.len() != requested_drafts.len() {
+            return Err(ServerError::InvalidRequest(
+                "a review must not contain duplicate drafts".to_owned(),
+            ));
+        }
+        if requested_drafts.len() > 1
+            && (request.candidate_id.is_some() || request.resolved_state.is_some())
+        {
+            return Err(ServerError::InvalidRequest(
+                "reconcile every draft before requesting a multi-file review".to_owned(),
+            ));
+        }
         let mut row = sqlx::query(
             "SELECT draft_id, project_id, author_user_id, title, description, status, version,
                     base_commit_id, resource_scope
@@ -2069,10 +2096,10 @@ impl ServerRepository {
              WHERE draft_id = $1
              FOR UPDATE",
         )
-        .bind(&request.draft_id)
+        .bind(&primary_draft_id)
         .fetch_optional(&mut *tx)
         .await?
-        .ok_or_else(|| ServerError::not_found("draft", &request.draft_id))?;
+        .ok_or_else(|| ServerError::not_found("draft", &primary_draft_id))?;
 
         if row.try_get::<String, _>("author_user_id")? != author_user_id {
             return Err(ServerError::Forbidden(
@@ -2088,10 +2115,10 @@ impl ServerRepository {
                 "submitted",
             ));
         }
-        if version != request.expected_draft_version {
+        if version != primary_expected_version {
             return Err(ServerError::version_conflict(
                 "draft",
-                request.expected_draft_version,
+                primary_expected_version,
                 version,
             ));
         }
@@ -2110,25 +2137,25 @@ impl ServerRepository {
             let Some(candidate_id) = request.candidate_id.clone() else {
                 let candidate = create_reconciliation_candidate_in_tx(
                     &mut tx,
-                    &request.draft_id,
-                    request.expected_draft_version,
+                    &primary_draft_id,
+                    primary_expected_version,
                 )
                 .await?;
                 tx.commit().await?;
                 return Err(ServerError::ReconciliationRequired {
-                    draft_id: request.draft_id,
+                    draft_id: primary_draft_id,
                     candidate_id: candidate.candidate_id,
                     current_commit_id: candidate.current_commit_id,
                 });
             };
             apply_draft_rebase_in_tx(
                 &mut tx,
-                &request.draft_id,
+                &primary_draft_id,
                 author_user_id,
                 expected_ref,
                 CreateDraftRebaseRequest {
                     candidate_id,
-                    expected_draft_version: request.expected_draft_version,
+                    expected_draft_version: primary_expected_version,
                     resolved_state: request.resolved_state.clone(),
                 },
             )
@@ -2138,7 +2165,7 @@ impl ServerRepository {
                         base_commit_id, resource_scope
                  FROM drafts WHERE draft_id = $1 FOR UPDATE",
             )
-            .bind(&request.draft_id)
+            .bind(&primary_draft_id)
             .fetch_one(&mut *tx)
             .await?;
             status = row.try_get("status")?;
@@ -2154,7 +2181,7 @@ impl ServerRepository {
                 "submitted",
             ));
         }
-        let operations = load_draft_operations(&mut tx, &request.draft_id).await?;
+        let operations = load_draft_operations(&mut tx, &primary_draft_id).await?;
         if operations.is_empty() {
             return Err(ServerError::InvalidRequest(
                 "a review draft must contain at least one operation".to_owned(),
@@ -2172,6 +2199,73 @@ impl ServerRepository {
             .await?;
         }
 
+        for (additional_draft_id, expected_version) in requested_drafts.iter().skip(1) {
+            let additional = sqlx::query(
+                "SELECT project_id, author_user_id, status, version, base_commit_id, resource_scope
+                 FROM drafts WHERE draft_id = $1 FOR UPDATE",
+            )
+            .bind(additional_draft_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .ok_or_else(|| ServerError::not_found("draft", additional_draft_id))?;
+            if additional.try_get::<String, _>("author_user_id")? != author_user_id {
+                return Err(ServerError::Forbidden(
+                    "only the draft author can create its review".to_owned(),
+                ));
+            }
+            let additional_status: String = additional.try_get("status")?;
+            if additional_status != "open" {
+                return Err(ServerError::invalid_transition(
+                    "draft",
+                    &additional_status,
+                    "submitted",
+                ));
+            }
+            let actual_version: i64 = additional.try_get("version")?;
+            if actual_version != *expected_version {
+                return Err(ServerError::version_conflict(
+                    "draft",
+                    *expected_version,
+                    actual_version,
+                ));
+            }
+            if additional.try_get::<String, _>("project_id")? != project_id {
+                return Err(ServerError::InvalidRequest(
+                    "all drafts in a review must belong to the same project".to_owned(),
+                ));
+            }
+            let additional_scope =
+                resource_scope(additional.try_get::<String, _>("resource_scope")?.as_str())?;
+            ensure_publishable_draft_scope(additional_scope)?;
+            if additional_scope != scope {
+                return Err(ServerError::InvalidRequest(
+                    "all drafts in a review must use the same scope".to_owned(),
+                ));
+            }
+            if additional.try_get::<Option<String>, _>("base_commit_id")? != current_ref {
+                return Err(ServerError::InvalidRequest(format!(
+                    "draft {additional_draft_id} must be reconciled before requesting this review"
+                )));
+            }
+            let additional_operations = load_draft_operations(&mut tx, additional_draft_id).await?;
+            if additional_operations.is_empty() {
+                return Err(ServerError::InvalidRequest(
+                    "a review draft must contain at least one operation".to_owned(),
+                ));
+            }
+            if scope == ResourceScope::Org {
+                let org_id = project_org_id(&mut tx, &project_id).await?;
+                validate_stored_org_draft_operations_are_selected(
+                    &mut tx,
+                    &project_id,
+                    &org_id,
+                    current_ref.as_deref(),
+                    &additional_operations,
+                )
+                .await?;
+            }
+        }
+
         let review_id = prefixed_id("rev");
         let fallback_title: String = row.try_get("title")?;
         let fallback_description: String = row.try_get("description")?;
@@ -2184,19 +2278,41 @@ impl ServerRepository {
              WHERE draft_id = $1
              RETURNING project_id, version",
         )
-        .bind(&request.draft_id)
+        .bind(&primary_draft_id)
         .fetch_one(&mut *tx)
         .await?;
-        invalidate_draft_candidates(&mut tx, &request.draft_id).await?;
+        invalidate_draft_candidates(&mut tx, &primary_draft_id).await?;
         insert_draft_event(
             &mut tx,
-            &request.draft_id,
+            &primary_draft_id,
             &draft_event_row.try_get::<String, _>("project_id")?,
             DraftEventType::Submitted,
             draft_event_row.try_get("version")?,
             None,
         )
         .await?;
+
+        for (additional_draft_id, _) in requested_drafts.iter().skip(1) {
+            let additional_event_row = sqlx::query(
+                "UPDATE drafts
+                 SET status = 'submitted', version = version + 1, updated_at = now()
+                 WHERE draft_id = $1
+                 RETURNING project_id, version",
+            )
+            .bind(additional_draft_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            invalidate_draft_candidates(&mut tx, additional_draft_id).await?;
+            insert_draft_event(
+                &mut tx,
+                additional_draft_id,
+                &additional_event_row.try_get::<String, _>("project_id")?,
+                DraftEventType::Submitted,
+                additional_event_row.try_get("version")?,
+                None,
+            )
+            .await?;
+        }
 
         sqlx::query(
             "INSERT INTO reviews (
@@ -2206,13 +2322,25 @@ impl ServerRepository {
              VALUES ($1, $2, $3, $4, $5, $6, 'open', 1)",
         )
         .bind(&review_id)
-        .bind(&request.draft_id)
+        .bind(&primary_draft_id)
         .bind(&project_id)
         .bind(author_user_id)
         .bind(&title)
         .bind(&description)
         .execute(&mut *tx)
         .await?;
+
+        for (ordinal, (draft_id, _)) in requested_drafts.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO review_drafts (review_id, draft_id, ordinal)
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(&review_id)
+            .bind(draft_id)
+            .bind(ordinal as i32)
+            .execute(&mut *tx)
+            .await?;
+        }
 
         let detail = load_review_detail(&mut tx, &review_id).await?;
         tx.commit().await?;
@@ -2353,15 +2481,20 @@ impl ServerRepository {
             ));
         }
         if let Some((anchor_path, anchor_line)) = anchor {
-            let draft_id: String = review_row.try_get("draft_id")?;
-            let final_state = draft_result_state(&mut tx, &draft_id).await?;
-            let final_path = final_state.resource.path.as_deref();
-            if !final_state.exists || final_path != Some(anchor_path) {
-                return Err(ServerError::InvalidRequest(format!(
-                    "review comment anchor_path must match the final review path ({})",
-                    final_path.unwrap_or("deleted resource")
-                )));
+            let draft_ids = load_review_draft_ids(&mut tx, review_id).await?;
+            let mut matching_state = None;
+            for draft_id in draft_ids {
+                let state = draft_result_state(&mut tx, &draft_id).await?;
+                if state.exists && state.resource.path.as_deref() == Some(anchor_path) {
+                    matching_state = Some(state);
+                    break;
+                }
             }
+            let Some(final_state) = matching_state else {
+                return Err(ServerError::InvalidRequest(format!(
+                    "review comment anchor_path must match a final review path ({anchor_path})"
+                )));
+            };
             let line_count = final_state
                 .content
                 .as_ref()
@@ -2408,12 +2541,10 @@ impl ServerRepository {
     ) -> Result<ReviewDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
         let row = sqlx::query(
-            "SELECT r.draft_id, r.status AS review_status, r.version AS review_version,
-                    d.project_id, d.status AS draft_status
+            "SELECT r.status AS review_status, r.version AS review_version
              FROM reviews r
-             JOIN drafts d ON d.draft_id = r.draft_id
              WHERE r.review_id = $1
-             FOR UPDATE OF r, d",
+             FOR UPDATE OF r",
         )
         .bind(review_id)
         .fetch_optional(&mut *tx)
@@ -2434,46 +2565,53 @@ impl ServerRepository {
                 version,
             ));
         }
-        let draft_status: String = row.try_get("draft_status")?;
-        if draft_status != "submitted" {
-            return Err(ServerError::invalid_transition(
-                "draft",
-                &draft_status,
-                "review_decided",
-            ));
+        let draft_ids = load_review_draft_ids(&mut tx, review_id).await?;
+        for draft_id in &draft_ids {
+            let draft_status: String =
+                sqlx::query_scalar("SELECT status FROM drafts WHERE draft_id = $1 FOR UPDATE")
+                    .bind(draft_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if draft_status != "submitted" {
+                return Err(ServerError::invalid_transition(
+                    "draft",
+                    &draft_status,
+                    "review_decided",
+                ));
+            }
         }
 
         let next_status = match request.decision {
             ReviewDecision::Approved => "approved",
             ReviewDecision::Rejected => "rejected",
         };
-        let draft_id: String = row.try_get("draft_id")?;
         let approved_result_hash = if request.decision == ReviewDecision::Approved {
-            Some(draft_result_hash(&mut tx, &draft_id).await?)
+            Some(review_result_hash(&mut tx, &draft_ids).await?)
         } else {
             None
         };
         if request.decision == ReviewDecision::Rejected {
-            let project_id: String = row.try_get("project_id")?;
-            let next_draft_version: i64 = sqlx::query_scalar(
-                "UPDATE drafts
-                 SET status = 'open', version = version + 1, updated_at = now()
-                 WHERE draft_id = $1
-                 RETURNING version",
-            )
-            .bind(&draft_id)
-            .fetch_one(&mut *tx)
-            .await?;
-            invalidate_draft_candidates(&mut tx, &draft_id).await?;
-            insert_draft_event(
-                &mut tx,
-                &draft_id,
-                &project_id,
-                DraftEventType::Reopened,
-                next_draft_version,
-                None,
-            )
-            .await?;
+            for draft_id in &draft_ids {
+                let reopened = sqlx::query(
+                    "UPDATE drafts
+                     SET status = 'open', version = version + 1, updated_at = now()
+                     WHERE draft_id = $1
+                     RETURNING project_id, version",
+                )
+                .bind(draft_id)
+                .fetch_one(&mut *tx)
+                .await?;
+                invalidate_draft_candidates(&mut tx, draft_id).await?;
+                insert_draft_event(
+                    &mut tx,
+                    draft_id,
+                    &reopened.try_get::<String, _>("project_id")?,
+                    DraftEventType::Reopened,
+                    reopened.try_get("version")?,
+                    None,
+                )
+                .await?;
+            }
         }
         sqlx::query(
             "UPDATE reviews
@@ -2503,6 +2641,27 @@ impl ServerRepository {
         request: CreateReviewSubmissionRequest,
     ) -> Result<ReviewDetail, ServerError> {
         let mut tx = self.pool.begin().await?;
+        let review_draft_ids = load_review_draft_ids(&mut tx, review_id).await?;
+        if request.drafts.len() != review_draft_ids.len()
+            || request
+                .drafts
+                .iter()
+                .zip(&review_draft_ids)
+                .any(|(requested, expected)| requested.draft_id != *expected)
+        {
+            return Err(ServerError::InvalidRequest(
+                "resubmission must include every review draft in its original order".to_owned(),
+            ));
+        }
+        let Some(primary_expected_version) = request
+            .drafts
+            .first()
+            .map(|draft| draft.expected_draft_version)
+        else {
+            return Err(ServerError::InvalidRequest(
+                "a review must contain at least one draft".to_owned(),
+            ));
+        };
         let row = sqlx::query(
             "SELECT r.draft_id, r.status AS review_status, r.version AS review_version,
                     d.project_id, d.author_user_id, d.status AS draft_status,
@@ -2548,10 +2707,10 @@ impl ServerRepository {
             ));
         }
         let draft_version: i64 = row.try_get("draft_version")?;
-        if draft_version != request.expected_draft_version {
+        if draft_version != primary_expected_version {
             return Err(ServerError::version_conflict(
                 "draft",
-                request.expected_draft_version,
+                primary_expected_version,
                 draft_version,
             ));
         }
@@ -2573,7 +2732,7 @@ impl ServerRepository {
                 let candidate = create_reconciliation_candidate_in_tx(
                     &mut tx,
                     &draft_id,
-                    request.expected_draft_version,
+                    primary_expected_version,
                 )
                 .await?;
                 tx.commit().await?;
@@ -2590,7 +2749,7 @@ impl ServerRepository {
                 expected_ref,
                 CreateDraftRebaseRequest {
                     candidate_id,
-                    expected_draft_version: request.expected_draft_version,
+                    expected_draft_version: primary_expected_version,
                     resolved_state: request.resolved_state.clone(),
                 },
             )
@@ -2598,6 +2757,13 @@ impl ServerRepository {
         } else if request.candidate_id.is_some() || request.resolved_state.is_some() {
             return Err(ServerError::InvalidRequest(
                 "a current draft must not submit reconciliation data".to_owned(),
+            ));
+        }
+        if review_draft_ids.len() > 1
+            && (request.candidate_id.is_some() || request.resolved_state.is_some())
+        {
+            return Err(ServerError::InvalidRequest(
+                "reconcile every draft before resubmitting a multi-file review".to_owned(),
             ));
         }
         let operations = load_draft_operations(&mut tx, &draft_id).await?;
@@ -2616,6 +2782,67 @@ impl ServerRepository {
                 &operations,
             )
             .await?;
+        }
+        for requested in request.drafts.iter().skip(1) {
+            let additional = sqlx::query(
+                "SELECT project_id, author_user_id, status, version, base_commit_id, resource_scope
+                 FROM drafts WHERE draft_id = $1 FOR UPDATE",
+            )
+            .bind(&requested.draft_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            if additional.try_get::<String, _>("author_user_id")? != author_user_id {
+                return Err(ServerError::Forbidden(
+                    "only the draft author can resubmit its review".to_owned(),
+                ));
+            }
+            let additional_status: String = additional.try_get("status")?;
+            if additional_status != "open" {
+                return Err(ServerError::invalid_transition(
+                    "draft",
+                    &additional_status,
+                    "submitted",
+                ));
+            }
+            let actual_version: i64 = additional.try_get("version")?;
+            if actual_version != requested.expected_draft_version {
+                return Err(ServerError::version_conflict(
+                    "draft",
+                    requested.expected_draft_version,
+                    actual_version,
+                ));
+            }
+            if additional.try_get::<String, _>("project_id")? != project_id
+                || resource_scope(additional.try_get::<String, _>("resource_scope")?.as_str())?
+                    != scope
+            {
+                return Err(ServerError::InvalidRequest(
+                    "all drafts in a review must share one project and scope".to_owned(),
+                ));
+            }
+            if additional.try_get::<Option<String>, _>("base_commit_id")? != current_ref {
+                return Err(ServerError::InvalidRequest(format!(
+                    "draft {} must be reconciled before resubmitting this review",
+                    requested.draft_id
+                )));
+            }
+            let operations = load_draft_operations(&mut tx, &requested.draft_id).await?;
+            if operations.is_empty() {
+                return Err(ServerError::InvalidRequest(
+                    "a review draft must contain at least one operation".to_owned(),
+                ));
+            }
+            if scope == ResourceScope::Org {
+                let org_id = project_org_id(&mut tx, &project_id).await?;
+                validate_stored_org_draft_operations_are_selected(
+                    &mut tx,
+                    &project_id,
+                    &org_id,
+                    current_ref.as_deref(),
+                    &operations,
+                )
+                .await?;
+            }
         }
         let next_draft_version: i64 = sqlx::query_scalar(
             "UPDATE drafts
@@ -2650,6 +2877,27 @@ impl ServerRepository {
             None,
         )
         .await?;
+        for requested in request.drafts.iter().skip(1) {
+            let submitted = sqlx::query(
+                "UPDATE drafts
+                 SET status = 'submitted', version = version + 1, updated_at = now()
+                 WHERE draft_id = $1
+                 RETURNING project_id, version",
+            )
+            .bind(&requested.draft_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            invalidate_draft_candidates(&mut tx, &requested.draft_id).await?;
+            insert_draft_event(
+                &mut tx,
+                &requested.draft_id,
+                &submitted.try_get::<String, _>("project_id")?,
+                DraftEventType::Submitted,
+                submitted.try_get("version")?,
+                None,
+            )
+            .await?;
+        }
 
         let detail = load_review_detail(&mut tx, review_id).await?;
         tx.commit().await?;
@@ -2686,14 +2934,10 @@ impl ServerRepository {
             .await?;
         }
         let row = sqlx::query(
-            "SELECT r.review_id, r.draft_id, r.project_id, r.status, r.version,
-                    r.approved_result_hash,
-                    d.resource_scope, d.base_commit_id, d.status AS draft_status,
-                    d.version AS draft_version
+            "SELECT r.project_id, r.status, r.version, r.approved_result_hash
              FROM reviews r
-             JOIN drafts d ON d.draft_id = r.draft_id
              WHERE r.review_id = $1
-             FOR UPDATE",
+             FOR UPDATE OF r",
         )
         .bind(review_id)
         .fetch_optional(&mut *tx)
@@ -2714,11 +2958,47 @@ impl ServerRepository {
         }
 
         let project_id: String = row.try_get("project_id")?;
-        let draft_id: String = row.try_get("draft_id")?;
+        let draft_ids = load_review_draft_ids(&mut tx, review_id).await?;
+        let mut draft_rows = Vec::with_capacity(draft_ids.len());
+        for draft_id in &draft_ids {
+            draft_rows.push(
+                sqlx::query(
+                    "SELECT resource_scope, base_commit_id, status, version
+                     FROM drafts WHERE draft_id = $1 FOR UPDATE",
+                )
+                .bind(draft_id)
+                .fetch_one(&mut *tx)
+                .await?,
+            );
+        }
+        let primary_scope = resource_scope(
+            draft_rows
+                .first()
+                .ok_or_else(|| {
+                    ServerError::InvalidRequest("a review must contain a draft".to_owned())
+                })?
+                .try_get::<String, _>("resource_scope")?
+                .as_str(),
+        )?;
+        ensure_publishable_draft_scope(primary_scope)?;
+        for draft_row in &draft_rows {
+            let scope = resource_scope(draft_row.try_get::<String, _>("resource_scope")?.as_str())?;
+            if scope != primary_scope {
+                return Err(ServerError::InvalidRequest(
+                    "all drafts in a review must use the same scope".to_owned(),
+                ));
+            }
+            let draft_status: String = draft_row.try_get("status")?;
+            if draft_status != "submitted" {
+                return Err(ServerError::invalid_transition(
+                    "draft",
+                    &draft_status,
+                    "merged",
+                ));
+            }
+        }
         let org_id = project_org_id(&mut tx, &project_id).await?;
-        let resource_scope = resource_scope(row.try_get::<String, _>("resource_scope")?.as_str())?;
-        ensure_publishable_draft_scope(resource_scope)?;
-        let current_head = match resource_scope {
+        let current_head = match primary_scope {
             ResourceScope::Org => current_org_ref(&mut tx, &org_id).await?,
             ResourceScope::Project => {
                 lock_org_ref_for_project_projection(&mut tx, &org_id).await?;
@@ -2731,25 +3011,27 @@ impl ServerRepository {
                 current_head.as_deref(),
             ));
         }
-        let draft_base_commit_id: Option<String> = row.try_get("base_commit_id")?;
-        if draft_base_commit_id != current_head {
-            let candidate = create_reconciliation_candidate_in_tx(
-                &mut tx,
-                &draft_id,
-                row.try_get("draft_version")?,
-            )
-            .await?;
-            let error = ServerError::ReconciliationRequired {
-                draft_id,
-                candidate_id: candidate.candidate_id,
-                current_commit_id: candidate.current_commit_id,
-            };
-            tx.commit().await?;
-            return Err(error);
+        for (draft_id, draft_row) in draft_ids.iter().zip(&draft_rows) {
+            let draft_base_commit_id: Option<String> = draft_row.try_get("base_commit_id")?;
+            if draft_base_commit_id != current_head {
+                let candidate = create_reconciliation_candidate_in_tx(
+                    &mut tx,
+                    draft_id,
+                    draft_row.try_get("version")?,
+                )
+                .await?;
+                let error = ServerError::ReconciliationRequired {
+                    draft_id: draft_id.clone(),
+                    candidate_id: candidate.candidate_id,
+                    current_commit_id: candidate.current_commit_id,
+                };
+                tx.commit().await?;
+                return Err(error);
+            }
         }
 
         let approved_result_hash: Option<String> = row.try_get("approved_result_hash")?;
-        let current_result_hash = draft_result_hash(&mut tx, &draft_id).await?;
+        let current_result_hash = review_result_hash(&mut tx, &draft_ids).await?;
         if approved_result_hash.as_deref() != Some(&current_result_hash) {
             return Err(ServerError::InvalidTransition {
                 entity: "review",
@@ -2758,9 +3040,12 @@ impl ServerRepository {
             });
         }
 
-        let operations = load_draft_operations(&mut tx, &draft_id).await?;
-        let materialized_operations = materialize_draft_operations(&operations)?;
-        if resource_scope == ResourceScope::Org {
+        let mut materialized_operations = Vec::new();
+        for draft_id in &draft_ids {
+            let operations = load_draft_operations(&mut tx, draft_id).await?;
+            materialized_operations.extend(materialize_draft_operations(&operations)?);
+        }
+        if primary_scope == ResourceScope::Org {
             validate_org_draft_operation_inputs_are_selected(
                 &mut tx,
                 &project_id,
@@ -2770,7 +3055,7 @@ impl ServerRepository {
             )
             .await?;
         }
-        let org_resource_impact = match resource_scope {
+        let org_resource_impact = match primary_scope {
             ResourceScope::Org => {
                 resolve_org_resource_impact(&mut tx, &org_id, &materialized_operations).await?
             }
@@ -2779,13 +3064,13 @@ impl ServerRepository {
         let mut created_resource_ids = Vec::new();
         for operation in &materialized_operations {
             if let Some(resource_id) =
-                apply_operation(&mut tx, &project_id, resource_scope, operation).await?
+                apply_operation(&mut tx, &project_id, primary_scope, operation).await?
             {
                 created_resource_ids.push(resource_id);
             }
         }
 
-        let commit_id = match resource_scope {
+        let commit_id = match primary_scope {
             ResourceScope::Org => {
                 let commit_id =
                     create_org_commit(&mut tx, &org_id, current_head.as_deref()).await?;
@@ -2830,24 +3115,26 @@ impl ServerRepository {
         .bind(materialized_operations.len() as i32)
         .execute(&mut *tx)
         .await?;
-        let merged_draft_version: i64 = sqlx::query_scalar(
-            "UPDATE drafts
-             SET status = 'merged', version = version + 1, updated_at = now()
-             WHERE draft_id = $1
-             RETURNING version",
-        )
-        .bind(&draft_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        insert_draft_event(
-            &mut tx,
-            &draft_id,
-            &project_id,
-            DraftEventType::Merged,
-            merged_draft_version,
-            None,
-        )
-        .await?;
+        for draft_id in &draft_ids {
+            let merged_draft_version: i64 = sqlx::query_scalar(
+                "UPDATE drafts
+                 SET status = 'merged', version = version + 1, updated_at = now()
+                 WHERE draft_id = $1
+                 RETURNING version",
+            )
+            .bind(draft_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            insert_draft_event(
+                &mut tx,
+                draft_id,
+                &project_id,
+                DraftEventType::Merged,
+                merged_draft_version,
+                None,
+            )
+            .await?;
+        }
 
         tx.commit().await?;
         let review = self.get_review(review_id).await?;
@@ -4770,6 +5057,23 @@ async fn draft_result_hash(
     state_hash(&draft_result_state(tx, draft_id).await?)
 }
 
+async fn review_result_hash(
+    tx: &mut Transaction<'_, Postgres>,
+    draft_ids: &[String],
+) -> Result<String, ServerError> {
+    if let [draft_id] = draft_ids {
+        return draft_result_hash(tx, draft_id).await;
+    }
+    let mut hasher = Sha256::new();
+    for draft_id in draft_ids {
+        hasher.update(draft_id.as_bytes());
+        hasher.update([0]);
+        hasher.update(draft_result_hash(tx, draft_id).await?.as_bytes());
+        hasher.update([0]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
 async fn target_ref_for_draft(
     tx: &mut Transaction<'_, Postgres>,
     project_id: &str,
@@ -5133,8 +5437,11 @@ async fn apply_draft_rebase_in_tx(
     invalidate_draft_candidates(tx, draft_id).await?;
     let result_hash = state_hash(&resolved_state)?;
     let review_row = sqlx::query(
-        "SELECT review_id, status, approved_result_hash
-         FROM reviews WHERE draft_id = $1 FOR UPDATE",
+        "SELECT reviews.review_id, reviews.status, reviews.approved_result_hash
+         FROM reviews
+         JOIN review_drafts ON review_drafts.review_id = reviews.review_id
+         WHERE review_drafts.draft_id = $1
+         FOR UPDATE OF reviews",
     )
     .bind(draft_id)
     .fetch_optional(&mut **tx)
@@ -5143,8 +5450,11 @@ async fn apply_draft_rebase_in_tx(
     if let Some(review_row) = review_row {
         let status: String = review_row.try_get("status")?;
         let approved_hash: Option<String> = review_row.try_get("approved_result_hash")?;
+        let review_id: String = review_row.try_get("review_id")?;
+        let draft_ids = load_review_draft_ids(tx, &review_id).await?;
+        let current_review_hash = review_result_hash(tx, &draft_ids).await?;
         let preserve_approval =
-            status == "approved" && approved_hash.as_deref() == Some(&result_hash);
+            status == "approved" && approved_hash.as_deref() == Some(&current_review_hash);
         approval_invalidated = status == "approved" && !preserve_approval;
         sqlx::query(
             "UPDATE reviews
@@ -5156,7 +5466,7 @@ async fn apply_draft_rebase_in_tx(
                  version = version + 1, updated_at = now()
              WHERE review_id = $1",
         )
-        .bind(review_row.try_get::<String, _>("review_id")?)
+        .bind(&review_id)
         .bind(preserve_approval)
         .execute(&mut **tx)
         .await?;
@@ -5187,15 +5497,16 @@ async fn apply_draft_rebase_in_tx(
     )
     .await?;
     let draft = load_draft_detail(tx, draft_id).await?;
-    let review =
-        match sqlx::query_scalar::<_, String>("SELECT review_id FROM reviews WHERE draft_id = $1")
-            .bind(draft_id)
-            .fetch_optional(&mut **tx)
-            .await?
-        {
-            Some(review_id) => Some(load_review(tx, &review_id).await?),
-            None => None,
-        };
+    let review = match sqlx::query_scalar::<_, String>(
+        "SELECT review_id FROM review_drafts WHERE draft_id = $1",
+    )
+    .bind(draft_id)
+    .fetch_optional(&mut **tx)
+    .await?
+    {
+        Some(review_id) => Some(load_review(tx, &review_id).await?),
+        None => None,
+    };
     Ok(DraftRebaseResult {
         rebase_id,
         previous_revision_id,
@@ -5229,9 +5540,13 @@ async fn load_review(
     .await?
     .ok_or_else(|| ServerError::not_found("review", review_id))?;
 
-    let draft_id: String = row.try_get("draft_id")?;
-    let draft = load_draft_detail(tx, &draft_id).await?;
-    review_from_row(&row, draft.draft.coordination)
+    let draft_ids = load_review_draft_ids(tx, review_id).await?;
+    let mut coordinations = Vec::with_capacity(draft_ids.len());
+    for draft_id in &draft_ids {
+        coordinations.push(load_draft_detail(tx, draft_id).await?.draft.coordination);
+    }
+    let coordination = aggregate_draft_coordination(&coordinations);
+    review_from_row(&row, draft_ids, coordination)
 }
 
 async fn load_review_detail(
@@ -5239,24 +5554,102 @@ async fn load_review_detail(
     review_id: &str,
 ) -> Result<ReviewDetail, ServerError> {
     let review = load_review(tx, review_id).await?;
-    let draft = load_draft_detail(tx, &review.draft_id).await?;
+    let mut drafts = Vec::with_capacity(review.draft_ids.len());
+    for draft_id in &review.draft_ids {
+        let detail = load_draft_detail(tx, draft_id).await?;
+        drafts.push(ReviewDraftDetail {
+            draft: detail.draft,
+            operations: detail.operations,
+        });
+    }
+    let primary = drafts
+        .first()
+        .cloned()
+        .ok_or_else(|| ServerError::InvalidRequest("a review must contain a draft".to_owned()))?;
     let comments = load_review_comments(tx, review_id).await?;
     Ok(ReviewDetail {
         review,
-        draft: draft.draft,
-        operations: draft.operations,
+        draft: primary.draft,
+        operations: primary.operations,
+        drafts,
         comments,
     })
 }
 
+async fn load_review_draft_ids(
+    tx: &mut Transaction<'_, Postgres>,
+    review_id: &str,
+) -> Result<Vec<String>, ServerError> {
+    let mut draft_ids = sqlx::query_scalar::<_, String>(
+        "SELECT draft_id FROM review_drafts WHERE review_id = $1 ORDER BY ordinal",
+    )
+    .bind(review_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    if draft_ids.is_empty() {
+        let primary =
+            sqlx::query_scalar::<_, String>("SELECT draft_id FROM reviews WHERE review_id = $1")
+                .bind(review_id)
+                .fetch_optional(&mut **tx)
+                .await?
+                .ok_or_else(|| ServerError::not_found("review", review_id))?;
+        draft_ids.push(primary);
+    }
+    Ok(draft_ids)
+}
+
+fn aggregate_draft_coordination(coordinations: &[DraftCoordination]) -> DraftCoordination {
+    let primary = coordinations.first().cloned().unwrap_or(DraftCoordination {
+        freshness: DraftFreshness::Current,
+        current_commit_id: None,
+        has_upstream_resource_changes: false,
+        reconciliation: DraftReconciliationStatus::Unknown,
+        candidate_id: None,
+    });
+    DraftCoordination {
+        freshness: if coordinations
+            .iter()
+            .any(|coordination| coordination.freshness == DraftFreshness::Behind)
+        {
+            DraftFreshness::Behind
+        } else {
+            DraftFreshness::Current
+        },
+        current_commit_id: primary.current_commit_id,
+        has_upstream_resource_changes: coordinations
+            .iter()
+            .any(|coordination| coordination.has_upstream_resource_changes),
+        reconciliation: if coordinations
+            .iter()
+            .any(|coordination| coordination.reconciliation == DraftReconciliationStatus::Conflicts)
+        {
+            DraftReconciliationStatus::Conflicts
+        } else if coordinations
+            .iter()
+            .any(|coordination| coordination.reconciliation == DraftReconciliationStatus::Unknown)
+        {
+            DraftReconciliationStatus::Unknown
+        } else {
+            DraftReconciliationStatus::Clean
+        },
+        candidate_id: if coordinations.len() == 1 {
+            primary.candidate_id
+        } else {
+            None
+        },
+    }
+}
+
 fn review_from_row(
     row: &sqlx::postgres::PgRow,
+    draft_ids: Vec<String>,
     coordination: DraftCoordination,
 ) -> Result<Review, ServerError> {
     Ok(Review {
         review_id: row.try_get("review_id")?,
         project_id: row.try_get("project_id")?,
         draft_id: row.try_get("draft_id")?,
+        draft_ids,
         author: user_ref_from_row(row)?,
         title: row.try_get("title")?,
         description: row.try_get("description")?,

--- a/crates/server/tests/draft_operation_ordering.rs
+++ b/crates/server/tests/draft_operation_ordering.rs
@@ -3,7 +3,7 @@ mod common;
 use server::api::{
     CreateDraftRequest, CreateReviewDecisionRequest, CreateReviewMergeRequest, CreateReviewRequest,
     DraftOperationAction, DraftOperationBatchItem, DraftOperationBatchRequest, DraftOperationInput,
-    DraftResourceContent, DraftResourceRef, ResourceScope, ReviewDecision,
+    DraftResourceContent, DraftResourceRef, ResourceScope, ReviewDecision, ReviewDraftRequest,
 };
 use server::repository::ServerRepository;
 
@@ -12,6 +12,132 @@ fn memory_content(content: &str) -> Option<DraftResourceContent> {
         description: None,
         content: content.to_owned(),
     })
+}
+
+#[tokio::test]
+async fn multi_draft_review_merges_every_file_in_one_commit() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Directory Review",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Directory Review",
+    )
+    .await;
+    let head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+
+    let mut drafts = Vec::new();
+    for (index, path) in [
+        "skills/coding/SKILL.md",
+        "skills/coding/references/workflow.md",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        drafts.push(
+            repo.create_draft(
+                &bootstrap.user_id,
+                CreateDraftRequest {
+                    daemon_installation_id: format!("daemon_directory_{index}"),
+                    project_id: bootstrap.project_id.clone(),
+                    base_commit_id: head.clone(),
+                    title: format!("Create {path}"),
+                    description: None,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: None,
+                        path: Some(path.to_owned()),
+                    },
+                    operations: vec![DraftOperationInput {
+                        action: DraftOperationAction::Create,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: None,
+                            path: Some(path.to_owned()),
+                        },
+                        content: memory_content(&format!("# File {index}")),
+                        new_path: None,
+                    }],
+                },
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    let detail = repo
+        .create_review(
+            &bootstrap.user_id,
+            head.as_deref(),
+            CreateReviewRequest {
+                drafts: drafts
+                    .iter()
+                    .map(|detail| ReviewDraftRequest {
+                        draft_id: detail.draft.draft_id.clone(),
+                        expected_draft_version: detail.draft.version,
+                    })
+                    .collect(),
+                title: Some("Create coding skill".to_owned()),
+                description: None,
+                candidate_id: None,
+                resolved_state: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(detail.review.draft_ids.len(), 2);
+    assert_eq!(detail.drafts.len(), 2);
+    assert!(
+        detail
+            .drafts
+            .iter()
+            .all(|item| item.draft.status == server::api::DraftStatus::Submitted)
+    );
+
+    let approved = repo
+        .create_review_decision(
+            &detail.review.review_id,
+            &bootstrap.user_id,
+            CreateReviewDecisionRequest {
+                decision: ReviewDecision::Approved,
+                expected_review_version: detail.review.version,
+                body: None,
+            },
+        )
+        .await
+        .unwrap();
+    let merged = repo
+        .create_review_merge(
+            &detail.review.review_id,
+            head.as_deref(),
+            CreateReviewMergeRequest {
+                expected_review_version: approved.review.version,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(merged.applied_operation_count, 2);
+
+    let commit = repo
+        .get_commit_payload(merged.commit_id.as_deref().unwrap())
+        .await
+        .unwrap();
+    let paths = commit
+        .tree
+        .entries
+        .iter()
+        .filter_map(|entry| entry.path.as_deref())
+        .collect::<Vec<_>>();
+    assert!(paths.contains(&"skills/coding/SKILL.md"));
+    assert!(paths.contains(&"skills/coding/references/workflow.md"));
 }
 
 async fn approve_and_merge(
@@ -26,8 +152,10 @@ async fn approve_and_merge(
             user_id,
             expected_ref,
             CreateReviewRequest {
-                draft_id: draft_id.to_owned(),
-                expected_draft_version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: draft_id.to_owned(),
+                    expected_draft_version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -15,8 +15,8 @@ use server::api::{
     MemoryDetail, MemoryListResponse, PersonalBundleDetail, PersonalBundleRequest,
     PersonalBundleUpdateRequest, Project, ProjectListResponse, ProjectOrgSelection,
     ReconciliationCandidateStatus, ReplaceProjectOrgSelectionRequest, ResourceScope, Review,
-    ReviewComment, ReviewCommentListResponse, ReviewDecision, ReviewDetail, ReviewListResponse,
-    ReviewMergeResult, ReviewStatus, UpdateDraftRequest, UpdateProjectRequest,
+    ReviewComment, ReviewCommentListResponse, ReviewDecision, ReviewDetail, ReviewDraftRequest,
+    ReviewListResponse, ReviewMergeResult, ReviewStatus, UpdateDraftRequest, UpdateProjectRequest,
 };
 use server::repository::ServerRepository;
 use tower::ServiceExt;
@@ -151,8 +151,10 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
             &bootstrap.user_id,
             None,
             CreateReviewRequest {
-                draft_id: legacy_draft.draft.draft_id.clone(),
-                expected_draft_version: legacy_draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: legacy_draft.draft.draft_id.clone(),
+                    expected_draft_version: legacy_draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -189,7 +191,10 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
             None,
             CreateReviewSubmissionRequest {
                 expected_review_version: 1,
-                expected_draft_version: legacy_draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: legacy_draft.draft.draft_id.clone(),
+                    expected_draft_version: legacy_draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -1423,8 +1428,10 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
             &bootstrap.user_id,
             org_head_before.as_deref(),
             CreateReviewRequest {
-                draft_id: org_draft.draft.draft_id,
-                expected_draft_version: org_draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: org_draft.draft.draft_id,
+                    expected_draft_version: org_draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -1703,7 +1710,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: 1,
-            expected_draft_version: edited.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: edited.draft.draft_id.clone(),
+                expected_draft_version: edited.draft.version,
+            }],
             title: None,
             description: None,
             candidate_id: None,
@@ -1719,7 +1729,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: rejected.review.version,
-            expected_draft_version: edited.draft.version - 1,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: edited.draft.draft_id.clone(),
+                expected_draft_version: edited.draft.version - 1,
+            }],
             title: None,
             description: None,
             candidate_id: None,
@@ -1735,7 +1748,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: rejected.review.version,
-            expected_draft_version: edited.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: edited.draft.draft_id.clone(),
+                expected_draft_version: edited.draft.version,
+            }],
             title: None,
             description: None,
             candidate_id: None,
@@ -1760,7 +1776,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: rejected.review.version,
-            expected_draft_version: edited.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: edited.draft.draft_id.clone(),
+                expected_draft_version: edited.draft.version,
+            }],
             title: Some("Revised review lifecycle context".to_owned()),
             description: None,
             candidate_id: None,
@@ -1808,7 +1827,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: rejected.review.version,
-            expected_draft_version: edited.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: edited.draft.draft_id.clone(),
+                expected_draft_version: edited.draft.version,
+            }],
             title: Some("Revised review lifecycle context".to_owned()),
             description: None,
             candidate_id: Some(candidate_id),
@@ -1847,7 +1869,10 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
         &submission_ref_etag,
         &CreateReviewSubmissionRequest {
             expected_review_version: resubmitted.review.version,
-            expected_draft_version: resubmitted.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: resubmitted.draft.draft_id.clone(),
+                expected_draft_version: resubmitted.draft.version,
+            }],
             title: None,
             description: None,
             candidate_id: None,
@@ -2299,8 +2324,10 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
             &bootstrap.user_id,
             None,
             CreateReviewRequest {
-                draft_id: seed.draft.draft_id,
-                expected_draft_version: seed.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: seed.draft.draft_id,
+                    expected_draft_version: seed.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -2375,8 +2402,10 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
             &bootstrap.user_id,
             Some(&base_commit_id),
             CreateReviewRequest {
-                draft_id: local_update.draft.draft_id.clone(),
-                expected_draft_version: local_update.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: local_update.draft.draft_id.clone(),
+                    expected_draft_version: local_update.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -2446,8 +2475,10 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
             &bootstrap.user_id,
             Some(&base_commit_id),
             CreateReviewRequest {
-                draft_id: remote.draft.draft_id,
-                expected_draft_version: remote.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: remote.draft.draft_id,
+                    expected_draft_version: remote.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -3149,8 +3180,10 @@ async fn project_org_selection_resolves_legacy_path_only_draft_after_authority_r
             &bootstrap.user_id,
             base_commit_id.as_deref(),
             CreateReviewRequest {
-                draft_id: rename_draft.draft.draft_id,
-                expected_draft_version: rename_draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: rename_draft.draft.draft_id,
+                    expected_draft_version: rename_draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -3531,8 +3564,10 @@ async fn created_org_draft_materializes_local_identity_updates_and_renames() {
             &bootstrap.user_id,
             current_head.as_deref(),
             CreateReviewRequest {
-                draft_id: draft.draft.draft_id,
-                expected_draft_version: draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: draft.draft.draft_id,
+                    expected_draft_version: draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -3670,8 +3705,10 @@ async fn org_delete_merge_advances_authority_past_other_projects_active_drafts()
             &bootstrap.user_id,
             current_head.as_deref(),
             CreateReviewRequest {
-                draft_id: deletion_draft.draft.draft_id,
-                expected_draft_version: deletion_draft.draft.version,
+                drafts: vec![ReviewDraftRequest {
+                    draft_id: deletion_draft.draft.draft_id,
+                    expected_draft_version: deletion_draft.draft.version,
+                }],
                 title: None,
                 description: None,
                 candidate_id: None,
@@ -4086,8 +4123,10 @@ async fn create_review_for_draft(app: axum::Router, draft: &DraftDetail) -> Revi
         "/api/v1/reviews",
         &ref_etag,
         &CreateReviewRequest {
-            draft_id: draft.draft.draft_id.clone(),
-            expected_draft_version: draft.draft.version,
+            drafts: vec![ReviewDraftRequest {
+                draft_id: draft.draft.draft_id.clone(),
+                expected_draft_version: draft.draft.version,
+            }],
             title: None,
             description: None,
             candidate_id: None,

--- a/packages/api-contract/generated/public.d.ts
+++ b/packages/api-contract/generated/public.d.ts
@@ -890,8 +890,7 @@ export interface components {
             page_info: components["schemas"]["PageInfo"];
         };
         CreateReviewRequest: {
-            draft_id: string;
-            expected_draft_version: number;
+            drafts: components["schemas"]["ReviewDraftRequest"][];
             title?: string;
             description?: string;
             candidate_id?: string;
@@ -900,7 +899,7 @@ export interface components {
         };
         CreateReviewSubmissionRequest: {
             expected_review_version: number;
-            expected_draft_version: number;
+            drafts: components["schemas"]["ReviewDraftRequest"][];
             title?: string;
             description?: string;
             /** @description Confirmed reconciliation candidate to apply atomically before resubmission when the Draft is behind. */
@@ -908,10 +907,19 @@ export interface components {
             /** @description Required complete user-resolved result for a conflicts candidate; must be omitted for a clean candidate. */
             resolved_state?: components["schemas"]["ReconciliationResourceState"] | null;
         };
+        ReviewDraftRequest: {
+            draft_id: string;
+            expected_draft_version: number;
+        };
+        ReviewDraftDetail: {
+            draft: components["schemas"]["Draft"];
+            operations: components["schemas"]["DraftOperation"][];
+        };
         ReviewDetail: {
             review: components["schemas"]["Review"];
             draft: components["schemas"]["Draft"];
             operations: components["schemas"]["DraftOperation"][];
+            drafts: components["schemas"]["ReviewDraftDetail"][];
             comments: components["schemas"]["ReviewComment"][];
         };
         Review: {
@@ -919,6 +927,7 @@ export interface components {
             /** @description Project carrying the reviewed Draft; the Draft resource scope identifies the authority target. */
             project_id: string;
             draft_id: string;
+            draft_ids: string[];
             author: components["schemas"]["UserRef"];
             title: string;
             description: string;

--- a/packages/api-contract/openapi/clumsies.public.v1.yaml
+++ b/packages/api-contract/openapi/clumsies.public.v1.yaml
@@ -1607,12 +1607,13 @@ components:
           $ref: "#/components/schemas/PageInfo"
     CreateReviewRequest:
       type: object
-      required: [draft_id, expected_draft_version]
+      required: [drafts]
       properties:
-        draft_id:
-          type: string
-        expected_draft_version:
-          type: integer
+        drafts:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ReviewDraftRequest"
         title:
           type: string
         description:
@@ -1626,12 +1627,15 @@ components:
             - type: "null"
     CreateReviewSubmissionRequest:
       type: object
-      required: [expected_review_version, expected_draft_version]
+      required: [expected_review_version, drafts]
       properties:
         expected_review_version:
           type: integer
-        expected_draft_version:
-          type: integer
+        drafts:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/ReviewDraftRequest"
         title:
           type: string
         description:
@@ -1644,9 +1648,27 @@ components:
           oneOf:
             - $ref: "#/components/schemas/ReconciliationResourceState"
             - type: "null"
+    ReviewDraftRequest:
+      type: object
+      required: [draft_id, expected_draft_version]
+      properties:
+        draft_id:
+          type: string
+        expected_draft_version:
+          type: integer
+    ReviewDraftDetail:
+      type: object
+      required: [draft, operations]
+      properties:
+        draft:
+          $ref: "#/components/schemas/Draft"
+        operations:
+          type: array
+          items:
+            $ref: "#/components/schemas/DraftOperation"
     ReviewDetail:
       type: object
-      required: [review, draft, operations, comments]
+      required: [review, draft, operations, drafts, comments]
       properties:
         review:
           $ref: "#/components/schemas/Review"
@@ -1656,6 +1678,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DraftOperation"
+        drafts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReviewDraftDetail"
         comments:
           type: array
           items:
@@ -1666,6 +1692,7 @@ components:
         - review_id
         - project_id
         - draft_id
+        - draft_ids
         - author
         - title
         - description
@@ -1684,6 +1711,10 @@ components:
           description: Project carrying the reviewed Draft; the Draft resource scope identifies the authority target.
         draft_id:
           type: string
+        draft_ids:
+          type: array
+          items:
+            type: string
         author:
           $ref: "#/components/schemas/UserRef"
         title:


### PR DESCRIPTION
## Summary

- allow a directory or multi-selection of changed Organization memories to create one Review
- require the breaking `drafts[]` request contract so older servers reject the request instead of silently submitting one file
- render every changed file in the macOS Review navigator and preserve per-file comments/reconciliation
- submit, approve, reject, resubmit, and merge every draft atomically; one merge produces one commit

## Data model

- add `review_drafts` with stable draft ordering
- backfill existing single-draft Reviews at ordinal 0

## Verification

- `DOCKER_HOST=unix:///Users/weiwang/.orbstack/run/docker.sock cargo test -p server`
- `sh apps/macos/Scripts/test.sh`
- `bun run api:check`
- `cargo clippy -p server --all-targets -- -D warnings -A clippy::too_many_arguments`
- `cargo fmt --all -- --check`
- `git diff --check`

## Deployment

After merge to `main`, successful main CI triggers Server Delivery. The repository variable `SERVER_AUTO_DEPLOY_ENABLED` is currently `true`, so the production server deployment is automatic.