### PR TITLE
feat(memory): restore directory actions

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -96,14 +96,14 @@ enum ProjectMemberError: LocalizedError, Sendable {
 enum MemoryValidationError: LocalizedError, Sendable {
     case invalidPath(String)
     case emptyRule
-    case unpublishedMemoryCannotBeRenamed
+    case memoryCannotBeRenamed
 
     var errorDescription: String? {
         switch self {
         case .invalidPath(let message): message
         case .emptyRule: "A Rule needs content."
-        case .unpublishedMemoryCannotBeRenamed:
-            "A new memory can be renamed after it becomes shared."
+        case .memoryCannotBeRenamed:
+            "This memory is no longer available to rename."
         }
     }
 }
@@ -2376,10 +2376,10 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    /// Renames a target-backed memory without coupling the path mutation to
-    /// whatever body happens to be loaded in the file tree. In particular,
-    /// metadata-only resources carry an empty placeholder body and must never
-    /// turn a rename into an empty-content update.
+    /// Renames without coupling the path mutation to whatever body happens to
+    /// be loaded in the file tree. Target-backed resources use their stable
+    /// resource id; a pure create Draft uses its provisional Draft id. Both
+    /// keep content and semantic metadata untouched.
     func rename(_ item: MemoryListItem, to newPath: String) async throws {
         guard !isSwitchingMemoryContext else {
             throw ServerClientError.forbidden(
@@ -2419,7 +2419,7 @@ final class WorkspaceStore: ObservableObject {
                 currentDraft: draft,
                 newPath: newPath
             ) else {
-                throw MemoryValidationError.unpublishedMemoryCannotBeRenamed
+                throw MemoryValidationError.memoryCannotBeRenamed
             }
             guard let projectId = draftCarrierProjectId(for: item, currentDraft: draft) else {
                 throw WorkspaceLoadError.noProjects
@@ -2474,7 +2474,10 @@ final class WorkspaceStore: ObservableObject {
         currentDraft: LocalDraft?,
         newPath: String
     ) -> DocumentRenamePlan? {
-        guard let targetId = item.resource?.id ?? currentDraft?.targetId else { return nil }
+        let targetId = item.resource?.id
+            ?? currentDraft?.targetId
+            ?? (item.resource == nil ? currentDraft?.id : nil)
+        guard let targetId else { return nil }
         return .init(targetId: targetId, newPath: newPath)
     }
 
@@ -2487,23 +2490,24 @@ final class WorkspaceStore: ObservableObject {
         return retargeted
     }
 
-    func delete(_ item: MemoryListItem) async {
-        guard item.draft?.isDeletion != true else { return }
+    @discardableResult
+    func delete(_ item: MemoryListItem) async -> Bool {
+        guard item.draft?.isDeletion != true else { return false }
         guard !isSwitchingMemoryContext else {
             errorMessage = "Wait for the Memory context switch to finish before deleting."
-            return
+            return false
         }
         guard canEditMemory(item) else {
             errorMessage = "You do not have permission to delete this memory."
-            return
+            return false
         }
         guard synchronizationItemId(for: item) == nil else {
             errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
-            return
+            return false
         }
         cancelDocumentSave(item)
         guard let projectId = draftCarrierProjectId(for: item, currentDraft: item.draft),
-              let targetId = item.resource?.id ?? item.draft?.targetId else { return }
+              let targetId = item.resource?.id ?? item.draft?.targetId else { return false }
         do {
             try await withDraftMutation {
                 guard synchronizationItemId(for: item) == nil else {
@@ -2523,15 +2527,18 @@ final class WorkspaceStore: ObservableObject {
                 )
                 try await refreshDraft(response.draftId)
             }
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 
-    func discard(_ draft: LocalDraft) async {
+    @discardableResult
+    func discard(_ draft: LocalDraft) async -> Bool {
         guard synchronizationItemId(for: draft) == nil else {
             errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
-            return
+            return false
         }
         cancelDocumentSave(
             .init(projectId: draft.projectId, itemId: draft.targetId ?? draft.id)
@@ -2556,8 +2563,10 @@ final class WorkspaceStore: ObservableObject {
                 pruneOrphanedMemoryTabs()
                 selectedItemId = nil
             }
+            return true
         } catch {
             errorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -283,6 +283,22 @@ private struct FileTreeView: View {
     }
 
     var body: some View {
+        fileTreeWithDestructiveAlerts
+        .sheet(item: $pendingDirectoryReview) { request in
+            ReviewRequestSheet(
+                initialTitle: request.initialTitle,
+                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
+            ) { title, description, _, _ in
+                try await store.requestReview(
+                    for: request.drafts,
+                    title: title,
+                    description: description
+                )
+            }
+        }
+    }
+
+    private var fileTreeContent: some View {
         List(selection: selection) {
             ForEach(visibleNodes) { entry in
                 fileTreeRow(for: entry)
@@ -322,6 +338,10 @@ private struct FileTreeView: View {
             pendingDirectoryDiscard = nil
             pendingDirectoryReview = nil
         }
+    }
+
+    private var fileTreeWithRenameAlerts: some View {
+        fileTreeContent
         .alert(
             itemRenameTitle,
             isPresented: Binding(
@@ -368,6 +388,10 @@ private struct FileTreeView: View {
         } message: {
             Text(directoryRenameMessage)
         }
+    }
+
+    private var fileTreeWithDestructiveAlerts: some View {
+        fileTreeWithRenameAlerts
         .alert(item: $pendingOrganizationDeletion) { deletion in
             Alert(
                 title: Text(deletion.title),
@@ -404,18 +428,6 @@ private struct FileTreeView: View {
                 },
                 secondaryButton: .cancel()
             )
-        }
-        .sheet(item: $pendingDirectoryReview) { request in
-            ReviewRequestSheet(
-                initialTitle: request.initialTitle,
-                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
-            ) { title, description, _, _ in
-                try await store.requestReview(
-                    for: request.drafts,
-                    title: title,
-                    description: description
-                )
-            }
         }
     }
 

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -285,20 +285,7 @@ private struct FileTreeView: View {
     var body: some View {
         List(selection: selection) {
             ForEach(visibleNodes) { entry in
-                FileTreeRow(
-                    entry: entry,
-                    isExpanded: expandedDirectoryIds.contains(entry.id),
-                    isStale: entry.node.item.map {
-                        $0.draft == nil
-                            && $0.resource.map { store.staleResourceIds.contains($0.id) } == true
-                    } == true,
-                    onDirectoryClick: { modifierFlags in
-                        handleDirectoryClick(entry.id, modifierFlags: modifierFlags)
-                    }
-                )
-                .tag(entry.id)
-                .listRowInsets(.init(top: 0, leading: 5, bottom: 0, trailing: 5))
-                .listRowSeparator(.hidden)
+                fileTreeRow(for: entry)
             }
         }
         .listStyle(.plain)
@@ -430,6 +417,25 @@ private struct FileTreeView: View {
                 )
             }
         }
+    }
+
+    private func fileTreeRow(for entry: VisibleFileTreeNode) -> some View {
+        FileTreeRow(
+            entry: entry,
+            isExpanded: expandedDirectoryIds.contains(entry.id),
+            isStale: resourceIsStale(for: entry.node.item),
+            onDirectoryClick: { modifierFlags in
+                handleDirectoryClick(entry.id, modifierFlags: modifierFlags)
+            }
+        )
+        .tag(entry.id)
+        .listRowInsets(.init(top: 0, leading: 5, bottom: 0, trailing: 5))
+        .listRowSeparator(.hidden)
+    }
+
+    private func resourceIsStale(for item: MemoryListItem?) -> Bool {
+        guard let item, item.draft == nil, let resource = item.resource else { return false }
+        return store.staleResourceIds.contains(resource.id)
     }
 
     private var isValidProposedName: Bool {

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -225,6 +225,39 @@ private struct PendingDirectoryReview: Identifiable {
     let initialTitle: String
 }
 
+private struct PendingDirectoryDiscard: Identifiable {
+    let id = UUID()
+    let name: String
+    let drafts: [LocalDraft]
+}
+
+private struct PendingDirectoryDeletion: Identifiable {
+    let id = UUID()
+    let name: String
+    let plan: MemoryDirectoryDeletionPlan
+
+    var message: String {
+        var effects: [String] = []
+        if !plan.itemsToDelete.isEmpty {
+            let noun = plan.itemsToDelete.count == 1 ? "memory" : "memories"
+            effects.append(
+                "create deletion proposals for \(plan.itemsToDelete.count) shared "
+                    + noun
+            )
+        }
+        if !plan.draftsToDiscard.isEmpty {
+            let noun = plan.draftsToDiscard.count == 1 ? "draft" : "drafts"
+            effects.append(
+                "discard \(plan.draftsToDiscard.count) unpublished "
+                    + noun
+            )
+        }
+        let joinedEffects = effects.joined(separator: " and ")
+        return "This will \(joinedEffects) in \(name). "
+            + "Shared memories are removed only after review and merge."
+    }
+}
+
 private struct FileTreeView: View {
     @ObservedObject var store: WorkspaceStore
     let items: [MemoryListItem]
@@ -234,7 +267,11 @@ private struct FileTreeView: View {
     @State private var initializedExpansion = false
     @State private var itemToRename: MemoryListItem?
     @State private var proposedName = ""
+    @State private var directoryToRenameId: String?
+    @State private var proposedDirectoryName = ""
     @State private var pendingOrganizationDeletion: PendingOrganizationDeletion?
+    @State private var pendingDirectoryDeletion: PendingDirectoryDeletion?
+    @State private var pendingDirectoryDiscard: PendingDirectoryDiscard?
     @State private var pendingDirectoryReview: PendingDirectoryReview?
 
     private var roots: [FileTreeNode] {
@@ -291,11 +328,15 @@ private struct FileTreeView: View {
         .onChange(of: store.activeProjectId) { _, _ in
             itemToRename = nil
             proposedName = ""
+            directoryToRenameId = nil
+            proposedDirectoryName = ""
             pendingOrganizationDeletion = nil
+            pendingDirectoryDeletion = nil
+            pendingDirectoryDiscard = nil
             pendingDirectoryReview = nil
         }
         .alert(
-            "Propose Organization Rename",
+            itemRenameTitle,
             isPresented: Binding(
                 get: { itemToRename != nil },
                 set: {
@@ -310,15 +351,35 @@ private struct FileTreeView: View {
             Button("Cancel", role: .cancel) {
                 itemToRename = nil
             }
-            Button("Propose Rename") {
+            Button(itemRenameConfirmationTitle) {
                 renameSelectedItem()
             }
             .disabled(!isValidProposedName)
         } message: {
-            Text(
-                "This creates a draft proposal. If it is reviewed and merged, "
-                    + "the organization memory will be renamed for every project that includes it."
+            Text(itemRenameMessage)
+        }
+        .alert(
+            "Rename Folder",
+            isPresented: Binding(
+                get: { directoryToRenameId != nil },
+                set: {
+                    if !$0 {
+                        directoryToRenameId = nil
+                        proposedDirectoryName = ""
+                    }
+                }
             )
+        ) {
+            TextField("Folder name", text: $proposedDirectoryName)
+            Button("Cancel", role: .cancel) {
+                directoryToRenameId = nil
+            }
+            Button(directoryRenameConfirmationTitle) {
+                renameSelectedDirectory()
+            }
+            .disabled(!isValidProposedDirectoryName)
+        } message: {
+            Text(directoryRenameMessage)
         }
         .alert(item: $pendingOrganizationDeletion) { deletion in
             Alert(
@@ -326,6 +387,33 @@ private struct FileTreeView: View {
                 message: Text(deletion.message),
                 primaryButton: .destructive(Text(deletion.confirmationTitle)) {
                     deleteItems(deletion.items)
+                },
+                secondaryButton: .cancel()
+            )
+        }
+        .alert(item: $pendingDirectoryDiscard) { request in
+            Alert(
+                title: Text(
+                    request.drafts.count == 1
+                        ? "Discard Draft in \(request.name)?"
+                        : "Discard \(request.drafts.count) Drafts in \(request.name)?"
+                ),
+                message: Text(
+                    "This removes the Project-carried Drafts in this folder. "
+                        + "Shared Organization Memory is unchanged."
+                ),
+                primaryButton: .destructive(Text("Discard Drafts")) {
+                    discardDrafts(request.drafts)
+                },
+                secondaryButton: .cancel()
+            )
+        }
+        .alert(item: $pendingDirectoryDeletion) { request in
+            Alert(
+                title: Text("Delete \(request.name)?"),
+                message: Text(request.message),
+                primaryButton: .destructive(Text("Delete Folder")) {
+                    deleteDirectory(request.plan)
                 },
                 secondaryButton: .cancel()
             )
@@ -347,6 +435,58 @@ private struct FileTreeView: View {
     private var isValidProposedName: Bool {
         let name = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
         return !name.isEmpty && name != "." && name != ".." && !name.contains("/")
+    }
+
+    private var itemRenameTitle: String {
+        itemToRename?.resource == nil ? "Rename Draft" : "Propose Organization Rename"
+    }
+
+    private var itemRenameConfirmationTitle: String {
+        itemToRename?.resource == nil ? "Rename" : "Propose Rename"
+    }
+
+    private var itemRenameMessage: String {
+        if itemToRename?.resource == nil {
+            return "This changes the path in the current Project-carried Draft."
+        }
+        return "This creates a draft proposal. If it is reviewed and merged, "
+            + "the organization memory will be renamed for every project that includes it."
+    }
+
+    private var directoryRenameItems: [MemoryListItem] {
+        guard let directoryToRenameId else { return [] }
+        return FileTreeNode.items(in: roots, selectedNodeIds: [directoryToRenameId])
+    }
+
+    private var directoryRenameConfirmationTitle: String {
+        directoryRenameItems.contains { $0.resource != nil } ? "Propose Renames" : "Rename"
+    }
+
+    private var directoryRenameMessage: String {
+        let items = directoryRenameItems
+        let sharedCount = items.filter { $0.resource != nil }.count
+        let draftCount = items.count - sharedCount
+        if sharedCount == 0 {
+            return "This preserves every relative file path in the current Project-carried "
+                + "Drafts. Shared Organization Memory is unchanged."
+        }
+        if draftCount > 0 {
+            return "This preserves every relative file path, renames \(draftCount) unpublished "
+                + "Drafts, and creates \(sharedCount) rename proposals. Shared Organization "
+                + "Memory changes only after review and merge."
+        }
+        return "This preserves every relative file path and creates Project-carried rename "
+            + "Drafts. Organization Memory changes only after review and merge."
+    }
+
+    private var isValidProposedDirectoryName: Bool {
+        let name = proposedDirectoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != ".", name != "..", !name.contains("/"),
+              let directoryToRenameId,
+              let directory = FileTreeNode.node(withId: directoryToRenameId, in: roots) else {
+            return false
+        }
+        return name != directory.name
     }
 
     private func beginRenaming(_ item: MemoryListItem) {
@@ -383,6 +523,79 @@ private struct FileTreeView: View {
             } catch {
                 store.errorMessage = error.localizedDescription
             }
+        }
+    }
+
+    private func beginRenamingDirectory(_ directory: FileTreeNode) {
+        let targetItems = FileTreeNode.items(
+            in: roots,
+            selectedNodeIds: [directory.id]
+        )
+        guard targetItems.allSatisfy({
+            MemoryFileTreeMenu.canRename($0, inOrgView: false)
+                && store.canEditMemory($0)
+                && !store.isSynchronizingDocument($0.id)
+        }) else {
+            store.errorMessage = MemoryDirectoryMutationError.readOnly.localizedDescription
+            return
+        }
+        directoryToRenameId = directory.id
+        proposedDirectoryName = directory.name
+    }
+
+    private func renameSelectedDirectory() {
+        guard let directoryToRenameId else { return }
+        let name = proposedDirectoryName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let targetItems = FileTreeNode.items(
+            in: roots,
+            selectedNodeIds: [directoryToRenameId]
+        )
+        do {
+            guard targetItems.allSatisfy({
+                MemoryFileTreeMenu.canRename($0, inOrgView: false)
+                    && store.canEditMemory($0)
+                    && !store.isSynchronizingDocument($0.id)
+            }) else {
+                throw MemoryDirectoryMutationError.readOnly
+            }
+            let resources = store.resources.filter {
+                $0.scope == .org
+                    || ($0.scope == .project && $0.projectId == store.activeProjectId)
+            }
+            let drafts = store.drafts.filter {
+                $0.projectId == store.activeProjectId
+                    && $0.status != .discarded
+                    && $0.status != .merged
+            }
+            let occupiedPaths = Set(resources.map(\.document.path))
+                .union(drafts.map(\.document.path))
+            let occupiedTreePaths = Set(items.map { FileTreeNode.treePath(for: $0) })
+            let plan = try MemoryFileTreeMenu.directoryRenamePlan(
+                directoryId: directoryToRenameId,
+                newName: name,
+                items: targetItems,
+                occupiedPaths: occupiedPaths,
+                occupiedTreePaths: occupiedTreePaths,
+                inOrgView: false
+            )
+            self.directoryToRenameId = nil
+            proposedDirectoryName = ""
+            Task {
+                var completed = 0
+                do {
+                    for change in plan.changes {
+                        try await store.rename(change.item, to: change.newPath)
+                        completed += 1
+                    }
+                } catch {
+                    let prefix = completed == 0
+                        ? ""
+                        : "Renamed \(completed) of \(plan.changes.count) memories. "
+                    store.errorMessage = prefix + error.localizedDescription
+                }
+            }
+        } catch {
+            store.errorMessage = error.localizedDescription
         }
     }
 
@@ -438,7 +651,13 @@ private struct FileTreeView: View {
     @ViewBuilder
     private func fileTreeMenu(for nodeIds: Set<String>) -> some View {
         let targetItems = FileTreeNode.items(in: roots, selectedNodeIds: nodeIds)
-        let singleItem = targetItems.count == 1 ? targetItems.first : nil
+        let selectedDirectory = FileTreeNode.selectedDirectory(
+            in: roots,
+            selectedNodeIds: nodeIds
+        )
+        let singleItem = selectedDirectory == nil && targetItems.count == 1
+            ? targetItems.first
+            : nil
         let isOrgView = store.activeProjectId == nil
         let addableItems = MemoryFileTreeMenu.addable(targetItems, inOrgView: isOrgView)
         let removableItems = MemoryFileTreeMenu.removable(targetItems, inOrgView: isOrgView)
@@ -470,18 +689,50 @@ private struct FileTreeView: View {
         let reviewSelectionIsReady = !reviewDrafts.isEmpty && reviewDrafts.allSatisfy {
             $0.syncStatus == .synced && $0.serverId != nil && $0.freshness == .current
         }
-        let hasDraftAction = !isOrgView && singleItem?.draft != nil
+        let directoryDrafts = selectedDirectory == nil
+            ? []
+            : MemoryFileTreeMenu.discardableDrafts(targetItems, inOrgView: isOrgView)
+        let directoryRenameable = selectedDirectory != nil
+            && !targetItems.isEmpty
+            && targetItems.allSatisfy {
+                MemoryFileTreeMenu.canRename($0, inOrgView: isOrgView)
+                    && store.canEditMemory($0)
+            }
+        let directoryDeletionPlan = selectedDirectory.flatMap { _ in
+            MemoryFileTreeMenu.directoryDeletionPlan(targetItems, inOrgView: isOrgView)
+        }
+        let directoryDeletionAllowed = directoryDeletionPlan?.itemsToDelete.allSatisfy {
+            store.canEditMemory($0)
+        } == true
+        let hasDraftAction = !isOrgView
+            && (singleItem?.draft != nil || !directoryDrafts.isEmpty)
         let hasDomainSection = !addableItems.isEmpty || !removableItems.isEmpty
             || hasDraftAction || !reviewDrafts.isEmpty || singleStale
 
         // ---- generic document operations (standard macOS conventions) ----
-        if let singleItem {
+        if let selectedDirectory {
+            if directoryRenameable {
+                Button("Rename Folder…") { beginRenamingDirectory(selectedDirectory) }
+                    .disabled(selectionContainsSynchronizingDocument)
+            }
+            if let directoryDeletionPlan, directoryDeletionAllowed {
+                Button("Delete Folder…", role: .destructive) {
+                    pendingDirectoryDeletion = .init(
+                        name: selectedDirectory.name,
+                        plan: directoryDeletionPlan
+                    )
+                }
+                .disabled(selectionContainsSynchronizingDocument)
+            }
+        } else if let singleItem {
             Button("Open") { store.open(singleItem) }
             if singleItem.supportsMarkdownPreview {
                 Button("Open Source") { store.open(singleItem, mode: .source) }
             }
             if singleRenameable {
-                Button("Propose Organization Rename…") { beginRenaming(singleItem) }
+                Button(
+                    singleItem.resource == nil ? "Rename…" : "Propose Organization Rename…"
+                ) { beginRenaming(singleItem) }
                     .disabled(singleSynchronizing)
             }
             if singleTrashable {
@@ -537,6 +788,20 @@ private struct FileTreeView: View {
                 )
             }
             .disabled(!reviewSelectionIsReady || selectionContainsSynchronizingDocument)
+        }
+        if let selectedDirectory, !directoryDrafts.isEmpty {
+            Button(
+                directoryDrafts.count == 1
+                    ? "Discard Draft in Folder…"
+                    : "Discard \(directoryDrafts.count) Drafts in Folder…",
+                role: .destructive
+            ) {
+                pendingDirectoryDiscard = .init(
+                    name: selectedDirectory.name,
+                    drafts: directoryDrafts
+                )
+            }
+            .disabled(selectionContainsSynchronizingDocument)
         }
         if let singleItem {
             let resourceIsStale = singleItem.resource.map {
@@ -630,7 +895,51 @@ private struct FileTreeView: View {
     private func deleteItems(_ items: [MemoryListItem]) {
         Task {
             for item in items {
-                await store.delete(item)
+                guard await store.delete(item) else { return }
+            }
+        }
+    }
+
+    private func discardDrafts(_ drafts: [LocalDraft]) {
+        Task {
+            for (index, draft) in drafts.enumerated() {
+                guard await store.discard(draft) else {
+                    if index > 0 {
+                        let detail = store.errorMessage ?? "The remaining Drafts were not changed."
+                        store.errorMessage = "Discarded \(index) of \(drafts.count) Drafts. "
+                            + detail
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    private func deleteDirectory(_ plan: MemoryDirectoryDeletionPlan) {
+        Task {
+            let total = plan.itemsToDelete.count + plan.draftsToDiscard.count
+            var completed = 0
+            for item in plan.itemsToDelete {
+                guard await store.delete(item) else {
+                    if completed > 0 {
+                        let detail = store.errorMessage ?? "The remaining files were not changed."
+                        store.errorMessage = "Completed \(completed) of \(total) folder changes. "
+                            + detail
+                    }
+                    return
+                }
+                completed += 1
+            }
+            for draft in plan.draftsToDiscard {
+                guard await store.discard(draft) else {
+                    if completed > 0 {
+                        let detail = store.errorMessage ?? "The remaining files were not changed."
+                        store.errorMessage = "Completed \(completed) of \(total) folder changes. "
+                            + detail
+                    }
+                    return
+                }
+                completed += 1
             }
         }
     }
@@ -853,13 +1162,9 @@ struct FileTreeNode: Identifiable {
         var itemsById: [String: MemoryListItem] = [:]
         let pathItems = items.map { item in
             itemsById[item.id] = item
-            var components = item.document.path.split(separator: "/").map(String.init)
-            if item.kind == .workflows, components.first == "workflow", components.count > 1 {
-                components.removeFirst()
-            }
             return PathTreeItem(
                 id: item.id,
-                path: components.joined(separator: "/"),
+                path: treePath(for: item),
                 fallbackName: item.document.title
             )
         }
@@ -874,6 +1179,33 @@ struct FileTreeNode: Identifiable {
         }
 
         return PathTreeNode.build(pathItems).map(convert)
+    }
+
+    static func treePath(for item: MemoryListItem) -> String {
+        treePath(for: item.document.path, kind: item.kind)
+    }
+
+    static func treePath(for documentPath: String, kind: MemoryKind) -> String {
+        var components = documentPath.split(separator: "/").map(String.init)
+        if kind == .workflows, components.first == "workflow", components.count > 1 {
+            components.removeFirst()
+        }
+        return components.joined(separator: "/")
+    }
+
+    static func documentPath(fromTreePath path: String, for item: MemoryListItem) -> String {
+        guard item.kind == .workflows,
+              item.document.path.split(separator: "/").first == "workflow" else {
+            return path
+        }
+        return "workflow/\(path)"
+    }
+
+    static func directoryPath(from id: String) -> String? {
+        let prefix = "directory:"
+        guard id.hasPrefix(prefix) else { return nil }
+        let path = String(id.dropFirst(prefix.count))
+        return path.isEmpty ? nil : path
     }
 
     static func directoryIds(in nodes: [FileTreeNode]) -> Set<String> {
@@ -899,6 +1231,19 @@ struct FileTreeNode: Identifiable {
             }
         }
         return nil
+    }
+
+    static func selectedDirectory(
+        in nodes: [FileTreeNode],
+        selectedNodeIds: Set<String>
+    ) -> FileTreeNode? {
+        guard selectedNodeIds.count == 1,
+              let id = selectedNodeIds.first,
+              let node = node(withId: id, in: nodes),
+              node.item == nil else {
+            return nil
+        }
+        return node
     }
 
     static func items(
@@ -1803,6 +2148,40 @@ private struct ReviewRequestSheet: View {
     }
 }
 
+struct MemoryDirectoryRenameChange: Hashable, Sendable {
+    let item: MemoryListItem
+    let newPath: String
+}
+
+struct MemoryDirectoryRenamePlan: Hashable, Sendable {
+    let changes: [MemoryDirectoryRenameChange]
+}
+
+struct MemoryDirectoryDeletionPlan: Hashable, Sendable {
+    let itemsToDelete: [MemoryListItem]
+    let draftsToDiscard: [LocalDraft]
+}
+
+enum MemoryDirectoryMutationError: LocalizedError, Equatable {
+    case invalidDirectory
+    case invalidName
+    case readOnly
+    case pathCollision(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDirectory:
+            "This folder no longer contains any memory."
+        case .invalidName:
+            "Choose a different folder name without a slash."
+        case .readOnly:
+            "Every memory in the folder must be editable before the folder can be changed."
+        case .pathCollision(let path):
+            "The folder cannot be renamed because \(path) already exists."
+        }
+    }
+}
+
 /// Pure classification of file-tree context menu operations (design v2).
 ///
 /// Menu = generic document operations (standard macOS conventions) + domain
@@ -1822,18 +2201,147 @@ enum MemoryFileTreeMenu {
         }
     }
 
+    static func discardableDrafts(
+        _ items: [MemoryListItem],
+        inOrgView: Bool
+    ) -> [LocalDraft] {
+        guard !inOrgView else { return [] }
+        var seen = Set<String>()
+        return items.compactMap(\.draft).filter {
+            $0.status != .discarded
+                && $0.status != .merged
+                && seen.insert($0.id).inserted
+        }
+            .sorted {
+                $0.document.path.localizedStandardCompare($1.document.path)
+                    == .orderedAscending
+            }
+    }
+
     /// Rename is an organization-authority proposal. Project views only
     /// expose it for Org resources that are still selected by that project.
     /// The Org overview is authority-only/read-only because it has no
     /// unambiguous Project carrier for a LocalDraft.
-    /// Target-backed draft-only rows (for example, after Remove from Project)
-    /// and legacy Project authority are intentionally excluded.
+    /// Pure create Drafts keep their full local document and can be renamed;
+    /// target-backed orphan rows and legacy Project authority stay read-only.
     static func canRename(_ item: MemoryListItem, inOrgView: Bool) -> Bool {
-        guard item.resource?.scope == .org,
-              item.draft?.isDeletion != true else {
+        guard !inOrgView, item.draft?.isDeletion != true else {
             return false
         }
-        return !inOrgView && item.inherited
+        if item.resource?.scope == .org { return item.inherited }
+        return item.resource == nil
+            && item.draft?.scope == .org
+            && item.draft?.targetId == nil
+    }
+
+    static func directoryRenamePlan(
+        directoryId: String,
+        newName: String,
+        items: [MemoryListItem],
+        occupiedPaths: Set<String>,
+        occupiedTreePaths: Set<String>,
+        inOrgView: Bool
+    ) throws -> MemoryDirectoryRenamePlan {
+        let name = newName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name != ".", name != "..", !name.contains("/") else {
+            throw MemoryDirectoryMutationError.invalidName
+        }
+        guard let sourceDirectory = FileTreeNode.directoryPath(from: directoryId),
+              !items.isEmpty else {
+            throw MemoryDirectoryMutationError.invalidDirectory
+        }
+        guard items.allSatisfy({ canRename($0, inOrgView: inOrgView) }) else {
+            throw MemoryDirectoryMutationError.readOnly
+        }
+
+        let parent = sourceDirectory.split(separator: "/").dropLast().joined(separator: "/")
+        let destinationDirectory = parent.isEmpty ? name : "\(parent)/\(name)"
+        guard destinationDirectory != sourceDirectory else {
+            throw MemoryDirectoryMutationError.invalidName
+        }
+
+        let sourcePaths = Set(items.flatMap { item in
+            [item.resource?.document.path, item.draft?.document.path].compactMap { $0 }
+        }.map { $0.lowercased() })
+        let sourceTreePaths = Set(items.flatMap { item in
+            [item.resource?.document.path, item.draft?.document.path]
+                .compactMap { $0 }
+                .map { FileTreeNode.treePath(for: $0, kind: item.kind) }
+        }.map { $0.lowercased() })
+        let externalPaths = Set(occupiedPaths.map { $0.lowercased() })
+            .subtracting(sourcePaths)
+        let externalTreePaths = Set(occupiedTreePaths.map { $0.lowercased() })
+            .subtracting(sourceTreePaths)
+        var destinationPaths = Set<String>()
+        var destinationTreePaths = Set<String>()
+        var changes: [MemoryDirectoryRenameChange] = []
+
+        for item in items {
+            let treePath = FileTreeNode.treePath(for: item)
+            let sourcePrefix = sourceDirectory + "/"
+            guard treePath.hasPrefix(sourcePrefix) else {
+                throw MemoryDirectoryMutationError.invalidDirectory
+            }
+            let relativePath = String(treePath.dropFirst(sourcePrefix.count))
+            let destinationTreePath = destinationDirectory + "/" + relativePath
+            let destinationPath = FileTreeNode.documentPath(
+                fromTreePath: destinationTreePath,
+                for: item
+            )
+            let destinationRoot = FileTreeNode.documentPath(
+                fromTreePath: destinationDirectory,
+                for: item
+            )
+            let normalizedDestinationRoot = destinationRoot.lowercased()
+            let normalizedDestinationDirectory = destinationDirectory.lowercased()
+            if containsPathConflict(externalPaths, at: normalizedDestinationRoot)
+                || containsPathConflict(
+                    externalTreePaths,
+                    at: normalizedDestinationDirectory
+                )
+                || !destinationPaths.insert(destinationPath.lowercased()).inserted
+                || !destinationTreePaths.insert(destinationTreePath.lowercased()).inserted {
+                throw MemoryDirectoryMutationError.pathCollision(destinationPath)
+            }
+            changes.append(.init(item: item, newPath: destinationPath))
+        }
+
+        return .init(changes: changes.sorted {
+            $0.item.document.path.localizedStandardCompare($1.item.document.path)
+                == .orderedAscending
+        })
+    }
+
+    private static func containsPathConflict(_ paths: Set<String>, at root: String) -> Bool {
+        let prefix = root + "/"
+        return paths.contains {
+            $0 == root || $0.hasPrefix(prefix) || root.hasPrefix($0 + "/")
+        }
+    }
+
+    static func directoryDeletionPlan(
+        _ items: [MemoryListItem],
+        inOrgView: Bool
+    ) -> MemoryDirectoryDeletionPlan? {
+        guard !inOrgView, !items.isEmpty else { return nil }
+        var itemsToDelete: [MemoryListItem] = []
+        var draftsToDiscard: [LocalDraft] = []
+        for item in items {
+            if canProposeOrganizationDeletion(item, inOrgView: inOrgView) {
+                itemsToDelete.append(item)
+            } else if item.resource == nil, let draft = item.draft {
+                draftsToDiscard.append(draft)
+            } else if item.draft?.isDeletion == true {
+                continue
+            } else {
+                return nil
+            }
+        }
+        guard !itemsToDelete.isEmpty || !draftsToDiscard.isEmpty else { return nil }
+        return .init(
+            itemsToDelete: itemsToDelete,
+            draftsToDiscard: draftsToDiscard
+        )
     }
 
     /// New memories are Project-bound proposals for Org authority. The Org

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -78,6 +78,27 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(selected.map(\.id), ["a", "b"])
     }
 
+    func testSingleFileDirectoryKeepsDirectoryIdentity() throws {
+        let roots = FileTreeNode.build([
+            memoryItem(id: "only", path: "notes/only.md"),
+        ])
+
+        let directory = try XCTUnwrap(FileTreeNode.selectedDirectory(
+            in: roots,
+            selectedNodeIds: ["directory:notes"]
+        ))
+
+        XCTAssertEqual(directory.id, "directory:notes")
+        XCTAssertNil(directory.item)
+        XCTAssertEqual(
+            FileTreeNode.items(
+                in: roots,
+                selectedNodeIds: [directory.id]
+            ).map(\.id),
+            ["only"]
+        )
+    }
+
     func testFileSelectionDoesNotIncludeSiblingFiles() {
         let items = [
             memoryItem(id: "a", path: "design/a.md"),

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -7,7 +7,9 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         scope: MemoryScope,
         inherited: Bool,
         projectId: String? = nil,
-        draft: LocalDraft? = nil
+        draft: LocalDraft? = nil,
+        path: String? = nil,
+        kind: MemoryKind = .context
     ) -> MemoryListItem {
         MemoryListItem(
             id: id,
@@ -16,12 +18,16 @@ final class MemoryFileTreeMenuTests: XCTestCase {
                 scope: scope,
                 projectId: projectId,
                 projectName: nil,
-                kind: .context,
+                kind: kind,
                 contentHash: "hash-\(id)",
                 updatedAt: "2026-01-01T00:00:00Z",
                 refCommitId: nil,
                 contentLoaded: false,
-                document: EditableMemoryDocument(title: id, path: "\(id).md", body: "")
+                document: EditableMemoryDocument(
+                    title: id,
+                    path: path ?? "\(id).md",
+                    body: ""
+                )
             ),
             draft: draft,
             inherited: inherited
@@ -33,7 +39,9 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         scope: MemoryScope,
         targetId: String? = nil,
         isDeletion: Bool = false,
-        status: DaemonLocalDraftStatus = .open
+        status: DaemonLocalDraftStatus = .open,
+        path: String? = nil,
+        kind: MemoryKind = .context
     ) -> LocalDraft {
         LocalDraft(
             id: id,
@@ -47,13 +55,17 @@ final class MemoryFileTreeMenuTests: XCTestCase {
             reconciliation: .clean,
             reconciliationCandidateId: nil,
             scope: scope,
-            kind: .context,
+            kind: kind,
             targetId: targetId,
             status: status,
             origin: .desktop,
             syncStatus: .queued,
             updatedAt: "2026-01-01T00:00:00Z",
-            document: EditableMemoryDocument(title: id, path: "\(id).md", body: ""),
+            document: EditableMemoryDocument(
+                title: id,
+                path: path ?? "\(id).md",
+                body: ""
+            ),
             isDeletion: isDeletion
         )
     }
@@ -62,12 +74,21 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         _ id: String,
         scope: MemoryScope,
         targetId: String? = nil,
-        isDeletion: Bool = false
+        isDeletion: Bool = false,
+        path: String? = nil,
+        kind: MemoryKind = .context
     ) -> MemoryListItem {
         MemoryListItem(
             id: targetId ?? id,
             resource: nil,
-            draft: localDraft(id, scope: scope, targetId: targetId, isDeletion: isDeletion),
+            draft: localDraft(
+                id,
+                scope: scope,
+                targetId: targetId,
+                isDeletion: isDeletion,
+                path: path,
+                kind: kind
+            ),
             inherited: false
         )
     }
@@ -146,6 +167,13 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertEqual(MemoryFileTreeMenu.creationScope(inOrgView: false), .org)
     }
 
+    func testProjectViewCanRenamePureCreateDraft() {
+        let item = draftItem("draft", scope: .org, path: "notes/new.md")
+
+        XCTAssertTrue(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: true))
+    }
+
     func testDirectoryReviewIncludesOnlyOpenOrganizationDraftsInProjectView() {
         let openOrg = resourceItem(
             "org-open",
@@ -176,6 +204,225 @@ final class MemoryFileTreeMenuTests: XCTestCase {
         XCTAssertTrue(
             MemoryFileTreeMenu.reviewableDrafts([openOrg], inOrgView: true).isEmpty
         )
+    }
+
+    func testDirectoryDiscardIncludesEveryProjectCarriedDraftOnce() {
+        let open = draftItem("open", scope: .org, path: "notes/open.md")
+        let submitted = resourceItem(
+            "shared",
+            scope: .org,
+            inherited: true,
+            draft: localDraft(
+                "submitted",
+                scope: .org,
+                targetId: "shared",
+                status: .submitted,
+                path: "notes/shared.md"
+            ),
+            path: "notes/shared.md"
+        )
+
+        XCTAssertEqual(
+            MemoryFileTreeMenu.discardableDrafts(
+                [open, submitted, submitted],
+                inOrgView: false
+            ).map(\.id),
+            ["open", "submitted"]
+        )
+        XCTAssertTrue(
+            MemoryFileTreeMenu.discardableDrafts([open], inOrgView: true).isEmpty
+        )
+    }
+
+    func testDirectoryRenamePreservesNestedPathsAndWorkflowNamespace() throws {
+        let context = resourceItem(
+            "context",
+            scope: .org,
+            inherited: true,
+            path: "guides/nested/context.md"
+        )
+        let workflow = resourceItem(
+            "workflow",
+            scope: .org,
+            inherited: true,
+            path: "workflow/guides/run.md",
+            kind: .workflows
+        )
+
+        let plan = try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:guides",
+            newName: "handbook",
+            items: [context, workflow],
+            occupiedPaths: [context.document.path, workflow.document.path],
+            occupiedTreePaths: ["guides/nested/context.md", "guides/run.md"],
+            inOrgView: false
+        )
+
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: plan.changes.map { ($0.item.id, $0.newPath) }),
+            [
+                "context": "handbook/nested/context.md",
+                "workflow": "workflow/handbook/run.md",
+            ]
+        )
+    }
+
+    func testDirectoryRenameRejectsExistingDestinationDirectory() {
+        let source = resourceItem(
+            "source",
+            scope: .org,
+            inherited: true,
+            path: "guides/source.md"
+        )
+
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:guides",
+            newName: "existing",
+            items: [source],
+            occupiedPaths: [source.document.path, "existing/other.md"],
+            occupiedTreePaths: [source.document.path, "existing/other.md"],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(
+                error as? MemoryDirectoryMutationError,
+                .pathCollision("existing/source.md")
+            )
+        }
+    }
+
+    func testDirectoryRenameRejectsFileAtDestinationDirectory() {
+        let source = resourceItem(
+            "source",
+            scope: .org,
+            inherited: true,
+            path: "guides/source.md"
+        )
+
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:guides",
+            newName: "handbook",
+            items: [source],
+            occupiedPaths: [source.document.path, "handbook"],
+            occupiedTreePaths: [source.document.path, "handbook"],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(
+                error as? MemoryDirectoryMutationError,
+                .pathCollision("handbook/source.md")
+            )
+        }
+    }
+
+    func testDirectoryRenameRejectsFileAboveDestinationDirectory() {
+        let source = resourceItem(
+            "source",
+            scope: .org,
+            inherited: true,
+            path: "parent/guides/source.md"
+        )
+
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:parent/guides",
+            newName: "handbook",
+            items: [source],
+            occupiedPaths: [source.document.path, "parent"],
+            occupiedTreePaths: [source.document.path, "parent"],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(
+                error as? MemoryDirectoryMutationError,
+                .pathCollision("parent/handbook/source.md")
+            )
+        }
+    }
+
+    func testDirectoryRenameRejectsCaseInsensitiveDestinationCollision() {
+        let source = resourceItem(
+            "source",
+            scope: .org,
+            inherited: true,
+            path: "guides/source.md"
+        )
+
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:guides",
+            newName: "handbook",
+            items: [source],
+            occupiedPaths: [source.document.path, "HandBook/other.md"],
+            occupiedTreePaths: [source.document.path, "HandBook/other.md"],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(
+                error as? MemoryDirectoryMutationError,
+                .pathCollision("handbook/source.md")
+            )
+        }
+    }
+
+    func testDirectoryRenameRejectsHiddenWorkflowTreeCollision() {
+        let source = resourceItem(
+            "source",
+            scope: .org,
+            inherited: true,
+            path: "guides/source.md"
+        )
+
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:guides",
+            newName: "handbook",
+            items: [source],
+            occupiedPaths: [source.document.path, "workflow/handbook/other.md"],
+            occupiedTreePaths: [source.document.path, "handbook/other.md"],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(
+                error as? MemoryDirectoryMutationError,
+                .pathCollision("handbook/source.md")
+            )
+        }
+    }
+
+    func testDirectoryDeletionCombinesSharedDeletionAndPureDraftDiscard() throws {
+        let shared = resourceItem(
+            "shared",
+            scope: .org,
+            inherited: true,
+            path: "notes/shared.md"
+        )
+        let draft = draftItem("draft", scope: .org, path: "notes/new.md")
+        let plan = try XCTUnwrap(
+            MemoryFileTreeMenu.directoryDeletionPlan(
+                [shared, draft],
+                inOrgView: false
+            )
+        )
+
+        XCTAssertEqual(plan.itemsToDelete.map(\.id), ["shared"])
+        XCTAssertEqual(plan.draftsToDiscard.map(\.id), ["draft"])
+    }
+
+    func testDirectoryMutationRejectsLegacyProjectAuthority() {
+        let legacy = resourceItem(
+            "legacy",
+            scope: .project,
+            inherited: false,
+            projectId: "p1",
+            path: "notes/legacy.md"
+        )
+
+        XCTAssertNil(
+            MemoryFileTreeMenu.directoryDeletionPlan([legacy], inOrgView: false)
+        )
+        XCTAssertThrowsError(try MemoryFileTreeMenu.directoryRenamePlan(
+            directoryId: "directory:notes",
+            newName: "renamed",
+            items: [legacy],
+            occupiedPaths: [legacy.document.path],
+            occupiedTreePaths: [legacy.document.path],
+            inOrgView: false
+        )) { error in
+            XCTAssertEqual(error as? MemoryDirectoryMutationError, .readOnly)
+        }
     }
 
     func testSelectedOrgAuthorityOffersExplicitMutationActionsInProjectView() {

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -1177,8 +1177,8 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertEqual(retargeted.body, "unsaved body")
     }
 
-    func testPureCreateDraftDoesNotOfferATargetBackedRename() {
-        let draft = localDraft(id: "draft", targetId: nil)
+    func testPureCreateDraftRenameUsesItsProvisionalDraftId() throws {
+        let draft = localDraft(id: "draft", targetId: nil, scope: .org)
         let item = MemoryListItem(
             id: draft.id,
             resource: nil,
@@ -1186,12 +1186,14 @@ final class WorkspaceNavigationTests: XCTestCase {
             inherited: false
         )
 
-        XCTAssertNil(WorkspaceStore.documentRenamePlan(
+        let plan = try XCTUnwrap(WorkspaceStore.documentRenamePlan(
             for: item,
             currentDraft: draft,
             newPath: "renamed.md"
         ))
-        XCTAssertFalse(MemoryFileTreeMenu.canRename(item, inOrgView: false))
+        XCTAssertEqual(plan.targetId, draft.id)
+        XCTAssertEqual(plan.newPath, "renamed.md")
+        XCTAssertTrue(MemoryFileTreeMenu.canRename(item, inOrgView: false))
     }
 
     func testDraftUploadBarrierRequiresASettledServerDraft() {

--- a/crates/daemon/src/search/mod.rs
+++ b/crates/daemon/src/search/mod.rs
@@ -2660,6 +2660,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pure_create_draft_path_only_rename_preserves_content_and_description() {
+        let (_temp, state) = test_state().await;
+        let service = DaemonIpcService::new(state.clone());
+        let original_content = DaemonDraftContent {
+            description: Some("Keep this semantic description.".to_owned()),
+            content: "# New Memory\n\nOriginal body.".to_owned(),
+        };
+        let created = service
+            .store_draft_operation(DaemonDraftOperationRequest {
+                draft_id: None,
+                base_commit_id: None,
+                project_id: "prj_test".to_owned(),
+                scope: crate::DaemonDraftScope::Org,
+                resource: crate::DaemonDraftResourceKind::Memory,
+                op: DaemonDraftOperation {
+                    create: Some(DaemonCreateDraftOperation {
+                        path: "guides/original.md".to_owned(),
+                        content: original_content.clone(),
+                        description: None,
+                    }),
+                    update: None,
+                    rename: None,
+                    delete: None,
+                    discard: None,
+                },
+                source: Some(DaemonDraftOperationSource::Desktop),
+            })
+            .await
+            .unwrap();
+
+        let renamed = service
+            .store_draft_operation(DaemonDraftOperationRequest {
+                draft_id: Some(created.draft_id.clone()),
+                base_commit_id: None,
+                project_id: "prj_test".to_owned(),
+                scope: crate::DaemonDraftScope::Org,
+                resource: crate::DaemonDraftResourceKind::Memory,
+                op: DaemonDraftOperation {
+                    create: None,
+                    update: None,
+                    rename: Some(DaemonRenameDraftOperation {
+                        id: created.draft_id.clone(),
+                        new_path: "guides/renamed.md".to_owned(),
+                        description: None,
+                    }),
+                    delete: None,
+                    discard: None,
+                },
+                source: Some(DaemonDraftOperationSource::Desktop),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(renamed.draft_id, created.draft_id);
+        let detail = service.get_draft(&created.draft_id).await.unwrap();
+        assert_eq!(detail.operations.len(), 2);
+        assert_eq!(
+            detail.operations[0]
+                .operation
+                .create
+                .as_ref()
+                .unwrap()
+                .content,
+            original_content
+        );
+
+        let effective = load_effective_memory(&state, "prj_test").await.unwrap();
+        let loaded = effective
+            .resources
+            .iter()
+            .find(|resource| resource.resource_id == created.draft_id)
+            .unwrap();
+        assert_eq!(loaded.path, "guides/renamed.md");
+        assert_eq!(loaded.description, "Keep this semantic description.");
+        assert_eq!(loaded.content, "# New Memory\n\nOriginal body.");
+    }
+
+    #[tokio::test]
     async fn mcp_text_update_of_org_resource_resolves_its_real_scope() {
         let (_temp, state) = test_state().await;
         sqlx::query(
@@ -2965,12 +3043,12 @@ mod tests {
     }
 
     #[test]
-    fn remote_create_draft_uses_the_provisional_resource_id_from_later_operations() {
+    fn remote_create_draft_accepts_the_server_draft_id_as_a_provisional_alias() {
         let create = DaemonDraftOperation {
             create: Some(DaemonCreateDraftOperation {
                 path: "context/new.md".to_owned(),
                 content: DaemonDraftContent {
-                    description: None,
+                    description: Some("Semantic metadata".to_owned()),
                     content: "# Initial".to_owned(),
                 },
                 description: None,
@@ -2996,6 +3074,17 @@ mod tests {
             delete: None,
             discard: None,
         };
+        let rename = DaemonDraftOperation {
+            create: None,
+            update: None,
+            rename: Some(DaemonRenameDraftOperation {
+                id: "drf_server".to_owned(),
+                new_path: "context/renamed.md".to_owned(),
+                description: None,
+            }),
+            delete: None,
+            discard: None,
+        };
         let overlay = super::overlay::DraftOverlay {
             draft_id: "drf_server".to_owned(),
             base_commit_id: Some("commit_base".to_owned()),
@@ -3007,6 +3096,7 @@ mod tests {
             operations: vec![
                 (1, serde_json::to_string(&create).unwrap(), create),
                 (2, serde_json::to_string(&update).unwrap(), update),
+                (3, serde_json::to_string(&rename).unwrap(), rename),
             ],
         };
 
@@ -3014,6 +3104,14 @@ mod tests {
         super::overlay::apply_draft_overlay("prj_test", &mut resources, overlay).unwrap();
 
         assert_eq!(resources["draft_provisional"].source.content, "# Updated");
+        assert_eq!(
+            resources["draft_provisional"].source.description,
+            "Semantic metadata"
+        );
+        assert_eq!(
+            resources["draft_provisional"].source.path,
+            "context/renamed.md"
+        );
         assert_eq!(
             resources["draft_provisional"].source.draft_id.as_deref(),
             Some("drf_server")

--- a/crates/daemon/src/search/overlay.rs
+++ b/crates/daemon/src/search/overlay.rs
@@ -258,6 +258,10 @@ pub(super) fn apply_draft_overlay(
         .iter()
         .find_map(|(_, _, operation)| operation.target_id().map(ToOwned::to_owned))
         .unwrap_or_else(|| draft.draft_id.clone());
+    let creates_resource = draft
+        .operations
+        .first()
+        .is_some_and(|(_, _, operation)| operation.create.is_some());
     let mut draft_resources = BTreeMap::new();
     if let Some(base_resource) = draft.base_resource {
         draft_resources.insert(target_key.clone(), base_resource);
@@ -287,7 +291,12 @@ pub(super) fn apply_draft_overlay(
                 ))
                 .into());
             };
-            let existing = draft_resources.remove(&update.id).ok_or_else(|| {
+            let target_id = if creates_resource && update.id == draft.draft_id {
+                &created_resource_id
+            } else {
+                &update.id
+            };
+            let existing = draft_resources.remove(target_id).ok_or_else(|| {
                 SearchFailure::failed(format!(
                     "Draft {} update target {} is absent from its Base Commit",
                     draft.draft_id, update.id
@@ -305,10 +314,15 @@ pub(super) fn apply_draft_overlay(
                 &draft.draft_id,
                 &draft_revision,
             )?;
-            draft_resources.insert(update.id.clone(), updated);
+            draft_resources.insert(target_id.clone(), updated);
         }
         if let Some(rename) = &operation.rename
-            && let Some(resource) = draft_resources.get_mut(&rename.id)
+            && let Some(resource) =
+                draft_resources.get_mut(if creates_resource && rename.id == draft.draft_id {
+                    &created_resource_id
+                } else {
+                    &rename.id
+                })
         {
             resource.source.path = rename.new_path.clone();
             if markdown_title(&resource.source.content).is_none() {
@@ -318,7 +332,11 @@ pub(super) fn apply_draft_overlay(
             resource.source.draft_revision = Some(draft_revision.clone());
         }
         if let Some(delete) = &operation.delete {
-            draft_resources.remove(&delete.id);
+            draft_resources.remove(if creates_resource && delete.id == draft.draft_id {
+                &created_resource_id
+            } else {
+                &delete.id
+            });
         }
     }
     if let Some(target_id) = draft.target_id.as_ref() {


### PR DESCRIPTION
## Summary

- restore file rename for pure create Drafts and Organization Memory proposals
- add folder rename, discard-all-Drafts, and delete-folder actions to Project Memory
- preserve relative paths while enforcing server-equivalent case and file/directory collision rules
- keep pure Draft rename path-only so body and semantic description remain unchanged
- resolve remote `drf_*` identities as aliases of their provisional created resources

## Why

Directory selections were flattened into descendant files before the menu classified the target. Multi-file folders therefore lost folder actions, while single-file folders were misclassified as files. Folder rename and discard-all were also never implemented end to end.

## Safety

- Organization authority still changes only through Project-carried Draft review and merge
- destructive folder actions require confirmation
- batch mutations stop on first failure and report partial completion
- legacy Project authority remains read-only; existing legacy Drafts can still be discarded

## Verification

- `bun run test:macos`
- `cargo test -p daemon`
- `cargo fmt --all -- --check`
- `git diff --check`
