### PR TITLE
fix: compress daemon server responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +477,23 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -4466,12 +4495,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -14,7 +14,7 @@ hf-hub = { version = "0.5.0", default-features = false, features = ["ureq", "rus
 hex = "0.4.3"
 libc = "0.2.177"
 pulldown-cmark = "0.13.4"
-reqwest = { version = "0.13.4", features = ["json", "rustls", "system-proxy"], default-features = false }
+reqwest = { version = "0.13.4", features = ["gzip", "json", "rustls", "system-proxy"], default-features = false }
 ruzstd = { version = "0.8", default-features = false, features = ["std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -3031,6 +3031,64 @@ mod tests {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn http_client_negotiates_and_decodes_gzip() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        const BODY: &str = "compressed response";
+        const GZIP_BODY: &[u8] = &[
+            0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x4b, 0xce, 0xcf, 0x2d,
+            0x28, 0x4a, 0x2d, 0x2e, 0x4e, 0x4d, 0x51, 0x00, 0x52, 0x05, 0xf9, 0x79, 0xc5, 0xa9,
+            0x00, 0xb1, 0xff, 0x32, 0x6f, 0x13, 0x00, 0x00, 0x00,
+        ];
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            loop {
+                let mut buffer = [0_u8; 1024];
+                let read = stream.read(&mut buffer).await.unwrap();
+                assert_ne!(read, 0, "client closed before completing HTTP headers");
+                request.extend_from_slice(&buffer[..read]);
+                assert!(
+                    request.len() <= 8 * 1024,
+                    "request headers are unexpectedly large"
+                );
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let request = String::from_utf8(request).unwrap().to_ascii_lowercase();
+            let accepts_gzip = request.lines().any(|line| {
+                line.split_once(':').is_some_and(|(name, value)| {
+                    name.trim() == "accept-encoding"
+                        && value.split(',').any(|encoding| encoding.trim() == "gzip")
+                })
+            });
+            assert!(accepts_gzip, "client did not negotiate gzip: {request}");
+
+            let response_head = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\ncontent-encoding: gzip\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                GZIP_BODY.len()
+            );
+            stream.write_all(response_head.as_bytes()).await.unwrap();
+            stream.write_all(GZIP_BODY).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let client = build_http_client(Duration::from_secs(1), Duration::from_secs(1))
+            .expect("build test HTTP client");
+        let response = client
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .expect("send compressed request");
+        assert_eq!(response.text().await.unwrap(), BODY);
+        server.await.unwrap();
+    }
+
     struct BlockingCredentialStore {
         gate: Arc<(StdMutex<bool>, Condvar)>,
     }


### PR DESCRIPTION
## Summary

- enable reqwest gzip support so the daemon uses the existing Caddy compression boundary
- keep response handling transparent to App callers: the daemon still returns the same decoded body
- add a raw TCP regression that proves Accept-Encoding negotiation and transparent gzip decoding

## Real XPC to Hong Kong A/B

| Metric | Before | After |
|---|---:|---:|
| Caddy wire bytes | 62,632 B | 10,194 B |
| XPC p50, 40 Reviews requests | 391.522 ms | 73.417 ms |
| XPC p95, 40 Reviews requests | 815.801 ms | 158.839 ms |
| XPC max | 1,049.878 ms | 414.386 ms |
| Caddy p95 | 37 ms | 39 ms |

The decoded Reviews body remains 62,632 bytes. Caddy wire size falls by 83.7%, while Server/Caddy compute time remains effectively unchanged. This isolates the improvement to response transfer rather than a coincidental backend speedup. Small /api/v1/me responses remain fast but are not the target of this change.

## Verification

- cargo test -p daemon
- cargo clippy -p daemon --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- installed Debug App: 20 real /me samples and 40 real Reviews samples through the resident XPC daemon
- aliyun Caddy logs: exact 40-request block, constant 10,194-byte compressed wire response and p95 39 ms upstream boundary

This is the response-compression follow-up for native ISSUE-028. It does not claim to improve DNS, TCP/TLS setup, or small-response TTFB.