### PR TITLE
fix: finish ISSUE-028 latency and release hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,41 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Ref resolving to the current default branch tip to sign
+        required: true
+        default: main
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   macos-release:
+    environment: macos-signing
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Verify release source is the default branch tip
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git fetch --depth=1 --no-tags origin "$DEFAULT_BRANCH"
+          test "$(git rev-parse HEAD)" = "$(git rev-parse FETCH_HEAD)" || {
+            echo "Release source must be the current default branch tip." >&2
+            exit 1
+          }
+          test -x apps/macos/Scripts/verify-release-signature.sh || {
+            echo "Release source is missing the signed release gate." >&2
+            exit 1
+          }
 
       - name: Verify tag matches native macOS version
+        if: github.event_name == 'push'
         run: |
           NATIVE_VERSION=$(awk -F'"' '/MARKETING_VERSION:/ { print $2; exit }' apps/macos/project.yml)
           test "$GITHUB_REF_NAME" = "v$NATIVE_VERSION"
@@ -36,7 +60,6 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
           for name in \
             APPLE_CERTIFICATE \
@@ -44,8 +67,7 @@ jobs:
             APPLE_ID \
             APPLE_PASSWORD \
             APPLE_TEAM_ID \
-            KEYCHAIN_PASSWORD \
-            SPARKLE_PRIVATE_KEY
+            KEYCHAIN_PASSWORD
           do
             test -n "${!name}" || { echo "Missing release secret: $name"; exit 1; }
           done
@@ -83,17 +105,23 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           CLUMSIES_BUILD_NUMBER: ${{ github.run_number }}
-          CLUMSIES_VERSION: ${{ github.ref_name }}
         run: |
-          export CLUMSIES_VERSION="${CLUMSIES_VERSION#v}"
+          if [ "$GITHUB_EVENT_NAME" = push ]; then
+            CLUMSIES_VERSION="${GITHUB_REF_NAME#v}"
+          else
+            CLUMSIES_VERSION=$(awk -F'"' '/MARKETING_VERSION:/ { print $2; exit }' apps/macos/project.yml)
+          fi
+          export CLUMSIES_VERSION
           apps/macos/Scripts/archive-release.sh
 
       - name: Generate Sparkle appcast
+        if: github.event_name == 'push'
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: apps/macos/Scripts/generate-appcast.sh
 
-      - name: Stage native macOS artifacts
+      - name: Stage tagged macOS artifacts
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: clumsies-macos
@@ -102,9 +130,21 @@ jobs:
             dist/macos/appcast.xml
           if-no-files-found: error
 
+      - name: Stage signed macOS candidate
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clumsies-macos
+          path: |
+            dist/macos/Clumsies-*-macos-universal.zip
+          if-no-files-found: error
+
   publish-release:
