### PR TITLE
reviews: refine list UI and merge approvals atomically

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -94,6 +94,7 @@ enum ReviewRequestError: LocalizedError, Sendable {
     case reconciliationRequired
     case reconcileDirectoryDrafts
     case mixedProjects
+    case reviewChanged
 
     var errorDescription: String? {
         switch self {
@@ -107,6 +108,8 @@ enum ReviewRequestError: LocalizedError, Sendable {
             "Sync every changed file in this directory before requesting one review."
         case .mixedProjects:
             "All drafts in a review must belong to the same Project."
+        case .reviewChanged:
+            "This Review changed on the Server. Review its latest state before deciding."
         }
     }
 }
@@ -197,7 +200,9 @@ enum ReviewMenuAction: Sendable, Equatable {
         isAuthor: Bool
     ) -> Bool {
         switch self {
-        case .approve, .reject:
+        case .approve:
+            return review.status == "open" && canDecideReviews && canMergeReviews
+        case .reject:
             return review.status == "open" && canDecideReviews
         case .merge:
             return review.status == "approved"
@@ -837,7 +842,7 @@ final class WorkspaceStore: ObservableObject {
         do {
             switch action {
             case .approve:
-                try await decide(review, decision: "approved", note: "")
+                try await merge(review)
             case .reject:
                 try await decide(review, decision: "rejected", note: "")
             case .merge:
@@ -3984,6 +3989,11 @@ final class WorkspaceStore: ObservableObject {
         // exact target Ref generation for both scopes; the carrying Project's
         // ETag is wrong for Org-targeted Drafts.
         let detail = try await reviewDetail(review.id)
+        let currentReview = WorkspaceLoader.mapReview(detail)
+        replaceReview(with: currentReview)
+        guard ReviewDecisionReadiness(review: review).matches(currentReview) else {
+            throw ReviewRequestError.reviewChanged
+        }
         guard Self.isOrganizationDraft(detail.draft) else {
             throw ReviewRequestError.legacyProjectDraftCannotBePublished
         }

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -178,10 +178,10 @@ struct ReviewListPage: View {
                             ReviewRow(
                                 review: review,
                                 projectName: projectName(for: review),
-                                state: state,
-                                showsState: statusFilter == .all || state.isQueueSignal
+                                state: state
                             )
                         }
+                        .listRowSeparator(.visible)
                         .accessibilityIdentifier("review-row-\(review.id)")
                     }
                 }
@@ -329,63 +329,82 @@ struct ReviewRow: View {
     let review: ReviewRecord
     let projectName: String?
     let state: ReviewQueueStatePresentation
-    let showsState: Bool
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline, spacing: 10) {
                 Text(review.title)
-                    .font(.body)
-                    .lineLimit(1)
+                    .font(.body.weight(.medium))
+                    .lineLimit(2)
                     .layoutPriority(1)
+                    .help(review.title)
 
                 Spacer(minLength: 8)
 
-                if showsState {
-                    ViewThatFits(in: .horizontal) {
-                        Label(state.title, systemImage: state.symbolName)
-                            .lineLimit(1)
-                            .fixedSize(horizontal: true, vertical: false)
+                ViewThatFits(in: .horizontal) {
+                    Label(state.title, systemImage: state.symbolName)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
 
-                        Image(systemName: state.symbolName)
-                    }
-                    .font(.caption)
-                    .foregroundStyle(state.tone.color)
-                    .help(state.title)
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(state.title)
+                    Image(systemName: state.symbolName)
                 }
+                .font(.caption)
+                .foregroundStyle(state.tone.color)
+                .help(state.title)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(state.title)
             }
 
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text(context)
+            if !description.isEmpty {
+                Text(description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-
-                Spacer(minLength: 8)
-
-                if let updatedAt = IssueTiming.date(from: review.updatedAt) {
-                    Text(updatedAt, style: .relative)
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .help(IssueTiming.absoluteText(review.updatedAt) ?? "")
-                }
+                    .help(review.description)
             }
+
+            metadata
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .help(metadataHelp)
         }
-        .padding(.vertical, 6)
+        .padding(.vertical, 7)
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
+        .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityText)
     }
 
+    private var author: String {
+        review.author.displayName ?? review.author.email
+    }
+
+    private var description: String {
+        review.description.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private var context: String {
-        let author = review.author.displayName ?? review.author.email
         guard let projectName, !projectName.isEmpty else { return author }
         return "\(projectName) · \(author)"
+    }
+
+    private var metadata: Text {
+        var text = Text("Submitted by \(author)")
+        if let projectName, !projectName.isEmpty {
+            text = text + Text(" for \(projectName)")
+        }
+        if let updatedAt = IssueTiming.date(from: review.updatedAt) {
+            text = text + Text(" · updated ") + Text(updatedAt, style: .relative)
+        }
+        return text
+    }
+
+    private var metadataHelp: String {
+        IssueTiming.absoluteText(review.updatedAt)
+            .map { "Last Review record update: \($0)" }
+            ?? "Review submission"
     }
 
     private var accessibilityText: String {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -751,8 +751,8 @@ struct WorkspaceView: View {
                     )
                     .help(review.freshness == .behind
                         ? "Review the latest shared changes before deciding"
-                        : "Approve this Review")
-                    .accessibilityLabel("Approve Review")
+                        : "Approve and merge this Review")
+                    .accessibilityLabel("Approve and Merge Review")
                     .accessibilityIdentifier("review-toolbar-approve")
                 }
             }

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -147,6 +147,11 @@ final class WorkspaceNavigationTests: XCTestCase {
             version: 8
         )))
         XCTAssertFalse(readiness.matches(reviewRecord(
+            status: "rejected",
+            id: reviewId,
+            version: 7
+        )))
+        XCTAssertFalse(readiness.matches(reviewRecord(
             status: "open",
             freshness: .behind,
             id: reviewId,
@@ -183,6 +188,18 @@ final class WorkspaceNavigationTests: XCTestCase {
             for: review,
             canDecideReviews: false,
             canMergeReviews: false,
+            isAuthor: false
+        ))
+        XCTAssertFalse(ReviewMenuAction.approve.isAvailable(
+            for: review,
+            canDecideReviews: true,
+            canMergeReviews: false,
+            isAuthor: false
+        ))
+        XCTAssertTrue(ReviewMenuAction.approve.isAvailable(
+            for: review,
+            canDecideReviews: true,
+            canMergeReviews: true,
             isAuthor: false
         ))
         XCTAssertTrue(ReviewMenuAction.reject.isAvailable(
@@ -233,7 +250,7 @@ final class WorkspaceNavigationTests: XCTestCase {
                 surface: .detail,
                 review: review,
                 canDecideReviews: true,
-                canMergeReviews: false,
+                canMergeReviews: true,
                 isAuthor: false
             ).items,
             [.decision(.reject), .decision(.approve)]

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -144,6 +144,7 @@ async fn approve_and_merge(
     repository
         .create_review_merge(
             &approved.review.review_id,
+            &approved.review.author.user_id,
             expected_ref,
             CreateReviewMergeRequest {
                 expected_review_version: approved.review.version,
@@ -1517,6 +1518,7 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
     let final_merge = repository
         .create_review_merge(
             &approved.review.review_id,
+            &approved.review.author.user_id,
             Some(&current_commit_id),
             CreateReviewMergeRequest {
                 expected_review_version: approved.review.version,
@@ -2662,6 +2664,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
     let merge = repository
         .create_review_merge(
             &approved.review.review_id,
+            &approved.review.author.user_id,
             None,
             CreateReviewMergeRequest {
                 expected_review_version: approved.review.version,

--- a/crates/server/src/http.rs
+++ b/crates/server/src/http.rs
@@ -1707,7 +1707,12 @@ async fn create_review_merge(
     Ok(Json(
         state
             .repository
-            .create_review_merge(&review_id, expected_ref.as_deref(), request)
+            .create_review_merge(
+                &review_id,
+                &principal.user_id,
+                expected_ref.as_deref(),
+                request,
+            )
             .await?,
     ))
 }

--- a/crates/server/src/repository.rs
+++ b/crates/server/src/repository.rs
@@ -2963,6 +2963,7 @@ impl ServerRepository {
     pub async fn create_review_merge(
         &self,
         review_id: &str,
+        actor_user_id: &str,
         expected_project_ref: Option<&str>,
         request: CreateReviewMergeRequest,
     ) -> Result<ReviewMergeResult, ServerError> {
@@ -3002,7 +3003,7 @@ impl ServerRepository {
 
         let status: String = row.try_get("status")?;
         let version: i64 = row.try_get("version")?;
-        if status != "approved" {
+        if status != "open" && status != "approved" {
             return Err(ServerError::invalid_transition("review", &status, "merged"));
         }
         if version != request.expected_review_version {
@@ -3012,7 +3013,6 @@ impl ServerRepository {
                 version,
             ));
         }
-
         let project_id: String = row.try_get("project_id")?;
         let draft_ids = load_review_draft_ids(&mut tx, review_id).await?;
         let mut draft_rows = Vec::with_capacity(draft_ids.len());
@@ -3088,7 +3088,7 @@ impl ServerRepository {
 
         let approved_result_hash: Option<String> = row.try_get("approved_result_hash")?;
         let current_result_hash = review_result_hash(&mut tx, &draft_ids).await?;
-        if approved_result_hash.as_deref() != Some(&current_result_hash) {
+        if status == "approved" && approved_result_hash.as_deref() != Some(&current_result_hash) {
             return Err(ServerError::InvalidTransition {
                 entity: "review",
                 from: "approval_for_previous_content".to_owned(),
@@ -3153,10 +3153,18 @@ impl ServerRepository {
         };
         sqlx::query(
             "UPDATE reviews
-             SET status = 'merged', version = version + 1, updated_at = now()
+             SET status = 'merged', version = version + 1,
+                 decision_body = CASE WHEN $2 THEN NULL ELSE decision_body END,
+                 approved_result_hash = CASE WHEN $2 THEN $3 ELSE approved_result_hash END,
+                 decided_by_user_id = CASE WHEN $2 THEN $4 ELSE decided_by_user_id END,
+                 decided_at = CASE WHEN $2 THEN now() ELSE decided_at END,
+                 updated_at = now()
              WHERE review_id = $1",
         )
         .bind(review_id)
+        .bind(status == "open")
+        .bind(&current_result_hash)
+        .bind(actor_user_id)
         .execute(&mut *tx)
         .await?;
         sqlx::query(

--- a/crates/server/tests/draft_operation_ordering.rs
+++ b/crates/server/tests/draft_operation_ordering.rs
@@ -150,6 +150,7 @@ async fn multi_draft_review_merges_every_file_in_one_commit() {
     let merged = repo
         .create_review_merge(
             &detail.review.review_id,
+            &bootstrap.user_id,
             head.as_deref(),
             CreateReviewMergeRequest {
                 expected_review_version: approved.review.version,
@@ -211,6 +212,7 @@ async fn approve_and_merge(
         .unwrap();
     repo.create_review_merge(
         &approved.review.review_id,
+        user_id,
         expected_ref,
         CreateReviewMergeRequest {
             expected_review_version: approved.review.version,

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -247,6 +247,7 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
     let merge_error = repo
         .create_review_merge(
             approved_review_id,
+            &bootstrap.user_id,
             None,
             CreateReviewMergeRequest {
                 expected_review_version: 1,
@@ -616,49 +617,72 @@ async fn draft_review_merge_produces_org_and_carrier_project_commits() {
     .await;
     assert_eq!(review_detail.comments, comments.items);
 
-    let review_detail: ReviewDetail = post_json(
+    let stale_approval = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/reviews/{}/merges", review.review_id))
+                .header("content-type", "application/json")
+                .header(
+                    "if-match",
+                    "\"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"",
+                )
+                .body(Body::from(
+                    serde_json::to_vec(&CreateReviewMergeRequest {
+                        expected_review_version: review.version,
+                    })
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stale_approval.status(), StatusCode::PRECONDITION_FAILED);
+    let unchanged: ReviewDetail = get_json(
         app.clone(),
-        &format!("/api/v1/reviews/{}/decisions", review.review_id),
-        &CreateReviewDecisionRequest {
-            decision: ReviewDecision::Approved,
-            expected_review_version: 1,
-            body: Some("Looks good".to_owned()),
-        },
+        &format!("/api/v1/reviews/{}", review.review_id),
     )
     .await;
-    let review = review_detail.review;
-    assert_eq!(review.status, ReviewStatus::Approved);
-    assert_eq!(
-        review.decided_by.as_ref().map(|user| user.user_id.as_str()),
-        Some(user_id.as_str())
-    );
-    assert_eq!(
-        review
-            .decided_by
-            .as_ref()
-            .and_then(|user| user.display_name.as_deref()),
-        Some("Owner")
-    );
-    let approved_at = review.decided_at.expect("approval time should be recorded");
-    let incomplete_decision_metadata =
-        sqlx::query("UPDATE reviews SET decided_by_user_id = NULL WHERE review_id = $1")
-            .bind(&review.review_id)
-            .execute(&postgres.pool)
-            .await;
-    assert!(incomplete_decision_metadata.is_err());
+    assert_eq!(unchanged.review.status, ReviewStatus::Open);
+    assert_eq!(unchanged.review.decided_by, None);
+    assert_eq!(unchanged.review.decided_at, None);
 
     let merge: ReviewMergeResult = post_json_with_etag(
         app.clone(),
         &format!("/api/v1/reviews/{}/merges", review.review_id),
         &org_ref_etag,
         &CreateReviewMergeRequest {
-            expected_review_version: 2,
+            expected_review_version: review.version,
         },
     )
     .await;
     assert_eq!(merge.review.status, ReviewStatus::Merged);
-    assert_eq!(merge.review.decided_by, review.decided_by);
-    assert_eq!(merge.review.decided_at, Some(approved_at));
+    assert_eq!(merge.review.version, review.version + 1);
+    assert_eq!(
+        merge
+            .review
+            .decided_by
+            .as_ref()
+            .map(|user| user.user_id.as_str()),
+        Some(user_id.as_str())
+    );
+    assert_eq!(
+        merge
+            .review
+            .decided_by
+            .as_ref()
+            .and_then(|user| user.display_name.as_deref()),
+        Some("Owner")
+    );
+    assert!(merge.review.decided_at.is_some());
+    assert!(merge.review.approved_result_hash.is_some());
+    let incomplete_decision_metadata =
+        sqlx::query("UPDATE reviews SET decided_by_user_id = NULL WHERE review_id = $1")
+            .bind(&merge.review.review_id)
+            .execute(&postgres.pool)
+            .await;
+    assert!(incomplete_decision_metadata.is_err());
     assert_eq!(merge.applied_operation_count, 1);
     let commit_id = merge.commit_id.expect("merge should create a commit");
     let merged_draft: DraftDetail = get_json(
@@ -1455,6 +1479,7 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
     let error = repo
         .create_review_merge(
             &org_review.review.review_id,
+            &bootstrap.user_id,
             org_head_before.as_deref(),
             CreateReviewMergeRequest {
                 expected_review_version: org_review.review.version,
@@ -2351,6 +2376,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     let base_commit_id = repo
         .create_review_merge(
             &seed_review.review.review_id,
+            &bootstrap.user_id,
             None,
             CreateReviewMergeRequest {
                 expected_review_version: seed_review.review.version,
@@ -2502,6 +2528,7 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
     let current_commit_id = repo
         .create_review_merge(
             &remote_review.review.review_id,
+            &bootstrap.user_id,
             Some(&base_commit_id),
             CreateReviewMergeRequest {
                 expected_review_version: remote_review.review.version,
@@ -3206,6 +3233,7 @@ async fn project_org_selection_resolves_legacy_path_only_draft_after_authority_r
         .unwrap();
     repo.create_review_merge(
         &approved.review.review_id,
+        &bootstrap.user_id,
         base_commit_id.as_deref(),
         CreateReviewMergeRequest {
             expected_review_version: approved.review.version,
@@ -3590,6 +3618,7 @@ async fn created_org_draft_materializes_local_identity_updates_and_renames() {
         .unwrap();
     repo.create_review_merge(
         &approved.review.review_id,
+        &bootstrap.user_id,
         current_head.as_deref(),
         CreateReviewMergeRequest {
             expected_review_version: approved.review.version,
@@ -3732,6 +3761,7 @@ async fn org_delete_merge_advances_authority_past_other_projects_active_drafts()
 
     repo.create_review_merge(
         &approved.review.review_id,
+        &bootstrap.user_id,
         current_head.as_deref(),
         CreateReviewMergeRequest {
             expected_review_version: approved.review.version,

--- a/docs/guides/how-to-use-clumsies.md
+++ b/docs/guides/how-to-use-clumsies.md
@@ -43,9 +43,8 @@ The collaboration flow is:
 2. keep editing normally while newer shared Commits synchronize
 3. review and explicitly merge the latest shared version when prompted
 4. submit the coordinated draft for review
-5. an Organization owner/admin records the Review decision
-6. an Organization owner/admin merges an approved current Review
-7. receive the new authority Commit
+5. an Organization owner/admin rejects it or approves and merges it atomically
+6. receive the new authority Commit
 
 When the target Ref advances, Desktop continuously shows **共享版本已有更新**.
 Viewing the candidate does not change the Draft. **合并最新版本** shows the
@@ -57,9 +56,9 @@ applied.
 Creating or resubmitting a Review must use the latest Ref. If it moves again
 during confirmation, Clumsies recalculates instead of overwriting authority.
 An existing Review may remain behind and continue to receive comments, but it
-must be coordinated before merge. An update that changes the final resource
-result invalidates prior approval; a Base-only change with byte-identical final
-result preserves it.
+must be coordinated before approval. Approval uses `If-Match` as a final guard;
+if the Ref moves, the Review remains Open rather than stopping in a partially
+approved state. Historical Approved Reviews can still be merged.
 
 ## Agent workflow
 

--- a/docs/reviews-ui-design.md
+++ b/docs/reviews-ui-design.md
@@ -54,10 +54,12 @@ Submitted by author for project · updated relative time
   an opaque Project ID or raw protocol timestamp.
 - Resolve one workflow state for the row. Precedence is `Merged`, `Conflicts`,
   `Update Required`/`Out of Date`, then the viewer-aware lifecycle state:
-  `Needs Review`, `Ready to Merge`/`Approved`, or `Resubmit`/`Awaiting Author`.
+  `Needs Review`, legacy `Ready to Merge`/`Approved`, or
+  `Resubmit`/`Awaiting Author`.
   A merged Review never displays stale merely because the merge advanced the
-  current Project ref. `Ready to Merge` also requires a nonempty approved result
-  hash; capability alone does not make a legacy approval mergeable.
+  current Project ref. `Ready to Merge` applies only to historical two-step
+  approvals and also requires a nonempty approved result hash; capability alone
+  does not make a legacy approval mergeable.
 - The workflow state is a plain system `Label` with an SF Symbol and semantic
   foreground color. It is neither a button nor a capsule. Never stack a status
   icon and freshness icon that require hover to distinguish. Always show the
@@ -71,8 +73,8 @@ Submitted by author for project · updated relative time
   twice during a programmatic deep-link.
 - The status Filter menu belongs to the list page's leading/navigation toolbar
   area. Its collapsed label communicates the selected scope; counts remain in
-  the menu, help, and accessibility value. The menu contains Open, Approved,
-  Rejected, Merged, and All with counts.
+  the menu, help, and accessibility value. The menu contains Open, Approved
+  (for historical records), Rejected, Merged, and All with counts.
 - Search is an independent window-level action and remains the trailing-most
   Review tool. Sync and decision actions are not grouped with Filter.
 - Loading without cached Reviews uses a labeled `ProgressView`. Existing cached
@@ -144,12 +146,14 @@ the UI labels these honestly rather than pretending they are inline comments.
 
 Decision actions remain native symbol toolbar items with menu-command parity:
 
-- Open: Org owners/admins with `review:decide` see Reject (`xmark`) and the
-  single prominent Approve (`checkmark`); ordinary members remain read/comment
-  participants and see neither authority action.
-- Approved: Merge (`arrow.triangle.merge`) when permitted and the Server
-  supplied a nonempty approved result hash. Legacy approvals without that
-  immutable result identity remain visible but cannot be merged.
+- Open: Org owners/admins with `review:decide` and `review:merge` see Reject
+  (`xmark`) and the single prominent Approve (`checkmark`). Approve records the
+  decision and merges into authority in one Server transaction; ordinary
+  members remain read/comment participants and see neither authority action.
+- Approved: historical records retain Merge (`arrow.triangle.merge`) when
+  permitted and the Server supplied a nonempty approved result hash. Legacy
+  approvals without that immutable result identity remain visible but cannot
+  be merged.
 - Rejected: Resubmit (`arrow.clockwise`) for the Draft author.
 
 Filter belongs only to the list page. Decision tools belong only to an active

--- a/docs/reviews-ui-design.md
+++ b/docs/reviews-ui-design.md
@@ -26,23 +26,32 @@ global sidebar | NavigationStack (Review list -> Review detail)
 
 ## 2. Review list
 
-Use a native inset `List`. Do not draw card borders, custom selection stripes,
-or web-style status pills.
+Use a native inset `List` with information-rich rows and visible row separators.
+A single click pushes the Review detail. The scroll area fills its content
+region without drawing an outer border; record boundaries come from system
+separators, focus, selection, hover, and inactive-window behavior. Do not enable
+alternating row backgrounds: AppKit continues their stripes through empty table
+space, making nonexistent Reviews look like blank rows. Pin the separator's
+leading alignment to the row rather than allowing trailing metadata such as the
+relative update time to shorten it.
 
-The list is a review queue, not a summary card. Each row answers five scan
-questions: what changed, where it belongs, who submitted it, when its Review
-record last changed, and what the current viewer can do next. It has at most
-two useful lines:
+The list is a review queue. Each row answers five scan questions: what changed,
+where it belongs, who submitted it, when its Review record last changed, and
+what the current viewer can do next:
 
 ```
 review title                     symbol + one semantic workflow state
-project · author                              relative update time
+description excerpt
+Submitted by author for project · updated relative time
 ```
 
-- Keep descriptions in the detail page.
-- Keep the relative time in its own trailing column so a long Project or author
-  cannot remove it. If a Project name or timestamp cannot be resolved, omit the
-  value; never expose an opaque Project ID or raw protocol timestamp.
+- Keep descriptions to a one-line excerpt; the complete description stays in
+  the detail page.
+- Express Project, author, and relative update time as one muted sentence in the
+  GitHub Issue metadata style. The author is the submitter, not necessarily the
+  person who last updated the Review record, so never label the update as theirs.
+  If a Project name or timestamp cannot be resolved, omit the value; never expose
+  an opaque Project ID or raw protocol timestamp.
 - Resolve one workflow state for the row. Precedence is `Merged`, `Conflicts`,
   `Update Required`/`Out of Date`, then the viewer-aware lifecycle state:
   `Needs Review`, `Ready to Merge`/`Approved`, or `Resubmit`/`Awaiting Author`.
@@ -51,14 +60,15 @@ project · author                              relative update time
   hash; capability alone does not make a legacy approval mergeable.
 - The workflow state is a plain system `Label` with an SF Symbol and semantic
   foreground color. It is neither a button nor a capsule. Never stack a status
-  icon and freshness icon that require hover to distinguish. In `All`, show the
-  lifecycle label. In a single-status scope, omit the repetitive baseline label
-  and show only queue signals that change the next step. At narrow widths, the
-  label may reduce to its symbol so the primary Review title retains priority.
-- Let macOS draw focus, hover/press feedback, separators, and inactive-window
-  state. In this push-navigation list, `NavigationLink` and the stack path are
-  the only navigation state; do not add a parallel `List(selection:)` binding
-  that can push the same route twice during a programmatic deep-link.
+  icon and freshness icon that require hover to distinguish. Always show the
+  resolved state because it anchors the row's workflow meaning even inside a
+  filtered scope. At narrow widths, the label may reduce to its symbol so the
+  primary Review title retains priority.
+- Let macOS draw separators, focus, hover/press feedback, and inactive-window
+  state. Do not draw an outer list border, per-row cards, or empty-space zebra
+  stripes. `NavigationLink` and the stack path are the only navigation state;
+  do not add a parallel `List(selection:)` binding that can push the same route
+  twice during a programmatic deep-link.
 - The status Filter menu belongs to the list page's leading/navigation toolbar
   area. Its collapsed label communicates the selected scope; counts remain in
   the menu, help, and accessibility value. The menu contains Open, Approved,
@@ -70,9 +80,9 @@ project · author                              relative update time
   `ContentUnavailableView`; filtered-empty includes `Show All Reviews`.
 
 The GitHub pull-request list informs the information order — title first,
-scope/author/time second, and a small number of workflow signals — but not the
-visual chrome. Do not copy its bordered Web container, row rules, blue links,
-colored pills, PR numbers, avatar stacks, comment counters, or pagination. The
+scope/author/time second, and a small number of workflow signals — but not its
+Web chrome. Do not copy blue links, colored pills, PR numbers, avatar stacks,
+comment counters, or pagination. The
 Server does not currently provide unread counts, unresolved-thread counts, or a
 true last-activity timestamp, and the macOS client must not invent them from
 `updatedAt`.

--- a/docs/server.md
+++ b/docs/server.md
@@ -53,12 +53,15 @@ revision before atomically changing `base_commit_id` and operations.
 Applying a clean candidate always uses the Server's canonical proposed result;
 only a conflicts candidate accepts a complete user-resolved state.
 
-Creating or resubmitting a Review and merging an approved Review are coordination
-boundaries. A Project member may propose, submit, inspect, and comment; only an
-Organization owner or administrator may approve, reject, or merge an Org
-publication Review. Review creation/submission can apply a confirmed candidate
-in the same Ref-locked transaction. Merge never performs the first stale check
-as a normal workflow; it retains `If-Match`/CAS as the final concurrency guard.
+Creating or resubmitting a Review and approving it for publication are
+coordination boundaries. A Project member may propose, submit, inspect, and
+comment; only an Organization owner or administrator may approve or reject an
+Org publication Review. Approval records the decision and advances the target
+Ref in one transaction, moving an Open Review directly to Merged. The merge
+endpoint still accepts historical Approved Reviews. Review creation/submission
+can apply a confirmed candidate in the same Ref-locked transaction. Publication
+never performs the first stale check as a normal workflow; it retains
+`If-Match`/CAS as the final concurrency guard.
 
 The detailed state model and failure semantics are maintained in the Obsidian
 architecture document `architecture/draft-reconciliation.md`.

--- a/packages/api-contract/openapi/clumsies.public.v1.yaml
+++ b/packages/api-contract/openapi/clumsies.public.v1.yaml
@@ -738,7 +738,7 @@ paths:
     post:
       operationId: createReviewDecision
       summary: Create an organization-authorized review decision.
-      description: Requires the caller to be an Organization owner or administrator and a member of the carrying Project.
+      description: Requires the caller to be an Organization owner or administrator and a member of the carrying Project. New clients use this endpoint for rejection; the approved decision value remains wire-compatible for older two-step clients, while current clients approve atomically through the merge endpoint.
       requestBody:
         required: true
         content:
@@ -794,7 +794,7 @@ paths:
       - $ref: "#/components/parameters/ReviewId"
     post:
       operationId: createReviewMerge
-      summary: Merge an approved review and produce authoritative external-memory resources.
+      summary: Atomically approve and merge an open review, or merge a historical approved review.
       parameters:
         - $ref: "#/components/parameters/IfMatch"
       requestBody:
@@ -805,7 +805,7 @@ paths:
               $ref: "#/components/schemas/CreateReviewMergeRequest"
       responses:
         "200":
-          description: Merge result.
+          description: Atomic approval and merge result.
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Summary
- present Reviews as a native inset list with clearer row hierarchy and metadata
- make Approve publish an Open Review atomically in the existing merge transaction
- preserve Merge for historical Approved Reviews and refresh stale client state before deciding

## Validation
- cargo test -p server
- sh apps/macos/Scripts/test.sh
- cargo fmt --all -- --check
- git diff --check