### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report a reproducible defect in Clumsies
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Clumsies. Do not disclose security vulnerabilities in a public issue. Remove credentials, tokens, private Memory, and personal data from every field and attachment.
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      description: How severely does this affect normal use?
+      options:
+        - Blocker — data loss or no usable workaround
+        - High — core workflow is unavailable
+        - Medium — workflow is degraded but has a workaround
+        - Low — minor or cosmetic problem
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: App version, release tag, or commit SHA where the issue occurs
+      placeholder: v1.2.3 or abc1234
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, installation method, and relevant server or daemon details
+      placeholder: macOS 15.6, Apple Silicon, release build, self-hosted server
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest deterministic sequence that reproduces the problem
+      placeholder: |
+        1. Open ...
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include exact error text when useful
+    validations:
+      required: true
+
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Regression
+      description: Did this work in an earlier version?
+      options:
+        - "Yes"
+        - "No"
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Logs or evidence
+      description: Add sanitized logs, screenshots, traces, or a minimal repository if available
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I removed secrets, credentials, private Memory, and personal data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Propose a product or engineering improvement
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with the problem and desired outcome. A solution is useful, but not required.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Who is affected, what are they trying to do, and what prevents them today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable success without prescribing an implementation
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Optional interaction, API, or architecture proposal
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing workarounds or simpler options you evaluated
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List the smallest verifiable conditions that make this request complete
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and dependencies
+      description: Compatibility, migration, privacy, security, performance, or rollout concerns
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This request describes a concrete user or engineering problem.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Summary
+
+<!-- What changed, and why is this the smallest complete change? -->
+
+<!-- Use "Closes #123" when this PR should close an issue. -->
+
+## Change type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor or maintenance
+- [ ] Documentation
+
+## Verification
+
+<!-- List exact commands, automated checks, and manual evidence. -->
+
+## Risk and rollout
+
+<!-- Name compatibility, migration, security, privacy, or performance risks. Write "None" when not applicable. -->
+
+- Risk:
+- Rollback:
+
+## Checklist
+
+- [ ] The PR has one clear purpose and no unrelated changes.
+- [ ] Tests cover behavior changes and pass locally or in CI.
+- [ ] User-facing behavior and operational docs are updated when needed.
+- [ ] Migrations and breaking changes include compatibility and rollback plans.
+- [ ] No credentials, private data, unintended generated/build artifacts, or debug output are included.


### PR DESCRIPTION
## Summary

- add structured GitHub Issue Forms for reproducible bugs and outcome-focused feature requests
- disable blank public issues so reports consistently include actionable context
- add one default PR template covering purpose, verification, risk, rollback, compatibility, and data hygiene

## Why

The repository currently has no native prompts for issue authors or pull request contributors. These templates make the minimum review context explicit without adding bots, dependencies, or CI maintenance.

Security vulnerabilities are explicitly excluded from the public bug form. This PR does not advertise the repository's Security Advisory URL because private vulnerability reporting is not currently enabled; enabling and documenting a private reporting channel should be a separate repository-policy decision.

## Verification

- parsed every Issue Form YAML file with Ruby Psych
- `git diff origin/main...HEAD --check`
- independently reviewed the forms for GitHub schema compatibility and repository fit
