### PR TITLE
fix(server): preserve ref etags through compression

### DIFF
--- a/crates/server/src/memory/http.rs
+++ b/crates/server/src/memory/http.rs
@@ -1,6 +1,6 @@
 use axum::Json;
 use axum::extract::{Extension, Path, Query, State};
-use axum::http::header::ETAG;
+use axum::http::header::{CACHE_CONTROL, ETAG};
 use axum::http::{HeaderMap, HeaderValue};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
@@ -237,6 +237,9 @@ pub(crate) async fn get_project_commit_state(
         HeaderValue::from_str(&etag)
             .map_err(|_| HttpError::bad_request("ref produced an invalid ETag"))?,
     );
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-transform"));
     Ok(response)
 }
 
@@ -265,6 +268,9 @@ pub(crate) async fn get_org_commit_state(
         HeaderValue::from_str(&etag)
             .map_err(|_| HttpError::bad_request("ref produced an invalid ETag"))?,
     );
+    response
+        .headers_mut()
+        .insert(CACHE_CONTROL, HeaderValue::from_static("no-transform"));
     Ok(response)
 }
 

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -4341,6 +4341,7 @@ where
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["cache-control"], "no-transform");
     let etag = response
         .headers()
         .get("etag")


### PR DESCRIPTION
## Summary

- Mark Organization and Project commit-state responses as no-transform.
- Preserve the domain Ref ETag across Caddy gzip encoding while retaining compression for larger API responses.
- Assert the response contract in the shared commit-state integration helper.

## Root cause

Caddy 2.11.4 correctly appends the selected encoding to strong representation ETags. After the daemon enabled gzip negotiation, commit-state returned an ETag ending in -gzip while its JSON Ref still carried the bare commit ID, so strict Commit sync validation failed.

## Validation

- cargo test -p server --test external_memory_lifecycle --quiet
- cargo clippy -p server --tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Production data migration is already complete and healthy; this follow-up restores Project Commit synchronization for existing clients.