### PR TITLE
feat(memory): retire project authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 
 ## Key Features
 
-- **Memory as a Team Asset (Git-Semantic Context)**: Rules, workflows, and project context live as first-class Markdown-backed Memory objects in Org and Project scopes. Changes are proposed as Drafts, verified through Peer Reviews, and merged atomically into immutable Commit history.
+- **Memory as a Team Asset (Git-Semantic Context)**: Rules, workflows, and project context live as first-class Markdown-backed Organization Memory. A Project selects the Organization resources it uses and carries private Draft overlays; reviewed changes merge atomically into immutable Organization Commit history.
 - **Hybrid Retrieval & Precise Activation**: Combines SQLite FTS5 BM25 text search, local dense vector embeddings, Reciprocal Rank Fusion (RRF), and Cross-Encoder reranking. Agents retrieve task-relevant fragments on demand without exhausting token budgets.
 - **Agent-Native Asynchronous Kanban**: Agents autonomously claim tasks (`begin_work`), build dependency DAGs, evaluate blocking predicates, and record structured verification steps. Human approval gates (`approve_closure`) ensure only verified work transitions to Done.
 - **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 
 ## 核心特性
 
-- **记忆即团队资产（Git 语义上下文管理）**：将架构规则、工作流规范与项目上下文收敛为统一的 Markdown 记忆对象，具备精准语义摘要与 Org / Project 命名空间。任何修改通过本地 Draft 提交并经过团队 Review 合并，杜绝静默覆盖。
+- **记忆即团队资产（Git 语义上下文管理）**：将架构规则、工作流规范与项目上下文收敛为统一的 Markdown 组织记忆。Project 只选择要使用的组织记忆并承载项目内可见的 Draft overlay；变更经过团队 Review 后原子合入组织 Commit 历史，杜绝静默覆盖。
 - **混合检索与按需精准激活**：深度融合 SQLite FTS5 BM25 全文检索、本地向量嵌入、倒数排名融合（RRF）与交叉编码器（Cross-Encoder）重排。Agent 通过 `activate` 按需动态召回最相关切片，避免上下文窗口浪费。
 - **面向 Agent 的原生异步看板（Issue DAG）**：Agent 通过类型化 MCP 操作自主认领任务（`begin_work`）、构建有向无环依赖图、评估阻塞谓词并沉淀验证步骤。最终必须由人类通过审批关卡（`approve_closure`）验收完成。
 - **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -4257,10 +4257,9 @@ final class WorkspaceStore: ObservableObject {
         guard canMergeReviews else {
             throw ServerClientError.forbidden("Your account cannot merge Reviews.")
         }
-        // A Review belongs to its carrying Project, but its Draft may target
-        // either the Org or Project authority. The coordination commit is the
-        // exact target Ref generation for both scopes; the carrying Project's
-        // ETag is wrong for Org-targeted Drafts.
+        // A Review belongs to its carrying Project, while its Draft targets
+        // Organization authority. The coordination commit is the exact Org Ref
+        // generation; the carrying Project's projection ETag is not that base.
         let detail = try await reviewDetail(review.id)
         let currentReview = WorkspaceLoader.mapReview(detail)
         replaceReview(with: currentReview)

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -1780,23 +1780,23 @@ mod tests {
         let first = state
             .activate_memory(ActivateMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                query: "hybrid".to_owned(),
+                query: "testing".to_owned(),
                 state: None,
             })
             .await
             .unwrap();
         assert!(first.fragments.iter().any(|fragment| {
-            fragment.resource_id == "ctx_retrieval"
+            fragment.resource_id == "rule_testing"
                 && fragment.action == ActivationAction::Add
                 && fragment
                     .content
                     .as_deref()
-                    .is_some_and(|content| content.contains("BM25"))
+                    .is_some_and(|content| content.contains("integration tests"))
         }));
         let second = state
             .activate_memory(ActivateMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                query: "hybrid".to_owned(),
+                query: "testing".to_owned(),
                 state: Some(first.next_state.clone()),
             })
             .await