+    if: github.event_name == 'push'
     needs: [macos-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download native macOS artifacts
         uses: actions/download-artifact@v4

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -30,7 +30,21 @@ bun run build:macos
 
 The local build is unsigned, targets the current Mac's architecture, and is written to `/private/tmp/clumsies-macos-build`. Distribution signing and notarization are separate release operations.
 
-Tagged releases build a universal Developer ID-signed app, notarize it, and publish a Sparkle-signed update archive and `appcast.xml` through GitHub Actions. The Sparkle private key is stored as the `SPARKLE_PRIVATE_KEY` repository secret; only its public key is committed in `project.yml`.
+Tagged releases build a universal Developer ID-signed app, notarize and staple it,
+verify the App and bundled Agent runtime share the expected signing team and
+hardened-runtime identity, then publish a Sparkle-signed update archive and
+`appcast.xml` through GitHub Actions. The same workflow can be dispatched manually
+from the current default-branch tip to produce a signed candidate. Manual candidates
+do not publish a GitHub Release or appcast.
+
+Keep the Apple certificate, certificate passphrase, notarization account,
+app-specific password, team ID, temporary keychain password, and Sparkle private key
+in the protected `macos-signing` GitHub environment, using the secret names referenced
+by `release.yml`. Restrict that environment to the default branch and release tags and
+require a reviewer before its secrets are exposed. The Sparkle private key is required
+only for a tagged release; only its public key is committed in `project.yml`. A local or
+ad-hoc build is suitable for tests, but the release signature gate deliberately rejects
+it for managed Coding Agent integration installation.
 
 ## Generate the Xcode project
 

--- a/apps/macos/Scripts/archive-release.sh
+++ b/apps/macos/Scripts/archive-release.sh
@@ -45,7 +45,7 @@ xcrun notarytool submit "$update_archive" \
   --team-id "$APPLE_TEAM_ID" \
   --wait
 xcrun stapler staple "$app_path"
-xcrun stapler validate "$app_path"
+apps/macos/Scripts/verify-release-signature.sh "$app_path" "$APPLE_TEAM_ID"
 
 rm "$update_archive"
 ditto -c -k --sequesterRsrc --keepParent "$app_path" "$update_archive"

--- a/apps/macos/Scripts/test-runtime-package.sh
+++ b/apps/macos/Scripts/test-runtime-package.sh
@@ -23,3 +23,10 @@ codesign --verify --deep --strict "$app"
 
 runtime_identifier="$(codesign -dvv "$runtime" 2>&1 | sed -n 's/^Identifier=//p')"
 test "$runtime_identifier" = "ai.clumsies.daemon"
+codesign --display --verbose=4 "$app" 2>&1 | grep -q '^Signature=adhoc$'
+codesign --display --verbose=4 "$runtime" 2>&1 | grep -q '^Signature=adhoc$'
+
+if apps/macos/Scripts/verify-release-signature.sh "$app" NOT_A_RELEASE_TEAM; then
+  echo "Ad-hoc package unexpectedly passed release signature verification." >&2
+  exit 1
+fi

--- a/apps/macos/Scripts/verify-release-signature.sh
+++ b/apps/macos/Scripts/verify-release-signature.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 /path/to/Clumsies.app APPLE_TEAM_ID" >&2
+  exit 2
+fi
+
+app="$1"
+expected_team="$2"
+runtime="$app/Contents/Resources/clumsiesd"
+
+[ -d "$app" ] || fail "Not an app bundle: $app"
+[ -x "$runtime" ] || fail "Missing bundled Agent runtime: $runtime"
+[ -n "$expected_team" ] || fail "APPLE_TEAM_ID must not be empty."
+
+codesign --verify --deep --strict --verbose=2 "$app"
+codesign --verify --strict --verbose=2 "$runtime"
+
+app_signature=$(codesign --display --verbose=4 "$app" 2>&1)
+runtime_signature=$(codesign --display --verbose=4 "$runtime" 2>&1)
+app_identifier=$(printf '%s\n' "$app_signature" | sed -n 's/^Identifier=//p')
+app_team=$(printf '%s\n' "$app_signature" | sed -n 's/^TeamIdentifier=//p')
+runtime_team=$(printf '%s\n' "$runtime_signature" | sed -n 's/^TeamIdentifier=//p')
+runtime_identifier=$(printf '%s\n' "$runtime_signature" | sed -n 's/^Identifier=//p')
+
+[ "$app_identifier" = ai.clumsies.desktop ] || fail "Clumsies.app has an unexpected signing identifier."
+[ "$app_team" = "$expected_team" ] || fail "Clumsies.app is not signed by the expected Apple team."
+[ "$runtime_team" = "$expected_team" ] || fail "clumsiesd is not signed by the expected Apple team."
+[ "$runtime_identifier" = ai.clumsies.daemon ] || fail "clumsiesd has an unexpected signing identifier."
+
+printf '%s\n' "$app_signature" \
+  | grep -Eq '^CodeDirectory .*flags=.*runtime' \
+  || fail "Clumsies.app is missing the hardened-runtime signing flag."
+printf '%s\n' "$runtime_signature" \
+  | grep -Eq '^CodeDirectory .*flags=.*runtime' \
+  || fail "clumsiesd is missing the hardened-runtime signing flag."
+
+xcrun stapler validate "$app"
+printf '%s\n' "Verified signed and notarized release app: $app"

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -223,8 +223,8 @@ struct ProjectState: Identifiable, Hashable, Sendable {
 
 struct RuntimeState: Sendable {
     let health: DaemonHealth
-    let sync: DaemonSyncStatus
-    let mcp: DaemonMCPStatus
+    let sync: DaemonSyncStatus?
+    let mcp: DaemonMCPStatus?
     let serverDataSource: String
 }
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -36,6 +36,21 @@ enum ApplicationPhase: Equatable, Sendable {
     case failed(String)
 }
 
+enum WorkspaceCollectionLoadState: Equatable, Sendable {
+    case loading
+    case loaded
+    case failed(String)
+
+    var isLoading: Bool {
+        self == .loading
+    }
+
+    var failureMessage: String? {
+        guard case .failed(let message) = self else { return nil }
+        return message
+    }
+}
+
 struct WorkspaceSnapshot: Sendable {
     let account: UserReference
     let organization: OrganizationReference
@@ -45,9 +60,6 @@ struct WorkspaceSnapshot: Sendable {
     let orgRefCommitId: String?
     let orgRefEtag: String
     let resources: [MemoryResource]
-    let drafts: [LocalDraft]
-    let bundles: [PersonalBundle]
-    let reviews: [ReviewRecord]
     let runtime: RuntimeState
     let legacyAgentAdapterConflicts: [DaemonLegacyAgentAdapterConflict]
     let legacyAgentAdapterInspectionWarning: String?
@@ -322,6 +334,9 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var drafts: [LocalDraft] = []
     @Published private(set) var bundles: [PersonalBundle] = []
     @Published private(set) var reviews: [ReviewRecord] = []
+    @Published private(set) var draftInventoryLoadState: WorkspaceCollectionLoadState = .loading
+    @Published private(set) var bundleLoadState: WorkspaceCollectionLoadState = .loading
+    @Published private(set) var reviewLoadState: WorkspaceCollectionLoadState = .loading
     @Published private(set) var runtime: RuntimeState?
     @Published private(set) var syncStatusAvailable = true
     @Published private(set) var legacyAgentAdapterConflicts: [DaemonLegacyAgentAdapterConflict] = []
@@ -372,6 +387,13 @@ final class WorkspaceStore: ObservableObject {
     private lazy var authentication = AuthenticationClient(daemon: daemon)
     private lazy var server = ServerClient(daemon: daemon)
     private var workspaceReloadGeneration = UUID()
+    private var draftInventoryLoadTask: Task<Void, Never>?
+    private var bundleLoadTask: Task<Void, Never>?
+    private var reviewLoadTask: Task<Void, Never>?
+    private var legacyAgentAdapterInspectionTask: Task<Void, Never>?
+    private var postReadySyncTask: Task<Void, Never>?
+    private var postReadyRetrySyncTask: Task<Void, Never>?
+    private var isSigningOut = false
     private var projectSelectionGeneration = UUID()
     private let projectSelectionSideEffectGate = ProjectSelectionSideEffectGate()
     private let draftMutationGate = AsyncMutex()
@@ -430,6 +452,7 @@ final class WorkspaceStore: ObservableObject {
     /// Organization Memory through a Project-bound LocalDraft. Legacy
     /// Project-scoped authority remains visible but read-only.
     func canEditMemory(_ item: MemoryListItem) -> Bool {
+        guard phase == .ready else { return false }
         let projectContextId = item.projectContextId
             ?? (item.scope == .project ? item.projectId : nil)
         guard let projectContextId,
@@ -1029,6 +1052,85 @@ final class WorkspaceStore: ObservableObject {
             && lhs.document.path == rhs.document.path
     }
 
+    nonisolated static func preservesDeferredAuthority(
+        currentAccount: UserReference?,
+        currentOrganization: OrganizationReference?,
+        nextAccount: UserReference,
+        nextOrganization: OrganizationReference
+    ) -> Bool {
+        currentAccount?.userId == nextAccount.userId
+            && currentOrganization?.orgId == nextOrganization.orgId
+    }
+
+    nonisolated static func invalidateWorkspaceTransitionState(
+        generation: inout UUID,
+        loadingProjectId: inout String?,
+        isSwitchingMemoryContext: inout Bool,
+        isPreparingWorkspaceIndex: inout Bool,
+        orgResourceRefreshGeneration: inout UUID?
+    ) {
+        generation = UUID()
+        loadingProjectId = nil
+        isSwitchingMemoryContext = false
+        isPreparingWorkspaceIndex = false
+        orgResourceRefreshGeneration = nil
+    }
+
+    nonisolated static func rejectsStaleAuthorityChange(
+        hadLoadedWorkspace: Bool,
+        sameAuthority: Bool,
+        snapshotWasStale: Bool
+    ) -> Bool {
+        hadLoadedWorkspace && !sameAuthority && snapshotWasStale
+    }
+
+    nonisolated static func deferredLoadRequiresFreshData(
+        hadLoadedWorkspace: Bool
+    ) -> Bool {
+        hadLoadedWorkspace
+    }
+
+    nonisolated static func retainingAccessibleProjectRecords<Record>(
+        _ records: [Record],
+        accessibleProjectIds: Set<String>,
+        projectId: KeyPath<Record, String>
+    ) -> [Record] {
+        records.filter { accessibleProjectIds.contains($0[keyPath: projectId]) }
+    }
+
+    nonisolated static func canPublishDeferredLoad(
+        requiresFreshData: Bool,
+        baseSnapshotWasStale: Bool,
+        responseWasStale: Bool
+    ) -> Bool {
+        !requiresFreshData || (!baseSnapshotWasStale && !responseWasStale)
+    }
+
+    nonisolated static func mergeDeferredRecords<Record>(
+        baseline: [Record],
+        current: [Record],
+        loaded: [Record]
+    ) -> [Record] where Record: Identifiable & Equatable, Record.ID: Hashable {
+        let baselineById = Dictionary(
+            baseline.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let currentById = Dictionary(
+            current.map { ($0.id, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        let loadedIds = Set(loaded.map(\.id))
+        var merged = current.filter {
+            !loadedIds.contains($0.id) && currentById[$0.id] != baselineById[$0.id]
+        }
+        merged.append(contentsOf: loaded.compactMap { loadedRecord -> Record? in
+            let id = loadedRecord.id
+            guard currentById[id] != baselineById[id] else { return loadedRecord }
+            return currentById[id]
+        })
+        return merged
+    }
+
     @discardableResult
     private func installLoadedResourceIfCurrent(_ loaded: MemoryResource) -> Bool {
         guard let index = resources.firstIndex(where: { $0.id == loaded.id }),
@@ -1046,18 +1148,23 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func reload(allowsDuringDocumentReconciliation: Bool = false) async {
+        guard !isSigningOut else { return }
         guard allowsDuringDocumentReconciliation
                 || (applyingDocumentReconciliationSessions.isEmpty
                     && standaloneReconciliationActivityIds.isEmpty) else {
             return
         }
-        let generation = UUID()
-        workspaceReloadGeneration = generation
+        guard loadingProjectId == nil, !isSwitchingMemoryContext else { return }
         if phase == .ready, hasPendingChanges, !(await flushPendingChanges()) {
             return
         }
-        guard workspaceReloadGeneration == generation else { return }
-        let preservesLoadedWorkspace = account != nil
+        // A project selection may have started while pending edits were
+        // flushing. Let that serialized intent finish before a later reload.
+        guard loadingProjectId == nil, !isSwitchingMemoryContext else { return }
+        cancelPostReadyWork()
+        let generation = UUID()
+        workspaceReloadGeneration = generation
+        let hadLoadedWorkspace = account != nil
         phase = .loading
         errorMessage = nil
         do {
@@ -1070,14 +1177,46 @@ final class WorkspaceStore: ObservableObject {
                 self?.applyLocalAgentAdapterResult(result)
             }
             guard workspaceReloadGeneration == generation else { return }
+            let sameAuthority = Self.preservesDeferredAuthority(
+                currentAccount: account,
+                currentOrganization: organization,
+                nextAccount: snapshot.account,
+                nextOrganization: snapshot.organization
+            )
+            let snapshotWasStale = snapshot.runtime.serverDataSource == "stale"
+            if Self.rejectsStaleAuthorityChange(
+                hadLoadedWorkspace: hadLoadedWorkspace,
+                sameAuthority: sameAuthority,
+                snapshotWasStale: snapshotWasStale
+            ) {
+                clearAuthorityScopedWorkspace()
+                phase = .failed(
+                    "Fresh account data is required before switching workspaces. "
+                        + "The previous account workspace was cleared."
+                )
+                return
+            }
+            let preservesLoadedWorkspace = hadLoadedWorkspace && sameAuthority
             // Stale-cache data keeps a cold start usable while offline, but it
             // must never replace a newer generation already held in memory.
-            guard !preservesLoadedWorkspace || snapshot.runtime.serverDataSource != "stale" else {
+            guard !preservesLoadedWorkspace || !snapshotWasStale else {
                 phase = .ready
+                startPostReadyWork(
+                    generation: generation,
+                    requiresFreshData: true,
+                    baseSnapshotWasStale: true
+                )
                 return
             }
             apply(snapshot)
             phase = .ready
+            startPostReadyWork(
+                generation: generation,
+                requiresFreshData: Self.deferredLoadRequiresFreshData(
+                    hadLoadedWorkspace: hadLoadedWorkspace
+                ),
+                baseSnapshotWasStale: false
+            )
         } catch WorkspaceLoadError.authenticationRequired {
             guard workspaceReloadGeneration == generation else { return }
             phase = .authenticationRequired
@@ -1215,15 +1354,25 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func refreshProjectMembers() async {
+        let generation = workspaceReloadGeneration
         guard let projectId = activeProjectId else {
             projectMembers = []
             return
         }
         do {
-            projectMembers = try await projectMemberDirectory(projectId: projectId)
+            let members = try await projectMemberDirectory(projectId: projectId)
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId else {
+                return
+            }
+            projectMembers = members
         } catch is CancellationError {
             return
         } catch {
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId else {
+                return
+            }
             projectMembers = []
             errorMessage = error.localizedDescription
         }
@@ -1358,6 +1507,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func showOrgMemory() async {
+        guard phase == .ready else { return }
         guard activeProjectId != nil || loadingProjectId != nil else { return }
         guard canCommitMemoryContextSwitch else {
             errorMessage = "Finish or cancel the active document Sync before switching Memory context."
@@ -1391,6 +1541,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func selectProject(_ projectId: String) async {
+        guard phase == .ready else { return }
         guard let project = projects.first(where: { $0.id == projectId }) else { return }
         if projectId == activeProjectId,
            project.isLoaded,
@@ -1403,6 +1554,7 @@ final class WorkspaceStore: ObservableObject {
             return
         }
         let generation = UUID()
+        let workspaceGeneration = workspaceReloadGeneration
         // Publish the newest intent before the first suspension point. This
         // closes the window where two clicks could both start a daemon-side
         // selection while a pending document save was flushing.
@@ -1458,7 +1610,10 @@ final class WorkspaceStore: ObservableObject {
                     projects[index] = loadedProject.state
                 }
                 replaceProjectResources(projectId: projectId, with: loadedProject.resources)
-                try await remapDrafts(projectId: projectId)
+                try await remapDrafts(
+                    projectId: projectId,
+                    workspaceGeneration: workspaceGeneration
+                )
             }
             guard projectSelectionGeneration == generation else { return }
             if needsBackgroundRefresh {
@@ -1485,21 +1640,29 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func prepareWorkspaceIndex(includeContent: Bool) async {
+        let generation = workspaceReloadGeneration
         while isPreparingWorkspaceIndex {
             try? await Task.sleep(for: .milliseconds(100))
+            guard workspaceReloadGeneration == generation else { return }
         }
+        guard workspaceReloadGeneration == generation else { return }
         let needsProjects = projects.contains { !$0.isLoaded }
         let needsContent = includeContent && resources.contains { !$0.contentLoaded }
         guard needsProjects || needsContent else { return }
 
         isPreparingWorkspaceIndex = true
-        defer { isPreparingWorkspaceIndex = false }
+        defer {
+            if workspaceReloadGeneration == generation {
+                isPreparingWorkspaceIndex = false
+            }
+        }
         do {
             let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
             let unloadedProjects = projects.filter { !$0.isLoaded }
             let loadedProjects = try await concurrentMap(unloadedProjects, maxConcurrent: 4) { project in
                 try await loader.loadProject(id: project.id, name: project.name)
             }
+            guard workspaceReloadGeneration == generation else { return }
             for loaded in loadedProjects {
                 clearStaleResourceState(for: loaded.state.id)
                 if let index = projects.firstIndex(where: { $0.id == loaded.state.id }) {
@@ -1513,15 +1676,21 @@ final class WorkspaceStore: ObservableObject {
                 let loadedResources = try await concurrentMap(unloadedResources) {
                     try await loader.loadContent(for: $0)
                 }
+                guard workspaceReloadGeneration == generation else { return }
                 for loaded in loadedResources {
                     installLoadedResourceIfCurrent(loaded)
                 }
             }
 
             for projectId in Set(drafts.map(\.projectId)) {
-                try await remapDrafts(projectId: projectId)
+                try await remapDrafts(
+                    projectId: projectId,
+                    workspaceGeneration: generation
+                )
+                guard workspaceReloadGeneration == generation else { return }
             }
         } catch {
+            guard workspaceReloadGeneration == generation else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -1861,29 +2030,41 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func signOut() async {
-        guard await flushPendingChanges() else { return }
+        guard !isSigningOut else { return }
+        isSigningOut = true
+        let priorPhase = phase
+        phase = .loading
+        defer { isSigningOut = false }
+        guard await flushPendingChanges() else {
+            phase = priorPhase
+            return
+        }
+        workspaceReloadGeneration = UUID()
+        cancelPostReadyWork()
+        Self.invalidateWorkspaceTransitionState(
+            generation: &projectSelectionGeneration,
+            loadingProjectId: &loadingProjectId,
+            isSwitchingMemoryContext: &isSwitchingMemoryContext,
+            isPreparingWorkspaceIndex: &isPreparingWorkspaceIndex,
+            orgResourceRefreshGeneration: &orgResourceRefreshGeneration
+        )
         _ = try? await server.raw(method: "DELETE", path: "/api/v1/auth/session")
         do {
-            _ = try await daemon.replaceProjectConfig(
-                .init(
-                    serverUrl: AuthenticationClient.serverURL.absoluteString,
-                    projectId: nil,
-                    accessToken: nil,
-                    refreshToken: nil
+            _ = try await projectSelectionSideEffectGate.run {
+                try await daemon.replaceProjectConfig(
+                    .init(
+                        serverUrl: AuthenticationClient.serverURL.absoluteString,
+                        projectId: nil,
+                        accessToken: nil,
+                        refreshToken: nil
+                    )
                 )
-            )
-            account = nil
-            organization = nil
-            capabilities = []
-            projects = []
-            resources = []
-            drafts = []
-            bundles = []
-            reviews = []
-            tabs = []
+            }
+            clearAuthorityScopedWorkspace()
             phase = .authenticationRequired
         } catch {
             errorMessage = error.localizedDescription
+            phase = .failed(error.localizedDescription)
         }
     }
 
@@ -1950,6 +2131,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func stageDocumentSave(_ item: MemoryListItem, document: EditableMemoryDocument) {
+        guard phase == .ready, !isSigningOut else { return }
         guard canEditMemory(item) else {
             errorMessage = "You do not have permission to edit this memory."
             return
@@ -2021,6 +2203,7 @@ final class WorkspaceStore: ObservableObject {
         description: String,
         resourceIds: Set<String>
     ) {
+        guard phase == .ready, !isSigningOut else { return }
         let generation = UUID()
         pendingBundleSaves[bundle.id] = .init(
             bundle: bundle,
@@ -2390,10 +2573,12 @@ final class WorkspaceStore: ObservableObject {
 
     func refreshSyncStatus() async {
         guard phase == .ready else { return }
+        let generation = workspaceReloadGeneration
         await refreshOrgResourcesIfNeeded()
-        guard phase == .ready, let runtime else { return }
+        guard workspaceReloadGeneration == generation, phase == .ready, let runtime else { return }
         do {
             let sync = try await daemon.syncStatus()
+            guard workspaceReloadGeneration == generation, phase == .ready else { return }
             self.runtime = .init(
                 health: runtime.health,
                 sync: sync,
@@ -2401,9 +2586,16 @@ final class WorkspaceStore: ObservableObject {
                 serverDataSource: server.dataSource
             )
             syncStatusAvailable = true
-            await refreshDraftInventory(includeFailed: sync.pendingOperationCount > 0)
+            if draftInventoryLoadTask == nil {
+                await refreshDraftInventory(
+                    includeFailed: sync.pendingOperationCount > 0,
+                    generation: generation
+                )
+            }
+            guard workspaceReloadGeneration == generation, phase == .ready else { return }
             await refreshStaleResourcesIfNeeded(sync: sync)
         } catch {
+            guard workspaceReloadGeneration == generation else { return }
             syncStatusAvailable = false
         }
     }
@@ -2502,6 +2694,7 @@ final class WorkspaceStore: ObservableObject {
     }
 
     private func refreshOrgResourcesIfNeeded() async {
+        let workspaceGeneration = workspaceReloadGeneration
         guard selectedSection == .memory,
               activeProjectId == nil,
               !isSwitchingMemoryContext,
@@ -2519,13 +2712,15 @@ final class WorkspaceStore: ObservableObject {
         do {
             let head: (value: CommitStateResponse, response: DaemonServerResponse) =
                 try await server.getWithMetadata("/api/v1/org/commit-state")
-            guard !head.response.isStaleCache,
+            guard workspaceReloadGeneration == workspaceGeneration,
+                  !head.response.isStaleCache,
                   head.value.ref.commitId != observedOrgRefCommitId else {
                 return
             }
             guard let snapshot = try await loadStableOrgAuthoritySnapshot(),
                   let snapshotCommitId = snapshot.commitId,
                   snapshotCommitId == head.value.ref.commitId,
+                  workspaceReloadGeneration == workspaceGeneration,
                   phase == .ready,
                   selectedSection == .memory,
                   activeProjectId == nil,
@@ -4210,11 +4405,87 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
+    func clearAuthorityScopedWorkspace() {
+        Self.invalidateWorkspaceTransitionState(
+            generation: &projectSelectionGeneration,
+            loadingProjectId: &loadingProjectId,
+            isSwitchingMemoryContext: &isSwitchingMemoryContext,
+            isPreparingWorkspaceIndex: &isPreparingWorkspaceIndex,
+            orgResourceRefreshGeneration: &orgResourceRefreshGeneration
+        )
+        documentSaveTasks.values.forEach { $0.cancel() }
+        documentSaveTasks.removeAll()
+        pendingDocumentSaves.removeAll()
+        bundleSaveTasks.values.forEach { $0.cancel() }
+        bundleSaveTasks.removeAll()
+        pendingBundleSaves.removeAll()
+        account = nil
+        organization = nil
+        capabilities.removeAll()
+        projects.removeAll()
+        projectMetadata.removeAll()
+        projectMembers.removeAll()
+        orgRefCommitId = nil
+        orgRefEtag = ""
+        activeProjectId = nil
+        resources.removeAll()
+        drafts.removeAll()
+        bundles.removeAll()
+        reviews.removeAll()
+        draftInventoryLoadState = .loading
+        bundleLoadState = .loading
+        reviewLoadState = .loading
+        runtime = nil
+        syncStatusAvailable = false
+        selectedSection = .memory
+        selectedItemId = nil
+        selectedBundleId = nil
+        selectedReviewId = nil
+        pendingReviewReconciliationId = nil
+        reviewDecisionReadiness = nil
+        projectOrgSelectionMutatingIds.removeAll()
+        applyingDocumentReconciliationSessions.removeAll()
+        standaloneReconciliationActivityIds.removeAll()
+        tabs.removeAll()
+        activeTabId = nil
+        navigationBackStack.removeAll()
+        navigationForwardStack.removeAll()
+        showsProjectSettings = false
+        clearAllStaleResourceState()
+        resourceLoadRequests.removeAll()
+        loadingResourceIds.removeAll()
+        documentSynchronizationTasks.values.forEach { $0.cancel() }
+        documentSynchronizationTasks.removeAll()
+        pendingDocumentReconciliationCandidatesBySession.removeAll()
+        documentReconciliationResolutions.removeAll()
+        pendingDocumentCommand = nil
+        documentReconciliationToolbarState = nil
+        synchronizingDocumentSessions.removeAll()
+        documentSynchronizationGenerations.removeAll()
+    }
+
     private func apply(_ snapshot: WorkspaceSnapshot) {
+        let preservesDeferredAuthority = Self.preservesDeferredAuthority(
+            currentAccount: account,
+            currentOrganization: organization,
+            nextAccount: snapshot.account,
+            nextOrganization: snapshot.organization
+        )
         let previousResources = Dictionary(
             resources.map { ($0.id, $0) },
             uniquingKeysWith: { _, latest in latest }
         )
+        if !preservesDeferredAuthority {
+            clearAuthorityScopedWorkspace()
+        } else {
+            Self.invalidateWorkspaceTransitionState(
+                generation: &projectSelectionGeneration,
+                loadingProjectId: &loadingProjectId,
+                isSwitchingMemoryContext: &isSwitchingMemoryContext,
+                isPreparingWorkspaceIndex: &isPreparingWorkspaceIndex,
+                orgResourceRefreshGeneration: &orgResourceRefreshGeneration
+            )
+        }
         clearAllStaleResourceState()
         resourceLoadRequests.removeAll()
         loadingResourceIds.removeAll()
@@ -4233,6 +4504,24 @@ final class WorkspaceStore: ObservableObject {
         projectMetadata = projectMetadata.filter { projectId, _ in
             projects.contains { $0.id == projectId }
         }
+        projectMembers.removeAll()
+        let accessibleProjectIds = Set(projects.map(\.id))
+        drafts = Self.retainingAccessibleProjectRecords(
+            drafts,
+            accessibleProjectIds: accessibleProjectIds,
+            projectId: \.projectId
+        )
+        reviews = Self.retainingAccessibleProjectRecords(
+            reviews,
+            accessibleProjectIds: accessibleProjectIds,
+            projectId: \.projectId
+        )
+        if let selectedReviewId,
+           !reviews.contains(where: { $0.id == selectedReviewId }) {
+            self.selectedReviewId = nil
+            reviewDecisionReadiness = nil
+            pendingReviewReconciliationId = nil
+        }
         orgRefCommitId = snapshot.orgRefCommitId
         orgRefEtag = snapshot.orgRefEtag
         activeProjectId = snapshot.activeProjectId
@@ -4245,22 +4534,14 @@ final class WorkspaceStore: ObservableObject {
         where previousResources[resourceId] != nextResources[resourceId] {
             bumpDocumentContentGeneration(for: resourceId)
         }
-        drafts = snapshot.drafts
         pruneOrphanedMemoryTabs()
         refreshAllDocumentTabs()
-        bundles = snapshot.bundles
-        reviews = snapshot.reviews
         runtime = snapshot.runtime
         applyLocalAgentAdapterResult(.init(
             conflicts: snapshot.legacyAgentAdapterConflicts,
             inspectionWarning: snapshot.legacyAgentAdapterInspectionWarning
         ))
-        syncStatusAvailable = true
-        selectedBundleId = selectedBundleId ?? bundles.first?.id
-        if let selectedReviewId,
-           !reviews.contains(where: { $0.id == selectedReviewId }) {
-            self.selectedReviewId = nil
-        }
+        syncStatusAvailable = false
         if projects.isEmpty {
             selectedSection = .memory
             showsProjectSettings = false
@@ -4270,13 +4551,261 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    private func applyLocalAgentAdapterResult(_ result: LocalAgentAdapterReconciliationResult) {
-        legacyAgentAdapterConflicts = result.conflicts
-        legacyAgentAdapterInspectionWarning = result.inspectionWarning
-        errorMessage = Self.localAgentAdapterWarning(result)
+    private func cancelPostReadyWork() {
+        draftInventoryLoadTask?.cancel()
+        draftInventoryLoadTask = nil
+        bundleLoadTask?.cancel()
+        bundleLoadTask = nil
+        reviewLoadTask?.cancel()
+        reviewLoadTask = nil
+        legacyAgentAdapterInspectionTask?.cancel()
+        legacyAgentAdapterInspectionTask = nil
+        postReadySyncTask?.cancel()
+        postReadySyncTask = nil
+        postReadyRetrySyncTask?.cancel()
+        postReadyRetrySyncTask = nil
     }
 
-    static func localAgentAdapterWarning(
+    private func startPostReadyWork(
+        generation: UUID,
+        requiresFreshData: Bool,
+        baseSnapshotWasStale: Bool
+    ) {
+        guard workspaceReloadGeneration == generation, phase == .ready else { return }
+        let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
+        let resourcesAtReady = resources
+        let accessibleProjectIds = Set(projects.map(\.id))
+        let baselineDrafts = drafts
+        let baselineBundles = bundles
+        let baselineReviews = reviews
+        draftInventoryLoadState = .loading
+        bundleLoadState = .loading
+        reviewLoadState = .loading
+
+        legacyAgentAdapterInspectionTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.legacyAgentAdapterInspectionTask = nil
+                }
+            }
+            let result = await loader.inspectLegacyAgentAdapters()
+            guard let self,
+                  self.workspaceReloadGeneration == generation,
+                  self.phase == .ready,
+                  !Task.isCancelled else {
+                return
+            }
+            self.applyLocalAgentAdapterResult(result)
+        }
+
+        draftInventoryLoadTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.draftInventoryLoadTask = nil
+                }
+            }
+            do {
+                let loaded = try await loader.loadDeferredDrafts(
+                    resources: resourcesAtReady,
+                    accessibleProjectIds: accessibleProjectIds
+                )
+                try Task.checkCancellation()
+                guard let self,
+                      self.workspaceReloadGeneration == generation,
+                      self.phase == .ready else {
+                    return
+                }
+                guard Self.canPublishDeferredLoad(
+                    requiresFreshData: requiresFreshData,
+                    baseSnapshotWasStale: baseSnapshotWasStale,
+                    responseWasStale: loaded.hasStaleServerResponse
+                ) else {
+                    self.draftInventoryLoadState = .failed(
+                        "Fresh Draft data was unavailable. Existing Drafts were kept."
+                    )
+                    return
+                }
+                for resource in loaded.loadedBaselines {
+                    self.installLoadedResourceIfCurrent(resource)
+                }
+                self.drafts = Self.mergeDeferredRecords(
+                    baseline: baselineDrafts,
+                    current: self.drafts,
+                    loaded: loaded.drafts
+                )
+                self.draftInventoryLoadState = .loaded
+                self.pruneOrphanedMemoryTabs()
+                self.refreshAllDocumentTabs()
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, self.workspaceReloadGeneration == generation else { return }
+                self.draftInventoryLoadState = .failed(error.localizedDescription)
+            }
+        }
+
+        bundleLoadTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.bundleLoadTask = nil
+                }
+            }
+            do {
+                let loaded = try await loader.loadBundles()
+                try Task.checkCancellation()
+                guard let self,
+                      self.workspaceReloadGeneration == generation,
+                      self.phase == .ready else {
+                    return
+                }
+                guard Self.canPublishDeferredLoad(
+                    requiresFreshData: requiresFreshData,
+                    baseSnapshotWasStale: baseSnapshotWasStale,
+                    responseWasStale: loaded.hasStaleServerResponse
+                ) else {
+                    self.bundleLoadState = .failed(
+                        "Fresh Bundle data was unavailable. Existing Bundles were kept."
+                    )
+                    return
+                }
+                self.bundles = Self.mergeDeferredRecords(
+                    baseline: baselineBundles,
+                    current: self.bundles,
+                    loaded: loaded.records
+                )
+                self.bundleLoadState = .loaded
+                if let selectedBundleId = self.selectedBundleId,
+                   !self.bundles.contains(where: { $0.id == selectedBundleId }) {
+                    self.selectedBundleId = self.bundles.first?.id
+                } else {
+                    self.selectedBundleId = self.selectedBundleId ?? self.bundles.first?.id
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, self.workspaceReloadGeneration == generation else { return }
+                self.bundleLoadState = .failed(error.localizedDescription)
+            }
+        }
+
+        reviewLoadTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.reviewLoadTask = nil
+                }
+            }
+            do {
+                let loaded = try await loader.loadReviews()
+                try Task.checkCancellation()
+                guard let self,
+                      self.workspaceReloadGeneration == generation,
+                      self.phase == .ready else {
+                    return
+                }
+                guard Self.canPublishDeferredLoad(
+                    requiresFreshData: requiresFreshData,
+                    baseSnapshotWasStale: baseSnapshotWasStale,
+                    responseWasStale: loaded.hasStaleServerResponse
+                ) else {
+                    self.reviewLoadState = .failed(
+                        "Fresh Review data was unavailable. Existing Reviews were kept."
+                    )
+                    return
+                }
+                self.reviews = Self.mergeDeferredRecords(
+                    baseline: baselineReviews,
+                    current: self.reviews,
+                    loaded: loaded.records
+                )
+                self.reviewLoadState = .loaded
+                if let selectedReviewId = self.selectedReviewId,
+                   !self.reviews.contains(where: { $0.id == selectedReviewId }) {
+                    self.selectedReviewId = nil
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                guard let self, self.workspaceReloadGeneration == generation else { return }
+                self.reviewLoadState = .failed(error.localizedDescription)
+            }
+        }
+
+        let daemon = daemon
+        postReadyRetrySyncTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.postReadyRetrySyncTask = nil
+                }
+            }
+            guard let self,
+                  self.workspaceReloadGeneration == generation,
+                  self.phase == .ready,
+                  !Task.isCancelled else {
+                return
+            }
+            _ = try? await daemon.retrySync()
+        }
+
+        postReadySyncTask = Task { @MainActor [weak self] in
+            defer {
+                if let self, self.workspaceReloadGeneration == generation {
+                    self.postReadySyncTask = nil
+                }
+            }
+            guard let self,
+                  self.workspaceReloadGeneration == generation,
+                  self.phase == .ready,
+                  !Task.isCancelled else {
+                return
+            }
+            async let syncRequest = try? daemon.syncStatus()
+            async let mcpRequest = try? daemon.mcpStatus()
+            let (sync, mcp) = await (syncRequest, mcpRequest)
+            guard self.workspaceReloadGeneration == generation,
+                  self.phase == .ready,
+                  !Task.isCancelled,
+                  let runtime = self.runtime else {
+                return
+            }
+            self.runtime = .init(
+                health: runtime.health,
+                sync: sync != nil ? sync : runtime.sync,
+                mcp: mcp != nil ? mcp : runtime.mcp,
+                serverDataSource: runtime.serverDataSource
+            )
+            if sync != nil {
+                self.syncStatusAvailable = true
+            }
+        }
+    }
+
+    private func applyLocalAgentAdapterResult(_ result: LocalAgentAdapterReconciliationResult) {
+        let nextErrorMessage = Self.errorMessageAfterUpdatingLocalAgentAdapters(
+            currentErrorMessage: errorMessage,
+            previous: .init(
+                conflicts: legacyAgentAdapterConflicts,
+                inspectionWarning: legacyAgentAdapterInspectionWarning
+            ),
+            next: result
+        )
+        legacyAgentAdapterConflicts = result.conflicts
+        legacyAgentAdapterInspectionWarning = result.inspectionWarning
+        errorMessage = nextErrorMessage
+    }
+
+    nonisolated static func errorMessageAfterUpdatingLocalAgentAdapters(
+        currentErrorMessage: String?,
+        previous: LocalAgentAdapterReconciliationResult,
+        next: LocalAgentAdapterReconciliationResult
+    ) -> String? {
+        let previousWarning = localAgentAdapterWarning(previous)
+        guard currentErrorMessage == nil || currentErrorMessage == previousWarning else {
+            return currentErrorMessage
+        }
+        return localAgentAdapterWarning(next)
+    }
+
+    nonisolated static func localAgentAdapterWarning(
         _ result: LocalAgentAdapterReconciliationResult
     ) -> String? {
         var messages: [String] = []
@@ -4305,7 +4834,10 @@ final class WorkspaceStore: ObservableObject {
         refreshDocumentTabs(for: mapped.targetId ?? mapped.id)
     }
 
-    private func remapDrafts(projectId: String) async throws {
+    private func remapDrafts(
+        projectId: String,
+        workspaceGeneration: UUID
+    ) async throws {
         let projectDrafts = drafts.filter { $0.projectId == projectId }
         let originalById = Dictionary(
             projectDrafts.map { ($0.id, $0) },
@@ -4315,6 +4847,7 @@ final class WorkspaceStore: ObservableObject {
         let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
         let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
         let loadedBaselines = try await concurrentMap(baselines) { try await loader.loadContent(for: $0) }
+        guard workspaceReloadGeneration == workspaceGeneration else { return }
         for loaded in loadedBaselines {
             installLoadedResourceIfCurrent(loaded)
         }
@@ -4325,6 +4858,7 @@ final class WorkspaceStore: ObservableObject {
                 resources: resourceSnapshot
             )
         }
+        guard workspaceReloadGeneration == workspaceGeneration else { return }
         for candidate in mapped {
             guard let original = originalById[candidate.id],
                   let index = drafts.firstIndex(where: { $0.id == candidate.id }),
@@ -4380,8 +4914,19 @@ final class WorkspaceStore: ObservableObject {
         return .init(refreshIds: refreshIds, terminalIds: terminalIds)
     }
 
-    private func refreshDraftInventory(includeFailed: Bool) async {
-        guard let page = try? await daemon.listDrafts(.init(limit: 500)) else { return }
+    private func refreshDraftInventory(
+        includeFailed: Bool,
+        generation: UUID
+    ) async {
+        guard workspaceReloadGeneration == generation,
+              phase == .ready,
+              !Task.isCancelled,
+              let page = try? await daemon.listDrafts(.init(limit: 500)) else {
+            return
+        }
+        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
+            return
+        }
         let plan = Self.draftInventoryPlan(
             summaries: page.items,
             currentDrafts: drafts,
@@ -4402,7 +4947,10 @@ final class WorkspaceStore: ObservableObject {
         pruneOrphanedMemoryTabs()
 
         let refreshIds = plan.refreshIds.subtracting(pendingDraftIds)
-        guard !refreshIds.isEmpty else { return }
+        guard !refreshIds.isEmpty else {
+            draftInventoryLoadState = .loaded
+            return
+        }
         let summaries = page.items.filter { refreshIds.contains($0.draftId) }
         let originalById = Dictionary(
             drafts.filter { refreshIds.contains($0.id) }.map { ($0.id, $0) },
@@ -4413,6 +4961,9 @@ final class WorkspaceStore: ObservableObject {
         let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
         let loadedBaselines = try? await concurrentMap(baselines) {
             try await loader.loadContent(for: $0)
+        }
+        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
+            return
         }
         if let loadedBaselines {
             for loaded in loadedBaselines {
@@ -4427,7 +4978,10 @@ final class WorkspaceStore: ObservableObject {
                 resources: resourceSnapshot
             )
         }
-        guard let mappedDrafts else { return }
+        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled,
+              let mappedDrafts else {
+            return
+        }
         for mapped in mappedDrafts {
             if let index = drafts.firstIndex(where: { $0.id == mapped.id }) {
                 guard originalById[mapped.id] == drafts[index] else { continue }
@@ -4437,6 +4991,7 @@ final class WorkspaceStore: ObservableObject {
             }
             refreshDocumentTabs(for: mapped.targetId ?? mapped.id)
         }
+        draftInventoryLoadState = .loaded
     }
 
     private func refreshProjectFromServer(
@@ -4445,6 +5000,7 @@ final class WorkspaceStore: ObservableObject {
         generation: UUID
     ) async {
         do {
+            let workspaceGeneration = workspaceReloadGeneration
             guard let observedProject = projects.first(where: { $0.id == projectId }),
                   observedProject.name == projectName else { return }
             let loaded = try await WorkspaceLoader(
@@ -4461,7 +5017,10 @@ final class WorkspaceStore: ObservableObject {
                 projects[index] = loaded.state
             }
             replaceProjectResources(projectId: projectId, with: loaded.resources)
-            try await remapDrafts(projectId: projectId)
+            try await remapDrafts(
+                projectId: projectId,
+                workspaceGeneration: workspaceGeneration
+            )
         } catch {
             // The installed Commit remains usable; commit sync reports refresh failures separately.
         }
@@ -4619,20 +5178,20 @@ struct WorkspaceLoader: Sendable {
     ) async throws -> WorkspaceSnapshot {
         server.resetDataSource()
         let health = try await ensureDaemon()
-        let (config, me, localAgentAdapters) = try await Self.loadAuthenticatedWorkspaceIdentity(
-            reconcileLocalAgentAdapters: {
-                try await reconcileInstalledAgentAdapters()
+        let (config, me, localAgentAdapters, currentUserWasStale) =
+            try await Self.loadAuthenticatedWorkspaceIdentity(
+            reconcileManagedAgentAdapters: {
+                try await reconcileManagedAgentAdapters()
             },
             projectConfig: {
                 try await daemon.projectConfig()
             },
-            retrySync: {
-                _ = try? await daemon.retrySync()
-            },
             currentUser: {
-                try await server.get("/api/v1/me")
+                let result: (value: CurrentUserResponse, response: DaemonServerResponse) =
+                    try await server.getWithMetadata("/api/v1/me")
+                return (result.value, result.response.isStaleCache)
             },
-            onLocalAgentAdapters: { result in
+            onManagedAgentAdapters: { result in
                 await onLocalAgentAdapters(result)
             }
         )
@@ -4644,22 +5203,20 @@ struct WorkspaceLoader: Sendable {
         async let orgCommitRequest: (value: CommitStateResponse, response: DaemonServerResponse) = server.getWithMetadata(
             "/api/v1/org/commit-state"
         )
-        let projectStates: [ProjectState]
+        let projectStateLoad: (
+            states: [ProjectState],
+            hasStaleServerResponse: Bool
+        )
         if let activeProjectId {
-            projectStates = try await loadProjectStates(
+            projectStateLoad = try await loadProjectStates(
                 me.projects,
                 activeProjectId: activeProjectId
             )
         } else {
-            projectStates = []
+            projectStateLoad = ([], false)
         }
+        let projectStates = projectStateLoad.states
         let orgCommit = try await orgCommitRequest
-
-        async let draftPageRequest = daemon.listDrafts(.init(limit: 500))
-        async let bundlesRequest = loadBundles()
-        async let reviewsRequest = loadReviews()
-        async let syncRequest = daemon.syncStatus()
-        async let mcpRequest = daemon.mcpStatus()
 
         var scopes = [
             ResourceLoadScope(projectId: nil, projectName: nil, refCommitId: orgCommit.value.ref.commitId),
@@ -4673,57 +5230,37 @@ struct WorkspaceLoader: Sendable {
             ))
         }
         let resourceGroups = try await concurrentMap(scopes, maxConcurrent: 2) { scope in
-            try await loadResources(
+            try await loadResourcesWithMetadata(
                 projectId: scope.projectId,
                 projectName: scope.projectName,
                 refCommitId: scope.refCommitId
             )
         }
-        var resources = resourceGroups.flatMap { $0 }
+        let resources = resourceGroups.flatMap { $0.resources }
 
-        let draftPage = try await draftPageRequest
-        let accessibleProjectIds = Set(me.projects.map(\.projectId))
-        let activeDrafts = draftPage.items.filter {
-            $0.status != .discarded
-                && $0.status != .merged
-                && accessibleProjectIds.contains($0.projectId)
-        }
-        let targetIds = Set(activeDrafts.compactMap(\.targetId))
-        let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
-        let loadedBaselines = try await concurrentMap(baselines) {
-            try await loadContent(for: $0, allowingStaleCache: true)
-        }
-        for loaded in loadedBaselines {
-            if let index = resources.firstIndex(where: { $0.id == loaded.id }) {
-                resources[index] = loaded
-            }
-        }
-        let resourceSnapshot = resources
-        let drafts = try await concurrentMap(activeDrafts) { summary in
-            Self.mapDraft(try await daemon.draft(summary.draftId), resources: resourceSnapshot)
-        }
-
-        let (bundles, reviews, syncStatus, mcpStatus) = try await (
-            bundlesRequest,
-            reviewsRequest,
-            syncRequest,
-            mcpRequest
-        )
         let verifiedOrgCommit: (value: CommitStateResponse, response: DaemonServerResponse) =
             try await server.getWithMetadata("/api/v1/org/commit-state")
         guard verifiedOrgCommit.value.ref.commitId == orgCommit.value.ref.commitId else {
             throw WorkspaceLoadError.sharedStateChangedDuringLoad
         }
+        var verifiedProjectWasStale = false
         if let activeProjectId,
            let initialProject = projectStates.first(where: { $0.id == activeProjectId }),
            let reference = me.projects.first(where: { $0.projectId == activeProjectId }) {
-            let verifiedProject = try await loadProjectStateWithMetadata(reference).state
-            guard verifiedProject.refCommitId == initialProject.refCommitId,
-                  verifiedProject.selectedOrgResourceIds == initialProject.selectedOrgResourceIds,
-                  verifiedProject.orgSelectionRevision == initialProject.orgSelectionRevision else {
+            let verifiedProject = try await loadProjectStateWithMetadata(reference)
+            verifiedProjectWasStale = verifiedProject.hasStaleServerResponse
+            guard verifiedProject.state.refCommitId == initialProject.refCommitId,
+                  verifiedProject.state.selectedOrgResourceIds == initialProject.selectedOrgResourceIds,
+                  verifiedProject.state.orgSelectionRevision == initialProject.orgSelectionRevision else {
                 throw WorkspaceLoadError.sharedStateChangedDuringLoad
             }
         }
+        let hasStaleServerResponse = currentUserWasStale
+            || orgCommit.response.isStaleCache
+            || projectStateLoad.hasStaleServerResponse
+            || resourceGroups.contains { $0.hasStaleServerResponse }
+            || verifiedOrgCommit.response.isStaleCache
+            || verifiedProjectWasStale
         return .init(
             account: me.user,
             organization: me.org,
@@ -4733,17 +5270,86 @@ struct WorkspaceLoader: Sendable {
             orgRefCommitId: orgCommit.value.ref.commitId,
             orgRefEtag: etag(from: orgCommit.response),
             resources: resources,
-            drafts: drafts,
-            bundles: bundles,
-            reviews: reviews,
             runtime: .init(
                 health: health,
-                sync: syncStatus,
-                mcp: mcpStatus,
-                serverDataSource: server.dataSource
+                sync: nil,
+                mcp: nil,
+                serverDataSource: hasStaleServerResponse ? "stale" : "live"
             ),
             legacyAgentAdapterConflicts: localAgentAdapters.conflicts,
             legacyAgentAdapterInspectionWarning: localAgentAdapters.inspectionWarning
+        )
+    }
+
+    func loadDeferredDrafts(
+        resources: [MemoryResource],
+        accessibleProjectIds: Set<String>
+    ) async throws -> (
+        loadedBaselines: [MemoryResource],
+        drafts: [LocalDraft],
+        hasStaleServerResponse: Bool
+    ) {
+        try await Self.loadDeferredDrafts(
+            resources: resources,
+            accessibleProjectIds: accessibleProjectIds,
+            listDrafts: {
+                try await daemon.listDrafts(.init(limit: 500))
+            },
+            loadDraft: { draftId in
+                try await daemon.draft(draftId)
+            },
+            loadContent: { resource in
+                try await loadContentWithMetadata(
+                    for: resource,
+                    allowingStaleCache: true
+                )
+            }
+        )
+    }
+
+    static func loadDeferredDrafts(
+        resources: [MemoryResource],
+        accessibleProjectIds: Set<String>,
+        listDrafts: @escaping @Sendable () async throws -> DaemonDraftListResponse,
+        loadDraft: @escaping @Sendable (String) async throws -> DaemonDraftDetail,
+        loadContent: @escaping @Sendable (MemoryResource) async throws
+            -> (resource: MemoryResource, hasStaleServerResponse: Bool)
+    ) async throws -> (
+        loadedBaselines: [MemoryResource],
+        drafts: [LocalDraft],
+        hasStaleServerResponse: Bool
+    ) {
+        let draftPage = try await listDrafts()
+        try Task.checkCancellation()
+        let activeDrafts = draftPage.items.filter {
+            $0.status != .discarded
+                && $0.status != .merged
+                && accessibleProjectIds.contains($0.projectId)
+        }
+        let targetIds = Set(activeDrafts.compactMap(\.targetId))
+        let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
+        let loadedBaselineResults = try await concurrentMap(
+            baselines,
+            transform: loadContent
+        )
+        try Task.checkCancellation()
+
+        let loadedBaselines = loadedBaselineResults.map(\.resource)
+        var hydratedResources = resources
+        for loaded in loadedBaselines {
+            if let index = hydratedResources.firstIndex(where: { $0.id == loaded.id }) {
+                hydratedResources[index] = loaded
+            }
+        }
+        let resourceSnapshot = hydratedResources
+        let drafts = try await concurrentMap(activeDrafts) { summary in
+            Self.mapDraft(try await loadDraft(summary.draftId), resources: resourceSnapshot)
+        }
+        try Task.checkCancellation()
+        return (
+            loadedBaselines,
+            drafts,
+            loadedBaselineResults.contains { $0.hasStaleServerResponse }
         )
     }
 
@@ -4836,7 +5442,18 @@ struct WorkspaceLoader: Sendable {
         for resource: MemoryResource,
         allowingStaleCache: Bool = false
     ) async throws -> MemoryResource {
-        guard !resource.contentLoaded else { return resource }
+        let loaded = try await loadContentWithMetadata(
+            for: resource,
+            allowingStaleCache: allowingStaleCache
+        )
+        return loaded.resource
+    }
+
+    func loadContentWithMetadata(
+        for resource: MemoryResource,
+        allowingStaleCache: Bool = false
+    ) async throws -> (resource: MemoryResource, hasStaleServerResponse: Bool) {
+        guard !resource.contentLoaded else { return (resource, false) }
         let prefix = resource.projectId.map { "/api/v1/projects/\($0)" } ?? "/api/v1/org"
         var loaded = resource
         let result: (value: MemoryDetail, response: DaemonServerResponse) =
@@ -4848,7 +5465,7 @@ struct WorkspaceLoader: Sendable {
             allowingStaleCache: allowingStaleCache
         )
         loaded.contentLoaded = true
-        return loaded
+        return (loaded, result.response.isStaleCache)
     }
 
     nonisolated static func validatedMemoryContent(
@@ -4914,11 +5531,9 @@ struct WorkspaceLoader: Sendable {
     /// files deliberately point at the App bundle, so an App update must
     /// reconcile existing installations even while the user is signed out or
     /// the Hub is unreachable.
-    private func reconcileInstalledAgentAdapters() async throws
+    private func reconcileManagedAgentAdapters() async throws
         -> LocalAgentAdapterReconciliationResult {
         let runtimePath = try Self.bundledAgentRuntimePath()
-        // Daemon-owned integrations are the safety-critical cutover and must
-        // never wait on advisory inspection of the archived external store.
         let installed = try await daemon.allProjectAgentAdapters()
         let requests = Self.agentAdapterReconciliationPlan(
             installed: installed,
@@ -4928,40 +5543,67 @@ struct WorkspaceLoader: Sendable {
         for request in requests {
             _ = try await daemon.installProjectAgentAdapter(request)
         }
+        return .init(conflicts: [], inspectionWarning: nil)
+    }
+
+    func inspectLegacyAgentAdapters() async -> LocalAgentAdapterReconciliationResult {
         do {
-            let legacyInspection = try await daemon.inspectLegacyAgentAdapters(
+            let runtimePath = try Self.bundledAgentRuntimePath()
+            let inspection = try await daemon.inspectLegacyAgentAdapters(
                 runtimeBinaryPath: runtimePath
             )
-            return .init(conflicts: legacyInspection.conflicts, inspectionWarning: nil)
+            return .init(conflicts: inspection.conflicts, inspectionWarning: nil)
         } catch {
             return .init(
                 conflicts: [],
-                inspectionWarning: "Clumsies updated its managed integrations, but could not inspect the archived Zig CLI integration store. Review any old global or repository MCP and hook entries manually. \(error.localizedDescription)"
+                inspectionWarning: Self.legacyAgentAdapterInspectionWarning(for: error)
             )
         }
     }
 
+    static func legacyAgentAdapterInspectionWarning(for error: Error) -> String {
+        if let daemonError = error as? DaemonXPCError,
+           case .daemon(let payload) = daemonError,
+           payload.code == "project_agent_adapter_invalid_runtime" {
+            return "The current Clumsies App and bundled Agent runtime do not have "
+                + "the required release signing identity. Archived integration inspection "
+                + "was skipped. This build cannot install or update managed Coding Agent integrations. "
+                + "Install an officially signed release build, then try again."
+        }
+        return "Clumsies updated its managed integrations, but could not inspect the "
+            + "archived Zig CLI integration store. Review any old global or repository "
+            + "MCP and hook entries manually. \(error.localizedDescription)"
+    }
+
     static func loadAuthenticatedWorkspaceIdentity(
-        reconcileLocalAgentAdapters: () async throws
+        reconcileManagedAgentAdapters: () async throws
             -> LocalAgentAdapterReconciliationResult,
         projectConfig: () async throws -> DaemonProjectConfig,
-        retrySync: @escaping @Sendable () async -> Void,
-        currentUser: () async throws -> CurrentUserResponse,
-        onLocalAgentAdapters: @MainActor @Sendable (LocalAgentAdapterReconciliationResult) async
+        currentUser: () async throws -> (
+            value: CurrentUserResponse,
+            hasStaleServerResponse: Bool
+        ),
+        onManagedAgentAdapters: @MainActor @Sendable (LocalAgentAdapterReconciliationResult) async
             -> Void = { _ in }
     ) async throws -> (
         DaemonProjectConfig,
         CurrentUserResponse,
-        LocalAgentAdapterReconciliationResult
+        LocalAgentAdapterReconciliationResult,
+        Bool
     ) {
-        let localAgentAdapters = try await reconcileLocalAgentAdapters()
-        await onLocalAgentAdapters(localAgentAdapters)
+        let localAgentAdapters = try await reconcileManagedAgentAdapters()
+        await onManagedAgentAdapters(localAgentAdapters)
         let config = try await projectConfig()
         guard config.hasAccessToken && config.hasRefreshToken else {
             throw WorkspaceLoadError.authenticationRequired
         }
-        Task { await retrySync() }
-        return (config, try await currentUser(), localAgentAdapters)
+        let currentUser = try await currentUser()
+        return (
+            config,
+            currentUser.value,
+            localAgentAdapters,
+            currentUser.hasStaleServerResponse
+        )
     }
 
     static func agentAdapterReconciliationPlan(
@@ -5014,27 +5656,26 @@ struct WorkspaceLoader: Sendable {
     private func loadProjectStates(
         _ projects: [ProjectReference],
         activeProjectId: String
-    ) async throws -> [ProjectState] {
+    ) async throws -> (states: [ProjectState], hasStaleServerResponse: Bool) {
         guard let active = projects.first(where: { $0.projectId == activeProjectId }) else {
             throw WorkspaceLoadError.noProjects
         }
-        let loaded = try await loadProjectState(active)
-        return projects.map { project in
-            if project.projectId == loaded.id { return loaded }
-            return .init(
-                id: project.projectId,
-                name: project.name,
-                refCommitId: nil,
-                refEtag: "",
-                selectedOrgResourceIds: [],
-                orgSelectionRevision: 0,
-                isLoaded: false
-            )
-        }
-    }
-
-    private func loadProjectState(_ project: ProjectReference) async throws -> ProjectState {
-        try await loadProjectStateWithMetadata(project).state
+        let loaded = try await loadProjectStateWithMetadata(active)
+        return (
+            projects.map { project in
+                if project.projectId == loaded.state.id { return loaded.state }
+                return .init(
+                    id: project.projectId,
+                    name: project.name,
+                    refCommitId: nil,
+                    refEtag: "",
+                    selectedOrgResourceIds: [],
+                    orgSelectionRevision: 0,
+                    isLoaded: false
+                )
+            },
+            loaded.hasStaleServerResponse
+        )
     }
 
     private func loadProjectStateWithMetadata(
@@ -5101,28 +5742,49 @@ struct WorkspaceLoader: Sendable {
         }, metadata.hasStaleServerResponse)
     }
 
-    private func loadBundles() async throws -> [PersonalBundle] {
-        let items: [PersonalBundleMetadata] = try await loadAll("/api/v1/me/bundles")
-        return try await concurrentMap(items) { metadata in
-            let detail: PersonalBundleDetail = try await server.get("/api/v1/me/bundles/\(metadata.bundleId)")
-            return .init(
-                id: metadata.bundleId,
-                name: metadata.name,
-                description: metadata.description,
-                resourceIds: detail.memories.map(\.memoryId),
-                revision: metadata.revision,
-                updatedAt: metadata.updatedAt
+    func loadBundles() async throws -> (
+        records: [PersonalBundle],
+        hasStaleServerResponse: Bool
+    ) {
+        let metadata: (
+            items: [PersonalBundleMetadata],
+            hasStaleServerResponse: Bool
+        ) = try await loadAllWithMetadata("/api/v1/me/bundles")
+        let bundles = try await concurrentMap(metadata.items) { item in
+            let detail: (value: PersonalBundleDetail, response: DaemonServerResponse) =
+                try await server.getWithMetadata("/api/v1/me/bundles/\(item.bundleId)")
+            let bundle = PersonalBundle(
+                id: item.bundleId,
+                name: item.name,
+                description: item.description,
+                resourceIds: detail.value.memories.map(\.memoryId),
+                revision: item.revision,
+                updatedAt: item.updatedAt
+            )
+            return (
+                record: bundle,
+                hasStaleServerResponse: detail.response.isStaleCache
             )
         }
+        return (
+            bundles.map { $0.record },
+            metadata.hasStaleServerResponse
+                || bundles.contains { $0.hasStaleServerResponse }
+        )
     }
 
-    private func loadReviews() async throws -> [ReviewRecord] {
-        let items: [ReviewMetadata] = try await loadAll("/api/v1/reviews")
-        return items.map(Self.mapReview)
-    }
-
-    private func loadAll<Item: Decodable & Sendable>(_ path: String) async throws -> [Item] {
-        try await loadAllWithMetadata(path).items
+    func loadReviews() async throws -> (
+        records: [ReviewRecord],
+        hasStaleServerResponse: Bool
+    ) {
+        let metadata: (
+            items: [ReviewMetadata],
+            hasStaleServerResponse: Bool
+        ) = try await loadAllWithMetadata("/api/v1/reviews")
+        return (
+            metadata.items.map(Self.mapReview),
+            metadata.hasStaleServerResponse
+        )
     }
 
     private func loadAllWithMetadata<Item: Decodable & Sendable>(
@@ -5136,10 +5798,12 @@ struct WorkspaceLoader: Sendable {
             if let cursor { query.append(.init(name: "cursor", value: cursor)) }
             let page: (value: ListResponse<Item>, response: DaemonServerResponse) =
                 try await server.getWithMetadata(path, query: query)
+            try Task.checkCancellation()
             output += page.value.items
             hasStaleServerResponse = hasStaleServerResponse || page.response.isStaleCache
             cursor = page.value.pageInfo.hasMore ? page.value.pageInfo.nextCursor : nil
         } while cursor != nil
+        try Task.checkCancellation()
         return (output, hasStaleServerResponse)
     }
 

--- a/apps/macos/Sources/Features/BundlesView.swift
+++ b/apps/macos/Sources/Features/BundlesView.swift
@@ -4,24 +4,33 @@ struct BundleNavigator: View {
     @ObservedObject var store: WorkspaceStore
 
     var body: some View {
-        List(selection: $store.selectedBundleId) {
-            ForEach(store.bundles) { bundle in
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(bundle.name)
-                        .lineLimit(1)
-                    Text("\(bundle.resourceIds.count) resources")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .tag(bundle.id)
-                .contextMenu {
-                    Button("Delete", role: .destructive) {
-                        Task { await store.deleteBundle(bundle) }
+        Group {
+            if store.bundles.isEmpty {
+                BundleCollectionStatusView(store: store)
+            } else {
+                List(selection: $store.selectedBundleId) {
+                    ForEach(store.bundles) { bundle in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(bundle.name)
+                                .lineLimit(1)
+                            Text("\(bundle.resourceIds.count) resources")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(bundle.id)
+                        .contextMenu {
+                            Button("Delete", role: .destructive) {
+                                Task { await store.deleteBundle(bundle) }
+                            }
+                        }
                     }
+                }
+                .listStyle(.inset)
+                .safeAreaInset(edge: .bottom) {
+                    BundleCollectionStatusBanner(store: store)
                 }
             }
         }
-        .listStyle(.inset)
         .task { await store.prepareWorkspaceIndex(includeContent: false) }
     }
 }
@@ -41,11 +50,64 @@ struct BundleDetail: View {
             )
                 .id(bundle.id)
         } else {
+            BundleCollectionStatusView(store: store)
+        }
+    }
+}
+
+private struct BundleCollectionStatusView: View {
+    @ObservedObject var store: WorkspaceStore
+
+    var body: some View {
+        switch store.bundleLoadState {
+        case .loading:
+            ProgressView("Loading Bundles...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .failed(let message):
+            ContentUnavailableView {
+                Label("Bundles Unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Try Again") { Task { await store.reload() } }
+            }
+        case .loaded:
             ContentUnavailableView(
                 "No Bundles",
                 systemImage: "shippingbox",
                 description: Text("Create a personal Bundle to collect memory for recurring work.")
             )
+        }
+    }
+}
+
+private struct BundleCollectionStatusBanner: View {
+    @ObservedObject var store: WorkspaceStore
+
+    @ViewBuilder
+    var body: some View {
+        switch store.bundleLoadState {
+        case .loading:
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Refreshing Bundles...")
+                    .font(.caption)
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .failed:
+            Button("Bundle refresh failed - Try Again") {
+                Task { await store.reload() }
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .loaded:
+            EmptyView()
         }
     }
 }
@@ -128,6 +190,7 @@ private struct BundleEditor: View {
             }
         }
         .formStyle(.grouped)
+        .disabled(store.phase != .ready)
         .sheet(isPresented: $showsResourcePicker) {
             BundleResourcePicker(resources: selectableResources, selection: $resourceIds)
         }

--- a/apps/macos/Sources/Features/DiagnosticsView.swift
+++ b/apps/macos/Sources/Features/DiagnosticsView.swift
@@ -114,27 +114,27 @@ private struct RuntimeDiagnosticsView: View {
                     LabeledContent("Project", value: runtime.health.projectId ?? "Not selected")
                     LabeledContent("Database", value: runtime.health.localDb.path)
                     LabeledContent("Schema", value: String(runtime.health.localDb.schemaVersion))
-                    LabeledContent("MCP", value: runtime.mcp.running ? "Running" : "Stopped")
+                    LabeledContent("MCP", value: runtime.mcp.map { $0.running ? "Running" : "Stopped" } ?? "Loading")
                     LabeledContent("Log directory", value: runtime.health.logDir)
                 }
                 Section("Synchronization") {
-                    LabeledContent("Drafts", value: runtime.sync.draftSync.state.capitalized)
-                    LabeledContent("Commits", value: runtime.sync.commitSync.state.capitalized)
+                    LabeledContent("Drafts", value: runtime.sync?.draftSync.state.capitalized ?? "Loading")
+                    LabeledContent("Commits", value: runtime.sync?.commitSync.state.capitalized ?? "Loading")
                     LabeledContent(
                         "Pending operations",
-                        value: String(runtime.sync.pendingOperationCount)
+                        value: runtime.sync.map { String($0.pendingOperationCount) } ?? "Loading"
                     )
                     LabeledContent(
                         "Failed operations",
-                        value: String(runtime.sync.failedOperationCount)
+                        value: runtime.sync.map { String($0.failedOperationCount) } ?? "Loading"
                     )
                     LabeledContent(
                         "Drafts behind",
-                        value: String(runtime.sync.behindDraftCount)
+                        value: runtime.sync.map { String($0.behindDraftCount) } ?? "Loading"
                     )
                     LabeledContent(
                         "Reconciliation conflicts",
-                        value: String(runtime.sync.reconciliationConflictCount)
+                        value: runtime.sync.map { String($0.reconciliationConflictCount) } ?? "Loading"
                     )
                     Button("Retry") { Task { await store.retrySync() } }
                 }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -6,9 +6,12 @@ struct MemoryNavigator: View {
 
     var body: some View {
         FileTreeView(store: store, items: store.visibleMemoryItems)
-        .onChange(of: store.selectedKind) { _, _ in
-            store.selectedItemId = nil
-        }
+            .safeAreaInset(edge: .bottom) {
+                DraftInventoryStatusBanner(store: store)
+            }
+            .onChange(of: store.selectedKind) { _, _ in
+                store.selectedItemId = nil
+            }
     }
 }
 
@@ -69,9 +72,54 @@ struct MemoryMainPane: View {
     @ViewBuilder
     private var emptyState: some View {
         if store.visibleMemoryItems.isEmpty {
-            EmptyMemoryCollectionView(store: store)
+            switch store.draftInventoryLoadState {
+            case .loading:
+                ProgressView("Loading Drafts...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .failed(let message):
+                ContentUnavailableView {
+                    Label("Drafts Unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(message)
+                } actions: {
+                    Button("Try Again") { Task { await store.reload() } }
+                }
+            case .loaded:
+                EmptyMemoryCollectionView(store: store)
+            }
         } else {
             EmptyWorkspaceView()
+        }
+    }
+}
+
+private struct DraftInventoryStatusBanner: View {
+    @ObservedObject var store: WorkspaceStore
+
+    @ViewBuilder
+    var body: some View {
+        switch store.draftInventoryLoadState {
+        case .loading:
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading Drafts...")
+                    .font(.caption)
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .failed:
+            Button("Draft refresh failed - Try Again") {
+                Task { await store.reload() }
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .loaded:
+            EmptyView()
         }
     }
 }

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -142,13 +142,21 @@ struct ReviewListPage: View {
     var body: some View {
         Group {
             switch ReviewListContentState.resolve(
-                phase: store.phase,
+                loadState: store.reviewLoadState,
                 totalCount: store.reviews.count,
                 visibleCount: reviews.count
             ) {
             case .loading:
                 ProgressView("Loading Reviews…")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .failed:
+                ContentUnavailableView {
+                    Label("Reviews Unavailable", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(store.reviewLoadState.failureMessage ?? "Reviews could not be loaded.")
+                } actions: {
+                    Button("Try Again") { Task { await store.reload() } }
+                }
             case .empty:
                 ContentUnavailableView(
                     "No Reviews",
@@ -186,6 +194,9 @@ struct ReviewListPage: View {
                     }
                 }
                 .listStyle(.inset)
+                .safeAreaInset(edge: .bottom) {
+                    ReviewCollectionStatusBanner(store: store)
+                }
             }
         }
         .navigationTitle("Reviews")
@@ -204,24 +215,58 @@ struct ReviewListPage: View {
     private func projectName(for review: ReviewRecord) -> String? {
         store.projects.first { $0.id == review.projectId }?.name
     }
-
 }
 
 enum ReviewListContentState: Equatable {
     case loading
+    case failed
     case empty
     case filteredEmpty
     case content
 
     static func resolve(
-        phase: ApplicationPhase,
+        loadState: WorkspaceCollectionLoadState,
         totalCount: Int,
         visibleCount: Int
     ) -> ReviewListContentState {
-        if totalCount == 0 {
-            return phase == .loading || phase == .launching ? .loading : .empty
+        if visibleCount > 0 { return .content }
+        switch loadState {
+        case .loading: return .loading
+        case .failed: return .failed
+        case .loaded:
+            return totalCount == 0 ? .empty : .filteredEmpty
         }
-        return visibleCount == 0 ? .filteredEmpty : .content
+    }
+}
+
+private struct ReviewCollectionStatusBanner: View {
+    @ObservedObject var store: WorkspaceStore
+
+    @ViewBuilder
+    var body: some View {
+        switch store.reviewLoadState {
+        case .loading:
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Refreshing Reviews…")
+                    .font(.caption)
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .failed:
+            Button("Review refresh failed — Try Again") {
+                Task { await store.reload() }
+            }
+            .buttonStyle(.plain)
+            .font(.caption)
+            .padding(8)
+            .frame(maxWidth: .infinity)
+            .background(.bar)
+        case .loaded:
+            EmptyView()
+        }
     }
 }
 

--- a/apps/macos/Sources/Infrastructure/ServerClient.swift
+++ b/apps/macos/Sources/Infrastructure/ServerClient.swift
@@ -84,13 +84,15 @@ struct ServerClient: Sendable {
         body: String? = nil
     ) async throws -> DaemonServerResponse {
         let requestPath = try buildPath(path, query: query)
+        let dataSourceGeneration = dataSourceTracker.generation
         let response = try await requestLimiter.run {
-            try await daemon.serverRequest(
+            try Task.checkCancellation()
+            return try await daemon.serverRequest(
                 .init(method: method, path: requestPath, headers: headers, body: body)
             )
         }
-        if response.isStaleCache {
-            dataSourceTracker.markStale()
+        if response.isStaleCache, !Task.isCancelled {
+            dataSourceTracker.markStale(generation: dataSourceGeneration)
         }
         return response
     }
@@ -235,19 +237,30 @@ private actor ServerRequestLimiter {
     }
 }
 
-private final class ServerDataSourceTracker: @unchecked Sendable {
+final class ServerDataSourceTracker: @unchecked Sendable {
     private let lock = NSLock()
     private var stale = false
+    private var currentGeneration = UUID()
 
     var value: String {
         lock.withLock { stale ? "stale" : "live" }
     }
 
-    func markStale() {
-        lock.withLock { stale = true }
+    var generation: UUID {
+        lock.withLock { currentGeneration }
+    }
+
+    func markStale(generation: UUID) {
+        lock.withLock {
+            guard generation == currentGeneration else { return }
+            stale = true
+        }
     }
 
     func reset() {
-        lock.withLock { stale = false }
+        lock.withLock {
+            currentGeneration = UUID()
+            stale = false
+        }
     }
 }

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -83,7 +83,7 @@ final class DaemonContractTests: XCTestCase {
         })
     }
 
-    func testWorkspaceStartupMigratesAdaptersBeforeAuthenticationAndDoesNotReachServer() async {
+    func testWorkspaceCoreReconcilesManagedAdaptersWithoutLegacyInspection() async {
         actor EventRecorder {
             var events: [String] = []
 
@@ -96,10 +96,9 @@ final class DaemonContractTests: XCTestCase {
 
         do {
             _ = try await WorkspaceLoader.loadAuthenticatedWorkspaceIdentity(
-                reconcileLocalAgentAdapters: {
+                reconcileManagedAgentAdapters: {
                     await recorder.append("list-all-native")
                     await recorder.append("install-native")
-                    await recorder.append("inspect-legacy")
                     return .init(conflicts: [], inspectionWarning: nil)
                 },
                 projectConfig: {
@@ -113,20 +112,17 @@ final class DaemonContractTests: XCTestCase {
                         missingFields: ["access_token", "refresh_token"]
                     )
                 },
-                retrySync: {
-                    await recorder.append("retry-sync")
-                },
                 currentUser: {
                     await recorder.append("api-v1-me")
                     throw DaemonContractTestError.unexpectedServerRequest
                 },
-                onLocalAgentAdapters: { _ in
-                    await recorder.append("publish-local-warning")
+                onManagedAgentAdapters: { _ in
+                    await recorder.append("publish-managed-result")
                 }
             )
             XCTFail("Expected authenticationRequired")
         } catch WorkspaceLoadError.authenticationRequired {
-            // Local discovery and native reconciliation complete before the auth gate.
+            // Managed cutover completes before auth; legacy inspection is post-ready.
         } catch {
             XCTFail("Unexpected error: \(error)")
         }
@@ -135,21 +131,13 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(
             events,
             [
-                "list-all-native", "install-native", "inspect-legacy",
-                "publish-local-warning", "project-config",
+                "list-all-native", "install-native",
+                "publish-managed-result", "project-config",
             ]
         )
     }
 
-    func testLegacyAdapterConflictDoesNotBlockAuthenticatedWorkspaceLoading() async throws {
-        let conflict = DaemonLegacyAgentAdapterConflict(
-            installId: "codex-old",
-            adapter: .codex,
-            scope: "workspace",
-            targetRoot: "/repos/old/.codex",
-            code: "legacy_adapter_generation_unsupported",
-            message: "This legacy Adapter generation was left unchanged."
-        )
+    func testWorkspaceCoreCarriesCurrentUserRequestFreshness() async throws {
         let user = CurrentUserResponse(
             user: .init(
                 userId: "user-1",
@@ -164,76 +152,401 @@ final class DaemonContractTests: XCTestCase {
             capabilities: []
         )
 
-        let (_, loadedUser, localResult) = try await WorkspaceLoader.loadAuthenticatedWorkspaceIdentity(
-            reconcileLocalAgentAdapters: {
-                return .init(conflicts: [conflict], inspectionWarning: nil)
-            },
-            projectConfig: {
-                .init(
-                    serverUrl: "https://app.clumsies.ai",
-                    projectId: nil,
-                    hasAccessToken: true,
-                    hasRefreshToken: true,
-                    ready: true,
-                    missingFields: []
-                )
-            },
-            retrySync: {},
-            currentUser: { user }
-        )
-
-        XCTAssertEqual(loadedUser.user.userId, "user-1")
-        XCTAssertEqual(localResult.conflicts, [conflict])
-    }
-
-    func testWarmDaemonRetrySyncDoesNotBlockAuthenticatedIdentityLoad() async throws {
-        let retryGate = WarmDaemonRetryGate()
-        let retryStarted = expectation(description: "retry sync started")
-        let currentUserLoaded = expectation(description: "current user loaded")
-        let loadCompleted = expectation(description: "workspace identity load completed")
-        let currentUser = CurrentUserResponse(
-            user: user,
-            org: .init(orgId: "org-1", name: "Example"),
-            projects: [],
-            defaultProjectId: nil,
-            capabilities: []
-        )
-
-        let load = Task {
-            defer { loadCompleted.fulfill() }
-            return try await WorkspaceLoader.loadAuthenticatedWorkspaceIdentity(
-                reconcileLocalAgentAdapters: {
+        let (_, loadedUser, managedResult, currentUserWasStale) =
+            try await WorkspaceLoader.loadAuthenticatedWorkspaceIdentity(
+                reconcileManagedAgentAdapters: {
                     .init(conflicts: [], inspectionWarning: nil)
                 },
                 projectConfig: {
                     .init(
                         serverUrl: "https://app.clumsies.ai",
-                        projectId: "project-1",
+                        projectId: nil,
                         hasAccessToken: true,
                         hasRefreshToken: true,
                         ready: true,
                         missingFields: []
                     )
                 },
-                retrySync: {
-                    retryStarted.fulfill()
-                    await retryGate.wait()
-                },
-                currentUser: {
-                    currentUserLoaded.fulfill()
-                    return currentUser
-                }
+                currentUser: { (user, true) }
             )
-        }
-
-        await fulfillment(
-            of: [retryStarted, currentUserLoaded, loadCompleted],
-            timeout: 1
-        )
-        await retryGate.open()
-        let (_, loadedUser, _) = try await load.value
 
         XCTAssertEqual(loadedUser.user.userId, "user-1")
+        XCTAssertTrue(managedResult.conflicts.isEmpty)
+        XCTAssertTrue(currentUserWasStale)
+    }
+
+    func testDeferredAuthorityRequiresSameUserAndOrganization() {
+        let currentOrganization = OrganizationReference(orgId: "org-1", name: "Old name")
+        let renamedAccount = UserReference(
+            userId: user.userId,
+            email: "renamed@example.com",
+            displayName: "Renamed",
+            avatarUrl: nil,
+            role: "admin"
+        )
+        let renamedOrganization = OrganizationReference(orgId: "org-1", name: "New name")
+        let otherAccount = UserReference(
+            userId: "user-2",
+            email: "other@example.com",
+            displayName: "Other",
+            avatarUrl: nil,
+            role: "member"
+        )
+
+        XCTAssertTrue(WorkspaceStore.preservesDeferredAuthority(
+            currentAccount: user,
+            currentOrganization: currentOrganization,
+            nextAccount: renamedAccount,
+            nextOrganization: renamedOrganization
+        ))
+        XCTAssertFalse(WorkspaceStore.preservesDeferredAuthority(
+            currentAccount: user,
+            currentOrganization: currentOrganization,
+            nextAccount: otherAccount,
+            nextOrganization: renamedOrganization
+        ))
+        XCTAssertFalse(WorkspaceStore.preservesDeferredAuthority(
+            currentAccount: user,
+            currentOrganization: currentOrganization,
+            nextAccount: renamedAccount,
+            nextOrganization: .init(orgId: "org-2", name: "Other")
+        ))
+    }
+
+    func testStaleAuthorityChangeFailsClosedOnlyForWarmDifferentAuthority() {
+        XCTAssertTrue(WorkspaceStore.rejectsStaleAuthorityChange(
+            hadLoadedWorkspace: true,
+            sameAuthority: false,
+            snapshotWasStale: true
+        ))
+        XCTAssertFalse(WorkspaceStore.rejectsStaleAuthorityChange(
+            hadLoadedWorkspace: false,
+            sameAuthority: false,
+            snapshotWasStale: true
+        ))
+        XCTAssertFalse(WorkspaceStore.rejectsStaleAuthorityChange(
+            hadLoadedWorkspace: true,
+            sameAuthority: true,
+            snapshotWasStale: true
+        ))
+        XCTAssertFalse(WorkspaceStore.rejectsStaleAuthorityChange(
+            hadLoadedWorkspace: true,
+            sameAuthority: false,
+            snapshotWasStale: false
+        ))
+    }
+
+    func testFreshApplyInvalidatesOldWorkspaceTransitionState() {
+        var generation = UUID()
+        let oldGeneration = generation
+        var loadingProjectId: String? = "project-old"
+        var isSwitchingMemoryContext = true
+        var isPreparingWorkspaceIndex = true
+        var orgResourceRefreshGeneration: UUID? = UUID()
+
+        WorkspaceStore.invalidateWorkspaceTransitionState(
+            generation: &generation,
+            loadingProjectId: &loadingProjectId,
+            isSwitchingMemoryContext: &isSwitchingMemoryContext,
+            isPreparingWorkspaceIndex: &isPreparingWorkspaceIndex,
+            orgResourceRefreshGeneration: &orgResourceRefreshGeneration
+        )
+
+        XCTAssertNotEqual(generation, oldGeneration)
+        XCTAssertNil(loadingProjectId)
+        XCTAssertFalse(isSwitchingMemoryContext)
+        XCTAssertFalse(isPreparingWorkspaceIndex)
+        XCTAssertNil(orgResourceRefreshGeneration)
+    }
+
+    func testWarmDeferredCollectionsRejectStaleBaseOrResponse() {
+        let warmReloadRequiresFreshData = WorkspaceStore.deferredLoadRequiresFreshData(
+            hadLoadedWorkspace: true
+        )
+        let coldStartRequiresFreshData = WorkspaceStore.deferredLoadRequiresFreshData(
+            hadLoadedWorkspace: false
+        )
+
+        XCTAssertTrue(warmReloadRequiresFreshData)
+        XCTAssertFalse(coldStartRequiresFreshData)
+        XCTAssertFalse(WorkspaceStore.canPublishDeferredLoad(
+            requiresFreshData: warmReloadRequiresFreshData,
+            baseSnapshotWasStale: false,
+            responseWasStale: true
+        ))
+        XCTAssertFalse(WorkspaceStore.canPublishDeferredLoad(
+            requiresFreshData: true,
+            baseSnapshotWasStale: true,
+            responseWasStale: false
+        ))
+        XCTAssertFalse(WorkspaceStore.canPublishDeferredLoad(
+            requiresFreshData: true,
+            baseSnapshotWasStale: false,
+            responseWasStale: true
+        ))
+        XCTAssertTrue(WorkspaceStore.canPublishDeferredLoad(
+            requiresFreshData: true,
+            baseSnapshotWasStale: false,
+            responseWasStale: false
+        ))
+        XCTAssertTrue(WorkspaceStore.canPublishDeferredLoad(
+            requiresFreshData: coldStartRequiresFreshData,
+            baseSnapshotWasStale: true,
+            responseWasStale: true
+        ))
+    }
+
+    @MainActor
+    func testSaveStagingIsIgnoredOutsideReadyAndAuthorityClearResetsState() {
+        let store = WorkspaceStore()
+        store.activeProjectId = "project-old"
+        let resource = MemoryResource(
+            id: "memory-old",
+            scope: .org,
+            projectId: nil,
+            projectName: nil,
+            kind: .rules,
+            contentHash: "hash",
+            updatedAt: timestamp,
+            refCommitId: "commit-old",
+            contentLoaded: true,
+            document: .init(title: "Old", path: "rules/old.md", body: "Old")
+        )
+        let item = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: true,
+            projectContextId: "project-old"
+        )
+        var edited = item.document
+        edited.body = "Unsaved old-authority edit"
+        let bundle = PersonalBundle(
+            id: "bundle-old",
+            name: "Old",
+            description: "",
+            resourceIds: [resource.id],
+            revision: 1,
+            updatedAt: timestamp
+        )
+        let tab = WorkbenchTab(
+            section: .memory,
+            projectId: "project-old",
+            itemId: resource.id,
+            mode: .source,
+            title: "Old"
+        )
+        store.selectedSection = .reviews
+        store.selectedItemId = resource.id
+        store.selectedBundleId = bundle.id
+        store.selectedReviewId = "review-old"
+        store.pendingReviewReconciliationId = "review-old"
+        store.tabs = [tab]
+        store.activeTabId = tab.id
+
+        XCTAssertFalse(store.canEditMemory(item))
+        store.stageDocumentSave(item, document: edited)
+        store.stageBundleSave(
+            bundle,
+            name: "Unsaved old-authority bundle",
+            description: "",
+            resourceIds: [resource.id]
+        )
+        XCTAssertNil(store.pendingDocument(for: item))
+        XCTAssertFalse(store.hasPendingChanges)
+
+        store.clearAuthorityScopedWorkspace()
+
+        XCTAssertNil(store.pendingDocument(for: item))
+        XCTAssertFalse(store.hasPendingChanges)
+        XCTAssertNil(store.activeProjectId)
+        XCTAssertEqual(store.selectedSection, .memory)
+        XCTAssertNil(store.selectedItemId)
+        XCTAssertNil(store.selectedBundleId)
+        XCTAssertNil(store.selectedReviewId)
+        XCTAssertNil(store.pendingReviewReconciliationId)
+        XCTAssertNil(store.reviewDecisionReadiness)
+        XCTAssertTrue(store.tabs.isEmpty)
+        XCTAssertNil(store.activeTabId)
+        XCTAssertFalse(store.syncStatusAvailable)
+        XCTAssertEqual(store.draftInventoryLoadState, .loading)
+        XCTAssertEqual(store.bundleLoadState, .loading)
+        XCTAssertEqual(store.reviewLoadState, .loading)
+    }
+
+    func testOldDataSourceGenerationCannotMarkNewLoadStale() async {
+        let tracker = ServerDataSourceTracker()
+        let started = DaemonContractTestLatch()
+        let finish = DaemonContractTestLatch()
+        let oldRequest = Task {
+            let generation = tracker.generation
+            await started.open()
+            await finish.wait()
+            tracker.markStale(generation: generation)
+        }
+
+        await started.wait()
+        tracker.reset()
+        await finish.open()
+        await oldRequest.value
+        XCTAssertEqual(tracker.value, "live")
+
+        tracker.markStale(generation: tracker.generation)
+        XCTAssertEqual(tracker.value, "stale")
+    }
+
+    func testDraftFanoutLivesInDeferredDraftLoad() async throws {
+        let summaries = (0..<48).map {
+            inventorySummary(id: "draft-\($0)", updatedAt: timestamp)
+        }
+
+        let loaded = try await WorkspaceLoader.loadDeferredDrafts(
+            resources: [],
+            accessibleProjectIds: ["project-1"],
+            listDrafts: {
+                .init(items: summaries)
+            },
+            loadDraft: { draftId in
+                guard let summary = summaries.first(where: { $0.draftId == draftId }) else {
+                    throw DaemonContractTestError.unexpectedServerRequest
+                }
+                return .init(draft: summary, operations: [])
+            },
+            loadContent: { resource in
+                XCTFail("A create Draft must not load a shared baseline.")
+                return (resource, false)
+            }
+        )
+
+        XCTAssertEqual(Set(loaded.drafts.map(\.id)), Set(summaries.map(\.draftId)))
+        XCTAssertTrue(loaded.loadedBaselines.isEmpty)
+        XCTAssertFalse(loaded.hasStaleServerResponse)
+    }
+
+    func testDeferredDraftLoadCarriesBaselineFreshness() async throws {
+        var baseline = resource(id: "memory-1", kind: .rules, path: "rules/shared.md")
+        baseline.contentLoaded = false
+        let summary = inventorySummary(
+            id: "draft-1",
+            targetId: baseline.id,
+            updatedAt: timestamp
+        )
+
+        let loaded = try await WorkspaceLoader.loadDeferredDrafts(
+            resources: [baseline],
+            accessibleProjectIds: ["project-1"],
+            listDrafts: {
+                .init(items: [summary])
+            },
+            loadDraft: { draftId in
+                XCTAssertEqual(draftId, summary.draftId)
+                return .init(draft: summary, operations: [])
+            },
+            loadContent: { resource in
+                var loaded = resource
+                loaded.contentLoaded = true
+                return (loaded, true)
+            }
+        )
+
+        XCTAssertTrue(loaded.hasStaleServerResponse)
+        XCTAssertEqual(loaded.loadedBaselines.map(\.id), [baseline.id])
+        XCTAssertEqual(loaded.drafts.first?.document.body, "Base body")
+    }
+
+    func testFreshCorePrunesRevokedProjectRecordsBeforeDeferredFailure() {
+        let draft = inventoryDraft(
+            from: inventorySummary(id: "draft-revoked", updatedAt: timestamp)
+        )
+        let review = ReviewRecord(
+            id: "review-revoked",
+            projectId: "project-1",
+            draftId: draft.id,
+            title: "Revoked",
+            description: "",
+            author: user,
+            status: "open",
+            version: 1,
+            decisionBody: nil,
+            approvedResultHash: nil,
+            decidedBy: nil,
+            decidedAt: nil,
+            freshness: .current,
+            reconciliation: .unknown,
+            reconciliationCandidateId: nil,
+            currentCommitId: "commit-1",
+            updatedAt: timestamp
+        )
+        let revokedAccess = Set<String>()
+        let retainedAccess = Set(["project-1"])
+
+        let draftsAfterRevocation = WorkspaceStore.retainingAccessibleProjectRecords(
+            [draft],
+            accessibleProjectIds: revokedAccess,
+            projectId: \.projectId
+        )
+        let reviewsAfterRevocation = WorkspaceStore.retainingAccessibleProjectRecords(
+            [review],
+            accessibleProjectIds: revokedAccess,
+            projectId: \.projectId
+        )
+
+        XCTAssertTrue(draftsAfterRevocation.isEmpty)
+        XCTAssertTrue(reviewsAfterRevocation.isEmpty)
+        XCTAssertEqual(WorkspaceStore.retainingAccessibleProjectRecords(
+            [draft],
+            accessibleProjectIds: retainedAccess,
+            projectId: \.projectId
+        ), [draft])
+        XCTAssertEqual(WorkspaceStore.retainingAccessibleProjectRecords(
+            [review],
+            accessibleProjectIds: retainedAccess,
+            projectId: \.projectId
+        ), [review])
+    }
+
+    func testDeferredRecordMergePreservesConcurrentMutationsPerRecord() {
+        let unchanged = inventoryDraft(
+            from: inventorySummary(id: "unchanged", updatedAt: timestamp)
+        )
+        let edited = inventoryDraft(
+            from: inventorySummary(id: "edited", updatedAt: timestamp)
+        )
+        let deleted = inventoryDraft(
+            from: inventorySummary(id: "deleted", updatedAt: timestamp)
+        )
+        let localNew = inventoryDraft(
+            from: inventorySummary(id: "local-new", updatedAt: timestamp)
+        )
+        let serverNew = inventoryDraft(
+            from: inventorySummary(id: "server-new", updatedAt: timestamp)
+        )
+
+        var serverUpdated = unchanged
+        serverUpdated.document.body = "Server update"
+        var localEdited = edited
+        localEdited.document.body = "Local edit"
+        var serverEdited = edited
+        serverEdited.document.body = "Server edit"
+        var serverDeleted = deleted
+        serverDeleted.document.body = "Server kept record"
+
+        let merged = WorkspaceStore.mergeDeferredRecords(
+            baseline: [unchanged, edited, deleted],
+            current: [unchanged, localEdited, localNew],
+            loaded: [serverUpdated, serverEdited, serverDeleted, serverNew]
+        )
+        let mergedById = Dictionary(uniqueKeysWithValues: merged.map { ($0.id, $0) })
+
+        XCTAssertEqual(
+            Set(mergedById.keys),
+            Set(["unchanged", "edited", "local-new", "server-new"])
+        )
+        XCTAssertEqual(mergedById["unchanged"]?.document.body, "Server update")
+        XCTAssertEqual(mergedById["edited"]?.document.body, "Local edit")
+        XCTAssertNil(mergedById["deleted"])
+        XCTAssertEqual(mergedById["local-new"], localNew)
+        XCTAssertEqual(mergedById["server-new"], serverNew)
     }
 
     @MainActor
@@ -254,6 +567,332 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertTrue(warning?.contains("could not be inspected") == true)
         XCTAssertTrue(warning?.contains("Claude Code user integration at /Users/example") == true)
         XCTAssertTrue(warning?.contains("enable each repository") == true)
+    }
+
+    func testAdapterWarningOnlyUpdatesItsOwnedErrorMessage() {
+        let previous = LocalAgentAdapterReconciliationResult(
+            conflicts: [],
+            inspectionWarning: "Previous adapter warning"
+        )
+        let next = LocalAgentAdapterReconciliationResult(
+            conflicts: [],
+            inspectionWarning: "Next adapter warning"
+        )
+        let empty = LocalAgentAdapterReconciliationResult(
+            conflicts: [],
+            inspectionWarning: nil
+        )
+
+        XCTAssertEqual(
+            WorkspaceStore.errorMessageAfterUpdatingLocalAgentAdapters(
+                currentErrorMessage: "Document save failed",
+                previous: previous,
+                next: next
+            ),
+            "Document save failed"
+        )
+        XCTAssertNil(WorkspaceStore.errorMessageAfterUpdatingLocalAgentAdapters(
+            currentErrorMessage: "Previous adapter warning",
+            previous: previous,
+            next: empty
+        ))
+        XCTAssertEqual(
+            WorkspaceStore.errorMessageAfterUpdatingLocalAgentAdapters(
+                currentErrorMessage: nil,
+                previous: empty,
+                next: next
+            ),
+            "Next adapter warning"
+        )
+    }
+
+    func testLegacyInspectionExplainsUnsignedReleaseRuntime() {
+        let warning = WorkspaceLoader.legacyAgentAdapterInspectionWarning(
+            for: DaemonXPCError.daemon(.init(
+                code: "project_agent_adapter_invalid_runtime",
+                message: "Missing release signing identity.",
+                requestId: nil
+            ))
+        )
+
+        XCTAssertTrue(warning.contains("Archived integration inspection was skipped"))
+        XCTAssertTrue(warning.contains("cannot install or update managed Coding Agent integrations"))
+        XCTAssertTrue(warning.contains("officially signed release build"))
+        XCTAssertFalse(warning.contains("archived Zig CLI integration store"))
+    }
+
+    func testLegacyInspectionOtherFailureStillRequestsManualReview() {
+        let warning = WorkspaceLoader.legacyAgentAdapterInspectionWarning(
+            for: DaemonXPCError.requestTimedOut()
+        )
+
+        XCTAssertTrue(warning.contains("archived Zig CLI integration store"))
+        XCTAssertTrue(warning.contains("Review any old global or repository"))
+        XCTAssertFalse(warning.contains("release signing identity"))
+    }
+
+    func testRetrySyncHasAnIndependentPostReadyTask() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let retryTask = try XCTUnwrap(
+            source.range(of: "postReadyRetrySyncTask = Task")
+        )
+        let statusTask = try XCTUnwrap(
+            source.range(of: "postReadySyncTask = Task")
+        )
+        let statusEnd = try XCTUnwrap(
+            source[statusTask.lowerBound...].range(
+                of: "\n    private func applyLocalAgentAdapterResult"
+            )
+        )
+
+        XCTAssertLessThan(retryTask.lowerBound, statusTask.lowerBound)
+        XCTAssertTrue(
+            source[retryTask.lowerBound..<statusTask.lowerBound]
+                .contains("daemon.retrySync()")
+        )
+        XCTAssertFalse(
+            source[statusTask.lowerBound..<statusEnd.lowerBound]
+                .contains("daemon.retrySync()")
+        )
+    }
+
+    func testOrgResourceRefreshIsScopedToWorkspaceGeneration() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(
+            source.range(of: "private func refreshOrgResourcesIfNeeded()")
+        )
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(
+                of: "\n    nonisolated static func staleResourcePlan"
+            )
+        )
+        let refresh = source[start.lowerBound..<end.lowerBound]
+
+        XCTAssertTrue(refresh.contains(
+            "let workspaceGeneration = workspaceReloadGeneration"
+        ))
+        XCTAssertGreaterThanOrEqual(
+            refresh.components(separatedBy: "workspaceReloadGeneration == workspaceGeneration")
+                .count - 1,
+            2
+        )
+    }
+
+    func testReloadAndProjectSelectionAreMutuallyExclusive() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let reloadStart = try XCTUnwrap(
+            source.range(of: "func reload(allowsDuringDocumentReconciliation:")
+        )
+        let reloadEnd = try XCTUnwrap(
+            source[reloadStart.lowerBound...].range(of: "\n    func signIn()")
+        )
+        let reload = source[reloadStart.lowerBound..<reloadEnd.lowerBound]
+        let selectionGuard =
+            "guard loadingProjectId == nil, !isSwitchingMemoryContext else { return }"
+        let firstGuard = try XCTUnwrap(reload.range(of: selectionGuard))
+        let secondGuard = try XCTUnwrap(
+            reload[firstGuard.upperBound...].range(of: selectionGuard)
+        )
+        let loading = try XCTUnwrap(reload.range(of: "phase = .loading"))
+        let loader = try XCTUnwrap(reload.range(of: "WorkspaceLoader("))
+
+        XCTAssertTrue(reload.contains("guard !isSigningOut else { return }"))
+        XCTAssertEqual(reload.components(separatedBy: selectionGuard).count - 1, 2)
+        XCTAssertLessThan(secondGuard.lowerBound, loading.lowerBound)
+        XCTAssertLessThan(loading.lowerBound, loader.lowerBound)
+        XCTAssertTrue(reload.contains(
+            "guard !preservesLoadedWorkspace || !snapshotWasStale"
+        ))
+
+        let selectStart = try XCTUnwrap(
+            source.range(of: "func selectProject(_ projectId: String) async")
+        )
+        let selectEnd = try XCTUnwrap(
+            source[selectStart.lowerBound...].range(of: "\n    func focusIssueSearch")
+        )
+        XCTAssertTrue(
+            source[selectStart.lowerBound..<selectEnd.lowerBound]
+                .contains("guard phase == .ready else { return }")
+        )
+
+        let orgStart = try XCTUnwrap(
+            source.range(of: "func showOrgMemory() async")
+        )
+        let orgEnd = try XCTUnwrap(
+            source[orgStart.lowerBound...].range(of: "\n    func selectProject")
+        )
+        XCTAssertTrue(
+            source[orgStart.lowerBound..<orgEnd.lowerBound]
+                .contains("guard phase == .ready else { return }")
+        )
+    }
+
+    func testSaveStagingAndBundleEditingRequireReadyWorkspace() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let storeSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let canEditStart = try XCTUnwrap(
+            storeSource.range(of: "func canEditMemory(_ item: MemoryListItem) -> Bool")
+        )
+        let canEditEnd = try XCTUnwrap(
+            storeSource[canEditStart.lowerBound...].range(of: "\n    var selectedItem")
+        )
+        XCTAssertTrue(
+            storeSource[canEditStart.lowerBound..<canEditEnd.lowerBound]
+                .contains("guard phase == .ready else { return false }")
+        )
+
+        let documentStart = try XCTUnwrap(
+            storeSource.range(of: "func stageDocumentSave")
+        )
+        let documentEnd = try XCTUnwrap(
+            storeSource[documentStart.lowerBound...].range(of: "\n    func flushDocumentSave")
+        )
+        XCTAssertTrue(
+            storeSource[documentStart.lowerBound..<documentEnd.lowerBound]
+                .contains("guard phase == .ready, !isSigningOut else { return }")
+        )
+
+        let bundleStart = try XCTUnwrap(storeSource.range(of: "func stageBundleSave"))
+        let bundleEnd = try XCTUnwrap(
+            storeSource[bundleStart.lowerBound...].range(of: "\n    func flushBundleSave")
+        )
+        XCTAssertTrue(
+            storeSource[bundleStart.lowerBound..<bundleEnd.lowerBound]
+                .contains("guard phase == .ready, !isSigningOut else { return }")
+        )
+
+        let bundleViewSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/BundlesView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(bundleViewSource.contains(".disabled(store.phase != .ready)"))
+    }
+
+    func testSignOutSerializesFinalConfigClearAndUsesFullAuthorityClear() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let signOutStart = try XCTUnwrap(source.range(of: "func signOut() async"))
+        let signOutEnd = try XCTUnwrap(
+            source[signOutStart.lowerBound...].range(of: "\n    func createMemory")
+        )
+        let signOut = source[signOutStart.lowerBound..<signOutEnd.lowerBound]
+        let signOutGuard = try XCTUnwrap(
+            signOut.range(of: "guard !isSigningOut else { return }")
+        )
+        let signOutSet = try XCTUnwrap(
+            signOut.range(of: "isSigningOut = true")
+        )
+        let priorPhase = try XCTUnwrap(
+            signOut.range(of: "let priorPhase = phase")
+        )
+        let signOutDefer = try XCTUnwrap(
+            signOut.range(of: "defer { isSigningOut = false }")
+        )
+        let flush = try XCTUnwrap(signOut.range(of: "await flushPendingChanges()"))
+        let loading = try XCTUnwrap(
+            signOut.range(of: "phase = .loading")
+        )
+        let invalidate = try XCTUnwrap(
+            signOut.range(of: "invalidateWorkspaceTransitionState")
+        )
+        let restorePhase = try XCTUnwrap(
+            signOut.range(of: "phase = priorPhase")
+        )
+        let sessionDelete = try XCTUnwrap(
+            signOut.range(of: #"server.raw(method: "DELETE""#)
+        )
+        let gate = try XCTUnwrap(
+            signOut.range(of: "projectSelectionSideEffectGate.run")
+        )
+        let configClear = try XCTUnwrap(
+            signOut.range(of: "daemon.replaceProjectConfig")
+        )
+        let authorityClear = try XCTUnwrap(
+            signOut.range(of: "clearAuthorityScopedWorkspace()")
+        )
+        let authenticationRequired = try XCTUnwrap(
+            signOut.range(of: "phase = .authenticationRequired")
+        )
+
+        XCTAssertLessThan(signOutGuard.lowerBound, signOutSet.lowerBound)
+        XCTAssertLessThan(signOutSet.lowerBound, priorPhase.lowerBound)
+        XCTAssertLessThan(priorPhase.lowerBound, loading.lowerBound)
+        XCTAssertLessThan(loading.lowerBound, signOutDefer.lowerBound)
+        XCTAssertLessThan(signOutDefer.lowerBound, flush.lowerBound)
+        XCTAssertLessThan(flush.lowerBound, restorePhase.lowerBound)
+        XCTAssertLessThan(restorePhase.lowerBound, invalidate.lowerBound)
+        XCTAssertLessThan(invalidate.lowerBound, sessionDelete.lowerBound)
+        XCTAssertLessThan(sessionDelete.lowerBound, gate.lowerBound)
+        XCTAssertLessThan(gate.lowerBound, configClear.lowerBound)
+        XCTAssertLessThan(configClear.lowerBound, authorityClear.lowerBound)
+        XCTAssertLessThan(authorityClear.lowerBound, authenticationRequired.lowerBound)
+        XCTAssertTrue(signOut.contains("phase = .failed(error.localizedDescription)"))
+
+        let clearStart = try XCTUnwrap(
+            source.range(of: "func clearAuthorityScopedWorkspace()")
+        )
+        let clearEnd = try XCTUnwrap(
+            source[clearStart.lowerBound...].range(of: "\n    private func apply(")
+        )
+        let clear = source[clearStart.lowerBound..<clearEnd.lowerBound]
+        let requiredFullClearOperations = [
+            "invalidateWorkspaceTransitionState",
+            "documentSaveTasks.values.forEach { $0.cancel() }",
+            "pendingDocumentSaves.removeAll()",
+            "bundleSaveTasks.values.forEach { $0.cancel() }",
+            "pendingBundleSaves.removeAll()",
+            "account = nil",
+            "organization = nil",
+            "projectMetadata.removeAll()",
+            "projectMembers.removeAll()",
+            "orgRefCommitId = nil",
+            #"orgRefEtag = """#,
+            "activeProjectId = nil",
+            "resources.removeAll()",
+            "drafts.removeAll()",
+            "bundles.removeAll()",
+            "reviews.removeAll()",
+            "runtime = nil",
+            "syncStatusAvailable = false",
+            "selectedItemId = nil",
+            "selectedBundleId = nil",
+            "selectedReviewId = nil",
+            "navigationBackStack.removeAll()",
+            "navigationForwardStack.removeAll()",
+            "resourceLoadRequests.removeAll()",
+            "documentSynchronizationTasks.values.forEach { $0.cancel() }",
+        ]
+        for operation in requiredFullClearOperations {
+            XCTAssertTrue(clear.contains(operation), "Missing full clear: \(operation)")
+        }
     }
 
     func testAppTranslocationIsRejectedBeforeRuntimePathsCanBePersisted() throws {
@@ -1634,6 +2273,17 @@ final class DaemonContractTests: XCTestCase {
         )
     }
 
+    func testSyncToolbarSurfacesDeferredStatusReader() {
+        XCTAssertEqual(
+            SyncToolbarPresentation.resolve(
+                status: nil,
+                isAvailable: false,
+                serverDataSource: "live"
+            ),
+            .unavailable(message: nil)
+        )
+    }
+
     func testSyncToolbarSurfacesCachedServerDataWhenSyncIsIdle() {
         XCTAssertEqual(
             SyncToolbarPresentation.resolve(
@@ -1692,6 +2342,7 @@ final class DaemonContractTests: XCTestCase {
         id: String,
         status: DaemonLocalDraftStatus = .open,
         hasUpstreamResourceChanges: Bool = false,
+        targetId: String? = nil,
         updatedAt: String
     ) -> DaemonDraftSummary {
         .init(
@@ -1707,7 +2358,7 @@ final class DaemonContractTests: XCTestCase {
             reconciliationCandidateId: nil,
             scope: .project,
             resourceKind: .memory,
-            targetId: nil,
+            targetId: targetId,
             path: "rules/\(id).md",
             status: status,
             createdAt: "2026-07-23T00:00:00Z",
@@ -1950,7 +2601,7 @@ private actor RetryingDaemonHealthProbe {
     }
 }
 
-private actor WarmDaemonRetryGate {
+private actor DaemonContractTestLatch {
     private var isOpen = false
     private var waiters: [CheckedContinuation<Void, Never>] = []
 

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -289,23 +289,27 @@ final class WorkspaceNavigationTests: XCTestCase {
 
     func testReviewListContentStateDistinguishesLoadingAndEmptyQueues() {
         XCTAssertEqual(
-            ReviewListContentState.resolve(phase: .launching, totalCount: 0, visibleCount: 0),
+            ReviewListContentState.resolve(loadState: .loading, totalCount: 0, visibleCount: 0),
             .loading
         )
         XCTAssertEqual(
-            ReviewListContentState.resolve(phase: .loading, totalCount: 0, visibleCount: 0),
+            ReviewListContentState.resolve(loadState: .failed("offline"), totalCount: 0, visibleCount: 0),
+            .failed
+        )
+        XCTAssertEqual(
+            ReviewListContentState.resolve(loadState: .loading, totalCount: 2, visibleCount: 0),
             .loading
         )
         XCTAssertEqual(
-            ReviewListContentState.resolve(phase: .ready, totalCount: 0, visibleCount: 0),
+            ReviewListContentState.resolve(loadState: .loaded, totalCount: 0, visibleCount: 0),
             .empty
         )
         XCTAssertEqual(
-            ReviewListContentState.resolve(phase: .ready, totalCount: 2, visibleCount: 0),
+            ReviewListContentState.resolve(loadState: .loaded, totalCount: 2, visibleCount: 0),
             .filteredEmpty
         )
         XCTAssertEqual(
-            ReviewListContentState.resolve(phase: .loading, totalCount: 2, visibleCount: 1),
+            ReviewListContentState.resolve(loadState: .loading, totalCount: 2, visibleCount: 1),
             .content
         )
     }

--- a/crates/daemon/src/server_client.rs
+++ b/crates/daemon/src/server_client.rs
@@ -8,7 +8,17 @@ use sqlx::{Row, SqlitePool};
 use crate::DaemonError;
 use crate::DaemonServerResponse;
 use crate::DaemonState;
+use crate::RuntimeProjectConfig;
 use crate::ServerTokenRefreshResponse;
+
+const SERVER_PROXY_MAX_PATH_BYTES: usize = 8 * 1024;
+
+const SERVER_RESPONSE_CACHE_MAX_ENTRIES: i64 = 512;
+const SERVER_RESPONSE_CACHE_MAX_LOGICAL_BYTES: i64 = 64 * 1024 * 1024;
+enum TokenRefreshOutcome {
+    Refreshed(RuntimeProjectConfig),
+    Superseded,
+}
 
 pub(crate) async fn post_server_json<T, R>(
     state: &DaemonState,
@@ -91,7 +101,9 @@ pub(crate) async fn execute_authenticated_server_request(
     body: Option<Vec<u8>>,
 ) -> Result<reqwest::Response, DaemonError> {
     validate_server_proxy_path(path)?;
-    let config = state.project_config_with_credentials().await;
+    let snapshot = state.project_config_with_credentials_snapshot().await;
+    let request_session_revision = snapshot.session_revision;
+    let config = snapshot.config;
     let access_token = config.access_token.clone().ok_or_else(|| {
         DaemonError::InvalidConfig("access_token is required for Server requests".to_owned())
     })?;
@@ -109,15 +121,18 @@ pub(crate) async fn execute_authenticated_server_request(
         return Ok(response);
     }
 
-    refresh_server_tokens(state, &access_token).await?;
-    let refreshed = state.project_config();
-    let refreshed_access_token = refreshed.access_token.ok_or_else(|| {
-        DaemonError::InvalidConfig("Server session is no longer authenticated".to_owned())
-    })?;
+    let TokenRefreshOutcome::Refreshed(refreshed) =
+        refresh_server_tokens(state, &config, request_session_revision).await?
+    else {
+        return Ok(response);
+    };
     send_server_request(
         state,
         &refreshed.server_url,
-        &refreshed_access_token,
+        refreshed
+            .access_token
+            .as_deref()
+            .expect("a refreshed session must contain an access token"),
         method,
         path,
         headers,
@@ -156,13 +171,28 @@ async fn send_server_request(
 
 async fn refresh_server_tokens(
     state: &DaemonState,
-    stale_access_token: &str,
-) -> Result<(), DaemonError> {
+    expected: &RuntimeProjectConfig,
+    expected_session_revision: u64,
+) -> Result<TokenRefreshOutcome, DaemonError> {
     let _refresh_guard = state.inner.token_refresh.lock().await;
-    let config = state.project_config();
-    if config.access_token.as_deref() != Some(stale_access_token) {
-        return Ok(());
+    let snapshot = state.project_config_snapshot();
+    if snapshot.session_revision != expected_session_revision
+        || snapshot.config.server_url != expected.server_url
+    {
+        return Ok(TokenRefreshOutcome::Superseded);
     }
+    let stale_access_token = expected
+        .access_token
+        .as_deref()
+        .expect("the rejected authenticated request must retain its access token");
+    if snapshot.config.access_token.as_deref() != Some(stale_access_token) {
+        if snapshot.config.access_token.is_some() {
+            return Ok(TokenRefreshOutcome::Refreshed(snapshot.config));
+        }
+        return Ok(TokenRefreshOutcome::Superseded);
+    }
+    let config = snapshot.config;
+    let session_revision = snapshot.session_revision;
     let refresh_token = config.refresh_token.clone().ok_or_else(|| {
         DaemonError::InvalidConfig("refresh_token is required to refresh the session".to_owned())
     })?;
@@ -187,7 +217,13 @@ async fn refresh_server_tokens(
             || status == reqwest::StatusCode::UNAUTHORIZED
             || status == reqwest::StatusCode::FORBIDDEN
         {
-            clear_server_tokens(state).await?;
+            state
+                .clear_server_tokens_if_current(
+                    session_revision,
+                    &config.server_url,
+                    stale_access_token,
+                )
+                .await?;
         }
         return Err(DaemonError::ServerResponse {
             status: status.as_u16(),
@@ -195,7 +231,16 @@ async fn refresh_server_tokens(
         });
     }
     let tokens: ServerTokenRefreshResponse = response.json().await?;
-    let mut refreshed = config;
+
+    let _mutation = state.inner.project_config_mutation.lock().await;
+    let current = state.project_config_snapshot();
+    if current.session_revision != session_revision
+        || current.config.server_url != config.server_url
+        || current.config.access_token.as_deref() != Some(stale_access_token)
+    {
+        return Ok(TokenRefreshOutcome::Superseded);
+    }
+    let mut refreshed = current.config;
     refreshed.access_token = Some(tokens.access_token);
     refreshed.refresh_token = Some(tokens.refresh_token);
     crate::replace_server_credentials(
@@ -203,26 +248,8 @@ async fn refresh_server_tokens(
         refreshed.credentials(),
     )
     .await?;
-    *state
-        .inner
-        .project_config
-        .write()
-        .expect("project config rwlock poisoned") = refreshed;
-    Ok(())
-}
-
-async fn clear_server_tokens(state: &DaemonState) -> Result<(), DaemonError> {
-    let mut config = state.project_config();
-    crate::replace_server_credentials(state.inner.credential_store.clone(), None).await?;
-    clear_server_response_cache(&state.inner.pool).await?;
-    config.access_token = None;
-    config.refresh_token = None;
-    *state
-        .inner
-        .project_config
-        .write()
-        .expect("project config rwlock poisoned") = config;
-    Ok(())
+    state.publish_project_config(refreshed.clone());
+    Ok(TokenRefreshOutcome::Refreshed(refreshed))
 }
 
 pub(crate) async fn decode_server_json<R>(response: reqwest::Response) -> Result<R, DaemonError>
@@ -248,7 +275,8 @@ pub(crate) async fn ensure_server_success(
 }
 
 pub(crate) fn validate_server_proxy_path(path: &str) -> Result<(), DaemonError> {
-    if !path.starts_with("/api/v1/")
+    if path.len() > SERVER_PROXY_MAX_PATH_BYTES
+        || !path.starts_with("/api/v1/")
         || path.contains("\r")
         || path.contains("\n")
         || path.contains("#")
@@ -313,6 +341,8 @@ pub(crate) async fn save_cached_server_response(
     path: &str,
     response: &DaemonServerResponse,
 ) -> Result<(), DaemonError> {
+    let headers_json = serde_json::to_string(&response.headers)?;
+    let mut transaction = pool.begin().await?;
     sqlx::query(
         "INSERT INTO server_response_cache (
             server_url, path, status, headers_json, body, updated_at
@@ -327,9 +357,53 @@ pub(crate) async fn save_cached_server_response(
     .bind(server_url)
     .bind(path)
     .bind(i64::from(response.status))
-    .bind(serde_json::to_string(&response.headers)?)
+    .bind(headers_json)
     .bind(&response.body)
-    .execute(pool)
+    .execute(&mut *transaction)
+    .await?;
+    prune_cached_server_responses(
+        &mut transaction,
+        SERVER_RESPONSE_CACHE_MAX_ENTRIES,
+        SERVER_RESPONSE_CACHE_MAX_LOGICAL_BYTES,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn prune_cached_server_responses(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    max_entries: i64,
+    max_logical_bytes: i64,
+) -> Result<(), DaemonError> {
+    sqlx::query(
+        "WITH ranked AS (
+            SELECT
+                rowid,
+                ROW_NUMBER() OVER (
+                    ORDER BY updated_at DESC, rowid DESC
+                ) AS cache_rank,
+                SUM(
+                    length(CAST(server_url AS BLOB))
+                    + length(CAST(path AS BLOB))
+                    + length(CAST(headers_json AS BLOB))
+                    + length(CAST(body AS BLOB))
+                ) OVER (
+                    ORDER BY updated_at DESC, rowid DESC
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                ) AS cumulative_bytes
+            FROM server_response_cache
+         )
+         DELETE FROM server_response_cache
+         WHERE rowid IN (
+            SELECT rowid
+            FROM ranked
+            WHERE cache_rank > $1 OR cumulative_bytes > $2
+         )",
+    )
+    .bind(max_entries)
+    .bind(max_logical_bytes)
+    .execute(&mut **transaction)
     .await?;
     Ok(())
 }
@@ -399,5 +473,96 @@ mod tests {
                 ("x-clumsies-request-id".to_owned(), "request-1".to_owned(),),
             ])
         );
+    }
+
+    #[test]
+    fn proxy_path_has_a_bounded_cache_key() {
+        let oversized = format!("/api/v1/{}", "a".repeat(SERVER_PROXY_MAX_PATH_BYTES));
+
+        assert!(validate_server_proxy_path(&oversized).is_err());
+        assert!(validate_server_proxy_path("/api/v1/reviews?limit=100").is_ok());
+    }
+    #[tokio::test]
+    async fn response_cache_pruning_enforces_entry_and_utf8_byte_limits() {
+        assert_eq!(SERVER_RESPONSE_CACHE_MAX_ENTRIES, 512);
+        assert_eq!(SERVER_RESPONSE_CACHE_MAX_LOGICAL_BYTES, 64 * 1024 * 1024);
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE server_response_cache (
+                server_url TEXT NOT NULL,
+                path TEXT NOT NULL,
+                status BIGINT NOT NULL,
+                headers_json TEXT NOT NULL,
+                body TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (server_url, path)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        for index in 0..4 {
+            sqlx::query(
+                "INSERT INTO server_response_cache (
+                    server_url, path, status, headers_json, body, updated_at
+                 ) VALUES ($1, $2, 200, '{}', 'body', $3)",
+            )
+            .bind("s")
+            .bind(format!("p{index}"))
+            .bind(format!("2026-01-01T00:00:0{index}Z"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let mut transaction = pool.begin().await.unwrap();
+        prune_cached_server_responses(&mut transaction, 2, i64::MAX)
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+        let paths: Vec<String> = sqlx::query_scalar(
+            "SELECT path FROM server_response_cache ORDER BY updated_at DESC, rowid DESC",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(paths, ["p3", "p2"]);
+
+        sqlx::query("DELETE FROM server_response_cache")
+            .execute(&pool)
+            .await
+            .unwrap();
+        for index in 0..3 {
+            sqlx::query(
+                "INSERT INTO server_response_cache (
+                    server_url, path, status, headers_json, body, updated_at
+                 ) VALUES ($1, $2, 200, '{}', $3, $4)",
+            )
+            .bind("s")
+            .bind(format!("p{index}"))
+            .bind("你好")
+            .bind(format!("2026-01-01T00:00:0{index}Z"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let mut transaction = pool.begin().await.unwrap();
+        // Each row is 11 logical bytes: server 1 + path 2 + headers 2 + UTF-8 body 6.
+        // A character-count implementation would incorrectly retain two rows under 15.
+        prune_cached_server_responses(&mut transaction, 10, 15)
+            .await
+            .unwrap();
+        transaction.commit().await.unwrap();
+        let paths: Vec<String> = sqlx::query_scalar(
+            "SELECT path FROM server_response_cache ORDER BY updated_at DESC, rowid DESC",
+        )
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+        assert_eq!(paths, ["p2"]);
     }
 }

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -18,6 +18,8 @@ const CREDENTIAL_RECOVERY_COOLDOWN: Duration = Duration::from_secs(10);
 
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const SERVER_RESPONSE_CACHE_MAX_BODY_BYTES: usize = 1024 * 1024;
+const SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES: usize = 16;
 
 fn build_http_client(
     connect_timeout: Duration,
@@ -41,6 +43,104 @@ pub(crate) struct CredentialRecovery {
     last_attempt: Option<Instant>,
 }
 
+pub(crate) struct RuntimeProjectConfigSnapshot {
+    pub(crate) config: RuntimeProjectConfig,
+    pub(crate) session_revision: u64,
+}
+
+struct RuntimeProjectConfigState {
+    config: RuntimeProjectConfig,
+    session_revision: u64,
+}
+
+type ServerResponseCacheKey = (String, String);
+
+#[derive(Default)]
+struct ServerResponseCacheKeyState {
+    in_flight: usize,
+    latest_success_revision: Option<u64>,
+}
+
+struct PendingServerResponseCacheWrite {
+    revision: u64,
+    response: DaemonServerResponse,
+}
+
+struct ServerResponseCacheRequest {
+    inner: Arc<DaemonInner>,
+    key: ServerResponseCacheKey,
+    revision: u64,
+}
+
+struct ServerResponseCacheTransition<'a> {
+    inner: &'a DaemonInner,
+    _write: tokio::sync::MutexGuard<'a, ()>,
+    published: bool,
+}
+
+impl ServerResponseCacheRequest {
+    fn server_url(&self) -> &str {
+        &self.key.0
+    }
+}
+
+impl Drop for ServerResponseCacheRequest {
+    fn drop(&mut self) {
+        self.inner
+            .server_response_cache
+            .lock()
+            .expect("server response cache mutex poisoned")
+            .finish_request(&self.key);
+    }
+}
+
+/// Coalesces successful GETs for one bounded background SQLite writer.
+/// Request state lives only until its request and queued write both finish.
+#[derive(Default)]
+struct ServerResponseCacheState {
+    next_revision: u64,
+    minimum_revision: u64,
+    keys: BTreeMap<ServerResponseCacheKey, ServerResponseCacheKeyState>,
+    pending: BTreeMap<ServerResponseCacheKey, PendingServerResponseCacheWrite>,
+    active: Option<(ServerResponseCacheKey, u64)>,
+    worker_running: bool,
+}
+
+impl ServerResponseCacheState {
+    fn invalidate(&mut self) {
+        self.minimum_revision = self.next_revision;
+        self.pending.clear();
+        for state in self.keys.values_mut() {
+            state.latest_success_revision = None;
+        }
+        let active_key = self.active.as_ref().map(|(key, _)| key.clone());
+        self.keys.retain(|key, state| {
+            state.in_flight > 0 || active_key.as_ref().is_some_and(|active| active == key)
+        });
+    }
+
+    fn finish_request(&mut self, key: &ServerResponseCacheKey) {
+        let state = self
+            .keys
+            .get_mut(key)
+            .expect("active cache request must retain its key state");
+        state.in_flight = state
+            .in_flight
+            .checked_sub(1)
+            .expect("cache request count underflow");
+        self.remove_key_if_idle(key);
+    }
+
+    fn remove_key_if_idle(&mut self, key: &ServerResponseCacheKey) {
+        let idle = self.keys.get(key).is_some_and(|state| state.in_flight == 0)
+            && !self.pending.contains_key(key)
+            && self.active.as_ref().is_none_or(|(active, _)| active != key);
+        if idle {
+            self.keys.remove(key);
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct DaemonState {
     pub(crate) inner: Arc<DaemonInner>,
@@ -48,7 +148,8 @@ pub struct DaemonState {
 
 pub(crate) struct DaemonInner {
     pub(crate) config: DaemonConfig,
-    pub(crate) project_config: RwLock<RuntimeProjectConfig>,
+    project_config: RwLock<RuntimeProjectConfigState>,
+    pub(crate) project_config_mutation: Mutex<()>,
     pub(crate) credential_store: Arc<dyn CredentialStore>,
     pub(crate) pool: SqlitePool,
     pub(crate) http: reqwest::Client,
@@ -57,6 +158,8 @@ pub(crate) struct DaemonInner {
     pub(crate) sync_lock: Mutex<()>,
     pub(crate) commit_sync_running: AtomicBool,
     pub(crate) token_refresh: Mutex<()>,
+    server_response_cache: std::sync::Mutex<ServerResponseCacheState>,
+    server_response_cache_write: Mutex<()>,
     pub(crate) credential_recovery: Mutex<CredentialRecovery>,
     pub(crate) search_models: Arc<dyn search::models::SearchModels>,
     pub(crate) search_model_gate: Arc<Semaphore>,
@@ -67,6 +170,58 @@ pub(crate) struct DaemonInner {
     pub(crate) local_setup_lock: Mutex<()>,
     pub(crate) agent_run_lock: Mutex<()>,
     pub(crate) storage_access: tokio::sync::RwLock<()>,
+}
+
+impl DaemonInner {
+    fn project_config_snapshot(&self) -> RuntimeProjectConfigSnapshot {
+        let state = self
+            .project_config
+            .read()
+            .expect("project config rwlock poisoned");
+        RuntimeProjectConfigSnapshot {
+            config: state.config.clone(),
+            session_revision: state.session_revision,
+        }
+    }
+
+    fn publish_project_config(&self, project_config: RuntimeProjectConfig, new_session: bool) {
+        let mut state = self
+            .project_config
+            .write()
+            .expect("project config rwlock poisoned");
+        if new_session {
+            state.session_revision = state
+                .session_revision
+                .checked_add(1)
+                .expect("Server session revision exhausted");
+        }
+        state.config = project_config;
+    }
+}
+
+impl ServerResponseCacheTransition<'_> {
+    fn publish(mut self, project_config: RuntimeProjectConfig) {
+        let mut cache = self
+            .inner
+            .server_response_cache
+            .lock()
+            .expect("server response cache mutex poisoned");
+        self.inner.publish_project_config(project_config, true);
+        cache.invalidate();
+        self.published = true;
+    }
+}
+
+impl Drop for ServerResponseCacheTransition<'_> {
+    fn drop(&mut self) {
+        if !self.published {
+            self.inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned")
+                .invalidate();
+        }
+    }
 }
 
 impl DaemonState {
@@ -118,7 +273,11 @@ impl DaemonState {
         let state = Self {
             inner: Arc::new(DaemonInner {
                 config,
-                project_config: RwLock::new(project_config),
+                project_config: RwLock::new(RuntimeProjectConfigState {
+                    config: project_config,
+                    session_revision: 0,
+                }),
+                project_config_mutation: Mutex::new(()),
                 credential_store,
                 pool,
                 http,
@@ -127,6 +286,8 @@ impl DaemonState {
                 sync_lock: Mutex::new(()),
                 commit_sync_running: AtomicBool::new(false),
                 token_refresh: Mutex::new(()),
+                server_response_cache: std::sync::Mutex::new(ServerResponseCacheState::default()),
+                server_response_cache_write: Mutex::new(()),
                 credential_recovery: Mutex::new(CredentialRecovery::default()),
                 search_models,
                 search_model_gate: Arc::new(Semaphore::new(1)),
@@ -156,17 +317,28 @@ impl DaemonState {
     }
 
     pub(crate) fn project_config(&self) -> RuntimeProjectConfig {
-        self.inner
-            .project_config
-            .read()
-            .expect("project config rwlock poisoned")
-            .clone()
+        self.project_config_snapshot().config
     }
 
+    pub(crate) fn project_config_snapshot(&self) -> RuntimeProjectConfigSnapshot {
+        self.inner.project_config_snapshot()
+    }
+
+    pub(crate) fn publish_project_config(&self, project_config: RuntimeProjectConfig) {
+        self.inner.publish_project_config(project_config, false);
+    }
+
+    #[cfg(test)]
     pub(crate) async fn project_config_with_credentials(&self) -> RuntimeProjectConfig {
-        let config = self.project_config();
-        if config.access_token.is_some() {
-            return config;
+        self.project_config_with_credentials_snapshot().await.config
+    }
+
+    pub(crate) async fn project_config_with_credentials_snapshot(
+        &self,
+    ) -> RuntimeProjectConfigSnapshot {
+        let snapshot = self.project_config_snapshot();
+        if snapshot.config.access_token.is_some() {
+            return snapshot;
         }
         {
             let mut recovery = self.inner.credential_recovery.lock().await;
@@ -174,7 +346,7 @@ impl DaemonState {
                 .last_attempt
                 .is_some_and(|attempt| attempt.elapsed() < CREDENTIAL_RECOVERY_COOLDOWN)
             {
-                return config;
+                return self.project_config_snapshot();
             }
             recovery.last_attempt = Some(Instant::now());
         }
@@ -184,21 +356,33 @@ impl DaemonState {
         )
         .await;
         let Ok(Ok(Some(credentials))) = loaded else {
-            return config;
+            return self.project_config_snapshot();
         };
-        if credentials.server_url != config.server_url {
-            return config;
+
+        let _mutation = self.inner.project_config_mutation.lock().await;
+        let current = self.project_config_snapshot();
+        if current.session_revision != snapshot.session_revision
+            || current.config.server_url != snapshot.config.server_url
+            || current.config.access_token.is_some()
+            || credentials.server_url != current.config.server_url
+        {
+            return current;
         }
-        let mut recovered = config;
+        let transition = match self.begin_server_response_cache_transition().await {
+            Ok(transition) => transition,
+            Err(error) => {
+                tracing::warn!(
+                    "failed to clear Server response cache before credential recovery: {error}"
+                );
+                return current;
+            }
+        };
+        let mut recovered = current.config;
         recovered.access_token = Some(credentials.access_token);
         recovered.refresh_token = credentials.refresh_token;
-        *self
-            .inner
-            .project_config
-            .write()
-            .expect("project config rwlock poisoned") = recovered.clone();
+        transition.publish(recovered);
         tracing::info!("recovered Server session from the credential store");
-        recovered
+        self.project_config_snapshot()
     }
 
     pub async fn replace_project_config(
@@ -213,7 +397,8 @@ impl DaemonState {
             refresh_token: request.refresh_token.and_then(non_empty_string),
         };
         project_config.validate()?;
-        clear_server_response_cache(&self.inner.pool).await?;
+        let _mutation = self.inner.project_config_mutation.lock().await;
+        let transition = self.begin_server_response_cache_transition().await?;
         let previous_credentials = self.project_config().credentials();
         replace_server_credentials(
             self.inner.credential_store.clone(),
@@ -237,14 +422,37 @@ impl DaemonState {
             }
             return Err(error);
         }
-        *self
-            .inner
-            .project_config
-            .write()
-            .expect("project config rwlock poisoned") = project_config;
-        queue_retrying_operations(&self.inner.pool).await?;
+        transition.publish(project_config);
+        if let Err(error) = queue_retrying_operations(&self.inner.pool).await {
+            tracing::warn!(
+                "failed to requeue retrying draft operations after project config commit: {error}"
+            );
+        }
         self.request_sync();
         Ok(self.project_config_view())
+    }
+
+    pub(crate) async fn clear_server_tokens_if_current(
+        &self,
+        expected_session_revision: u64,
+        expected_server_url: &str,
+        expected_access_token: &str,
+    ) -> Result<bool, DaemonError> {
+        let _mutation = self.inner.project_config_mutation.lock().await;
+        let current = self.project_config_snapshot();
+        if current.session_revision != expected_session_revision
+            || current.config.server_url != expected_server_url
+            || current.config.access_token.as_deref() != Some(expected_access_token)
+        {
+            return Ok(false);
+        }
+        let transition = self.begin_server_response_cache_transition().await?;
+        replace_server_credentials(self.inner.credential_store.clone(), None).await?;
+        let mut project_config = current.config;
+        project_config.access_token = None;
+        project_config.refresh_token = None;
+        transition.publish(project_config);
+        Ok(true)
     }
 
     pub async fn select_project(
@@ -254,15 +462,12 @@ impl DaemonState {
         let project_id = non_empty_string(request.project_id).ok_or_else(|| {
             DaemonError::InvalidRequest("project_id must not be empty".to_owned())
         })?;
+        let _mutation = self.inner.project_config_mutation.lock().await;
         let mut project_config = self.project_config();
         project_config.project_id = Some(project_id);
         project_config.validate()?;
         save_project_metadata(&self.inner.pool, &project_config.metadata()).await?;
-        *self
-            .inner
-            .project_config
-            .write()
-            .expect("project config rwlock poisoned") = project_config;
+        self.publish_project_config(project_config);
         self.request_sync();
         Ok(self.project_config_view())
     }
@@ -575,8 +780,9 @@ impl DaemonState {
             ));
         }
         let headers = filter_proxy_request_headers(request.headers);
-        let server_url = self.project_config().server_url;
         let cacheable = method == reqwest::Method::GET;
+        let cache_request =
+            cacheable.then(|| self.start_server_response_cache_request(&request.path));
         let response = match execute_authenticated_server_request(
             self,
             method,
@@ -588,9 +794,15 @@ impl DaemonState {
         {
             Ok(response) => response,
             Err(error) if cacheable && error.is_retryable() => {
-                if let Some(cached) =
-                    load_cached_server_response(&self.inner.pool, &server_url, &request.path)
-                        .await?
+                if let Some(cached) = load_cached_server_response(
+                    &self.inner.pool,
+                    cache_request
+                        .as_ref()
+                        .expect("cacheable request must retain cache state")
+                        .server_url(),
+                    &request.path,
+                )
+                .await?
                 {
                     return Ok(cached);
                 }
@@ -603,9 +815,15 @@ impl DaemonState {
         let body = match response.text().await {
             Ok(body) => body,
             Err(error) if cacheable => {
-                if let Some(cached) =
-                    load_cached_server_response(&self.inner.pool, &server_url, &request.path)
-                        .await?
+                if let Some(cached) = load_cached_server_response(
+                    &self.inner.pool,
+                    cache_request
+                        .as_ref()
+                        .expect("cacheable request must retain cache state")
+                        .server_url(),
+                    &request.path,
+                )
+                .await?
                 {
                     return Ok(cached);
                 }
@@ -619,16 +837,208 @@ impl DaemonState {
             body,
         };
         if cacheable && ((200..300).contains(&status) || status == 404) {
-            save_cached_server_response(&self.inner.pool, &server_url, &request.path, &response)
-                .await?;
+            self.queue_server_response_cache_write(
+                cache_request
+                    .as_ref()
+                    .expect("cacheable request must retain cache state"),
+                &response,
+            );
         } else if cacheable
             && is_retryable_http_status(status)
-            && let Some(cached) =
-                load_cached_server_response(&self.inner.pool, &server_url, &request.path).await?
+            && let Some(cached) = load_cached_server_response(
+                &self.inner.pool,
+                cache_request
+                    .as_ref()
+                    .expect("cacheable request must retain cache state")
+                    .server_url(),
+                &request.path,
+            )
+            .await?
         {
             return Ok(cached);
         }
         Ok(response)
+    }
+
+    fn start_server_response_cache_request(&self, path: &str) -> ServerResponseCacheRequest {
+        let mut cache = self
+            .inner
+            .server_response_cache
+            .lock()
+            .expect("server response cache mutex poisoned");
+        let revision = cache.next_revision;
+        cache.next_revision = cache
+            .next_revision
+            .checked_add(1)
+            .expect("server response cache revision exhausted");
+        let server_url = self.project_config().server_url;
+        let key = (server_url, path.to_owned());
+        let key_state = cache.keys.entry(key.clone()).or_default();
+        key_state.in_flight = key_state
+            .in_flight
+            .checked_add(1)
+            .expect("cache request count exhausted");
+        ServerResponseCacheRequest {
+            inner: self.inner.clone(),
+            key,
+            revision,
+        }
+    }
+
+    fn queue_server_response_cache_write(
+        &self,
+        request: &ServerResponseCacheRequest,
+        response: &DaemonServerResponse,
+    ) {
+        let should_copy = {
+            let mut cache = self
+                .inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned");
+            if request.revision < cache.minimum_revision {
+                return;
+            }
+            let key_state = cache
+                .keys
+                .get_mut(&request.key)
+                .expect("active cache request must retain its key state");
+            if key_state
+                .latest_success_revision
+                .is_some_and(|latest| latest >= request.revision)
+            {
+                false
+            } else {
+                key_state.latest_success_revision = Some(request.revision);
+                true
+            }
+        };
+        if !should_copy || response.body.len() > SERVER_RESPONSE_CACHE_MAX_BODY_BYTES {
+            return;
+        }
+        let response = response.clone();
+        let start_worker = {
+            let mut cache = self
+                .inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned");
+            if request.revision < cache.minimum_revision
+                || cache
+                    .keys
+                    .get(&request.key)
+                    .and_then(|state| state.latest_success_revision)
+                    != Some(request.revision)
+            {
+                return;
+            }
+            if !cache.pending.contains_key(&request.key)
+                && cache.pending.len() == SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES
+            {
+                let (evicted_key, _) = cache
+                    .pending
+                    .pop_first()
+                    .expect("a full pending cache must contain an entry");
+                cache.remove_key_if_idle(&evicted_key);
+            }
+            cache.pending.insert(
+                request.key.clone(),
+                PendingServerResponseCacheWrite {
+                    revision: request.revision,
+                    response,
+                },
+            );
+            if cache.worker_running {
+                false
+            } else {
+                cache.worker_running = true;
+                true
+            }
+        };
+        if start_worker {
+            let state = self.clone();
+            drop(tokio::spawn(async move {
+                state.run_server_response_cache_writer().await;
+            }));
+        }
+    }
+
+    async fn run_server_response_cache_writer(&self) {
+        loop {
+            let Some((key, pending)) = ({
+                let mut cache = self
+                    .inner
+                    .server_response_cache
+                    .lock()
+                    .expect("server response cache mutex poisoned");
+                let pending = cache.pending.pop_first();
+                if let Some((key, pending)) = &pending {
+                    cache.active = Some((key.clone(), pending.revision));
+                } else {
+                    cache.worker_running = false;
+                }
+                pending
+            }) else {
+                return;
+            };
+
+            let _write = self.inner.server_response_cache_write.lock().await;
+            let is_latest = {
+                let cache = self
+                    .inner
+                    .server_response_cache
+                    .lock()
+                    .expect("server response cache mutex poisoned");
+                pending.revision >= cache.minimum_revision
+                    && cache
+                        .keys
+                        .get(&key)
+                        .and_then(|state| state.latest_success_revision)
+                        == Some(pending.revision)
+            };
+            if is_latest
+                && let Err(error) =
+                    save_cached_server_response(&self.inner.pool, &key.0, &key.1, &pending.response)
+                        .await
+            {
+                tracing::warn!("failed to cache Server response: {error}");
+            }
+            drop(_write);
+
+            let mut cache = self
+                .inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned");
+            if cache
+                .active
+                .as_ref()
+                .is_some_and(|(active, revision)| active == &key && *revision == pending.revision)
+            {
+                cache.active = None;
+            }
+            cache.remove_key_if_idle(&key);
+        }
+    }
+
+    async fn begin_server_response_cache_transition(
+        &self,
+    ) -> Result<ServerResponseCacheTransition<'_>, DaemonError> {
+        let write = self.inner.server_response_cache_write.lock().await;
+        {
+            let mut cache = self
+                .inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned");
+            cache.invalidate();
+        }
+        clear_server_response_cache(&self.inner.pool).await?;
+        Ok(ServerResponseCacheTransition {
+            inner: self.inner.as_ref(),
+            _write: write,
+            published: false,
+        })
     }
 
     pub(crate) fn project_config_view(&self) -> DaemonProjectConfig {
@@ -2590,8 +3000,8 @@ impl DaemonIpcService {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Condvar, Mutex as StdMutex};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Barrier, Condvar, Mutex as StdMutex};
 
     use super::*;
     use crate::search::SearchFailure;
@@ -2680,6 +3090,9 @@ mod tests {
     struct DeferredCredentialStore {
         credentials: Arc<StdMutex<Option<ServerCredentials>>>,
         load_count: Arc<AtomicUsize>,
+        replace_gate: Option<(Arc<Barrier>, Arc<Barrier>)>,
+        load_gate: StdMutex<Option<(Arc<Barrier>, Arc<Barrier>)>>,
+        fail_replace: AtomicBool,
     }
 
     impl DeferredCredentialStore {
@@ -2687,11 +3100,33 @@ mod tests {
             Self {
                 credentials: Arc::new(StdMutex::new(None)),
                 load_count: Arc::new(AtomicUsize::new(0)),
+                replace_gate: None,
+                load_gate: StdMutex::new(None),
+                fail_replace: AtomicBool::new(false),
             }
+        }
+
+        fn with_replace_gate(entered: Arc<Barrier>, release: Arc<Barrier>) -> Self {
+            Self {
+                replace_gate: Some((entered, release)),
+                ..Self::new()
+            }
+        }
+
+        fn gate_next_load(&self, entered: Arc<Barrier>, release: Arc<Barrier>) {
+            *self.load_gate.lock().unwrap() = Some((entered, release));
         }
 
         fn set(&self, credentials: ServerCredentials) {
             *self.credentials.lock().unwrap() = Some(credentials);
+        }
+
+        fn credentials(&self) -> Option<ServerCredentials> {
+            self.credentials.lock().unwrap().clone()
+        }
+
+        fn fail_replace(&self) {
+            self.fail_replace.store(true, Ordering::SeqCst);
         }
 
         fn load_count(&self) -> usize {
@@ -2702,10 +3137,26 @@ mod tests {
     impl CredentialStore for DeferredCredentialStore {
         fn load(&self) -> Result<Option<ServerCredentials>, CredentialStoreError> {
             self.load_count.fetch_add(1, Ordering::SeqCst);
-            Ok(self.credentials.lock().unwrap().clone())
+            let credentials = self.credentials.lock().unwrap().clone();
+            let gate = self.load_gate.lock().unwrap().take();
+            if let Some((entered, release)) = gate {
+                entered.wait();
+                release.wait();
+            }
+            Ok(credentials)
         }
 
-        fn replace(&self, _credentials: &ServerCredentials) -> Result<(), CredentialStoreError> {
+        fn replace(&self, credentials: &ServerCredentials) -> Result<(), CredentialStoreError> {
+            if let Some((entered, release)) = &self.replace_gate {
+                entered.wait();
+                release.wait();
+            }
+            if self.fail_replace.load(Ordering::SeqCst) {
+                return Err(CredentialStoreError::new(
+                    "injected credential replace failure",
+                ));
+            }
+            *self.credentials.lock().unwrap() = Some(credentials.clone());
             Ok(())
         }
 
@@ -2750,9 +3201,7 @@ mod tests {
         }
     }
 
-    async fn unauthenticated_test_state(
-        store: Arc<DeferredCredentialStore>,
-    ) -> (tempfile::TempDir, DaemonState) {
+    async fn test_state(store: Arc<DeferredCredentialStore>) -> (tempfile::TempDir, DaemonState) {
         let root = tempfile::tempdir().unwrap();
         let mut config = DaemonConfig::for_root(root.path().join("daemon"));
         config.project.server_url = "https://clumsies.example.test".to_owned();
@@ -2764,6 +3213,13 @@ mod tests {
         )
         .await
         .unwrap();
+        (root, state)
+    }
+
+    async fn unauthenticated_test_state(
+        store: Arc<DeferredCredentialStore>,
+    ) -> (tempfile::TempDir, DaemonState) {
+        let (root, state) = test_state(store).await;
         assert!(state.project_config().access_token.is_none());
         (root, state)
     }
@@ -2837,5 +3293,625 @@ mod tests {
         assert!(first.access_token.is_none());
         assert!(second.access_token.is_none());
         assert_eq!(store.load_count(), 2);
+    }
+    #[tokio::test]
+    async fn lazy_recovery_clears_cached_responses_before_session_activation() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        let path = "/api/v1/lazy-session-cache";
+        let server_url = state.project_config().server_url;
+        seed_server_response_cache(&state, path).await;
+        let before = state.project_config_snapshot();
+
+        store.set(ServerCredentials {
+            server_url: server_url.clone(),
+            access_token: "lazy-access".to_owned(),
+            refresh_token: Some("lazy-refresh".to_owned()),
+        });
+
+        let recovered = state.project_config_with_credentials_snapshot().await;
+
+        assert_eq!(
+            recovered.config.access_token.as_deref(),
+            Some("lazy-access")
+        );
+        assert!(recovered.session_revision > before.session_revision);
+        assert!(
+            load_cached_server_response(&state.inner.pool, &server_url, path)
+                .await
+                .unwrap()
+                .is_none(),
+            "activating a recovered session must not expose another session's cached response"
+        );
+    }
+
+    #[tokio::test]
+    async fn lazy_recovery_cache_delete_failure_keeps_session_inactive() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        let path = "/api/v1/lazy-session-cache-delete-failure";
+        let server_url = state.project_config().server_url;
+        seed_server_response_cache(&state, path).await;
+        reject_server_response_cache_deletes(&state).await;
+        let before = state.project_config_snapshot();
+
+        store.set(ServerCredentials {
+            server_url: server_url.clone(),
+            access_token: "lazy-access".to_owned(),
+            refresh_token: Some("lazy-refresh".to_owned()),
+        });
+
+        let recovered = state.project_config_with_credentials_snapshot().await;
+
+        assert!(recovered.config.access_token.is_none());
+        assert_eq!(recovered.session_revision, before.session_revision);
+        assert!(state.project_config().access_token.is_none());
+        assert!(
+            load_cached_server_response(&state.inner.pool, &server_url, path)
+                .await
+                .unwrap()
+                .is_some(),
+            "a failed cache delete must leave the recovered identity unpublished"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_recovery_does_not_overwrite_a_concurrent_config_replace() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        store.set(ServerCredentials {
+            server_url: "https://clumsies.example.test".to_owned(),
+            access_token: "stale-access".to_owned(),
+            refresh_token: Some("stale-refresh".to_owned()),
+        });
+        store.gate_next_load(entered.clone(), release.clone());
+
+        let recovery_state = state.clone();
+        let recovery = tokio::spawn(async move {
+            recovery_state
+                .project_config_with_credentials_snapshot()
+                .await
+        });
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .unwrap();
+
+        state
+            .replace_project_config(DaemonProjectConfigUpdateRequest {
+                server_url: "https://replacement.example.test".to_owned(),
+                project_id: Some("prj_replacement".to_owned()),
+                memory_guidelines_path: None,
+                access_token: Some("replacement-access".to_owned()),
+                refresh_token: Some("replacement-refresh".to_owned()),
+            })
+            .await
+            .unwrap();
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .unwrap();
+
+        let recovered = recovery.await.unwrap();
+        assert_eq!(
+            recovered.config.server_url,
+            "https://replacement.example.test"
+        );
+        assert_eq!(
+            recovered.config.access_token.as_deref(),
+            Some("replacement-access")
+        );
+        let persisted = store.credentials().unwrap();
+        assert_eq!(persisted.server_url, "https://replacement.example.test");
+        assert_eq!(persisted.access_token, "replacement-access");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_recovery_preserves_a_concurrent_project_selection() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        store.set(ServerCredentials {
+            server_url: "https://clumsies.example.test".to_owned(),
+            access_token: "lazy-access".to_owned(),
+            refresh_token: Some("lazy-refresh".to_owned()),
+        });
+        store.gate_next_load(entered.clone(), release.clone());
+
+        let recovery_state = state.clone();
+        let recovery = tokio::spawn(async move {
+            recovery_state
+                .project_config_with_credentials_snapshot()
+                .await
+        });
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .unwrap();
+        state
+            .select_project(DaemonProjectSelectionRequest {
+                project_id: "prj_selected".to_owned(),
+            })
+            .await
+            .unwrap();
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .unwrap();
+
+        let recovered = recovery.await.unwrap();
+        assert_eq!(recovered.config.project_id.as_deref(), Some("prj_selected"));
+        assert_eq!(
+            recovered.config.access_token.as_deref(),
+            Some("lazy-access")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn project_selection_waits_for_credential_transition() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let store = Arc::new(DeferredCredentialStore::with_replace_gate(
+            entered.clone(),
+            release.clone(),
+        ));
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+
+        let replace_state = state.clone();
+        let replace = tokio::spawn(async move {
+            replace_state
+                .replace_project_config(DaemonProjectConfigUpdateRequest {
+                    server_url: "https://replacement.example.test".to_owned(),
+                    project_id: Some("prj_replacement".to_owned()),
+                    memory_guidelines_path: None,
+                    access_token: Some("replacement-access".to_owned()),
+                    refresh_token: Some("replacement-refresh".to_owned()),
+                })
+                .await
+        });
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .unwrap();
+
+        let select_state = state.clone();
+        let mut select = tokio::spawn(async move {
+            select_state
+                .select_project(DaemonProjectSelectionRequest {
+                    project_id: "prj_selected".to_owned(),
+                })
+                .await
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut select)
+                .await
+                .is_err(),
+            "project selection must wait for the in-flight credential transition"
+        );
+
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .unwrap();
+        replace.await.unwrap().unwrap();
+        select.await.unwrap().unwrap();
+
+        let config = state.project_config();
+        assert_eq!(config.server_url, "https://replacement.example.test");
+        assert_eq!(config.project_id.as_deref(), Some("prj_selected"));
+        assert_eq!(config.access_token.as_deref(), Some("replacement-access"));
+        let persisted = store.credentials().unwrap();
+        assert_eq!(persisted.server_url, "https://replacement.example.test");
+        assert_eq!(persisted.access_token, "replacement-access");
+    }
+
+    async fn wait_for_server_response_cache_worker(state: &DaemonState) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let running = state
+                    .inner
+                    .server_response_cache
+                    .lock()
+                    .expect("server response cache mutex poisoned")
+                    .worker_running;
+                if !running {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("bounded Server response cache writer should become idle");
+    }
+
+    async fn wait_for_active_server_response_cache_write(state: &DaemonState) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let active = state
+                    .inner
+                    .server_response_cache
+                    .lock()
+                    .expect("server response cache mutex poisoned")
+                    .active
+                    .is_some();
+                if active {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("Server response cache writer should claim its queued write");
+    }
+
+    async fn reject_server_response_cache_deletes(state: &DaemonState) {
+        sqlx::query(
+            "CREATE TRIGGER reject_server_response_cache_delete
+             BEFORE DELETE ON server_response_cache
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected Server response cache delete failure');
+             END",
+        )
+        .execute(&state.inner.pool)
+        .await
+        .unwrap();
+    }
+
+    async fn seed_server_response_cache(state: &DaemonState, path: &str) {
+        save_cached_server_response(
+            &state.inner.pool,
+            &state.project_config().server_url,
+            path,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: r#"{"account":"old"}"#.to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn queued_cache_writes_keep_the_newest_response() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store).await;
+        let path = "/api/v1/cache-order".to_owned();
+        let write_gate = state.inner.server_response_cache_write.lock().await;
+        let older = state.start_server_response_cache_request(&path);
+        let newer = state.start_server_response_cache_request(&path);
+        let server_url = newer.server_url().to_owned();
+        state.queue_server_response_cache_write(
+            &newer,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: r#"{"version":"newer"}"#.to_owned(),
+            },
+        );
+        state.queue_server_response_cache_write(
+            &older,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: r#"{"version":"older"}"#.to_owned(),
+            },
+        );
+        drop(older);
+        drop(newer);
+        drop(write_gate);
+
+        wait_for_server_response_cache_worker(&state).await;
+        let cached = load_cached_server_response(&state.inner.pool, &server_url, &path)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(cached.body, r#"{"version":"newer"}"#);
+    }
+
+    #[tokio::test]
+    async fn cache_writer_bounds_distinct_paths_and_body_copies() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store).await;
+        let write_gate = state.inner.server_response_cache_write.lock().await;
+
+        for index in 0..SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES * 4 {
+            let request =
+                state.start_server_response_cache_request(&format!("/api/v1/cache-{index}"));
+            state.queue_server_response_cache_write(
+                &request,
+                &DaemonServerResponse {
+                    status: 200,
+                    headers: BTreeMap::new(),
+                    body: format!("response-{index}"),
+                },
+            );
+        }
+        let oversized_path = "/api/v1/cache-oversized";
+        let oversized = state.start_server_response_cache_request(oversized_path);
+        state.queue_server_response_cache_write(
+            &oversized,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: "x".repeat(SERVER_RESPONSE_CACHE_MAX_BODY_BYTES + 1),
+            },
+        );
+        drop(oversized);
+        tokio::task::yield_now().await;
+
+        {
+            let cache = state
+                .inner
+                .server_response_cache
+                .lock()
+                .expect("server response cache mutex poisoned");
+            let active_count = usize::from(cache.active.is_some());
+            assert!(cache.worker_running);
+            assert!(cache.pending.len() <= SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES);
+            assert!(
+                cache.pending.len() + active_count <= SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES + 1
+            );
+            assert!(
+                cache.keys.len() <= SERVER_RESPONSE_CACHE_MAX_PENDING_WRITES + 1,
+                "finished request watermarks must not grow with distinct paths"
+            );
+            assert!(
+                !cache
+                    .pending
+                    .contains_key(&(state.project_config().server_url, oversized_path.to_owned())),
+                "oversized responses must not be copied into the pending cache"
+            );
+        }
+
+        drop(write_gate);
+        wait_for_server_response_cache_worker(&state).await;
+        let cache = state
+            .inner
+            .server_response_cache
+            .lock()
+            .expect("server response cache mutex poisoned");
+        assert!(cache.pending.is_empty());
+        assert!(cache.active.is_none());
+        assert!(cache.keys.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cache_delete_failure_precedes_project_identity_mutations() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        let original = state.project_config();
+        seed_server_response_cache(&state, "/api/v1/cache-delete-failure").await;
+        reject_server_response_cache_deletes(&state).await;
+
+        let error = state
+            .replace_project_config(DaemonProjectConfigUpdateRequest {
+                server_url: "https://replacement.example.test".to_owned(),
+                project_id: Some("prj_replacement".to_owned()),
+                memory_guidelines_path: None,
+                access_token: Some("replacement-access".to_owned()),
+                refresh_token: None,
+            })
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("injected Server response cache delete failure")
+        );
+        let runtime = state.project_config();
+        assert_eq!(runtime.server_url, original.server_url);
+        assert_eq!(runtime.project_id, original.project_id);
+        assert!(runtime.access_token.is_none());
+        assert!(store.credentials().is_none());
+        assert!(
+            load_meta_value(&state.inner.pool, "project_config_server_url")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            load_meta_value(&state.inner.pool, "project_config_project_id")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_delete_failure_does_not_clear_tokens() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        store.set(ServerCredentials {
+            server_url: "https://clumsies.example.test".to_owned(),
+            access_token: "existing-access".to_owned(),
+            refresh_token: Some("existing-refresh".to_owned()),
+        });
+        let (_root, state) = test_state(store.clone()).await;
+        seed_server_response_cache(&state, "/api/v1/cache-clear-token-failure").await;
+        reject_server_response_cache_deletes(&state).await;
+
+        let snapshot = state.project_config_snapshot();
+        let error = state
+            .clear_server_tokens_if_current(
+                snapshot.session_revision,
+                &snapshot.config.server_url,
+                snapshot.config.access_token.as_deref().unwrap(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("injected Server response cache delete failure")
+        );
+        let runtime = state.project_config();
+        assert_eq!(runtime.access_token.as_deref(), Some("existing-access"));
+        assert_eq!(runtime.refresh_token.as_deref(), Some("existing-refresh"));
+        let persisted = store
+            .credentials()
+            .expect("cache failure must leave Keychain credentials untouched");
+        assert_eq!(persisted.access_token, "existing-access");
+        assert_eq!(persisted.refresh_token.as_deref(), Some("existing-refresh"));
+    }
+
+    #[tokio::test]
+    async fn post_commit_retry_queue_failure_does_not_fail_config_replace() {
+        let store = Arc::new(DeferredCredentialStore::new());
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        sqlx::query("DROP TABLE local_draft_operations")
+            .execute(&state.inner.pool)
+            .await
+            .unwrap();
+
+        let replaced = state
+            .replace_project_config(DaemonProjectConfigUpdateRequest {
+                server_url: "https://replacement.example.test".to_owned(),
+                project_id: Some("prj_replacement".to_owned()),
+                memory_guidelines_path: None,
+                access_token: Some("replacement-access".to_owned()),
+                refresh_token: Some("replacement-refresh".to_owned()),
+            })
+            .await
+            .expect("post-commit retry queue failure must not report a rolled-back config");
+
+        assert!(replaced.has_access_token);
+        let runtime = state.project_config();
+        assert_eq!(runtime.server_url, "https://replacement.example.test");
+        assert_eq!(runtime.access_token.as_deref(), Some("replacement-access"));
+        let persisted = store.credentials().unwrap();
+        assert_eq!(persisted.server_url, "https://replacement.example.test");
+        assert_eq!(persisted.access_token, "replacement-access");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_credential_transition_discards_queued_cache_writes() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let store = Arc::new(DeferredCredentialStore::with_replace_gate(
+            entered.clone(),
+            release.clone(),
+        ));
+        store.fail_replace();
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        let path = "/api/v1/cache-failed-credential-transition".to_owned();
+
+        let replace_state = state.clone();
+        let replace = tokio::spawn(async move {
+            replace_state
+                .replace_project_config(DaemonProjectConfigUpdateRequest {
+                    server_url: "https://replacement.example.test".to_owned(),
+                    project_id: Some("prj_replacement".to_owned()),
+                    memory_guidelines_path: None,
+                    access_token: Some("replacement-access".to_owned()),
+                    refresh_token: None,
+                })
+                .await
+        });
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .unwrap();
+
+        let request = state.start_server_response_cache_request(&path);
+        let server_url = request.server_url().to_owned();
+        state.queue_server_response_cache_write(
+            &request,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: r#"{"account":"old"}"#.to_owned(),
+            },
+        );
+        drop(request);
+        wait_for_active_server_response_cache_write(&state).await;
+
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .unwrap();
+        let error = replace.await.unwrap().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("injected credential replace failure")
+        );
+        wait_for_server_response_cache_worker(&state).await;
+
+        assert!(
+            load_cached_server_response(&state.inner.pool, &server_url, &path)
+                .await
+                .unwrap()
+                .is_none(),
+            "an unpublished transition must discard queued old-account responses"
+        );
+        assert!(store.credentials().is_none());
+        assert!(state.project_config().access_token.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_change_blocks_cache_writes_during_credential_transition() {
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let store = Arc::new(DeferredCredentialStore::with_replace_gate(
+            entered.clone(),
+            release.clone(),
+        ));
+        let (_root, state) = unauthenticated_test_state(store.clone()).await;
+        let path = "/api/v1/cache-session-transition".to_owned();
+
+        let replace_state = state.clone();
+        let replace = tokio::spawn(async move {
+            replace_state
+                .replace_project_config(DaemonProjectConfigUpdateRequest {
+                    server_url: "https://clumsies.example.test".to_owned(),
+                    project_id: Some("prj_test".to_owned()),
+                    memory_guidelines_path: None,
+                    access_token: Some("replacement-access".to_owned()),
+                    refresh_token: None,
+                })
+                .await
+        });
+        tokio::task::spawn_blocking(move || entered.wait())
+            .await
+            .unwrap();
+
+        let transition = state.start_server_response_cache_request(&path);
+        let server_url = transition.server_url().to_owned();
+        state.queue_server_response_cache_write(
+            &transition,
+            &DaemonServerResponse {
+                status: 200,
+                headers: BTreeMap::new(),
+                body: r#"{"account":"old"}"#.to_owned(),
+            },
+        );
+        drop(transition);
+        wait_for_active_server_response_cache_write(&state).await;
+        reject_server_response_cache_deletes(&state).await;
+        assert!(
+            load_cached_server_response(&state.inner.pool, &server_url, &path)
+                .await
+                .unwrap()
+                .is_none(),
+            "the transition barrier must prevent the old account response from reaching SQLite"
+        );
+
+        tokio::task::spawn_blocking(move || release.wait())
+            .await
+            .unwrap();
+        replace.await.unwrap().unwrap();
+        wait_for_server_response_cache_worker(&state).await;
+        assert!(
+            load_cached_server_response(&state.inner.pool, &server_url, &path)
+                .await
+                .unwrap()
+                .is_none(),
+            "the old account response must not survive the runtime session change"
+        );
+        let credentials = store
+            .credentials()
+            .expect("successful transition must persist replacement credentials");
+        assert_eq!(credentials.access_token, "replacement-access");
+        assert_eq!(
+            state.project_config().access_token.as_deref(),
+            Some("replacement-access")
+        );
     }
 }

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -4840,6 +4840,199 @@ async fn server_proxy_preserves_contract_headers_and_rejects_caller_credentials(
 
     server.abort();
 }
+#[tokio::test]
+async fn concurrent_unauthorized_requests_share_a_same_session_refresh() {
+    let probe = RefreshProbeState::default();
+    let app = Router::new()
+        .route("/api/v1/refresh-probe", post(refresh_probe_request))
+        .route("/api/v1/auth/token", post(refresh_probe_token))
+        .with_state(probe.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{address}");
+    config.project.project_id = Some("prj_refresh".to_owned());
+    let (state, credential_store) = common::initialize_authenticated_daemon(
+        config,
+        "stale-token",
+        Some("initial-refresh-token".to_owned()),
+    )
+    .await;
+
+    let first_state = state.clone();
+    let first = tokio::spawn(async move {
+        first_state
+            .server_request(refresh_probe_server_request())
+            .await
+    });
+    let second_state = state.clone();
+    let second = tokio::spawn(async move {
+        second_state
+            .server_request(refresh_probe_server_request())
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), probe.refresh_started.notified())
+        .await
+        .expect("the first unauthorized request should start token refresh");
+    tokio::time::timeout(Duration::from_secs(2), probe.both_stale.notified())
+        .await
+        .expect("both requests should receive 401 before refresh completes");
+    probe.release_refresh.notify_one();
+
+    let (first, second) = tokio::time::timeout(Duration::from_secs(2), async {
+        (
+            first.await.unwrap().unwrap(),
+            second.await.unwrap().unwrap(),
+        )
+    })
+    .await
+    .expect("both requests should reuse the completed same-session refresh");
+    assert_eq!(first.status, 200);
+    assert_eq!(second.status, 200);
+    assert_eq!(probe.stale_requests.load(Ordering::Acquire), 2);
+    assert_eq!(probe.fresh_requests.load(Ordering::Acquire), 2);
+    assert_eq!(probe.refresh_requests.load(Ordering::Acquire), 1);
+    let credentials = credential_store.credentials().unwrap();
+    assert_eq!(credentials.access_token, "fresh-token");
+    assert_eq!(
+        credentials.refresh_token.as_deref(),
+        Some("rotated-refresh-token")
+    );
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn request_is_not_replayed_after_same_server_session_replacement_during_refresh() {
+    let old_probe = RefreshProbeState::default();
+    let old_app = Router::new()
+        .route("/api/v1/refresh-probe", post(refresh_probe_request))
+        .route("/api/v1/auth/token", post(refresh_probe_token))
+        .with_state(old_probe.clone());
+    let old_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let old_address = old_listener.local_addr().unwrap();
+    let old_server = tokio::spawn(async move {
+        axum::serve(old_listener, old_app).await.unwrap();
+    });
+
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{old_address}");
+    config.project.project_id = Some("prj_old".to_owned());
+    let (state, credential_store) = common::initialize_authenticated_daemon(
+        config,
+        "stale-token",
+        Some("initial-refresh-token".to_owned()),
+    )
+    .await;
+
+    let request_state = state.clone();
+    let request = tokio::spawn(async move {
+        request_state
+            .server_request(refresh_probe_server_request())
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(2), old_probe.refresh_started.notified())
+        .await
+        .expect("the old session should enter token refresh");
+
+    state
+        .replace_project_config(DaemonProjectConfigUpdateRequest {
+            server_url: format!("http://{old_address}"),
+            project_id: Some("prj_replacement".to_owned()),
+            memory_guidelines_path: None,
+            access_token: Some("replacement-token".to_owned()),
+            refresh_token: Some("replacement-refresh-token".to_owned()),
+        })
+        .await
+        .unwrap();
+    old_probe.release_refresh.notify_one();
+
+    let response = tokio::time::timeout(Duration::from_secs(2), request)
+        .await
+        .expect("the superseded request should return its original 401")
+        .unwrap()
+        .unwrap();
+    assert_eq!(response.status, 401);
+    assert_eq!(old_probe.replacement_requests.load(Ordering::Acquire), 0);
+    assert_eq!(old_probe.refresh_requests.load(Ordering::Acquire), 1);
+    let credentials = credential_store.credentials().unwrap();
+    assert_eq!(credentials.server_url, format!("http://{old_address}"));
+    assert_eq!(credentials.access_token, "replacement-token");
+    assert_eq!(
+        credentials.refresh_token.as_deref(),
+        Some("replacement-refresh-token")
+    );
+
+    old_server.abort();
+}
+
+#[tokio::test]
+async fn server_proxy_returns_live_get_while_cache_write_is_locked() {
+    let proxy_state = CachedProxyState {
+        unavailable: Arc::new(AtomicBool::new(false)),
+    };
+    let app = Router::new()
+        .route("/api/v1/cache-probe", get(cached_proxy_get))
+        .with_state(proxy_state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{address}");
+    config.project.project_id = Some("prj_cache_lock".to_owned());
+    let (state, _) = common::initialize_authenticated_daemon(config, "test-token", None).await;
+    let request = DaemonServerRequest {
+        method: "GET".to_owned(),
+        path: "/api/v1/cache-probe".to_owned(),
+        headers: BTreeMap::new(),
+        body: None,
+    };
+    let cache_pool = sqlx::SqlitePool::connect(&state.local_db_path().display().to_string())
+        .await
+        .unwrap();
+    let mut cache_lock = cache_pool.acquire().await.unwrap();
+    sqlx::query("BEGIN IMMEDIATE")
+        .execute(&mut *cache_lock)
+        .await
+        .unwrap();
+
+    let live = tokio::time::timeout(
+        Duration::from_secs(1),
+        state.server_request(request.clone()),
+    )
+    .await
+    .expect("live GET must not wait for the SQLite cache writer")
+    .unwrap();
+    assert_eq!(live.status, 200);
+    assert_eq!(live.body, r#"{"source":"live"}"#);
+
+    sqlx::query("ROLLBACK")
+        .execute(&mut *cache_lock)
+        .await
+        .unwrap();
+    drop(cache_lock);
+    cache_pool.close().await;
+    wait_for_server_response_cache(&state, &request.path, &live.body).await;
+
+    proxy_state.unavailable.store(true, Ordering::Release);
+    let stale = state.server_request(request).await.unwrap();
+    assert_eq!(stale.body, live.body);
+    assert_eq!(
+        stale.headers.get("x-clumsies-cache").map(String::as_str),
+        Some("stale")
+    );
+
+    server.abort();
+}
 
 #[tokio::test]
 async fn server_proxy_uses_stale_cache_only_for_read_failures() {
@@ -4874,6 +5067,7 @@ async fn server_proxy_uses_stale_cache_only_for_read_failures() {
     assert_eq!(live.status, 200);
     assert_eq!(live.body, r#"{"source":"live"}"#);
     assert_eq!(live.headers.get("x-clumsies-cache"), None);
+    wait_for_server_response_cache(&state, &get_request.path, &live.body).await;
 
     let missing_request = DaemonServerRequest {
         method: "GET".to_owned(),
@@ -4884,6 +5078,7 @@ async fn server_proxy_uses_stale_cache_only_for_read_failures() {
     let missing = state.server_request(missing_request.clone()).await.unwrap();
     assert_eq!(missing.status, 404);
     assert_eq!(missing.headers.get("x-clumsies-cache"), None);
+    wait_for_server_response_cache(&state, &missing_request.path, &missing.body).await;
 
     proxy_state.unavailable.store(true, Ordering::Release);
     let cached_after_503 = state.server_request(get_request.clone()).await.unwrap();
@@ -5346,9 +5541,100 @@ async fn empty_draft_events() -> Json<serde_json::Value> {
     }))
 }
 
+#[derive(Clone, Default)]
+struct RefreshProbeState {
+    stale_requests: Arc<AtomicUsize>,
+    fresh_requests: Arc<AtomicUsize>,
+    refresh_requests: Arc<AtomicUsize>,
+    replacement_requests: Arc<AtomicUsize>,
+    both_stale: Arc<Notify>,
+    refresh_started: Arc<Notify>,
+    release_refresh: Arc<Notify>,
+}
+
+fn refresh_probe_server_request() -> DaemonServerRequest {
+    DaemonServerRequest {
+        method: "POST".to_owned(),
+        path: "/api/v1/refresh-probe".to_owned(),
+        headers: BTreeMap::new(),
+        body: Some("{}".to_owned()),
+    }
+}
+
+async fn refresh_probe_request(
+    axum::extract::State(state): axum::extract::State<RefreshProbeState>,
+    headers: axum::http::HeaderMap,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    match proxy_header_value(&headers, "authorization").as_deref() {
+        Some("Bearer stale-token") => {
+            if state.stale_requests.fetch_add(1, Ordering::AcqRel) == 1 {
+                state.both_stale.notify_one();
+            }
+            (
+                axum::http::StatusCode::UNAUTHORIZED,
+                Json(json!({ "error": "expired" })),
+            )
+                .into_response()
+        }
+        Some("Bearer fresh-token") => {
+            state.fresh_requests.fetch_add(1, Ordering::AcqRel);
+            Json(json!({ "ok": true })).into_response()
+        }
+        Some("Bearer replacement-token") => {
+            state.replacement_requests.fetch_add(1, Ordering::AcqRel);
+            Json(json!({ "ok": true })).into_response()
+        }
+        _ => (
+            axum::http::StatusCode::FORBIDDEN,
+            Json(json!({ "error": "unexpected credential" })),
+        )
+            .into_response(),
+    }
+}
+
+async fn refresh_probe_token(
+    axum::extract::State(state): axum::extract::State<RefreshProbeState>,
+) -> Json<serde_json::Value> {
+    state.refresh_requests.fetch_add(1, Ordering::AcqRel);
+    state.refresh_started.notify_one();
+    state.release_refresh.notified().await;
+    Json(json!({
+        "access_token": "fresh-token",
+        "refresh_token": "rotated-refresh-token"
+    }))
+}
+
 #[derive(Clone)]
 struct CachedProxyState {
     unavailable: Arc<AtomicBool>,
+}
+
+async fn wait_for_server_response_cache(state: &DaemonState, path: &str, expected_body: &str) {
+    let server_url = state.project_config_status().server_url;
+    let pool = sqlx::SqlitePool::connect(&state.local_db_path().display().to_string())
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let body: Option<String> = sqlx::query_scalar(
+                "SELECT body FROM server_response_cache WHERE server_url = $1 AND path = $2",
+            )
+            .bind(&server_url)
+            .bind(path)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            if body.as_deref() == Some(expected_body) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("live Server response should eventually reach the stale cache");
+    pool.close().await;
 }
 
 #[derive(Deserialize)]

--- a/deploy/server/server-release-test.sh
+++ b/deploy/server/server-release-test.sh
@@ -164,20 +164,44 @@ test_failed_preflight_leaves_production_untouched() {
   assert_absent "restore:"
 }
 
-test_exit_137_after_stop_aborts_cutover() {
+test_nonzero_exit_after_stop_aborts_cutover() {
+  local exit_code
+
+  for exit_code in 1 137; do
+    reset_case
+    STOP_EXIT_CODE="$exit_code"
+
+    if (deploy_release "$TARGET_IMAGE" "$TARGET_COMMIT"); then
+      printf 'expected exit-%s stop to fail\n' "$exit_code" >&2
+      exit 1
+    fi
+
+    assert_present "record:cutover-stop-failed "
+    assert_absent "backup:pre-deploy-"
+    assert_absent "write-image:$TARGET_IMAGE"
+    assert_absent "compose[$TARGET_IMAGE]:up "
+    assert_absent "restore:"
+  done
+}
+
+test_isolated_server_requires_clean_exit() {
+  local exit_code
+
   reset_case
-  STOP_EXIT_CODE=137
+  stop_isolated_server isolated-server
+  assert_before "docker:stop --time 10 isolated-server" \
+    "docker:inspect isolated-server --format {{.State.ExitCode}}"
 
-  if (deploy_release "$TARGET_IMAGE" "$TARGET_COMMIT"); then
-    printf 'expected exit-137 stop to fail\n' >&2
-    exit 1
-  fi
-
-  assert_present "record:cutover-stop-failed "
-  assert_absent "backup:pre-deploy-"
-  assert_absent "write-image:$TARGET_IMAGE"
-  assert_absent "compose[$TARGET_IMAGE]:up "
-  assert_absent "restore:"
+  for exit_code in 1 137; do
+    reset_case
+    STOP_EXIT_CODE="$exit_code"
+    if (stop_isolated_server isolated-server); then
+      printf 'expected isolated Server exit %s to fail\n' "$exit_code" >&2
+      exit 1
+    fi
+    assert_present "docker:stop --time 10 isolated-server"
+    assert_present "docker:inspect isolated-server --format {{.State.ExitCode}}"
+  done
 }
 
 test_failed_target_restores_database_before_old_image() {
@@ -202,7 +226,8 @@ test_failed_target_restores_database_before_old_image() {
 
 test_successful_cutover
 test_failed_preflight_leaves_production_untouched
-test_exit_137_after_stop_aborts_cutover
+test_nonzero_exit_after_stop_aborts_cutover
+test_isolated_server_requires_clean_exit
 test_failed_target_restores_database_before_old_image
 
 printf 'server release transaction tests passed\n'

--- a/deploy/server/server-release.sh
+++ b/deploy/server/server-release.sh
@@ -67,8 +67,27 @@ stop_server() {
     log "stopped Server container returned an invalid exit code: $exit_code"
     return 1
   fi
-  if [[ "$exit_code" == 137 ]]; then
-    log "Server container was killed while stopping"
+  if [[ "$exit_code" != 0 ]]; then
+    log "Server container exited with code $exit_code while stopping"
+    return 1
+  fi
+}
+
+stop_isolated_server() {
+  local container="$1"
+  local exit_code
+
+  if ! docker stop --time "$SERVER_STOP_TIMEOUT_SECONDS" "$container" >/dev/null; then
+    log "isolated Server did not stop within ${SERVER_STOP_TIMEOUT_SECONDS} seconds"
+    return 1
+  fi
+
+  exit_code="$(docker inspect "$container" --format '{{.State.ExitCode}}' 2>/dev/null)" || {
+    log "could not inspect the stopped isolated Server"
+    return 1
+  }
+  if [[ "$exit_code" != 0 ]]; then
+    log "isolated Server exited with code $exit_code"
     return 1
   fi
 }
@@ -679,6 +698,8 @@ verify_backup_with_image() (
     "SELECT count(*) FROM pg_catalog.pg_tables WHERE schemaname = 'public';")"
   migration_count="$(docker exec "$postgres_container" psql -At -U postgres \
     -d clumsies_restore -c 'SELECT count(*) FROM _sqlx_migrations;')"
+  stop_isolated_server "$server_container" ||
+    die "$purpose Server did not stop cleanly"
   log "$purpose healthy: backup=$backup tables=$table_count migrations=$migration_count image=$image"
 )
 


### PR DESCRIPTION
## Summary

- make first-ready wait only for authenticated workspace identity, active project metadata, resource metadata, and consistency checks; load drafts, bundles, reviews, legacy inspection, sync, MCP, and retries independently after ready with authority and generation guards
- return successful daemon GET responses before bounded, coalesced SQLite cache persistence; add session epochs, serialized credential transitions, safe concurrent 401 refresh, and 512 row / 64 MiB cache pruning
- require exact zero-exit server shutdown and add fault-injection coverage
- add an explicit Developer ID, hardened-runtime, notarization, stapling, embedded-runtime, and Sparkle release gate; manual workflow runs create candidates without publishing

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --all-targets
- bun run test:macos
- bun run test:macos:package
- bun run api:check
- docs build
- actionlint .github/workflows/release.yml
- shellcheck apps/macos/Scripts/archive-release.sh apps/macos/Scripts/test-runtime-package.sh apps/macos/Scripts/verify-release-signature.sh deploy/server/server-release.sh deploy/server/server-release-test.sh
- bash deploy/server/server-release-test.sh

## Performance evidence

- candidate Swift first-ready with the currently authenticated installed daemon: cold 0.979s / 1.034s / 1.088s
- candidate warm p95 on the old synchronous-cache daemon: 2.429s
- old daemon Reviews XPC baseline: p50 416.617ms, p95 683.342ms, max 1250.774ms across 40 samples
- the new daemon removes synchronous SQLite persistence from that response path; full signed-candidate measurement remains pending because an ad-hoc rebuilt runtime cannot access the existing Keychain credential identity

## Release blocker

This machine has zero valid Developer ID signing identities. The installed App and candidate are ad-hoc signed, and GitHub currently has no protected macos-signing environment or Apple signing, notarization, and Sparkle credentials. The package test confirms the new release gate rejects that candidate. Kanban ISSUE-028 remains open until a formally signed candidate completes the final performance and integration checks.