### PR TITLE
fix: decouple legacy inspection from runtime signing

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -42,9 +42,11 @@ app-specific password, team ID, temporary keychain password, and Sparkle private
 in the protected `macos-signing` GitHub environment, using the secret names referenced
 by `release.yml`. Restrict that environment to the default branch and release tags and
 require a reviewer before its secrets are exposed. The Sparkle private key is required
-only for a tagged release; only its public key is committed in `project.yml`. A local or
-ad-hoc build is suitable for tests, but the release signature gate deliberately rejects
-it for managed Coding Agent integration installation.
+only for a tagged release; only its public key is committed in `project.yml`. The Debug
+App installed by `bun run dev:macos` uses the supported ad-hoc development path and can
+exercise managed Coding Agent integrations. A Debug ad-hoc runtime is accepted at the
+installation boundary; Release packages must carry an accepted team identity and the
+hardened-runtime flag.
 
 ## Generate the Xcode project
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -5565,10 +5565,10 @@ struct WorkspaceLoader: Sendable {
         if let daemonError = error as? DaemonXPCError,
            case .daemon(let payload) = daemonError,
            payload.code == "project_agent_adapter_invalid_runtime" {
-            return "The current Clumsies App and bundled Agent runtime do not have "
-                + "the required release signing identity. Archived integration inspection "
-                + "was skipped. This build cannot install or update managed Coding Agent integrations. "
-                + "Install an officially signed release build, then try again."
+            return "The resident daemon rejected the bundled Agent runtime. Archived integration "
+                + "inspection was skipped. Reinstall and restart Clumsies so the App and daemon use "
+                + "the same build. For local development, use bun run dev:macos; distributed Release "
+                + "builds must use an accepted release signature."
         }
         return "Clumsies updated its managed integrations, but could not inspect the "
             + "archived Zig CLI integration store. Review any old global or repository "

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -606,7 +606,7 @@ final class DaemonContractTests: XCTestCase {
         )
     }
 
-    func testLegacyInspectionExplainsUnsignedReleaseRuntime() {
+    func testLegacyInspectionExplainsOlderDaemonRuntimeRejection() {
         let warning = WorkspaceLoader.legacyAgentAdapterInspectionWarning(
             for: DaemonXPCError.daemon(.init(
                 code: "project_agent_adapter_invalid_runtime",
@@ -616,8 +616,8 @@ final class DaemonContractTests: XCTestCase {
         )
 
         XCTAssertTrue(warning.contains("Archived integration inspection was skipped"))
-        XCTAssertTrue(warning.contains("cannot install or update managed Coding Agent integrations"))
-        XCTAssertTrue(warning.contains("officially signed release build"))
+        XCTAssertTrue(warning.contains("bun run dev:macos"))
+        XCTAssertTrue(warning.contains("distributed Release"))
         XCTAssertFalse(warning.contains("archived Zig CLI integration store"))
     }
 

--- a/crates/daemon/src/agent_adapter/legacy.rs
+++ b/crates/daemon/src/agent_adapter/legacy.rs
@@ -67,11 +67,17 @@ pub(super) async fn inspect(
     _state: &DaemonState,
     request: DaemonLegacyAgentAdapterInspectionRequest,
 ) -> Result<DaemonLegacyAgentAdapterInspectionResponse, DaemonError> {
-    let runtime = canonical_agent_runtime_binary(&request.runtime_binary_path)?;
-    #[cfg(target_os = "macos")]
-    verify_code_signature(&runtime)?;
-
     let home = home_dir()?;
+    inspect_at(home, request).await
+}
+
+async fn inspect_at(
+    home: PathBuf,
+    _request: DaemonLegacyAgentAdapterInspectionRequest,
+) -> Result<DaemonLegacyAgentAdapterInspectionResponse, DaemonError> {
+    // Keep the runtime path in the request for wire compatibility with older
+    // Apps. This read-only discovery never launches or installs that runtime;
+    // the native installer validates it at the write boundary instead.
     let installs_root = home.join(".clumsies/adapters/installs");
     // This is advisory filesystem discovery, not part of native Adapter
     // ownership. Keep synchronous directory I/O off Tokio's worker threads
@@ -400,6 +406,23 @@ mod tests {
     fn missing_store_is_empty() {
         let root = TempDir::new().unwrap();
         let result = discover_at(root.path(), &root.path().join("missing")).unwrap();
+        assert_eq!(result.scanned, 0);
+        assert!(result.conflicts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn inspection_does_not_require_an_agent_runtime() {
+        let root = TempDir::new().unwrap();
+        let result = inspect_at(
+            root.path().to_path_buf(),
+            DaemonLegacyAgentAdapterInspectionRequest {
+                runtime_binary_path: "/missing/Clumsies.app/Contents/Resources/clumsiesd"
+                    .to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+
         assert_eq!(result.scanned, 0);
         assert!(result.conflicts.is_empty());
     }

--- a/packages/api-contract/generated/daemon.d.ts
+++ b/packages/api-contract/generated/daemon.d.ts
@@ -112,7 +112,7 @@ export interface components {
             project_id: string;
         };
         DaemonLegacyAgentAdapterInspectionRequest: {
-            /** @description Signed App-bundled clumsiesd Agent runtime executable. */
+            /** @description Compatibility field retained for existing Apps and daemons; ignored by this read-only operation. */
             runtime_binary_path: string;
         };
         DaemonLegacyAgentAdapterConflict: {

--- a/packages/api-contract/openapi/clumsies.daemon.v1.yaml
+++ b/packages/api-contract/openapi/clumsies.daemon.v1.yaml
@@ -295,7 +295,7 @@ components:
       properties:
         runtime_binary_path:
           type: string
-          description: Signed App-bundled clumsiesd Agent runtime executable.
+          description: Compatibility field retained for existing Apps and daemons; ignored by this read-only operation.
     DaemonLegacyAgentAdapterConflict:
       type: object
       required: [install_id, adapter, scope, target_root, code, message]


### PR DESCRIPTION
## Summary
- stop validating the bundled Agent runtime during read-only archived Zig integration discovery
- keep the runtime request field for wire compatibility and preserve strict validation at managed install/update boundaries
- correct the macOS recovery guidance and API documentation so Debug ad-hoc and distributed Release signing are not conflated

## Verification
- cargo test -p daemon
- cargo fmt --all -- --check
- cargo clippy -p daemon --all-targets -- -D warnings
- bun run test:macos
- bun run api:check
- git diff --check

Follow-up to #204 and ISSUE-028.