@@ -1804,7 +1804,7 @@ mod tests {
         let reused = second
             .fragments
             .iter()
-            .find(|fragment| fragment.resource_id == "ctx_retrieval")
+            .find(|fragment| fragment.resource_id == "rule_testing")
             .unwrap();
         assert_eq!(reused.action, ActivationAction::Reuse);
         assert!(reused.content.is_none());
@@ -1812,18 +1812,18 @@ mod tests {
         state
             .store_draft_operation(DaemonDraftOperationRequest {
                 draft_id: None,
-                base_commit_id: None,
+                base_commit_id: Some("commit_test".to_owned()),
                 project_id: "prj_test".to_owned(),
-                scope: crate::DaemonDraftScope::Project,
+                scope: crate::DaemonDraftScope::Org,
                 resource: crate::DaemonDraftResourceKind::Memory,
                 op: DaemonDraftOperation {
                     create: None,
                     update: Some(DaemonUpdateDraftOperation::Content(
                         DaemonContentDraftUpdate {
-                        id: "ctx_retrieval".to_owned(),
+                        id: "rule_testing".to_owned(),
                         content: DaemonDraftContent {
                             description: None,
-                            content: "# Retrieval\n\nHybrid search now uses BM25, vectors, RRF, and reranking."
+                            content: "# Testing\n\nTesting now covers BM25, vectors, RRF, and reranking."
                                 .to_owned(),
                         },
                         description: None,
@@ -1843,7 +1843,7 @@ mod tests {
         let stale = state
             .activate_memory(ActivateMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                query: "hybrid".to_owned(),
+                query: "testing".to_owned(),
                 state: Some(second.next_state.clone()),
             })
             .await
@@ -1854,7 +1854,7 @@ mod tests {
         let third = state
             .activate_memory(ActivateMemoryRequest {
                 project_id: "prj_test".to_owned(),
-                query: "hybrid".to_owned(),
+                query: "testing".to_owned(),
                 state: Some(second.next_state),
             })
             .await
@@ -1863,7 +1863,7 @@ mod tests {
         let replaced = third
             .fragments
             .iter()
-            .find(|fragment| fragment.resource_id == "ctx_retrieval")
+            .find(|fragment| fragment.resource_id == "rule_testing")
             .unwrap();
         assert_eq!(replaced.action, ActivationAction::Replace);
         assert!(
@@ -1878,13 +1878,13 @@ mod tests {
                 "load_memory",
                 serde_json::to_value(LoadMemoryRequest {
                     project_id: "prj_test".to_owned(),
-                    ids: vec!["architecture/retrieval.md".to_owned()],
+                    ids: vec!["coding/TESTING.md".to_owned()],
                     known_hashes: BTreeMap::from([(
-                        "ctx_retrieval".to_owned(),
+                        "rule_testing".to_owned(),
                         first
                             .fragments
                             .iter()
-                            .find(|fragment| fragment.resource_id == "ctx_retrieval")
+                            .find(|fragment| fragment.resource_id == "rule_testing")
                             .unwrap()
                             .content_hash
                             .clone(),
@@ -2543,33 +2543,32 @@ mod tests {
         let (_temp, state) = test_state().await;
         let pool = state.inner.pool.clone();
         let service = DaemonIpcService::new(state);
-        let draft = service
-            .store_draft_operation(DaemonDraftOperationRequest {
-                draft_id: None,
-                base_commit_id: None,
-                project_id: "prj_test".to_owned(),
-                scope: crate::DaemonDraftScope::Project,
-                resource: crate::DaemonDraftResourceKind::Memory,
-                op: DaemonDraftOperation {
-                    create: None,
-                    update: Some(DaemonUpdateDraftOperation::Content(
-                        DaemonContentDraftUpdate {
-                            id: "ctx_retrieval".to_owned(),
-                            content: DaemonDraftContent {
-                                description: None,
-                                content: "# Legacy draft\n\nCleanup only.".to_owned(),
-                            },
-                            description: None,
-                        },
-                    )),
-                    rename: None,
-                    delete: None,
-                    discard: None,
-                },
-                source: Some(DaemonDraftOperationSource::Desktop),
-            })
-            .await
-            .unwrap();
+        let draft_id = "draft_legacy_project";
+        sqlx::query(
+            "INSERT INTO local_drafts (
+                draft_id, project_id, base_commit_id, current_commit_id,
+                resource_scope, resource_kind, target_id, status
+             ) VALUES ($1, 'prj_test', 'commit_test', 'commit_test',
+                       'project', 'memory', 'ctx_retrieval', 'open')",
+        )
+        .bind(draft_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO local_draft_operations (
+                local_operation_id, draft_id, resource_kind, operation_json,
+                source, sync_status
+             ) VALUES (
+                'op_legacy_project', $1, 'memory',
+                '{\"update\":{\"id\":\"ctx_retrieval\",\"content\":{\"description\":null,\"content\":\"# Legacy draft\\n\\nCleanup only.\"},\"description\":null}}',
+                'server', 'synced'
+             )",
+        )
+        .bind(draft_id)
+        .execute(&pool)
+        .await
+        .unwrap();
 
         let discarded = service
             .dispatch(DaemonIpcRequest::new(
@@ -2578,7 +2577,7 @@ mod tests {
                     "project_id": "prj_test",
                     "scope": "org",
                     "resource": "memory",
-                    "op": {"discard": {"id": draft.draft_id}},
+                    "op": {"discard": {"id": draft_id}},
                     "source": "mcp_store"
                 }),
             ))
@@ -2586,8 +2585,8 @@ mod tests {
         assert!(discarded.ok, "discard failed: {:?}", discarded.error);
         let response: DaemonDraftOperationResponse =
             serde_json::from_value(discarded.payload).unwrap();
-        assert_eq!(response.draft_id, draft.draft_id);
-        let detail = service.get_draft(&draft.draft_id).await.unwrap();
+        assert_eq!(response.draft_id, draft_id);
+        let detail = service.get_draft(draft_id).await.unwrap();
         assert_eq!(detail.draft.scope, crate::DaemonDraftScope::Project);
         assert_eq!(
             detail.draft.status,
@@ -2618,6 +2617,46 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(final_draft_count, 1);
+    }
+
+    #[tokio::test]
+    async fn desktop_cannot_create_new_project_authority_drafts() {
+        let (_temp, state) = test_state().await;
+        let error = state
+            .store_draft_operation(DaemonDraftOperationRequest {
+                draft_id: None,
+                base_commit_id: Some("commit_test".to_owned()),
+                project_id: "prj_test".to_owned(),
+                scope: crate::DaemonDraftScope::Project,
+                resource: crate::DaemonDraftResourceKind::Memory,
+                op: DaemonDraftOperation {
+                    create: Some(DaemonCreateDraftOperation {
+                        path: "project/new.md".to_owned(),
+                        content: DaemonDraftContent {
+                            description: Some("No Project authority".to_owned()),
+                            content: "# New".to_owned(),
+                        },
+                        description: None,
+                    }),
+                    update: None,
+                    rename: None,
+                    delete: None,
+                    discard: None,
+                },
+                source: Some(DaemonDraftOperationSource::Desktop),
+            })
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Project is a Draft carrier, not a Memory authority scope")
+        );
+        let draft_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts")
+            .fetch_one(&state.inner.pool)
+            .await
+            .unwrap();
+        assert_eq!(draft_count, 0);
     }
 
     #[tokio::test]

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -38,6 +38,13 @@ fn legacy_project_memory_read_only_error(resource_id: &str) -> DaemonError {
     ))
 }
 
+fn project_memory_authority_removed_error() -> DaemonError {
+    DaemonError::InvalidRequest(
+        "Project is a Draft carrier, not a Memory authority scope; store an Organization proposal"
+            .to_owned(),
+    )
+}
+
 #[derive(Default)]
 pub(crate) struct CredentialRecovery {
     last_attempt: Option<Instant>,
@@ -2206,6 +2213,11 @@ impl DaemonState {
         &self,
         mut request: DaemonDraftOperationRequest,
     ) -> Result<DaemonDraftOperationResponse, DaemonError> {
+        if request.scope == DaemonDraftScope::Project
+            && (request.op.discard.is_none() || request.draft_id.is_none())
+        {
+            return Err(project_memory_authority_removed_error());
+        }
         let source = request
             .source
             .unwrap_or(DaemonDraftOperationSource::Desktop);

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -352,7 +352,7 @@ async fn project_storage_is_local_per_project_and_moves_managed_cache_safely() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_a".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2011,7 +2011,7 @@ async fn draft_operation_is_written_to_local_queue_and_visible_in_sync_status() 
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2053,7 +2053,7 @@ async fn draft_operation_service_method_writes_local_queue_without_http() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2348,7 +2348,7 @@ async fn deleting_an_authoritative_resource_keeps_an_open_deletion_draft() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -2373,7 +2373,7 @@ async fn deleting_an_authoritative_resource_keeps_an_open_deletion_draft() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -2615,7 +2615,7 @@ async fn ipc_dispatch_routes_the_complete_daemon_api() {
                 draft_id: None,
                 base_commit_id: None,
                 project_id: "prj_test".to_owned(),
-                scope: DaemonDraftScope::Project,
+                scope: DaemonDraftScope::Org,
                 resource: DaemonDraftResourceKind::Memory,
                 op: DaemonDraftOperation {
                     create: Some(DaemonCreateDraftOperation {
@@ -2707,7 +2707,7 @@ async fn mcp_store_envelope_matches_the_daemon_contract() {
             "method": "store_draft_operation",
             "payload": {
                 "project_id": "prj_mcp",
-                "scope": "project",
+                "scope": "org",
                 "resource": "memory",
                 "op": {
                     "create": {
@@ -2736,7 +2736,7 @@ async fn mcp_store_envelope_matches_the_daemon_contract() {
         .unwrap();
     assert_eq!(drafts.items.len(), 1);
     assert_eq!(drafts.items[0].project_id, "prj_mcp");
-    assert_eq!(drafts.items[0].scope, DaemonDraftScope::Project);
+    assert_eq!(drafts.items[0].scope, DaemonDraftScope::Org);
 
     let detail = service.get_draft(&drafts.items[0].draft_id).await.unwrap();
     assert_eq!(detail.operations.len(), 1);
@@ -2842,7 +2842,7 @@ async fn local_drafts_can_be_listed_and_read_with_operation_history() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2865,7 +2865,7 @@ async fn local_drafts_can_be_listed_and_read_with_operation_history() {
             draft_id: Some(created.draft_id.clone()),
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -4062,7 +4062,7 @@ async fn sync_retry_uploads_new_local_draft_to_server() {
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned(),
             ),
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -4141,7 +4141,7 @@ async fn sync_retry_uploads_new_local_draft_to_server() {
     assert_eq!(requests.len(), 1);
     assert!(requests[0].get("author_user_id").is_none());
     assert_eq!(requests[0]["project_id"], "prj_test");
-    assert_eq!(requests[0]["resource"]["scope"], "project");
+    assert_eq!(requests[0]["resource"]["scope"], "org");
     assert_eq!(
         requests[0]["base_commit_id"],
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -4438,7 +4438,7 @@ async fn queued_draft_syncs_after_project_config_is_set() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_late".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -4517,7 +4517,7 @@ async fn draft_operation_notifies_auto_sync_worker() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -4586,7 +4586,7 @@ async fn transient_server_failure_is_retried_automatically() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_recovery".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -4709,7 +4709,7 @@ async fn successful_new_draft_does_not_hide_an_existing_retrying_operation() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_retrying".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -4753,7 +4753,7 @@ async fn daemon_restart_requeues_an_interrupted_operation() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_restart".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -5153,7 +5153,7 @@ async fn sync_retry_uploads_later_new_resource_edits_to_the_same_draft() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -5193,7 +5193,7 @@ async fn sync_retry_uploads_later_new_resource_edits_to_the_same_draft() {
             draft_id: Some(first.draft_id.clone()),
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -5233,7 +5233,7 @@ async fn sync_retry_uploads_later_new_resource_edits_to_the_same_draft() {
             draft_id: Some(first.draft_id),
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: None,
@@ -5301,7 +5301,7 @@ async fn draft_operation_rejects_multiple_operation_variants() {
             draft_id: None,
             base_commit_id: None,
             project_id: "prj_test".to_owned(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -2315,7 +2315,7 @@ async fn two_daemon_installations_converge_on_the_same_draft_history() {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2375,7 +2375,7 @@ async fn two_daemon_installations_converge_on_the_same_draft_history() {
             draft_id: Some(projected_on_b.draft.draft_id.clone()),
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2519,33 +2519,33 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
     .execute(&pool)
     .await
     .unwrap();
-    sqlx::query(
-        "INSERT INTO resources (
-            resource_id, org_id, project_id, scope, resource_kind, path, name,
-            status, content_hash, body
-         ) VALUES (
-            'ctx_secondary_project', $1, $2, 'project', 'memory',
-            'context/secondary.md', 'Secondary', 'active', 'secondary-hash',
-            '# Secondary project'
-         )",
-    )
-    .bind(&bootstrap.org_id)
-    .bind(&secondary_project_id)
-    .execute(&pool)
-    .await
-    .unwrap();
+    let secondary_memory_id = repository
+        .create_org_context(
+            &bootstrap.org_id,
+            "context/secondary.md",
+            "# Secondary project",
+        )
+        .await
+        .unwrap();
     repository
         .replace_project_org_selection(
             &secondary_project_id,
             0,
             ReplaceProjectOrgSelectionRequest {
-                resource_ids: Vec::new(),
+                resource_ids: vec![secondary_memory_id],
             },
         )
         .await
         .unwrap();
     let secondary_commit_id = repository
         .get_project_commit_state(&secondary_project_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap();
+    let initial_org_commit_id = repository
+        .get_org_commit_state(&bootstrap.org_id, None)
         .await
         .unwrap()
         .reference
@@ -2607,7 +2607,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
             CreateDraftRequest {
                 daemon_installation_id: "daemon_commit_origin".to_owned(),
                 project_id: bootstrap.project_id.clone(),
-                base_commit_id: None,
+                base_commit_id: Some(initial_org_commit_id.clone()),
                 title: "Add synchronized context".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
@@ -2635,7 +2635,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
     let review = repository
         .create_review(
             &bootstrap.user_id,
-            None,
+            Some(&initial_org_commit_id),
             CreateReviewRequest {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft.draft.draft_id,
@@ -2665,7 +2665,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
         .create_review_merge(
             &approved.review.review_id,
             &approved.review.author.user_id,
-            None,
+            Some(&initial_org_commit_id),
             CreateReviewMergeRequest {
                 expected_review_version: approved.review.version,
             },
@@ -2804,12 +2804,19 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
         Some(roots[0].to_str().unwrap())
     );
 
+    let current_org_commit_id = repository
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id
+        .unwrap();
     let next_draft = restarted_a
         .store_draft_operation(DaemonDraftOperationRequest {
             draft_id: None,
             base_commit_id: None,
             project_id: bootstrap.project_id.clone(),
-            scope: DaemonDraftScope::Project,
+            scope: DaemonDraftScope::Org,
             resource: DaemonDraftResourceKind::Memory,
             op: DaemonDraftOperation {
                 create: Some(DaemonCreateDraftOperation {
@@ -2829,7 +2836,7 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
     let next_draft = restarted_a.get_draft(&next_draft.draft_id).await.unwrap();
     assert_eq!(
         next_draft.draft.base_commit_id.as_deref(),
-        Some(commit_id.as_str())
+        Some(current_org_commit_id.as_str())
     );
 
     let selected = restarted_a

--- a/crates/server/migrations/20260826000100_close_project_memory_authority.sql
+++ b/crates/server/migrations/20260826000100_close_project_memory_authority.sql
@@ -1,0 +1,17 @@
+-- Project remains the carrier for local Draft overlays and keeps its Ref for
+-- selected Organization Memory. It is no longer a Memory authority scope.
+--
+-- NOT VALID preserves historical rows while immediately rejecting new or
+-- updated active Project authority. The explicit migration command archives
+-- the remaining resources, discards active legacy Drafts, and then validates
+-- both constraints.
+ALTER TABLE resources
+    ADD CONSTRAINT resources_no_active_project_authority
+    CHECK (scope <> 'project' OR status <> 'active') NOT VALID;
+
+ALTER TABLE drafts
+    ADD CONSTRAINT drafts_no_active_project_authority
+    CHECK (
+        resource_scope <> 'project'
+        OR status NOT IN ('open', 'submitted')
+    ) NOT VALID;

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -6,6 +6,7 @@ use crate::auth::AuthService;
 use crate::config::ServerConfig;
 use crate::db::{DatabaseConfig, connect, run_migrations};
 use crate::installation::InstallationService;
+use crate::project_authority_migration::{MigrationMode, migrate_project_authority};
 use crate::telemetry;
 
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(4);
@@ -50,6 +51,22 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         result?;
     }
     tracing::info!("clumsies server stopped");
+    Ok(())
+}
+
+pub async fn run_project_authority_migration(
+    expected_plan_hash: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let database_url = std::env::var("DATABASE_URL")?;
+    let pool = connect(&DatabaseConfig::from_url(database_url)).await?;
+    if expected_plan_hash.is_some() {
+        run_migrations(&pool).await?;
+    }
+    let mode = expected_plan_hash.map_or(MigrationMode::DryRun, |expected_plan_hash| {
+        MigrationMode::Apply { expected_plan_hash }
+    });
+    let report = migrate_project_authority(&pool, mode).await?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
     Ok(())
 }
 

--- a/crates/server/src/changes/mod.rs
+++ b/crates/server/src/changes/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod api;
 pub(crate) mod http;
-mod postgres;
+pub(crate) mod postgres;
 mod service;

--- a/crates/server/src/changes/postgres.rs
+++ b/crates/server/src/changes/postgres.rs
@@ -95,7 +95,17 @@ pub(super) fn validate_draft_operation_resource(
 pub(super) fn ensure_publishable_draft_scope(scope: ResourceScope) -> Result<(), ServerError> {
     if scope == ResourceScope::Project {
         return Err(ServerError::InvalidRequest(
-            "project-scoped Memory authority is read-only; publish an Organization-scoped Draft"
+            "Project is not a Memory authority scope; publish an Organization-scoped Draft"
+                .to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_writable_draft_scope(scope: ResourceScope) -> Result<(), ServerError> {
+    if scope == ResourceScope::Project {
+        return Err(ServerError::InvalidRequest(
+            "Project is a Draft carrier, not a Memory authority scope; create an Organization-scoped Draft"
                 .to_owned(),
         ));
     }
@@ -461,6 +471,7 @@ pub(super) async fn append_draft_operation_in_tx(
     .await?
     .ok_or_else(|| ServerError::not_found("draft", draft_id))?;
     let identity_scope = resource_scope(identity.try_get::<String, _>("resource_scope")?.as_str())?;
+    ensure_writable_draft_scope(identity_scope)?;
     if identity_scope == ResourceScope::Org && !org_coordination_already_locked {
         lock_org_draft_selection_coordination_for_project(
             tx,
@@ -603,7 +614,7 @@ pub(super) async fn refresh_review_after_draft_content_change(
     Ok(())
 }
 
-pub(super) async fn insert_draft_event(
+pub(crate) async fn insert_draft_event(
     tx: &mut Transaction<'_, Postgres>,
     draft_id: &str,
     project_id: &str,
@@ -2284,11 +2295,12 @@ pub(super) async fn ensure_review_exists(
     Ok(())
 }
 
-pub(super) async fn create_draft(
+pub(crate) async fn create_draft(
     tx: &mut Transaction<'_, Postgres>,
     author_user_id: &str,
     mut request: CreateDraftRequest,
 ) -> Result<String, ServerError> {
+    ensure_writable_draft_scope(request.resource.scope)?;
     if request.resource.scope == ResourceScope::Org {
         lock_org_draft_selection_coordination_for_project(tx, &request.project_id).await?;
     }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,6 +5,7 @@ mod health;
 mod memory;
 mod middleware;
 mod organization;
+pub mod project_authority_migration;
 mod shared;
 mod telemetry;
 
@@ -17,4 +18,4 @@ pub mod installation;
 pub mod repository;
 
 pub use app::build_app;
-pub use bootstrap::run;
+pub use bootstrap::{run, run_project_authority_migration};

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,4 +1,27 @@
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    server::run().await
+    let arguments = std::env::args().skip(1).collect::<Vec<_>>();
+    match arguments.as_slice() {
+        [] => server::run().await,
+        [command] if command == "migrate-project-authority" => {
+            server::run_project_authority_migration(None).await
+        }
+        [command, dry_run]
+            if command == "migrate-project-authority" && dry_run == "--dry-run" =>
+        {
+            server::run_project_authority_migration(None).await
+        }
+        [command, apply, expected_flag, expected_plan_hash]
+            if command == "migrate-project-authority"
+                && apply == "--apply"
+                && expected_flag == "--expected-plan-hash" =>
+        {
+            server::run_project_authority_migration(Some(expected_plan_hash)).await
+        }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "usage: clumsies-server [migrate-project-authority [--dry-run | --apply --expected-plan-hash HASH]]",
+        )
+        .into()),
+    }
 }

--- a/crates/server/src/project_authority_migration.rs
+++ b/crates/server/src/project_authority_migration.rs
@@ -1,0 +1,1300 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use sqlx::{PgPool, Postgres, Row, Transaction, types::Json};
+
+use crate::api::{
+    CreateDraftRequest, DraftEventType, DraftOperationAction, DraftOperationInput,
+    DraftResourceContent, DraftResourceRef, ResourceScope,
+};
+use crate::changes::postgres::{create_draft, insert_draft_event};
+use crate::memory::{
+    advance_project_ref, create_project_commit, current_project_ref,
+    lock_org_draft_selection_coordination,
+};
+use crate::repository::ServerError;
+use crate::shared::{
+    content_hash, insert_materialization_path, materialization_output_path, prefixed_id,
+    validate_resource_path,
+};
+
+const MIGRATION_DAEMON_ID: &str = "server-project-authority-migration-v1";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MigrationMode<'a> {
+    DryRun,
+    Apply { expected_plan_hash: &'a str },
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct ProjectAuthorityMigrationReport {
+    pub version: u32,
+    pub plan_hash: String,
+    pub ready: bool,
+    pub applied: bool,
+    pub legacy_authority_count: usize,
+    pub legacy_active_draft_count: usize,
+    pub replacement_draft_count: usize,
+    pub projects: Vec<ProjectMigrationReport>,
+    pub blockers: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct ProjectMigrationReport {
+    pub project_id: String,
+    pub project_name: String,
+    pub author_user_id: Option<String>,
+    pub legacy_authority_count: usize,
+    pub legacy_active_draft_count: usize,
+    pub replacement_draft_count: usize,
+    pub effective_path_content_hash: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MemoryState {
+    id: String,
+    path: String,
+    description: String,
+    content: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ReplacementDraft {
+    source_id: String,
+    target_id: Option<String>,
+    path: String,
+    description: String,
+    content: String,
+}
+
+#[derive(Clone, Debug)]
+struct AuthorityIdentity {
+    resource_id: String,
+    revision: i64,
+    path: String,
+    content_hash: String,
+}
+
+#[derive(Clone, Debug)]
+struct DraftOverlay {
+    draft_id: String,
+    author_user_id: String,
+    scope: String,
+    base_commit_id: Option<String>,
+    target_id: Option<String>,
+    path: Option<String>,
+    status: String,
+    version: i64,
+    operations: Vec<OverlayOperation>,
+}
+
+#[derive(Clone, Debug)]
+struct OverlayOperation {
+    action: DraftOperationAction,
+    target_id: Option<String>,
+    path: Option<String>,
+    new_path: Option<String>,
+    content: Option<DraftResourceContent>,
+}
+
+#[derive(Clone, Debug)]
+struct ProjectPlan {
+    report: ProjectMigrationReport,
+    org_id: String,
+    author_user_id: Option<String>,
+    current_org_commit_id: Option<String>,
+    current_project_commit_id: Option<String>,
+    authority: Vec<AuthorityIdentity>,
+    legacy_drafts: Vec<DraftOverlay>,
+    replacements: Vec<ReplacementDraft>,
+    before_state_hash: Option<String>,
+    blockers: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct MigrationPlan {
+    plan_hash: String,
+    projects: Vec<ProjectPlan>,
+    blockers: Vec<String>,
+}
+
+pub async fn migrate_project_authority(
+    pool: &PgPool,
+    mode: MigrationMode<'_>,
+) -> Result<ProjectAuthorityMigrationReport, ServerError> {
+    let mut tx = pool.begin().await?;
+    if matches!(mode, MigrationMode::Apply { .. }) {
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "SELECT pg_advisory_xact_lock(hashtextextended('project_memory_authority_migration', 0))",
+        )
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    let plan = build_plan(&mut tx).await?;
+    let mut report = report_for_plan(&plan, false);
+    match mode {
+        MigrationMode::DryRun => {
+            tx.rollback().await?;
+            Ok(report)
+        }
+        MigrationMode::Apply { expected_plan_hash } => {
+            if !plan.blockers.is_empty() {
+                return Err(ServerError::InvalidRequest(format!(
+                    "project authority migration is blocked: {}",
+                    plan.blockers.join("; ")
+                )));
+            }
+            if expected_plan_hash != plan.plan_hash {
+                return Err(ServerError::InvalidRequest(format!(
+                    "project authority migration plan changed: expected {expected_plan_hash}, actual {}",
+                    plan.plan_hash
+                )));
+            }
+            apply_plan(&mut tx, &plan).await?;
+            tx.commit().await?;
+            report.applied = true;
+            Ok(report)
+        }
+    }
+}
+
+async fn build_plan(tx: &mut Transaction<'_, Postgres>) -> Result<MigrationPlan, ServerError> {
+    let project_rows = sqlx::query(
+        "SELECT p.project_id, p.org_id, p.name
+         FROM projects p
+         WHERE EXISTS (
+             SELECT 1 FROM resources r
+             WHERE r.project_id = p.project_id
+               AND r.scope = 'project'
+               AND r.status = 'active'
+         ) OR EXISTS (
+             SELECT 1 FROM drafts d
+             WHERE d.project_id = p.project_id
+               AND d.resource_scope = 'project'
+               AND d.status IN ('open', 'submitted')
+         )
+         ORDER BY p.project_id",
+    )
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut projects = Vec::with_capacity(project_rows.len());
+    let mut blockers = Vec::new();
+    for row in project_rows {
+        let project_id: String = row.try_get("project_id")?;
+        let project_name: String = row.try_get("name")?;
+        let org_id: String = row.try_get("org_id")?;
+        let project = build_project_plan(tx, project_id, project_name, org_id).await?;
+        blockers.extend(project.blockers.iter().cloned());
+        projects.push(project);
+    }
+    let plan_hash = plan_hash(&projects);
+    Ok(MigrationPlan {
+        plan_hash,
+        projects,
+        blockers,
+    })
+}
+
+async fn build_project_plan(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: String,
+    project_name: String,
+    org_id: String,
+) -> Result<ProjectPlan, ServerError> {
+    let mut blockers = Vec::new();
+    let mut warnings = Vec::new();
+    let member_ids = sqlx::query_scalar::<_, String>(
+        "SELECT u.user_id
+         FROM project_members pm
+         JOIN users u ON u.user_id = pm.user_id
+         WHERE pm.project_id = $1 AND u.status = 'active'
+         ORDER BY u.user_id",
+    )
+    .bind(&project_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let author_user_id = match member_ids.as_slice() {
+        [user_id] => Some(user_id.clone()),
+        [] => {
+            blockers.push(format!(
+                "project {project_id} has no active member to own replacement Drafts"
+            ));
+            None
+        }
+        _ => {
+            blockers.push(format!(
+                "project {project_id} has {} active members; replacement Draft ownership is ambiguous",
+                member_ids.len()
+            ));
+            None
+        }
+    };
+
+    let current_org_commit_id = current_ref(tx, "org", &org_id).await?;
+    let current_project_commit_id = current_ref(tx, "project", &project_id).await?;
+    let (authority, mut legacy_state) = load_active_project_authority(tx, &project_id).await?;
+    if !authority.is_empty() {
+        match current_project_commit_id.as_deref() {
+            Some(commit_id) => {
+                let committed = load_commit_state(tx, commit_id, "project").await?;
+                let active_ids = legacy_state.keys().cloned().collect::<BTreeSet<_>>();
+                let committed_ids = committed.keys().cloned().collect::<BTreeSet<_>>();
+                if active_ids != committed_ids {
+                    blockers.push(format!(
+                        "project {project_id} current Ref does not contain the same Project Memory identities as active authority"
+                    ));
+                } else {
+                    let mut description_drift = 0;
+                    for (resource_id, active) in &legacy_state {
+                        let committed = &committed[resource_id];
+                        if active.path != committed.path || active.content != committed.content {
+                            blockers.push(format!(
+                                "project {project_id} current Ref differs from active authority at {resource_id}"
+                            ));
+                        } else if active.description != committed.description {
+                            description_drift += 1;
+                        }
+                    }
+                    if description_drift > 0 {
+                        warnings.push(format!(
+                            "{description_drift} current Ref descriptions differ from authority; the authority descriptions will be preserved"
+                        ));
+                    }
+                }
+            }
+            None => blockers.push(format!(
+                "project {project_id} has active Project Memory authority but no current Project Commit"
+            )),
+        }
+    }
+
+    let legacy_drafts = load_overlays(tx, &project_id, "project", None).await?;
+    if let Some(author_user_id) = author_user_id.as_deref() {
+        let foreign_authors = legacy_drafts
+            .iter()
+            .filter(|draft| draft.author_user_id != author_user_id)
+            .map(|draft| draft.author_user_id.clone())
+            .collect::<BTreeSet<_>>();
+        if !foreign_authors.is_empty() {
+            blockers.push(format!(
+                "project {project_id} has active Project Drafts owned by another user: {}",
+                foreign_authors.into_iter().collect::<Vec<_>>().join(", ")
+            ));
+        }
+    }
+
+    let mut commit_cache = BTreeMap::new();
+    if let Err(error) =
+        apply_overlays(tx, &mut commit_cache, &mut legacy_state, &legacy_drafts).await
+    {
+        blockers.push(format!(
+            "project {project_id} cannot materialize legacy Drafts: {error}"
+        ));
+        legacy_state.clear();
+    }
+
+    let selected_org_authority = load_selected_org_authority(tx, &project_id).await?;
+    if let Some(commit_id) = current_project_commit_id.as_deref() {
+        let committed = load_commit_state(tx, commit_id, "org").await?;
+        let selected_ids = selected_org_authority
+            .keys()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let committed_ids = committed.keys().cloned().collect::<BTreeSet<_>>();
+        if selected_ids != committed_ids {
+            blockers.push(format!(
+                "project {project_id} current Ref does not contain the same selected Organization Memory identities as current authority"
+            ));
+        } else {
+            let mut description_drift = 0;
+            for (resource_id, selected) in &selected_org_authority {
+                let committed = &committed[resource_id];
+                if selected.path != committed.path || selected.content != committed.content {
+                    blockers.push(format!(
+                        "project {project_id} current Ref differs from selected Organization authority at {resource_id}"
+                    ));
+                } else if selected.description != committed.description {
+                    description_drift += 1;
+                }
+            }
+            if description_drift > 0 {
+                warnings.push(format!(
+                    "{description_drift} selected Organization Memory descriptions differ from the current Ref; current authority descriptions will be preserved"
+                ));
+            }
+        }
+    } else if !selected_org_authority.is_empty() {
+        blockers.push(format!(
+            "project {project_id} selects Organization Memory but has no current Project Commit"
+        ));
+    }
+    if let Err(error) = validate_materialized_state(&project_id, &selected_org_authority) {
+        blockers.push(format!(
+            "project {project_id} selected Organization authority is invalid: {error}"
+        ));
+    }
+
+    let mut full_state = selected_org_authority.clone();
+    let org_drafts = if let Some(author_user_id) = author_user_id.as_deref() {
+        load_overlays(tx, &project_id, "org", Some(author_user_id)).await?
+    } else {
+        Vec::new()
+    };
+    if !org_drafts.is_empty()
+        && let Err(error) =
+            apply_overlays(tx, &mut commit_cache, &mut full_state, &org_drafts).await
+    {
+        blockers.push(format!(
+            "project {project_id} cannot materialize Organization Drafts: {error}"
+        ));
+    }
+    if let Err(error) = validate_materialized_state(&project_id, &full_state) {
+        blockers.push(format!(
+            "project {project_id} Organization authority plus active Drafts is invalid: {error}"
+        ));
+    }
+
+    let mut replacements = plan_replacements(
+        &project_id,
+        &selected_org_authority,
+        &org_drafts,
+        &mut full_state,
+        legacy_state,
+        &mut warnings,
+        &mut blockers,
+    );
+    if let Err(error) = validate_materialized_state(&project_id, &full_state) {
+        blockers.push(error.to_string());
+    }
+
+    let before_state_hash = blockers.is_empty().then(|| path_content_hash(&full_state));
+    replacements.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.source_id.cmp(&right.source_id))
+    });
+    let report = ProjectMigrationReport {
+        project_id: project_id.clone(),
+        project_name,
+        author_user_id: author_user_id.clone(),
+        legacy_authority_count: authority.len(),
+        legacy_active_draft_count: legacy_drafts.len(),
+        replacement_draft_count: replacements.len(),
+        effective_path_content_hash: before_state_hash.clone(),
+        warnings,
+    };
+    Ok(ProjectPlan {
+        report,
+        org_id,
+        author_user_id,
+        current_org_commit_id,
+        current_project_commit_id,
+        authority,
+        legacy_drafts,
+        replacements,
+        before_state_hash,
+        blockers,
+    })
+}
+
+async fn current_ref(
+    tx: &mut Transaction<'_, Postgres>,
+    scope: &str,
+    owner_id: &str,
+) -> Result<Option<String>, ServerError> {
+    let query = match scope {
+        "org" => {
+            "SELECT commit_id FROM refs
+             WHERE scope = 'org' AND org_id = $1 AND ref_name = 'refs/heads/main'"
+        }
+        "project" => {
+            "SELECT commit_id FROM refs
+             WHERE scope = 'project' AND project_id = $1 AND ref_name = 'refs/heads/main'"
+        }
+        _ => {
+            return Err(ServerError::InvalidRequest(format!(
+                "unknown migration Ref scope: {scope}"
+            )));
+        }
+    };
+    sqlx::query_scalar::<_, Option<String>>(query)
+        .bind(owner_id)
+        .fetch_optional(&mut **tx)
+        .await?
+        .ok_or_else(|| ServerError::not_found("ref", owner_id))
+}
+
+async fn load_active_project_authority(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+) -> Result<(Vec<AuthorityIdentity>, BTreeMap<String, MemoryState>), ServerError> {
+    let rows = sqlx::query(
+        "SELECT resource_id, revision, path, description, content_hash, body
+         FROM resources
+         WHERE project_id = $1 AND scope = 'project' AND status = 'active'
+         ORDER BY resource_id",
+    )
+    .bind(project_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut identity = Vec::with_capacity(rows.len());
+    let mut state = BTreeMap::new();
+    for row in rows {
+        let resource_id: String = row.try_get("resource_id")?;
+        let body: String = row.try_get("body")?;
+        let stored_hash: String = row.try_get("content_hash")?;
+        let actual_hash = content_hash(&body);
+        if stored_hash != actual_hash {
+            return Err(ServerError::InvalidRequest(format!(
+                "Project Memory {resource_id} stores {stored_hash} but its body hashes to {actual_hash}"
+            )));
+        }
+        let path: String = row.try_get("path")?;
+        validate_resource_path(&path)?;
+        identity.push(AuthorityIdentity {
+            resource_id: resource_id.clone(),
+            revision: row.try_get("revision")?,
+            path: path.clone(),
+            content_hash: stored_hash,
+        });
+        state.insert(
+            resource_id.clone(),
+            MemoryState {
+                id: resource_id,
+                path,
+                description: row.try_get("description")?,
+                content: body,
+            },
+        );
+    }
+    Ok((identity, state))
+}
+
+async fn load_selected_org_authority(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+) -> Result<BTreeMap<String, MemoryState>, ServerError> {
+    let rows = sqlx::query(
+        "SELECT r.resource_id, r.path, r.description, r.body
+         FROM project_org_resource_selections selection
+         JOIN resources r ON r.resource_id = selection.resource_id
+         WHERE selection.project_id = $1
+           AND r.scope = 'org'
+           AND r.status = 'active'
+         ORDER BY r.resource_id",
+    )
+    .bind(project_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    rows.into_iter()
+        .map(|row| {
+            let resource_id: String = row.try_get("resource_id")?;
+            Ok((
+                resource_id.clone(),
+                MemoryState {
+                    id: resource_id,
+                    path: row.try_get("path")?,
+                    description: row.try_get("description")?,
+                    content: row.try_get("body")?,
+                },
+            ))
+        })
+        .collect()
+}
+
+async fn load_commit_state(
+    tx: &mut Transaction<'_, Postgres>,
+    commit_id: &str,
+    scope: &str,
+) -> Result<BTreeMap<String, MemoryState>, ServerError> {
+    let rows = sqlx::query(
+        "SELECT entry.item_id, entry.path, entry.description, blob.content
+         FROM commits commit
+         JOIN tree_entries entry ON entry.tree_id = commit.tree_id
+         JOIN blobs blob ON blob.blob_id = entry.blob_id
+         WHERE commit.commit_id = $1
+           AND entry.scope = $2
+           AND entry.resource_kind = 'memory'
+         ORDER BY entry.item_id",
+    )
+    .bind(commit_id)
+    .bind(scope)
+    .fetch_all(&mut **tx)
+    .await?;
+    let mut output = BTreeMap::new();
+    for row in rows {
+        let id: String = row.try_get("item_id")?;
+        let path: Option<String> = row.try_get("path")?;
+        let path = path.ok_or_else(|| {
+            ServerError::InvalidRequest(format!(
+                "Commit {commit_id} Memory {id} has no materialization path"
+            ))
+        })?;
+        output.insert(
+            id.clone(),
+            MemoryState {
+                id,
+                path,
+                description: row.try_get("description")?,
+                content: row.try_get("content")?,
+            },
+        );
+    }
+    Ok(output)
+}
+
+async fn load_overlays(
+    tx: &mut Transaction<'_, Postgres>,
+    project_id: &str,
+    scope: &str,
+    author_user_id: Option<&str>,
+) -> Result<Vec<DraftOverlay>, ServerError> {
+    let rows = sqlx::query(
+        "SELECT d.draft_id, d.author_user_id, d.base_commit_id, d.target_id,
+                d.path AS draft_path, d.status, d.version,
+                operation.ordinal, operation.action, operation.target_id AS operation_target_id,
+                operation.path AS operation_path, operation.new_path, operation.content
+         FROM drafts d
+         LEFT JOIN draft_operations operation ON operation.draft_id = d.draft_id
+         WHERE d.project_id = $1
+           AND d.resource_scope = $2
+           AND d.status IN ('open', 'submitted')
+           AND ($3::text IS NULL OR d.author_user_id = $3)
+         ORDER BY d.created_at, d.draft_id, operation.ordinal",
+    )
+    .bind(project_id)
+    .bind(scope)
+    .bind(author_user_id)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut overlays = Vec::<DraftOverlay>::new();
+    for row in rows {
+        let draft_id: String = row.try_get("draft_id")?;
+        if overlays
+            .last()
+            .is_none_or(|overlay| overlay.draft_id != draft_id)
+        {
+            overlays.push(DraftOverlay {
+                draft_id: draft_id.clone(),
+                author_user_id: row.try_get("author_user_id")?,
+                scope: scope.to_owned(),
+                base_commit_id: row.try_get("base_commit_id")?,
+                target_id: row.try_get("target_id")?,
+                path: row.try_get("draft_path")?,
+                status: row.try_get("status")?,
+                version: row.try_get("version")?,
+                operations: Vec::new(),
+            });
+        }
+        let Some(action) = row.try_get::<Option<String>, _>("action")? else {
+            continue;
+        };
+        let action = match action.as_str() {
+            "create" => DraftOperationAction::Create,
+            "update" => DraftOperationAction::Update,
+            "rename" => DraftOperationAction::Rename,
+            "delete" => DraftOperationAction::Delete,
+            _ => {
+                return Err(ServerError::InvalidRequest(format!(
+                    "Draft {draft_id} has unknown operation action {action}"
+                )));
+            }
+        };
+        overlays
+            .last_mut()
+            .expect("Draft overlay inserted above")
+            .operations
+            .push(OverlayOperation {
+                action,
+                target_id: row.try_get("operation_target_id")?,
+                path: row.try_get("operation_path")?,
+                new_path: row.try_get("new_path")?,
+                content: row
+                    .try_get::<Option<Json<DraftResourceContent>>, _>("content")?
+                    .map(|content| content.0),
+            });
+    }
+    Ok(overlays)
+}
+
+async fn apply_overlays(
+    tx: &mut Transaction<'_, Postgres>,
+    commit_cache: &mut BTreeMap<(String, String), BTreeMap<String, MemoryState>>,
+    state: &mut BTreeMap<String, MemoryState>,
+    overlays: &[DraftOverlay],
+) -> Result<(), ServerError> {
+    for overlay in overlays {
+        let commit_scope = overlay.scope.as_str();
+        let base = if let Some(commit_id) = overlay.base_commit_id.as_deref() {
+            let key = (commit_id.to_owned(), commit_scope.to_owned());
+            if !commit_cache.contains_key(&key) {
+                let loaded = load_commit_state(tx, commit_id, commit_scope).await?;
+                commit_cache.insert(key.clone(), loaded);
+            }
+            commit_cache.get(&key)
+        } else {
+            None
+        };
+        apply_overlay(state, overlay, base)?;
+    }
+    Ok(())
+}
+
+fn apply_overlay(
+    resources: &mut BTreeMap<String, MemoryState>,
+    overlay: &DraftOverlay,
+    base: Option<&BTreeMap<String, MemoryState>>,
+) -> Result<(), ServerError> {
+    let creates_resource = overlay
+        .operations
+        .first()
+        .is_some_and(|operation| operation.action == DraftOperationAction::Create);
+    let base_resource = base.and_then(|base| {
+        if let Some(target_id) = overlay.target_id.as_deref() {
+            base.get(target_id).cloned()
+        } else if !creates_resource {
+            overlay.path.as_deref().and_then(|path| {
+                base.values()
+                    .find(|resource| resource.path == path)
+                    .cloned()
+            })
+        } else {
+            None
+        }
+    });
+    let target_key = overlay
+        .target_id
+        .clone()
+        .unwrap_or_else(|| overlay.draft_id.clone());
+    let created_resource_id = overlay
+        .operations
+        .iter()
+        .find_map(|operation| operation.target_id.clone())
+        .unwrap_or_else(|| overlay.draft_id.clone());
+    let mut draft_resources = BTreeMap::new();
+    if let Some(base_resource) = base_resource {
+        draft_resources.insert(target_key.clone(), base_resource);
+    }
+
+    for operation in &overlay.operations {
+        match operation.action {
+            DraftOperationAction::Create => {
+                let path = operation.path.clone().ok_or_else(|| {
+                    ServerError::InvalidRequest(format!(
+                        "Draft {} create operation has no path",
+                        overlay.draft_id
+                    ))
+                })?;
+                validate_resource_path(&path)?;
+                let content = operation.content.as_ref().ok_or_else(|| {
+                    ServerError::InvalidRequest(format!(
+                        "Draft {} create operation has no content",
+                        overlay.draft_id
+                    ))
+                })?;
+                draft_resources.clear();
+                draft_resources.insert(
+                    created_resource_id.clone(),
+                    MemoryState {
+                        id: created_resource_id.clone(),
+                        path,
+                        description: content.description.clone().unwrap_or_default(),
+                        content: content.content.clone(),
+                    },
+                );
+            }
+            DraftOperationAction::Update => {
+                let key = operation_target_key(operation, &draft_resources).ok_or_else(|| {
+                    ServerError::InvalidRequest(format!(
+                        "Draft {} update operation has no resolvable target",
+                        overlay.draft_id
+                    ))
+                })?;
+                let existing = draft_resources.remove(&key).ok_or_else(|| {
+                    ServerError::InvalidRequest(format!(
+                        "Draft {} update target {key} is absent from its Base Commit",
+                        overlay.draft_id
+                    ))
+                })?;
+                let content = operation.content.as_ref().ok_or_else(|| {
+                    ServerError::InvalidRequest(format!(
+                        "Draft {} update operation has no content",
+                        overlay.draft_id
+                    ))
+                })?;
+                draft_resources.insert(
+                    key,
+                    MemoryState {
+                        id: existing.id,
+                        path: existing.path,
+                        description: content.description.clone().unwrap_or(existing.description),
+                        content: content.content.clone(),
+                    },
+                );
+            }
+            DraftOperationAction::Rename => {
+                if let Some(key) = operation_target_key(operation, &draft_resources)
+                    && let Some(resource) = draft_resources.get_mut(&key)
+                {
+                    let new_path = operation.new_path.clone().ok_or_else(|| {
+                        ServerError::InvalidRequest(format!(
+                            "Draft {} rename operation has no new path",
+                            overlay.draft_id
+                        ))
+                    })?;
+                    validate_resource_path(&new_path)?;
+                    resource.path = new_path;
+                }
+            }
+            DraftOperationAction::Delete => {
+                if let Some(key) = operation_target_key(operation, &draft_resources) {
+                    draft_resources.remove(&key);
+                }
+            }
+        }
+    }
+    if let Some(target_id) = overlay.target_id.as_ref() {
+        resources.remove(target_id);
+    }
+    resources.remove(&overlay.draft_id);
+    resources.extend(draft_resources);
+    Ok(())
+}
+
+fn operation_target_key(
+    operation: &OverlayOperation,
+    resources: &BTreeMap<String, MemoryState>,
+) -> Option<String> {
+    operation.target_id.clone().or_else(|| {
+        operation.path.as_deref().and_then(|path| {
+            resources
+                .iter()
+                .find(|(_, resource)| resource.path == path)
+                .map(|(key, _)| key.clone())
+        })
+    })
+}
+
+fn plan_replacements(
+    project_id: &str,
+    selected_org_authority: &BTreeMap<String, MemoryState>,
+    org_drafts: &[DraftOverlay],
+    full_state: &mut BTreeMap<String, MemoryState>,
+    legacy_state: BTreeMap<String, MemoryState>,
+    warnings: &mut Vec<String>,
+    blockers: &mut Vec<String>,
+) -> Vec<ReplacementDraft> {
+    let mut replacements = Vec::with_capacity(legacy_state.len());
+    for legacy in legacy_state.into_values() {
+        if let Some(selected) = selected_org_authority
+            .values()
+            .find(|selected| selected.path == legacy.path)
+        {
+            let superseding_drafts = org_drafts
+                .iter()
+                .filter(|draft| draft_targets_resource(draft, selected))
+                .map(|draft| draft.draft_id.as_str())
+                .collect::<Vec<_>>();
+            if !superseding_drafts.is_empty() {
+                warnings.push(format!(
+                    "legacy Project Memory {} at {} overlaps selected Organization Memory {} and is superseded by active Organization Drafts {}; its history will be discarded without creating a duplicate Draft",
+                    legacy.id,
+                    legacy.path,
+                    selected.id,
+                    superseding_drafts.join(", ")
+                ));
+                continue;
+            }
+
+            full_state.insert(
+                selected.id.clone(),
+                MemoryState {
+                    id: selected.id.clone(),
+                    path: legacy.path.clone(),
+                    description: legacy.description.clone(),
+                    content: legacy.content.clone(),
+                },
+            );
+            replacements.push(ReplacementDraft {
+                source_id: legacy.id,
+                target_id: Some(selected.id.clone()),
+                path: legacy.path,
+                description: legacy.description,
+                content: legacy.content,
+            });
+            continue;
+        }
+
+        if full_state.contains_key(&legacy.id) {
+            blockers.push(format!(
+                "project {project_id} reuses Memory identity {} across Organization and Project state",
+                legacy.id
+            ));
+            continue;
+        }
+        full_state.insert(legacy.id.clone(), legacy.clone());
+        replacements.push(ReplacementDraft {
+            source_id: legacy.id,
+            target_id: None,
+            path: legacy.path,
+            description: legacy.description,
+            content: legacy.content,
+        });
+    }
+    replacements
+}
+
+fn draft_targets_resource(draft: &DraftOverlay, resource: &MemoryState) -> bool {
+    if draft.target_id.as_deref() == Some(resource.id.as_str()) {
+        return true;
+    }
+    let creates_resource = draft
+        .operations
+        .first()
+        .is_some_and(|operation| operation.action == DraftOperationAction::Create);
+    if !creates_resource && draft.path.as_deref() == Some(resource.path.as_str()) {
+        return true;
+    }
+    draft.operations.iter().any(|operation| {
+        operation.target_id.as_deref() == Some(resource.id.as_str())
+            || (!creates_resource && operation.path.as_deref() == Some(resource.path.as_str()))
+    })
+}
+
+fn validate_materialized_state(
+    project_id: &str,
+    state: &BTreeMap<String, MemoryState>,
+) -> Result<(), ServerError> {
+    let mut paths = BTreeMap::new();
+    for (key, resource) in state {
+        validate_resource_path(&resource.path)?;
+        if resource.content.trim().is_empty() {
+            return Err(ServerError::InvalidRequest(format!(
+                "project {project_id} effective Memory {key} at {} has empty content",
+                resource.path
+            )));
+        }
+        insert_materialization_path(
+            &mut paths,
+            key,
+            &materialization_output_path(&resource.path)?,
+            &format!("project {project_id} effective memory"),
+        )?;
+    }
+    Ok(())
+}
+
+fn path_content_hash(state: &BTreeMap<String, MemoryState>) -> String {
+    let mut resources = state.values().collect::<Vec<_>>();
+    resources.sort_by(|left, right| {
+        left.path
+            .cmp(&right.path)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    let mut hasher = Sha256::new();
+    for resource in resources {
+        hasher.update(resource.path.as_bytes());
+        hasher.update([0]);
+        hasher.update(content_hash(&resource.content).as_bytes());
+        hasher.update([0]);
+    }
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+fn plan_hash(projects: &[ProjectPlan]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"project-memory-authority-migration-v1\0");
+    for project in projects {
+        hash_field(&mut hasher, &project.report.project_id);
+        hash_field(&mut hasher, &project.org_id);
+        hash_optional(&mut hasher, project.author_user_id.as_deref());
+        hash_optional(&mut hasher, project.current_org_commit_id.as_deref());
+        hash_optional(&mut hasher, project.current_project_commit_id.as_deref());
+        hash_optional(&mut hasher, project.before_state_hash.as_deref());
+        for authority in &project.authority {
+            hash_field(&mut hasher, &authority.resource_id);
+            hash_field(&mut hasher, &authority.revision.to_string());
+            hash_field(&mut hasher, &authority.path);
+            hash_field(&mut hasher, &authority.content_hash);
+        }
+        for draft in &project.legacy_drafts {
+            hash_field(&mut hasher, &draft.draft_id);
+            hash_field(&mut hasher, &draft.version.to_string());
+            hash_field(&mut hasher, &draft.status);
+            hash_field(&mut hasher, &draft.author_user_id);
+        }
+        for replacement in &project.replacements {
+            hash_field(&mut hasher, &replacement.source_id);
+            hash_optional(&mut hasher, replacement.target_id.as_deref());
+            hash_field(&mut hasher, &replacement.path);
+            hash_field(&mut hasher, &replacement.description);
+            hash_field(&mut hasher, &content_hash(&replacement.content));
+        }
+        for blocker in &project.blockers {
+            hash_field(&mut hasher, blocker);
+        }
+    }
+    format!("sha256:{}", hex::encode(hasher.finalize()))
+}
+
+fn hash_field(hasher: &mut Sha256, value: &str) {
+    hasher.update(value.len().to_le_bytes());
+    hasher.update(value.as_bytes());
+}
+
+fn hash_optional(hasher: &mut Sha256, value: Option<&str>) {
+    match value {
+        Some(value) => {
+            hasher.update([1]);
+            hash_field(hasher, value);
+        }
+        None => hasher.update([0]),
+    }
+}
+
+fn report_for_plan(plan: &MigrationPlan, applied: bool) -> ProjectAuthorityMigrationReport {
+    ProjectAuthorityMigrationReport {
+        version: 1,
+        plan_hash: plan.plan_hash.clone(),
+        ready: plan.blockers.is_empty(),
+        applied,
+        legacy_authority_count: plan
+            .projects
+            .iter()
+            .map(|project| project.authority.len())
+            .sum(),
+        legacy_active_draft_count: plan
+            .projects
+            .iter()
+            .map(|project| project.legacy_drafts.len())
+            .sum(),
+        replacement_draft_count: plan
+            .projects
+            .iter()
+            .map(|project| project.replacements.len())
+            .sum(),
+        projects: plan
+            .projects
+            .iter()
+            .map(|project| project.report.clone())
+            .collect(),
+        blockers: plan.blockers.clone(),
+    }
+}
+
+async fn apply_plan(
+    tx: &mut Transaction<'_, Postgres>,
+    plan: &MigrationPlan,
+) -> Result<(), ServerError> {
+    let org_ids = plan
+        .projects
+        .iter()
+        .map(|project| project.org_id.as_str())
+        .collect::<BTreeSet<_>>();
+    for org_id in org_ids {
+        lock_org_draft_selection_coordination(tx, org_id).await?;
+    }
+
+    for project in &plan.projects {
+        apply_project_plan(tx, project).await?;
+    }
+    sqlx::query("ALTER TABLE resources VALIDATE CONSTRAINT resources_no_active_project_authority")
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("ALTER TABLE drafts VALIDATE CONSTRAINT drafts_no_active_project_authority")
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn apply_project_plan(
+    tx: &mut Transaction<'_, Postgres>,
+    project: &ProjectPlan,
+) -> Result<(), ServerError> {
+    let author_user_id = project.author_user_id.as_deref().ok_or_else(|| {
+        ServerError::InvalidRequest(format!(
+            "project {} has no migration Draft owner",
+            project.report.project_id
+        ))
+    })?;
+    let current_project_commit_id = current_project_ref(tx, &project.report.project_id).await?;
+    if current_project_commit_id != project.current_project_commit_id {
+        return Err(ServerError::precondition_failed(
+            project.current_project_commit_id.as_deref(),
+            current_project_commit_id.as_deref(),
+        ));
+    }
+    let current_org_commit_id = current_ref(tx, "org", &project.org_id).await?;
+    if current_org_commit_id != project.current_org_commit_id {
+        return Err(ServerError::precondition_failed(
+            project.current_org_commit_id.as_deref(),
+            current_org_commit_id.as_deref(),
+        ));
+    }
+
+    let draft_ids = project
+        .legacy_drafts
+        .iter()
+        .map(|draft| draft.draft_id.as_str())
+        .collect::<Vec<_>>();
+    if !draft_ids.is_empty() {
+        sqlx::query(
+            "UPDATE reviews review
+             SET status = 'rejected', version = version + 1,
+                 decision_body = 'Legacy Project authority migrated to Organization Drafts.',
+                 approved_result_hash = NULL, decided_by_user_id = $2,
+                 decided_at = now(), updated_at = now()
+             WHERE review.review_id IN (
+                 SELECT review_draft.review_id
+                 FROM review_drafts review_draft
+                 WHERE review_draft.draft_id = ANY($1)
+             ) AND review.status IN ('open', 'approved')",
+        )
+        .bind(&draft_ids)
+        .bind(author_user_id)
+        .execute(&mut **tx)
+        .await?;
+        sqlx::query(
+            "UPDATE draft_reconciliation_candidates
+             SET invalidated_at = now()
+             WHERE draft_id = ANY($1) AND invalidated_at IS NULL",
+        )
+        .bind(&draft_ids)
+        .execute(&mut **tx)
+        .await?;
+        for draft in &project.legacy_drafts {
+            let next_version: i64 = sqlx::query_scalar(
+                "UPDATE drafts
+                 SET status = 'discarded', version = version + 1, updated_at = now()
+                 WHERE draft_id = $1
+                   AND version = $2
+                   AND status IN ('open', 'submitted')
+                 RETURNING version",
+            )
+            .bind(&draft.draft_id)
+            .bind(draft.version)
+            .fetch_optional(&mut **tx)
+            .await?
+            .ok_or_else(|| {
+                ServerError::InvalidRequest(format!(
+                    "legacy Draft {} changed after planning",
+                    draft.draft_id
+                ))
+            })?;
+            insert_draft_event(
+                tx,
+                &draft.draft_id,
+                &project.report.project_id,
+                DraftEventType::Discarded,
+                next_version,
+                None,
+            )
+            .await?;
+        }
+    }
+
+    let resource_ids = project
+        .authority
+        .iter()
+        .map(|resource| resource.resource_id.as_str())
+        .collect::<Vec<_>>();
+    if !resource_ids.is_empty() {
+        let archived = sqlx::query(
+            "UPDATE resources
+             SET status = 'archived', revision = revision + 1, updated_at = now()
+             WHERE resource_id = ANY($1)
+               AND scope = 'project'
+               AND status = 'active'",
+        )
+        .bind(&resource_ids)
+        .execute(&mut **tx)
+        .await?;
+        if archived.rows_affected() != resource_ids.len() as u64 {
+            return Err(ServerError::InvalidRequest(format!(
+                "project {} authority changed after planning",
+                project.report.project_id
+            )));
+        }
+    }
+
+    for replacement in &project.replacements {
+        let action = if replacement.target_id.is_some() {
+            DraftOperationAction::Update
+        } else {
+            DraftOperationAction::Create
+        };
+        let resource = DraftResourceRef {
+            scope: ResourceScope::Org,
+            id: replacement.target_id.clone(),
+            path: replacement
+                .target_id
+                .is_none()
+                .then(|| replacement.path.clone()),
+        };
+        create_draft(
+            tx,
+            author_user_id,
+            CreateDraftRequest {
+                daemon_installation_id: MIGRATION_DAEMON_ID.to_owned(),
+                project_id: project.report.project_id.clone(),
+                base_commit_id: project.current_org_commit_id.clone(),
+                title: format!("Migrate Project Memory: {}", replacement.path),
+                description: Some(
+                    "Converted from legacy Project Memory state; publication remains subject to Organization Review."
+                        .to_owned(),
+                ),
+                resource: resource.clone(),
+                operations: vec![DraftOperationInput {
+                    action,
+                    resource,
+                    content: Some(DraftResourceContent {
+                        description: Some(replacement.description.clone()),
+                        content: replacement.content.clone(),
+                    }),
+                    new_path: None,
+                }],
+            },
+        )
+        .await?;
+    }
+
+    verify_converted_effective_state(tx, project, author_user_id).await?;
+
+    let commit_id = create_project_commit(
+        tx,
+        &project.report.project_id,
+        project.current_project_commit_id.as_deref(),
+    )
+    .await?;
+    advance_project_ref(tx, &project.report.project_id, &commit_id).await?;
+    sqlx::query(
+        "INSERT INTO audit_events (
+            event_id, org_id, actor_user_id, action, target_type, target_id
+         ) VALUES ($1, $2, $3, 'project_memory_authority_migrated', 'project', $4)",
+    )
+    .bind(prefixed_id("aud"))
+    .bind(&project.org_id)
+    .bind(author_user_id)
+    .bind(&project.report.project_id)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+async fn verify_converted_effective_state(
+    tx: &mut Transaction<'_, Postgres>,
+    project: &ProjectPlan,
+    author_user_id: &str,
+) -> Result<(), ServerError> {
+    let mut state = load_selected_org_authority(tx, &project.report.project_id).await?;
+    let drafts = load_overlays(tx, &project.report.project_id, "org", Some(author_user_id)).await?;
+    apply_overlays(tx, &mut BTreeMap::new(), &mut state, &drafts).await?;
+    validate_materialized_state(&project.report.project_id, &state)?;
+    let actual_hash = path_content_hash(&state);
+    let expected_hash = project.before_state_hash.as_deref().ok_or_else(|| {
+        ServerError::InvalidRequest(format!(
+            "project {} has no planned Effective Memory hash",
+            project.report.project_id
+        ))
+    })?;
+    if actual_hash != expected_hash {
+        return Err(ServerError::InvalidRequest(format!(
+            "project {} Effective Memory changed during conversion: expected {expected_hash}, actual {actual_hash}",
+            project.report.project_id
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn memory(id: &str, path: &str, content: &str) -> MemoryState {
+        MemoryState {
+            id: id.to_owned(),
+            path: path.to_owned(),
+            description: format!("Description for {id}"),
+            content: content.to_owned(),
+        }
+    }
+
+    #[test]
+    fn exact_selected_org_path_becomes_an_update_replacement() {
+        let selected = memory("mem_org", "workflow/CODING.md", "Org authority");
+        let legacy = memory("draft_project", "workflow/CODING.md", "Project proposal");
+        let selected_state = BTreeMap::from([(selected.id.clone(), selected.clone())]);
+        let mut full_state = selected_state.clone();
+        let mut warnings = Vec::new();
+        let mut blockers = Vec::new();
+
+        let replacements = plan_replacements(
+            "prj_test",
+            &selected_state,
+            &[],
+            &mut full_state,
+            BTreeMap::from([(legacy.id.clone(), legacy)]),
+            &mut warnings,
+            &mut blockers,
+        );
+
+        assert!(warnings.is_empty());
+        assert!(blockers.is_empty());
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].target_id.as_deref(), Some("mem_org"));
+        assert_eq!(full_state.len(), 1);
+        assert_eq!(full_state["mem_org"].content, "Project proposal");
+    }
+
+    #[test]
+    fn active_org_draft_supersedes_an_exact_legacy_project_path() {
+        let selected = memory("mem_org", "workflow/CODING.md", "Org authority");
+        let legacy = memory(
+            "draft_project",
+            "workflow/CODING.md",
+            "Old Project proposal",
+        );
+        let selected_state = BTreeMap::from([(selected.id.clone(), selected)]);
+        let mut full_state = BTreeMap::from([(
+            "mem_org".to_owned(),
+            memory("mem_org", "workflow/CODING.md", "Current Org proposal"),
+        )]);
+        let org_drafts = vec![DraftOverlay {
+            draft_id: "drf_org".to_owned(),
+            author_user_id: "usr_test".to_owned(),
+            scope: "org".to_owned(),
+            base_commit_id: None,
+            target_id: Some("mem_org".to_owned()),
+            path: None,
+            status: "open".to_owned(),
+            version: 1,
+            operations: Vec::new(),
+        }];
+        let mut warnings = Vec::new();
+        let mut blockers = Vec::new();
+
+        let replacements = plan_replacements(
+            "prj_test",
+            &selected_state,
+            &org_drafts,
+            &mut full_state,
+            BTreeMap::from([(legacy.id.clone(), legacy)]),
+            &mut warnings,
+            &mut blockers,
+        );
+
+        assert!(replacements.is_empty());
+        assert!(blockers.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("superseded by active Organization Drafts drf_org"));
+        assert_eq!(full_state["mem_org"].content, "Current Org proposal");
+    }
+}

--- a/crates/server/tests/admin_api.rs
+++ b/crates/server/tests/admin_api.rs
@@ -605,6 +605,17 @@ async fn seed_memory(seed: SeedMemory<'_>) {
 #[tokio::test]
 async fn memory_export_contains_verifiable_full_state() {
     let postgres = common::migrated_postgres().await;
+    // This export fixture intentionally represents a pre-cutover database.
+    // The production migration installs these guards as NOT VALID around
+    // existing legacy rows, so remove them before seeding that old state.
+    sqlx::query("ALTER TABLE resources DROP CONSTRAINT resources_no_active_project_authority")
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE drafts DROP CONSTRAINT drafts_no_active_project_authority")
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
     let bootstrap = common::initialize_installation(
         postgres.pool.clone(),
         "Acme Memory",

--- a/crates/server/tests/authorization_boundaries.rs
+++ b/crates/server/tests/authorization_boundaries.rs
@@ -71,7 +71,7 @@ async fn bearer_identity_enforces_personal_and_project_boundaries() {
                         title: "Owner draft".to_owned(),
                         description: None,
                         resource: DraftResourceRef {
-                            scope: ResourceScope::Project,
+                            scope: ResourceScope::Org,
                             id: None,
                             path: Some("context/private.md".to_owned()),
                         },

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -35,7 +35,7 @@ async fn draft_created_resource_must_be_discarded_instead_of_deleted() {
     )
     .await;
     let resource = DraftResourceRef {
-        scope: ResourceScope::Project,
+        scope: ResourceScope::Org,
         id: None,
         path: Some("rules/new-rule.md".to_owned()),
     };
@@ -113,7 +113,7 @@ async fn draft_created_resource_must_be_discarded_instead_of_deleted() {
 }
 
 #[tokio::test]
-async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
+async fn project_authority_drafts_are_rejected_at_creation() {
     let postgres = common::migrated_postgres().await;
     let repo = ServerRepository::new(postgres.pool.clone());
     let bootstrap = common::initialize_installation(
@@ -130,7 +130,7 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
         id: None,
         path: Some("context/legacy.md".to_owned()),
     };
-    let legacy_draft = repo
+    let error = repo
         .create_draft(
             &bootstrap.user_id,
             CreateDraftRequest {
@@ -139,21 +139,67 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
                 base_commit_id: None,
                 title: "Legacy Project draft".to_owned(),
                 description: None,
-                resource: legacy_resource.clone(),
+                resource: legacy_resource,
                 operations: Vec::new(),
             },
         )
         .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("Project is a Draft carrier, not a Memory authority scope")
+    );
+    let draft_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM drafts")
+        .fetch_one(&postgres.pool)
+        .await
         .unwrap();
+    assert_eq!(draft_count, 0);
+}
 
-    let create_review_error = repo
+#[tokio::test]
+async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "External Memory",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Migration Project",
+    )
+    .await;
+    sqlx::query("ALTER TABLE drafts DROP CONSTRAINT drafts_no_active_project_authority")
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO drafts (
+            draft_id, project_id, author_user_id, title, description,
+            resource_scope, resource_kind, path, status, version,
+            daemon_installation_id
+         ) VALUES
+            ('drf_legacy_open', $1, $2, 'Legacy open', '',
+             'project', 'memory', 'context/legacy-open.md', 'open', 1, 'daemon_legacy'),
+            ('drf_legacy_submitted', $1, $2, 'Legacy submitted', '',
+             'project', 'memory', 'context/legacy-submitted.md', 'submitted', 1,
+             'daemon_legacy')",
+    )
+    .bind(&bootstrap.project_id)
+    .bind(&bootstrap.user_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
+    let create_error = repo
         .create_review(
             &bootstrap.user_id,
             None,
             CreateReviewRequest {
                 drafts: vec![ReviewDraftRequest {
-                    draft_id: legacy_draft.draft.draft_id.clone(),
-                    expected_draft_version: legacy_draft.draft.version,
+                    draft_id: "drf_legacy_open".to_owned(),
+                    expected_draft_version: 1,
                 }],
                 title: None,
                 description: None,
@@ -164,36 +210,45 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
         .await
         .unwrap_err();
     assert!(
-        create_review_error
+        create_error
             .to_string()
-            .contains("project-scoped Memory authority is read-only")
+            .contains("Project is not a Memory authority scope")
     );
 
-    let rejected_review_id = "rev_legacy_rejected";
     sqlx::query(
         "INSERT INTO reviews (
             review_id, draft_id, project_id, author_user_id,
             title, description, status, version
-         )
-         VALUES ($1, $2, $3, $4, 'Legacy rejected Review', '', 'rejected', 1)",
+         ) VALUES
+            ('rev_legacy_rejected', 'drf_legacy_open', $1, $2,
+             'Legacy rejected', '', 'rejected', 1),
+            ('rev_legacy_approved', 'drf_legacy_submitted', $1, $2,
+             'Legacy approved', '', 'approved', 1)",
     )
-    .bind(rejected_review_id)
-    .bind(&legacy_draft.draft.draft_id)
     .bind(&bootstrap.project_id)
     .bind(&bootstrap.user_id)
     .execute(&postgres.pool)
     .await
     .unwrap();
+    sqlx::query(
+        "INSERT INTO review_drafts (review_id, draft_id, ordinal) VALUES
+            ('rev_legacy_rejected', 'drf_legacy_open', 0),
+            ('rev_legacy_approved', 'drf_legacy_submitted', 0)",
+    )
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
     let resubmit_error = repo
         .create_review_submission(
-            rejected_review_id,
+            "rev_legacy_rejected",
             &bootstrap.user_id,
             None,
             CreateReviewSubmissionRequest {
                 expected_review_version: 1,
                 drafts: vec![ReviewDraftRequest {
-                    draft_id: legacy_draft.draft.draft_id.clone(),
-                    expected_draft_version: legacy_draft.draft.version,
+                    draft_id: "drf_legacy_open".to_owned(),
+                    expected_draft_version: 1,
                 }],
                 title: None,
                 description: None,
@@ -206,47 +261,12 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
     assert!(
         resubmit_error
             .to_string()
-            .contains("project-scoped Memory authority is read-only")
+            .contains("Project is not a Memory authority scope")
     );
 
-    let approved_draft = repo
-        .create_draft(
-            &bootstrap.user_id,
-            CreateDraftRequest {
-                daemon_installation_id: "daemon_legacy".to_owned(),
-                project_id: bootstrap.project_id.clone(),
-                base_commit_id: None,
-                title: "Legacy approved Project draft".to_owned(),
-                description: None,
-                resource: legacy_resource,
-                operations: Vec::new(),
-            },
-        )
-        .await
-        .unwrap();
-    sqlx::query("UPDATE drafts SET status = 'submitted' WHERE draft_id = $1")
-        .bind(&approved_draft.draft.draft_id)
-        .execute(&postgres.pool)
-        .await
-        .unwrap();
-    let approved_review_id = "rev_legacy_approved";
-    sqlx::query(
-        "INSERT INTO reviews (
-            review_id, draft_id, project_id, author_user_id,
-            title, description, status, version, approved_result_hash
-         )
-         VALUES ($1, $2, $3, $4, 'Legacy approved Review', '', 'approved', 1, 'legacy')",
-    )
-    .bind(approved_review_id)
-    .bind(&approved_draft.draft.draft_id)
-    .bind(&bootstrap.project_id)
-    .bind(&bootstrap.user_id)
-    .execute(&postgres.pool)
-    .await
-    .unwrap();
     let merge_error = repo
         .create_review_merge(
-            approved_review_id,
+            "rev_legacy_approved",
             &bootstrap.user_id,
             None,
             CreateReviewMergeRequest {
@@ -258,7 +278,7 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
     assert!(
         merge_error
             .to_string()
-            .contains("project-scoped Memory authority is read-only")
+            .contains("Project is not a Memory authority scope")
     );
 }
 
@@ -1390,6 +1410,10 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
     // Compatibility fixture: releases before Org-only authority could leave
     // Project-owned rows behind. They remain readable but no Review may
     // create or mutate them after this cutover.
+    sqlx::query("ALTER TABLE resources DROP CONSTRAINT resources_no_active_project_authority")
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
     sqlx::query(
         "INSERT INTO resources (
             resource_id, org_id, project_id, scope, resource_kind, path, name,
@@ -2709,6 +2733,10 @@ async fn project_org_selection_rejects_foreign_and_colliding_resources_atomicall
         )
         .await
         .unwrap();
+    sqlx::query("ALTER TABLE resources DROP CONSTRAINT resources_no_active_project_authority")
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
     sqlx::query(
         "INSERT INTO resources (
             resource_id, org_id, project_id, scope, resource_kind, path, name,
@@ -3814,14 +3842,14 @@ async fn invalid_memory_paths_and_rule_shapes_are_rejected_before_draft_storage(
         title: "Valid memory under workflow namespace".to_owned(),
         description: None,
         resource: DraftResourceRef {
-            scope: ResourceScope::Project,
+            scope: ResourceScope::Org,
             id: None,
             path: Some("workflows/valid".to_owned()),
         },
         operations: vec![DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("workflows/valid".to_owned()),
             },
@@ -3848,14 +3876,14 @@ async fn invalid_memory_paths_and_rule_shapes_are_rejected_before_draft_storage(
         title: "Invalid empty memory draft".to_owned(),
         description: None,
         resource: DraftResourceRef {
-            scope: ResourceScope::Project,
+            scope: ResourceScope::Org,
             id: None,
             path: Some("memories/empty".to_owned()),
         },
         operations: vec![DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("memories/empty".to_owned()),
             },
@@ -3880,14 +3908,14 @@ async fn invalid_memory_paths_and_rule_shapes_are_rejected_before_draft_storage(
         title: "Empty Rule".to_owned(),
         description: None,
         resource: DraftResourceRef {
-            scope: ResourceScope::Project,
+            scope: ResourceScope::Org,
             id: None,
             path: Some("rules/empty".to_owned()),
         },
         operations: vec![DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("rules/empty".to_owned()),
             },
@@ -3912,14 +3940,14 @@ async fn invalid_memory_paths_and_rule_shapes_are_rejected_before_draft_storage(
         title: "Invalid Context path".to_owned(),
         description: None,
         resource: DraftResourceRef {
-            scope: ResourceScope::Project,
+            scope: ResourceScope::Org,
             id: None,
             path: Some("context//invalid.md".to_owned()),
         },
         operations: vec![DraftOperationInput {
             action: DraftOperationAction::Create,
             resource: DraftResourceRef {
-                scope: ResourceScope::Project,
+                scope: ResourceScope::Org,
                 id: None,
                 path: Some("context//invalid.md".to_owned()),
             },

--- a/crates/server/tests/project_authority_migration.rs
+++ b/crates/server/tests/project_authority_migration.rs
@@ -1,0 +1,398 @@
+mod common;
+
+use server::project_authority_migration::{MigrationMode, migrate_project_authority};
+use server::repository::ServerRepository;
+use sha2::{Digest, Sha256};
+use sqlx::Executor;
+
+#[tokio::test]
+async fn migration_flattens_effective_project_memory_into_org_drafts() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Project Authority Migration",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Legacy Project",
+    )
+    .await;
+    let selected_org_id = repo
+        .create_org_context(
+            &bootstrap.org_id,
+            "shared/selected.md",
+            "# Selected Organization Memory",
+        )
+        .await
+        .unwrap();
+    repo.select_org_resource_for_project(&bootstrap.project_id, &selected_org_id)
+        .await
+        .unwrap();
+
+    // Recreate the state seen during a rolling upgrade: the NOT VALID guards
+    // are installed around rows written by an older release.
+    postgres
+        .pool
+        .execute(
+            "ALTER TABLE resources DROP CONSTRAINT resources_no_active_project_authority;
+             ALTER TABLE drafts DROP CONSTRAINT drafts_no_active_project_authority;",
+        )
+        .await
+        .unwrap();
+
+    for (id, path, description, body) in [
+        (
+            "mem_project_a",
+            "project/a.md",
+            "Authority A",
+            "# Authority A",
+        ),
+        (
+            "mem_project_b",
+            "project/b.md",
+            "Authority B",
+            "# Authority B",
+        ),
+    ] {
+        sqlx::query(
+            "INSERT INTO resources (
+                resource_id, org_id, project_id, scope, resource_kind, path, name,
+                status, revision, content_hash, body, description
+             ) VALUES ($1, $2, $3, 'project', 'memory', $4, $4,
+                       'active', 1, $5, $6, $7)",
+        )
+        .bind(id)
+        .bind(&bootstrap.org_id)
+        .bind(&bootstrap.project_id)
+        .bind(path)
+        .bind(sha256(body))
+        .bind(body)
+        .bind(description)
+        .execute(&postgres.pool)
+        .await
+        .unwrap();
+    }
+
+    let previous_commit_id: String = sqlx::query_scalar(
+        "SELECT commit_id
+         FROM refs
+         WHERE scope = 'project' AND project_id = $1 AND ref_name = 'refs/heads/main'",
+    )
+    .bind(&bootstrap.project_id)
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    let previous_tree_id: String =
+        sqlx::query_scalar("SELECT tree_id FROM commits WHERE commit_id = $1")
+            .bind(&previous_commit_id)
+            .fetch_one(&postgres.pool)
+            .await
+            .unwrap();
+    postgres
+        .pool
+        .execute(
+            "INSERT INTO blobs (blob_id, content) VALUES
+                ('blob_project_a', '# Authority A'),
+                ('blob_project_b', '# Authority B');
+             INSERT INTO trees (tree_id) VALUES ('tree_legacy_project');",
+        )
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO tree_entries (
+            tree_id, item_id, resource_kind, scope, project_id, path,
+            blob_id, source, description
+         )
+         SELECT 'tree_legacy_project', item_id, resource_kind, scope, project_id,
+                path, blob_id, source, description
+         FROM tree_entries WHERE tree_id = $1",
+    )
+    .bind(&previous_tree_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO tree_entries (
+            tree_id, item_id, resource_kind, scope, project_id, path,
+            blob_id, source, description
+         ) VALUES
+            ('tree_legacy_project', 'mem_project_a', 'memory', 'project', $1,
+             'project/a.md', 'blob_project_a', 'project', 'Authority A'),
+            ('tree_legacy_project', 'mem_project_b', 'memory', 'project', $1,
+             'project/b.md', 'blob_project_b', 'project', 'Authority B')",
+    )
+    .bind(&bootstrap.project_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO commits (
+            commit_id, scope, org_id, project_id, tree_id, parent_commit_id, version
+         ) VALUES (
+            'cmt_legacy_project', 'project', $1, $2, 'tree_legacy_project', $3, 2
+         )",
+    )
+    .bind(&bootstrap.org_id)
+    .bind(&bootstrap.project_id)
+    .bind(&previous_commit_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE refs SET commit_id = 'cmt_legacy_project'
+         WHERE scope = 'project' AND project_id = $1 AND ref_name = 'refs/heads/main'",
+    )
+    .bind(&bootstrap.project_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
+    sqlx::query(
+        r##"
+        INSERT INTO drafts (
+            draft_id, project_id, author_user_id, title, description,
+            resource_scope, resource_kind, base_commit_id, target_id, path,
+            status, version, daemon_installation_id, created_at
+        ) VALUES
+            ('drf_rename_a', $1, $2, 'Rename A', '', 'project', 'memory',
+             'cmt_legacy_project', 'mem_project_a', NULL, 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:00Z'),
+            ('drf_update_b', $1, $2, 'Update B', '', 'project', 'memory',
+             'cmt_legacy_project', 'mem_project_b', NULL, 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:01Z'),
+            ('drf_create_c', $1, $2, 'Create C', '', 'project', 'memory',
+             'cmt_legacy_project', NULL, 'project/c.md', 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:02Z'),
+            ('drf_delete_c', $1, $2, 'Delete C', '', 'project', 'memory',
+             'cmt_legacy_project', 'draft_local_c', NULL, 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:03Z'),
+            ('drf_create_d', $1, $2, 'Create D', '', 'project', 'memory',
+             'cmt_legacy_project', NULL, 'project/d.md', 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:04Z'),
+            ('drf_shadow_selected', $1, $2, 'Replace selected Org path', '',
+             'project', 'memory', 'cmt_legacy_project', NULL,
+             'shared/selected.md', 'open', 1, 'daemon_old',
+             '2026-08-01T00:00:05Z')
+        "##,
+    )
+    .bind(&bootstrap.project_id)
+    .bind(&bootstrap.user_id)
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        r##"
+        INSERT INTO draft_operations (
+            operation_id, draft_id, action, resource_scope, resource_kind,
+            target_id, path, new_path, content, ordinal
+        ) VALUES
+            ('dop_rename_a', 'drf_rename_a', 'rename', 'project', 'memory',
+             'mem_project_a', NULL, 'project/renamed-a.md', NULL, 1),
+            ('dop_update_b', 'drf_update_b', 'update', 'project', 'memory',
+             'mem_project_b', NULL, NULL,
+             '{"description":"Updated B","content":"# Updated B"}', 1),
+            ('dop_create_c', 'drf_create_c', 'create', 'project', 'memory',
+             'draft_local_c', 'project/c.md', NULL,
+             '{"description":"Created C","content":"# Created C"}', 1),
+            ('dop_delete_c', 'drf_delete_c', 'delete', 'project', 'memory',
+             'draft_local_c', NULL, NULL, NULL, 1),
+            ('dop_create_d', 'drf_create_d', 'create', 'project', 'memory',
+             'draft_local_d', 'project/d.md', NULL,
+             '{"description":"Created D","content":"# Created D"}', 1),
+            ('dop_shadow_selected', 'drf_shadow_selected', 'create', 'project', 'memory',
+             'draft_shadow_selected', 'shared/selected.md', NULL,
+             '{"description":"Project refinement","content":"# Refined selected memory"}', 1);
+        "##,
+    )
+    .execute(&postgres.pool)
+    .await
+    .unwrap();
+
+    postgres
+        .pool
+        .execute(
+            "ALTER TABLE resources
+                 ADD CONSTRAINT resources_no_active_project_authority
+                 CHECK (scope <> 'project' OR status <> 'active') NOT VALID;
+             ALTER TABLE drafts
+                 ADD CONSTRAINT drafts_no_active_project_authority
+                 CHECK (resource_scope <> 'project' OR status NOT IN ('open', 'submitted'))
+                 NOT VALID;",
+        )
+        .await
+        .unwrap();
+
+    let dry_run = migrate_project_authority(&postgres.pool, MigrationMode::DryRun)
+        .await
+        .unwrap();
+    assert!(dry_run.ready, "blockers: {:?}", dry_run.blockers);
+    assert!(!dry_run.applied);
+    assert_eq!(dry_run.legacy_authority_count, 2);
+    assert_eq!(dry_run.legacy_active_draft_count, 6);
+    assert_eq!(dry_run.replacement_draft_count, 4);
+
+    let stale_plan = migrate_project_authority(
+        &postgres.pool,
+        MigrationMode::Apply {
+            expected_plan_hash: "sha256:stale",
+        },
+    )
+    .await
+    .unwrap_err();
+    assert!(stale_plan.to_string().contains("plan changed"));
+    let still_active: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM resources WHERE scope = 'project' AND status = 'active'",
+    )
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(still_active, 2);
+
+    let applied = migrate_project_authority(
+        &postgres.pool,
+        MigrationMode::Apply {
+            expected_plan_hash: &dry_run.plan_hash,
+        },
+    )
+    .await
+    .unwrap();
+    assert!(applied.applied);
+    assert_eq!(applied.plan_hash, dry_run.plan_hash);
+
+    let active_project_resources: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM resources WHERE scope = 'project' AND status = 'active'",
+    )
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(active_project_resources, 0);
+    let active_project_drafts: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM drafts
+         WHERE resource_scope = 'project' AND status IN ('open', 'submitted')",
+    )
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(active_project_drafts, 0);
+
+    let replacements: Vec<(String, String, String)> = sqlx::query_as(
+        "SELECT operation.path,
+                operation.content->>'description',
+                operation.content->>'content'
+         FROM drafts draft
+         JOIN draft_operations operation ON operation.draft_id = draft.draft_id
+         WHERE draft.project_id = $1
+           AND draft.resource_scope = 'org'
+           AND draft.daemon_installation_id = 'server-project-authority-migration-v1'
+           AND operation.action = 'create'
+         ORDER BY operation.path",
+    )
+    .bind(&bootstrap.project_id)
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        replacements,
+        vec![
+            (
+                "project/b.md".to_owned(),
+                "Updated B".to_owned(),
+                "# Updated B".to_owned(),
+            ),
+            (
+                "project/d.md".to_owned(),
+                "Created D".to_owned(),
+                "# Created D".to_owned(),
+            ),
+            (
+                "project/renamed-a.md".to_owned(),
+                "Authority A".to_owned(),
+                "# Authority A".to_owned(),
+            ),
+        ]
+    );
+    let update_replacement: (String, String, String) = sqlx::query_as(
+        "SELECT operation.target_id,
+                operation.content->>'description',
+                operation.content->>'content'
+         FROM drafts draft
+         JOIN draft_operations operation ON operation.draft_id = draft.draft_id
+         WHERE draft.project_id = $1
+           AND draft.resource_scope = 'org'
+           AND draft.daemon_installation_id = 'server-project-authority-migration-v1'
+           AND operation.action = 'update'",
+    )
+    .bind(&bootstrap.project_id)
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        update_replacement,
+        (
+            selected_org_id.clone(),
+            "Project refinement".to_owned(),
+            "# Refined selected memory".to_owned(),
+        )
+    );
+
+    let project_entries: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM refs ref
+         JOIN commits commit ON commit.commit_id = ref.commit_id
+         JOIN tree_entries entry ON entry.tree_id = commit.tree_id
+         WHERE ref.scope = 'project'
+           AND ref.project_id = $1
+           AND ref.ref_name = 'refs/heads/main'
+           AND entry.scope = 'project'
+           AND entry.resource_kind = 'memory'",
+    )
+    .bind(&bootstrap.project_id)
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(project_entries, 0);
+    let selected_entries: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*)
+         FROM refs ref
+         JOIN commits commit ON commit.commit_id = ref.commit_id
+         JOIN tree_entries entry ON entry.tree_id = commit.tree_id
+         WHERE ref.scope = 'project'
+           AND ref.project_id = $1
+           AND ref.ref_name = 'refs/heads/main'
+           AND entry.item_id = $2
+           AND entry.scope = 'org'",
+    )
+    .bind(&bootstrap.project_id)
+    .bind(&selected_org_id)
+    .fetch_one(&postgres.pool)
+    .await
+    .unwrap();
+    assert_eq!(selected_entries, 1);
+
+    let constraints: Vec<(String, bool)> = sqlx::query_as(
+        "SELECT conname, convalidated
+         FROM pg_constraint
+         WHERE conname IN (
+             'resources_no_active_project_authority',
+             'drafts_no_active_project_authority'
+         )
+         ORDER BY conname",
+    )
+    .fetch_all(&postgres.pool)
+    .await
+    .unwrap();
+    assert!(constraints.iter().all(|(_, validated)| *validated));
+
+    let second_dry_run = migrate_project_authority(&postgres.pool, MigrationMode::DryRun)
+        .await
+        .unwrap();
+    assert!(second_dry_run.ready);
+    assert_eq!(second_dry_run.legacy_authority_count, 0);
+    assert_eq!(second_dry_run.legacy_active_draft_count, 0);
+    assert_eq!(second_dry_run.replacement_draft_count, 0);
+}
+
+fn sha256(value: &str) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(value.as_bytes())))
+}

--- a/crates/server/tests/read_path_performance.rs
+++ b/crates/server/tests/read_path_performance.rs
@@ -37,6 +37,12 @@ async fn metadata_and_draft_reads_skip_payloads_and_ref_locks() {
         .commit_id
         .expect("project selection should create a project commit");
     repo.get_commit_payload(&project_head).await.unwrap();
+    let org_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
 
     let draft = repo
         .create_draft(
@@ -44,18 +50,18 @@ async fn metadata_and_draft_reads_skip_payloads_and_ref_locks() {
             CreateDraftRequest {
                 daemon_installation_id: "daemon_read_paths".to_owned(),
                 project_id: bootstrap.project_id.clone(),
-                base_commit_id: Some(project_head.clone()),
-                title: "Create project memory".to_owned(),
+                base_commit_id: org_head,
+                title: "Create Organization memory".to_owned(),
                 description: None,
                 resource: DraftResourceRef {
-                    scope: ResourceScope::Project,
+                    scope: ResourceScope::Org,
                     id: None,
                     path: Some("context/read-paths.md".to_owned()),
                 },
                 operations: vec![DraftOperationInput {
                     action: DraftOperationAction::Create,
                     resource: DraftResourceRef {
-                        scope: ResourceScope::Project,
+                        scope: ResourceScope::Org,
                         id: None,
                         path: Some("context/read-paths.md".to_owned()),
                     },
@@ -74,10 +80,10 @@ async fn metadata_and_draft_reads_skip_payloads_and_ref_locks() {
     sqlx::query_scalar::<_, String>(
         "SELECT ref_id
          FROM refs
-         WHERE scope = 'project' AND project_id = $1 AND ref_name = 'refs/heads/main'
+         WHERE scope = 'org' AND org_id = $1 AND ref_name = 'refs/heads/main'
          FOR UPDATE",
     )
-    .bind(&bootstrap.project_id)
+    .bind(&bootstrap.org_id)
     .fetch_one(&mut *ref_lock)
     .await
     .unwrap();

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -87,7 +87,8 @@ export default withMermaid(
               items: [
                 { text: "Organization memory", link: "/artifact" },
                 { text: "Project", link: "/workspace" },
-                { text: "Unified Memory model", link: "/unified-memory-model" }
+                { text: "Unified Memory model", link: "/unified-memory-model" },
+                { text: "Project authority cutover", link: "/project-authority-migration" }
               ]
             },
             {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ sequenceDiagram
     participant S as Server
     participant P as PostgreSQL
 
-    C->>D: store(project_id, scope, memory ref, op, base_commit_id)
+    C->>D: store(project_id, org memory ref, op, org base_commit_id)
     D->>P: no direct access
     D->>D: persist local draft and queued operation
     D-->>C: local operation accepted
@@ -101,9 +101,11 @@ sequenceDiagram
     Server-->>Desktop: new commit_id
 ```
 
-Organization and project Refs are independent. Merging an organization-scope
-draft advances the organization Ref only; merging a project-scope draft
-advances the selected project Ref only.
+Organization is the sole Memory authority, so every publishable Draft targets
+the Organization Ref. A Project Ref is an independently versioned projection of
+that Project's selected Organization Memory and configuration; selection or
+Organization-authority changes rebuild affected Project projections. No Review
+merge publishes to a Project authority namespace.
 
 ## Authority read path
 
@@ -129,11 +131,13 @@ sequenceDiagram
     D-->>P: ranked fragments or complete resources
 ```
 
-The SQLite Ref is the only mutable authority pointer. Moving it does not move a
-Draft Base. Search heads are local derived pointers bound to an Effective Memory
-hash. For Draft resources, that memory uses `Base + operations`; for all other
-resources it uses the latest installed Commit. MCP never scans cache files or
-falls back to an old generation when daemon has no matching ready index.
+The Organization Ref is the mutable authority pointer. The locally installed
+Project Ref selects one immutable materialization generation; moving it does
+not move an Organization Draft Base. Search heads are local derived pointers
+bound to an Effective Memory hash. For Draft resources, that memory uses
+`Base + operations`; for all other resources it uses the latest installed
+Project projection. MCP never scans cache files or falls back to an old
+generation when daemon has no matching ready index.
 
 ## Project Local Storage
 

--- a/docs/artifact.md
+++ b/docs/artifact.md
@@ -1,16 +1,15 @@
 # Organization memory
 
-Organization memory is the organization-scoped half of the unified Memory
-model. This page keeps the former `/artifact` URL because `Artifact` was the
-retired name for this product surface, and the historical UI called the view
-**Hub**.
+Organization memory is the authority surface of the unified Memory model. This
+page keeps the former `/artifact` URL because `Artifact` was the retired name
+for this product surface, and the historical UI called the view **Hub**.
 
 ## Scope and authority
 
-Organization memory is shared across the organization and has an independent
-Ref and immutable Commit history. Projects may consume selected organization
-Memory resources, but they do not create unrelated copies or turn local paths
-into identity.
+Organization memory is shared across the organization and has the sole
+authority Ref and immutable Commit history. Projects consume selected
+Organization Memory and carry private Draft overlays, but they do not create a
+second authority namespace, unrelated copies, or path-based identities.
 
 Resource identity is stable while the display path may change. Blob, Tree,
 Commit, and Ref provide version history; Draft, Review, and merge provide the
@@ -21,8 +20,9 @@ human coordination boundary.
 Every Memory object — whether it reads as a rule, a workflow, or reusable
 project context — uses a Markdown body, a required semantic `description`, and
 stable resource metadata. There are no closed Context / Rule / Workflow types;
-the unified model stores one object in organization or project scope. Editing
-in Desktop creates a Draft; it never mutates the authority Ref directly.
+the active model stores one object in Organization authority. Editing in a
+Project creates an Organization-scoped Draft carried by that Project; it never
+mutates the authority Ref directly.
 
 ## Bundles
 
@@ -33,8 +33,9 @@ authority source:
 - a resource may exist outside every Bundle;
 - the same resource may appear in multiple Bundles;
 - Bundle membership does not change resource identity;
-- a Project's memory history remains independent from the member's Bundle
-  selection.
+- a Project's selected-memory projection remains independent from the member's
+  Bundle selection.
 
-See [Project](/workspace) for project-scoped memory and [Architecture](/architecture)
-for the independent organization and Project Ref model.
+See [Project](/workspace) for selection and Draft overlay semantics and
+[Architecture](/architecture) for the Organization authority / Project
+projection model.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,18 +2,19 @@
 
 ## Server
 
-Server is the authority layer. It owns organization and project Memory,
-personal Bundles, Draft and Review lifecycles, identity and authorization, and
-the Blob / Tree / Commit / Ref version graph.
+Server is the authority layer. It owns Organization Memory, Project selections
+and projections, personal Bundles, Draft and Review lifecycles, identity and
+authorization, and the Blob / Tree / Commit / Ref version graph.
 
 This is the architectural center of gravity for the whole project. If a page explains clumsies as a set of local files plus some helper commands, it is missing the point.
 
 ## Memory
 
-Memory is the single first-class content object in clumsies. It carries a
-stable opaque ID, a scope (`org` or `project`), a title, a stable path, a
-required semantic `description`, a Markdown `content` body, a `revision`, and a
-`status` (`active`, `deprecated`, or `archived`).
+Memory is the single first-class content object in clumsies. Active authority
+is Organization-scoped and carries a stable opaque ID, title, stable path,
+required semantic `description`, Markdown `content` body, `revision`, and
+`status` (`active`, `deprecated`, or `archived`). The wire/storage scope value
+`project` remains only for reading and discarding historical rows.
 
 New objects get `mem_`-prefixed IDs. Existing `ctx_` / `rul_` / `wfl_` IDs stay
 stable and opaque; the migration emits an `old_id -> memory_id` map as their
@@ -40,17 +41,18 @@ docs mean a single behavioral instruction, they should usually say `rule`, not
 `prompt`. A rule tells the agent what to do; it does not tell the agent what
 the project is.
 
-## Scope: organization and project
+## Organization authority and Project view
 
-Memory lives in one of two scopes. Organization memory is shared across the
-organization and has an independent Ref and Commit history. Project memory is
-repository-scoped; a Project may also consume selected organization resources.
+Organization Memory is shared across the Organization and has the sole
+authority Ref and Commit history. A Project selects the Organization resources
+its repository consumes and carries Organization Draft overlays that remain
+visible only in that Project before merge. Its Project Ref versions this
+selection projection; it is not a second authority head.
 
-The historical UI labels were **Hub** (organization-scoped view) and **Local**
-(the selected project's resources and local drafts). The macOS app has since
-merged both into one Memory section with an Org/project filter; the old labels
-may still appear in scope labels, but they are not separate product sections
-or second backends.
+The historical UI labels were **Hub** (Organization authority) and **Local**
+(Project-scoped authority). The macOS app has since merged navigation into one
+Memory section. Any surviving Project-scoped resource is legacy read-only data
+scheduled for the authority cutover, not an active product namespace.
 
 ## Artifact
 
@@ -60,10 +62,10 @@ The current product surface is the Memory section's organization scope
 
 ## Project
 
-Project is the collaboration and authority boundary for project-scoped Memory.
-It may also consume selected organization resources. A Project is not a local
-folder or Git repository; local paths resolve to a stable Server-issued
-project ID.
+Project is the repository binding, membership boundary, Organization Memory
+selection, projection Ref, and carrier for private Draft overlays. It is not a
+Memory authority scope or a local folder; local paths resolve to a stable
+Server-issued Project ID.
 
 `Workspace` is a retired name that may still appear in old code and legacy
 documents.
@@ -170,9 +172,9 @@ target are separate concepts; Organization is not modeled as a Project.
 
 Draft is local-first state. Review is shared workflow.
 
-For organization-scope content, Review targets organization authority. For
-project-scope content, Review targets project authority. Those are related
-lifecycles, but they move different Refs.
+Every new Draft targets Organization authority. `project_id` identifies the
+Project carrying its private pre-merge overlay; it does not select a Project
+authority Ref. Project-scoped Drafts exist only as historical cleanup inputs.
 
 Draft lifecycle is only `open`, `submitted`, `merged`, or `discarded`.
 `behind` is freshness, not a lifecycle state; `clean` and `conflicts` describe a
@@ -194,7 +196,8 @@ moves an authority Ref; only Review merge does that.
 
 ## Effective Memory
 
-Effective Memory is the daemon's local read model. A resource with a personal
-Draft uses that Draft's complete `Base + operations` result. Resources without a
-Draft use the latest installed authority Commit. It is not a personal Ref or a
-whole-project branch pinned to an old Commit.
+Effective Memory is the daemon's local read model. It starts with the latest
+installed Project projection of selected Organization Memory. A resource with
+a personal Draft uses that Draft's complete `Base + operations` result; all
+other resources use the projection generation. It is not a personal Ref or a
+whole-Project branch pinned to an old Organization Commit.

--- a/docs/guides/how-to-use-clumsies.md
+++ b/docs/guides/how-to-use-clumsies.md
@@ -18,14 +18,13 @@ profiles in the app.
 
 ## Browse memory
 
-The unified **Memory** section shows both scopes of one Memory model in a
-single navigator, with a Project filter that also offers the **Org** scope for
-organization-shared memory:
+The unified **Memory** section shows two views of one Organization-authority
+model in a single navigator:
 
 - **Org** (organization scope, historically called Hub) contains
   organization-shared Memory.
-- **Project** (project scope, historically called Local) contains the selected
-  project's resources and local drafts.
+- **Project** contains that Project's selected Organization resources plus its
+  private pre-merge Organization Draft overlays.
 
 There are no closed Context / Rule / Workflow types — a Memory's role is
 carried by its content and path. The navigator lists Memory by path; opening

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,13 +19,13 @@ hero:
 features:
   - icon: 🧠
     title: One Memory model
-    details: Rules, workflows, and context are a single Markdown-backed Memory object with a semantic description and stable IDs, in organization or project scope.
+    details: Rules, workflows, and context are one Markdown-backed Organization Memory object with a semantic description and stable IDs; Projects select resources and carry private Draft overlays.
   - icon: 📝
     title: Automatic drafts
     details: Desktop and MCP write to the same always-on daemon; local changes synchronize without a manual push step.
   - icon: ✅
     title: Reviewed authority
-    details: Drafts become authoritative only through review and a Commit that advances the organization or project Ref.
+    details: Project-carried Drafts become authoritative only through review and a Commit that advances the Organization Ref.
   - icon: 🗂️
     title: Agent-native Kanban
     details: Agents claim, pause, and propose closure of native Issues through typed kanban operations; only the user's Approve gate makes an Issue Done.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -80,7 +80,7 @@ The response contains:
       "unit_key": "mem_123/memory-delta/0/0",
       "content_hash": "sha256:...",
       "resource_id": "mem_123",
-      "scope": "project",
+      "scope": "org",
       "kind": "memory",
       "path": "architecture/retrieval.md",
       "heading_path": ["MCP", "Memory Delta"],

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,9 +14,9 @@ a type discriminator.
 
 | Concept | Meaning |
 | --- | --- |
-| Memory | Markdown-backed content with stable `id`, `scope`, `title`, `path`, `description`, `content`, `revision`, and `status` |
-| Organization scope | shared memory with its own Ref and immutable Commit history |
-| Project scope | repository-scoped memory; projects may consume selected organization resources |
+| Memory | Markdown-backed Organization authority with stable `id`, `title`, `path`, `description`, `content`, `revision`, and `status` |
+| Organization authority | the sole publication namespace, with its own Ref and immutable Commit history |
+| Project | repository binding that selects Organization Memory, owns a projection Ref, and carries private pre-merge Draft overlays |
 | Bundle | a personal selection of shared memory resources (`resource_ids`) |
 | Issue | a native agent-managed Kanban object, distinct from Memory |
 
@@ -29,16 +29,17 @@ field, chunked and indexed separately from `content`.
 
 | Surface | Role |
 | --- | --- |
-| Desktop | primary human product for browsing, editing, reviewing, and merging memory; the unified Memory section shows organization and project memory with a scope filter |
+| Desktop | primary human product for browsing Organization authority, each Project's selected/effective Memory, Drafts, Reviews, and merges |
 | resident `clumsiesd` | always-on Rust runtime for drafts, sync, retrieval, native transport, and client coordination |
 | Agent runtime | short-lived `clumsiesd mcp serve` and `_agent` proxies used by supported hosts |
 | Server | self-hosted authority service backed by PostgreSQL |
 | MCP | agent-facing `activate`, `load`, `store`, and `kanban` interface |
 | Web Admin | organization, member, project, token, audit, and health administration |
 
-Organization memory (historically the Hub view) and project memory
-(historically Local) are the two scopes of one Memory model. Server is the
-process name; neither scope is a second backend.
+Organization is the sole Memory authority. A Project view is a projection of
+selected Organization Memory plus Project-carried Organization Draft overlays;
+it is not a second authority scope. Historical Project-scoped rows remain
+parseable only so the authority cutover can archive or discard them safely.
 
 ## Memory lifecycle
 
@@ -64,16 +65,17 @@ Clumsies uses Git terminology for Git-equivalent concepts:
 - Blob: immutable resource content
 - Tree: the indexed resource set for a version
 - Commit: an immutable authority version with a parent
-- Ref: the movable organization or project head
+- Ref: a movable head; the Organization Ref is authoritative and a Project Ref
+  identifies that Project's current selected-memory projection
 
 HTTP `ETag` and `If-Match` protect Ref updates. They do not replace Commit
-history. A draft records `base_commit_id`; a merge is rejected if the target Ref
-has moved.
+history. An Organization Draft records its Organization `base_commit_id`; a
+merge is rejected if the Organization Ref has moved.
 
 ## Current implementation boundary
 
-The unified Memory model (Server, daemon, OpenAPI, MCP, macOS), the
-organization/project memory endpoints (`/api/v1/org/memories` and
+The unified Memory model (Server, daemon, OpenAPI, MCP, macOS), the Organization
+authority and Project-view endpoints (`/api/v1/org/memories` and
 `/api/v1/projects/{project_id}/memories`), description-aware retrieval, the
 org-admin `memory-export` migration endpoint, generic organization OIDC,
 complete Public/Admin contracts, Desktop transport, local draft queue,

--- a/docs/project-authority-migration.md
+++ b/docs/project-authority-migration.md
@@ -1,0 +1,96 @@
+# Project Memory authority cutover
+
+Date: 2026-08-26 · Migration format: version 1
+
+## Target model
+
+Organization is the only active Memory authority. Project remains responsible
+for repository binding, membership, Organization Memory selection, its
+materialization Ref, and the visibility boundary for pre-merge Draft overlays.
+
+A new repository-specific proposal therefore has this identity:
+
+```text
+draft.project_id = <carrying Project>
+draft.resource_scope = org
+```
+
+It is not represented by changing `resources.scope` from `project` to `org`.
+That would bypass Review and could collide with existing Organization identity
+or paths.
+
+## Legacy conversion
+
+For every Project containing active Project authority or an active
+Project-scoped Draft, the migration:
+
+1. verifies the active resource bodies, current Project Ref, selected
+   Organization authority, and Draft ownership;
+2. materializes legacy Draft operations in daemon order
+   (`created_at`, Draft ID, operation ordinal), including provisional IDs;
+3. combines that result with the selected Organization authority and the
+   carrying user's active Organization Drafts; an exact legacy path becomes an
+   update proposal for the selected resource, while an already-active Org Draft
+   for that resource supersedes the legacy duplicate and is reported;
+4. rejects every remaining case, prefix, or file/directory path collision;
+5. records a deterministic plan hash and an Effective Memory path/content hash;
+6. on apply, discards the old Drafts, archives Project resources, creates one
+   Organization-scoped create/update Draft per retained final legacy file, and
+   advances a Project Ref containing selected Organization Memory only.
+
+Descriptions from the active authority row are preserved when an old Project
+Commit differs only in description. Any identity, path, or body drift is a
+blocker. Projects with zero or multiple active members are also blocked because
+replacement Draft ownership would be ambiguous.
+
+The apply phase is one serializable PostgreSQL transaction. It takes migration
+and Organization coordination locks, rechecks Ref and Draft versions, rejects a
+stale plan hash, writes audit history, and validates the permanent database
+guards that prohibit active Project resources and active Project Drafts.
+
+## Runbook
+
+First take a PostgreSQL custom-format backup and preserve the affected clients'
+SQLite databases. Exercise both commands against a restored database before
+touching production.
+
+```bash
+DATABASE_URL=postgres://... clumsies-server migrate-project-authority --dry-run
+```
+
+Dry-run rolls back its planning transaction and does not run schema migrations.
+Review `ready`, `blockers`, each Project's counts and warnings, and preserve the
+returned `plan_hash`.
+
+```bash
+DATABASE_URL=postgres://... clumsies-server migrate-project-authority \
+  --apply --expected-plan-hash 'sha256:...'
+```
+
+Apply first installs pending schema migrations, then proceeds only if the live
+plan still has the exact reviewed hash. A failed apply rolls back all data
+changes. Running dry-run again after success must report zero legacy authority,
+zero active legacy Drafts, and zero replacements.
+
+Verify these database invariants after apply:
+
+```sql
+SELECT count(*) FROM resources
+WHERE scope = 'project' AND status = 'active';
+
+SELECT count(*) FROM drafts
+WHERE resource_scope = 'project' AND status IN ('open', 'submitted');
+
+SELECT conname, convalidated
+FROM pg_constraint
+WHERE conname IN (
+  'resources_no_active_project_authority',
+  'drafts_no_active_project_authority'
+);
+```
+
+Both counts must be zero and both constraints must be validated. Keep the
+backup until clients have synchronized the discard events, replacement Drafts,
+and new Project Ref. The Desktop's legacy lock accessory then disappears
+naturally because no active Project-scoped rows remain; parsing and discard of
+historical rows stay available only for recovery compatibility.

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -18,8 +18,9 @@ tests, packaging, and release artifacts.
 
 ## Authority boundaries
 
-`crates/server` owns authoritative organization and project memory, identity,
-authorization, Bundles, review lifecycle, and Commit history.
+`crates/server` owns Organization Memory authority, Project selections and
+projection Refs, identity, authorization, Bundles, review lifecycle, and Commit
+history.
 
 `crates/daemon` owns local drafts, queued operations, automatic synchronization,
 token refresh, retrieval, native Server transport, and both short-lived Agent
@@ -28,9 +29,9 @@ process over XPC; it does not initialize daemon state. The crate is not an
 authority source.
 
 `apps/macos` is the primary human product. It uses typed XPC requests and never
-persists Server credentials. The unified Memory section shows both
-organization-scoped and project-scoped memory with an Org/project filter; the
-historical Hub/Local labels survive only as scope labels.
+persists Server credentials. The unified Memory section switches between the
+Organization authority view and a Project's selected/effective Memory view.
+Historical Project-scoped rows are displayed only for migration compatibility.
 
 The App bundle contains one signed `clumsiesd`. launchd runs it as the resident
 daemon, while supported Agent hosts run the same binary as `mcp serve` or

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -17,7 +17,7 @@ The database currently stores:
 - local drafts and ordered operations
 - synchronization status, failures, and Server draft identity
 - immutable Blob, Tree, and Commit metadata
-- installed organization and project Refs
+- installed Organization authority and Project projection Refs
 - the active search head and storage-location revision for each Project
 
 Each Project search database stores its derived search revisions, complete
@@ -56,7 +56,8 @@ in the Ref.
 Each draft carries:
 
 - `project_id`
-- `scope` (`org` or `project`)
+- authority `scope` (`org` for every new Draft; `project` is accepted only
+  while discarding historical local rows)
 - the unified Memory identity (id or path; no three-type kind)
 - `base_commit_id`
 - the currently installed target Ref Commit
@@ -104,8 +105,8 @@ migrated path from the old file. Missing or duplicate matches fail explicitly;
 the legacy `ws_id` value is never sent to daemon.
 
 When the caller omits `base_commit_id`, daemon reads it from the installed
-project Ref before creating the local draft. A missing Ref produces a draft
-with no base; daemon never invents a Commit ID.
+Organization Ref before creating the local Draft. A missing Ref produces a
+Draft with no base; daemon never invents a Commit ID.
 
 MCP does not expose a caller-selectable scope, Review decision, merge, or
 publish operation. `store` can only create a Project-carried proposal. Before
@@ -138,11 +139,11 @@ edit or Ref advance invalidates the old candidate.
 
 ## Commit synchronization
 
-The daemon synchronizes both organization and project Refs on its background
-interval and through explicit retry. Its target set is the union of durable
-directory bindings, active Draft Projects, and the Project currently selected
-by Desktop. Desktop selection is UI state and cannot redirect an MCP process in
-another directory.
+The daemon synchronizes both the Organization authority Ref and each Project
+projection Ref on its background interval and through explicit retry. Its
+target set is the union of durable directory bindings, active Draft Projects,
+and the Project currently selected by Desktop. Desktop selection is UI state
+and cannot redirect an MCP process in another directory.
 
 ```text
 Server commit-state + ETag

--- a/docs/server.md
+++ b/docs/server.md
@@ -9,10 +9,11 @@ the unified Memory model. The Rust binary and container are named Server.
 Server owns:
 
 - organization membership, project membership, roles, and token sessions
-- organization and project Memory (the unified model)
+- Organization Memory authority and Project Memory selections/projections
 - personal Bundles (`resource_ids`)
 - drafts, draft operation history, reviews, decisions, comments, and merges
-- immutable Commit history, Trees, Blobs, and movable organization/project Refs
+- immutable Commit history, Trees, Blobs, the Organization authority Ref, and
+  Project projection Refs
 - admin configuration, token revocation, audit events, and health reporting
 
 Desktop and MCP write local drafts through the daemon. The daemon synchronizes
@@ -32,10 +33,12 @@ Blob -> Tree -> Commit -> Ref
 Draft(base_commit_id)
 ```
 
-Each organization and project has its own Ref. A merge locks the target Ref,
+Each Organization has an authority Ref; each Project has a separately versioned
+Ref for its selected-memory projection. A merge locks the Organization Ref,
 checks `If-Match`, verifies that the Draft is based on that Commit, creates a new
-immutable Commit, and advances only that Ref. Project metadata revision is
-separate from memory history.
+immutable Organization Commit, and advances the authority Ref. Project Refs are
+rebuilt when their selection or selected Organization authority changes.
+Project metadata revision is separate from both histories.
 
 The unified Memory endpoints are `GET /api/v1/org/memories`,
 `GET /api/v1/projects/{project_id}/memories`, and the corresponding

--- a/docs/unified-memory-model.md
+++ b/docs/unified-memory-model.md
@@ -10,6 +10,12 @@ page is the design and migration record for that change. It is a destructive
 refactor: existing data is protected and migrated, while the old
 three-type write contracts are not preserved for the long term.
 
+> Authority update (2026-08-26): Organization is now the only active Memory
+> authority. Projects select Organization Memory, own a projection Ref, and
+> carry Organization-scoped Draft overlays. References to Project-scoped
+> authority below describe the ISSUE-012 historical schema; they are retained
+> only as migration context. See [Project authority cutover](/project-authority-migration).
+
 ## Core object
 
 A Memory is the only first-class content object. No Category/Tag is
@@ -19,8 +25,7 @@ primary semantic surface an Agent can understand.
 ```text
 Memory {
   id: string            // stable opaque ID, e.g. mem_... (see ID policy)
-  scope: org | project
-  project_id: string?   // required when scope == project
+  scope: org            // project is historical read/cleanup compatibility
   title: string
   path: string          // stable path within org or project namespace
   description: string   // required on create, optional on update
@@ -66,10 +71,10 @@ Memory {
 
 ## What is retained
 
-- Org/Project scope and per-project isolation.
+- Organization authority and per-Project Draft-overlay isolation.
 - Draft / Review / Commit lifecycle (drafts still belong to a project).
-- Commit and Ref mechanics; old Commit history is archived offline and a new
-  baseline Commit is generated from the migrated effective state.
+- Commit and Ref mechanics; the Organization Ref is authoritative and each
+  Project Ref is a selected-memory projection.
 - Authority and provenance: `provenance`, `status` and `scope` remain system
   fields and are never inferred from `description` text or user naming.
 - Content format detection for Markdown preview (via `content_format`, not

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -1,8 +1,9 @@
 # Project
 
-`Project` is the current product term for a repository-scoped memory and
-authorization boundary. This page keeps its historical `/workspace` URL so old
-links continue to resolve, but active APIs and runtime state use `project_id`.
+`Project` is the repository binding, authorization boundary, Organization
+Memory selection, and Draft carrier. It is not a Memory authority namespace.
+This page keeps its historical `/workspace` URL so old links continue to
+resolve, but active APIs and runtime state use `project_id`.
 
 ## Identity and local binding
 
@@ -27,13 +28,23 @@ closed or showing a third Project.
 Legacy `ws_id` configuration is only a one-time migration input. It is never
 sent to daemon as a Project identity and is not a runtime fallback.
 
-## Memory scope
+## Memory authority and Project projection
 
-Projects own repository-specific Memory. Organization memory remains under the
-independent organization scope (historically the Hub view). Each scope has its
-own Ref and immutable Commit history; merging one scope never advances the
-other. A Memory's role — rule, workflow, or context — is carried by its content
-and path, not by a closed type.
+Organization is the only active Memory authority. A Project selects the
+Organization Memory used by its repository and stores that selection in a
+Project Commit and movable Project Ref. The Project Ref is a materialization
+projection, not another publication target: Review merge advances the
+Organization Ref, while selection changes advance the Project Ref.
+
+Repository-specific knowledge starts as an Organization-scoped Draft carrying
+the Project's `project_id`. Before merge, its overlay is visible only in that
+Project's Effective Memory. After approval, it becomes Organization authority
+and is automatically selected for the carrying Project. A Memory's role — rule,
+workflow, or context — is carried by its content and path, not by a closed type.
+
+Historical Project-scoped resources and Drafts are read-only compatibility
+inputs. The authority cutover archives/discards them after flattening their
+effective result into Organization-scoped Drafts.
 
 Bundles are personal selections of shared organization memory. They help a
 member reuse a curated set but do not become Project identity or replace the
@@ -45,15 +56,16 @@ changes resource identity.
 The resident daemon owns the Project's installation-local state:
 
 - directory binding and selected Server authority;
-- installed organization and Project Refs;
+- installed Organization authority and Project projection Refs;
 - immutable Commit generations;
 - current local Drafts and their queued operations;
 - the derived search index for the current Effective Memory;
 - optional Project Local Storage location and move status;
 - adapter installation records for the repository.
 
-Server remains authoritative for Project membership, memory history, Reviews,
-and merges. A local binding or cache never creates authority.
+Server remains authoritative for Project membership and selection,
+Organization Memory history, Reviews, and merges. A local binding or cache
+never creates authority.
 
 ## Effective Memory
 
@@ -61,17 +73,17 @@ For Agent reads, daemon composes the latest installed authority generations
 with the Project's current open/submitted Draft operations:
 
 ```text
-organization Commit + Project Commit + local Draft overlay
+Project Commit (selected Organization Memory) + Project-carried Org Draft overlay
   -> Effective Memory hash
   -> matching derived Index Revision
   -> activate / load
 ```
 
-`store` writes a durable proposal Draft carried by the bound Project through
-daemon. Its pre-merge overlay is visible only in that Project. The Draft may
-target Organization authority, but it does not update the Org Ref. Desktop
-shows the same Draft for coordination and submission; an Org administrator
-must decide and merge its Review.
+`store` writes a durable Organization-scoped proposal Draft carried by the
+bound Project through daemon. Its pre-merge overlay is visible only in that
+Project, and it does not update the Organization Ref. Desktop shows the same
+Draft for coordination and submission; an Org administrator must decide and
+merge its Review.
 
 ## Project Local Storage
 

--- a/docs/zh/architecture.md
+++ b/docs/zh/architecture.md
@@ -2,7 +2,7 @@
 
 clumsies 是编码 Agent 的协作式外部记忆基础设施：把规则、工作流与项目上下文作为统一的 **Memory** 对象分发到 Agent，并把本地 Draft 变更同步回组织。
 
-- **Memory**：唯一的头等内容对象（Markdown 正文 + 必填语义 `description` + 稳定 ID），处于 **组织作用域**（历史 UI 称 Hub）或 **项目作用域**（历史 UI 称 Local）；两者在 Desktop 的 Memory 分区中合并展示，用 Org/项目过滤器切换。
+- **Memory**：唯一的头等内容对象（Markdown 正文 + 必填语义 `description` + 稳定 ID）。组织是唯一权威作用域；Project 只选择组织记忆、维护物化 Ref，并承载合并前仅在该 Project 生效的组织 Draft overlay。历史 Project scope 只用于迁移兼容。
 - **常驻 `clumsiesd`**：由 launchd 管理的 Rust 本地服务，独占数据库、模型、同步与检索任务。
 - **Agent runtime proxy**：同一份 App 内签名的 `clumsiesd` 以 `mcp serve` 或 `_agent` 短进程模式运行，通过 XPC 转发给常驻服务。
 - **Adapter**：把 Codex / Claude Code / opencode / dsh 固定到 App 内的 `clumsiesd` 路径，并接入 MCP 与 AgentRun lifecycle。

--- a/docs/zh/guides/how-to-use-clumsies.md
+++ b/docs/zh/guides/how-to-use-clumsies.md
@@ -1,7 +1,7 @@
 # 如何开始使用 clumsies
 
 1. 安装 clumsies，登录 Server，选择或创建 Project。
-2. 在 Desktop 的 Memory 分区中浏览组织（Org）与项目作用域的统一 Memory，创建带 `description` 的 Markdown Memory（不再区分 Rule / Workflow / Context 三种类型）。
+2. 在 Desktop 的 Memory 分区中浏览组织权威与当前 Project 的 Effective Memory，创建带 `description` 的组织 Memory Draft（不再区分 Rule / Workflow / Context 三种类型）。
 3. 让编码 Agent（Codex / Claude Code / opencode / dsh）接入 MCP，AgentRun 自动进入看板；Agent 用 `kanban` 工具创建并推进 Issue。
 4. 个人 Draft 自动同步，变更经 Review 后发布。
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -19,13 +19,13 @@ hero:
 features:
   - icon: 🧠
     title: 统一的 Memory 模型
-    details: Rule、Workflow 与 Context 统一为单一 Markdown Memory 对象，携带语义 description 与稳定 ID，处于组织或项目作用域。
+    details: Rule、Workflow 与 Context 统一为携带语义 description 与稳定 ID 的 Markdown 组织记忆；Project 负责选择资源并承载私有 Draft overlay。
   - icon: 📝
     title: 自动 Draft
     details: Desktop 与 MCP 写入同一个常驻 daemon；本地变更无需手动 push 即可同步。
   - icon: ✅
     title: Review 后发布
-    details: Draft 只有通过 Review 和推进组织/项目 Ref 的 Commit 才会成为权威。
+    details: Project 承载的 Draft 只有通过 Review 并以 Commit 推进组织 Ref 后才会成为权威。
   - icon: 🗂️
     title: Agent 原生看板
     details: Agent 通过 typed kanban 操作认领、暂停、释放并提议关闭 Issue；只有用户的 Approve 闸门能让 Issue 进入 Done。


### PR DESCRIPTION
## Summary

- Make Organization the sole active Memory authority while Project remains the repository, selection, projection, and Draft-carrier boundary.
- Reject new Project-scoped Drafts in the server and daemon while retaining legacy read/discard compatibility.
- Add a plan-hash-gated, serializable migration that archives Project authority, converts effective state into Project-carried Organization Drafts, advances Project projections, and validates permanent database guards.
- Update architecture documentation and add the production cutover runbook.

## Validation

- cargo test --workspace --quiet
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- bun run api:check
- bun run build
- bun run test:macos
- sh dev/check-retired-terms.sh
- git diff --check

## Production rehearsal

A production backup clone was exercised with dry-run, plan-hash-gated apply, post-apply Effective Memory hash verification, and idempotent second dry-run. The reviewed plan contains 207 legacy authority resources, 252 active legacy Project Drafts, and 281 replacement Organization Drafts. Production itself has not been changed.

## Rollout gate

Keep this PR in draft. Merge, deployment, and production data cutover require separate approval.