### PR TITLE
fix(memory): paginate local draft inventory

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -4920,14 +4920,18 @@ final class WorkspaceStore: ObservableObject {
         guard workspaceReloadGeneration == generation,
               phase == .ready,
               !Task.isCancelled,
-              let page = try? await daemon.listDrafts(.init(limit: 500)) else {
+              let inventory = try? await WorkspaceLoader.listAllDraftSummaries(
+                  listDrafts: { query in
+                      try await self.daemon.listDrafts(query)
+                  }
+              ) else {
             return
         }
         guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
             return
         }
         let plan = Self.draftInventoryPlan(
-            summaries: page.items,
+            summaries: inventory,
             currentDrafts: drafts,
             includeFailed: includeFailed
         )
@@ -4950,7 +4954,7 @@ final class WorkspaceStore: ObservableObject {
             draftInventoryLoadState = .loaded
             return
         }
-        let summaries = page.items.filter { refreshIds.contains($0.draftId) }
+        let summaries = inventory.filter { refreshIds.contains($0.draftId) }
         let originalById = Dictionary(
             drafts.filter { refreshIds.contains($0.id) }.map { ($0.id, $0) },
             uniquingKeysWith: { _, latest in latest }
@@ -5280,6 +5284,26 @@ struct WorkspaceLoader: Sendable {
         )
     }
 
+    static func listAllDraftSummaries(
+        listDrafts: @escaping @Sendable (DaemonDraftListQuery) async throws -> DaemonDraftListResponse
+    ) async throws -> [DaemonDraftSummary] {
+        var items: [DaemonDraftSummary] = []
+        var cursor: String?
+
+        while true {
+            let page = try await listDrafts(.init(cursor: cursor, limit: 500))
+            try Task.checkCancellation()
+            items.append(contentsOf: page.items)
+            guard let nextCursor = page.nextCursor else {
+                return items
+            }
+            guard !page.items.isEmpty, nextCursor != cursor else {
+                throw DaemonXPCError.invalidReply
+            }
+            cursor = nextCursor
+        }
+    }
+
     func loadDeferredDrafts(
         resources: [MemoryResource],
         accessibleProjectIds: Set<String>
@@ -5291,8 +5315,8 @@ struct WorkspaceLoader: Sendable {
         try await Self.loadDeferredDrafts(
             resources: resources,
             accessibleProjectIds: accessibleProjectIds,
-            listDrafts: {
-                try await daemon.listDrafts(.init(limit: 500))
+            listDrafts: { query in
+                try await daemon.listDrafts(query)
             },
             loadDraft: { draftId in
                 try await daemon.draft(draftId)
@@ -5309,7 +5333,7 @@ struct WorkspaceLoader: Sendable {
     static func loadDeferredDrafts(
         resources: [MemoryResource],
         accessibleProjectIds: Set<String>,
-        listDrafts: @escaping @Sendable () async throws -> DaemonDraftListResponse,
+        listDrafts: @escaping @Sendable (DaemonDraftListQuery) async throws -> DaemonDraftListResponse,
         loadDraft: @escaping @Sendable (String) async throws -> DaemonDraftDetail,
         loadContent: @escaping @Sendable (MemoryResource) async throws
             -> (resource: MemoryResource, hasStaleServerResponse: Bool)
@@ -5318,9 +5342,9 @@ struct WorkspaceLoader: Sendable {
         drafts: [LocalDraft],
         hasStaleServerResponse: Bool
     ) {
-        let draftPage = try await listDrafts()
+        let draftSummaries = try await listAllDraftSummaries(listDrafts: listDrafts)
         try Task.checkCancellation()
-        let activeDrafts = draftPage.items.filter {
+        let activeDrafts = draftSummaries.filter {
             $0.status != .discarded
                 && $0.status != .merged
                 && accessibleProjectIds.contains($0.projectId)

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -350,13 +350,13 @@ struct DaemonServerResponse: Codable, Sendable {
 }
 
 struct DaemonDraftListQuery: Codable, Sendable {
-    let projectId: String?
+    let resource: String?
     let status: String?
     let cursor: String?
     let limit: Int?
 
-    init(projectId: String? = nil, status: String? = nil, cursor: String? = nil, limit: Int? = nil) {
-        self.projectId = projectId
+    init(resource: String? = nil, status: String? = nil, cursor: String? = nil, limit: Int? = nil) {
+        self.resource = resource
         self.status = status
         self.cursor = cursor
         self.limit = limit
@@ -365,6 +365,12 @@ struct DaemonDraftListQuery: Codable, Sendable {
 
 struct DaemonDraftListResponse: Codable, Sendable {
     let items: [DaemonDraftSummary]
+    let nextCursor: String?
+
+    init(items: [DaemonDraftSummary], nextCursor: String? = nil) {
+        self.items = items
+        self.nextCursor = nextCursor
+    }
 }
 
 struct DaemonDraftDetailRequest: Codable, Sendable {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -403,7 +403,7 @@ final class DaemonContractTests: XCTestCase {
         let loaded = try await WorkspaceLoader.loadDeferredDrafts(
             resources: [],
             accessibleProjectIds: ["project-1"],
-            listDrafts: {
+            listDrafts: { _ in
                 .init(items: summaries)
             },
             loadDraft: { draftId in
@@ -423,6 +423,52 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertFalse(loaded.hasStaleServerResponse)
     }
 
+    func testDeferredDraftLoadPaginatesPastTerminalHistory() async throws {
+        let terminal = (0..<500).map { index in
+            inventorySummary(
+                id: "terminal-\(index)",
+                status: index.isMultiple(of: 2) ? .discarded : .merged,
+                updatedAt: "2026-08-26T12:00:00Z"
+            )
+        }
+        let active = [
+            inventorySummary(id: "older-open", updatedAt: "2026-08-25T12:00:00Z"),
+            inventorySummary(
+                id: "older-submitted",
+                status: .submitted,
+                updatedAt: "2026-08-25T11:00:00Z"
+            ),
+        ]
+
+        let loaded = try await WorkspaceLoader.loadDeferredDrafts(
+            resources: [],
+            accessibleProjectIds: ["project-1"],
+            listDrafts: { query in
+                XCTAssertEqual(query.limit, 500)
+                switch query.cursor {
+                case nil:
+                    return .init(items: terminal, nextCursor: "page-2")
+                case "page-2":
+                    return .init(items: active)
+                default:
+                    throw DaemonContractTestError.unexpectedServerRequest
+                }
+            },
+            loadDraft: { draftId in
+                guard let summary = active.first(where: { $0.draftId == draftId }) else {
+                    throw DaemonContractTestError.unexpectedServerRequest
+                }
+                return .init(draft: summary, operations: [])
+            },
+            loadContent: { resource in
+                XCTFail("A create Draft must not load a shared baseline.")
+                return (resource, false)
+            }
+        )
+
+        XCTAssertEqual(Set(loaded.drafts.map(\.id)), Set(active.map(\.draftId)))
+    }
+
     func testDeferredDraftLoadCarriesBaselineFreshness() async throws {
         var baseline = resource(id: "memory-1", kind: .rules, path: "rules/shared.md")
         baseline.contentLoaded = false
@@ -435,7 +481,7 @@ final class DaemonContractTests: XCTestCase {
         let loaded = try await WorkspaceLoader.loadDeferredDrafts(
             resources: [baseline],
             accessibleProjectIds: ["project-1"],
-            listDrafts: {
+            listDrafts: { _ in
                 .init(items: [summary])
             },
             loadDraft: { draftId in

--- a/crates/daemon/src/draft.rs
+++ b/crates/daemon/src/draft.rs
@@ -1,5 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Row, SqlitePool};
@@ -25,6 +28,13 @@ use crate::types::{
 use crate::{commit_sync, delete_server_json, get_server_json, load_meta_value, post_server_json};
 
 const MAX_CONCURRENT_DRAFT_PROJECTION_REQUESTS: usize = 8;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct DraftListCursor {
+    updated_at: String,
+    created_at: String,
+    draft_id: String,
+}
 
 pub(crate) struct LocalDraftResolutionInput<'a> {
     pub(crate) requested_draft_id: Option<&'a str>,
@@ -244,6 +254,11 @@ pub(crate) async fn list_local_drafts(
         .transpose()?
         .map(ToOwned::to_owned);
     let limit = query.limit.unwrap_or(100).clamp(1, 500);
+    let cursor = query
+        .cursor
+        .as_deref()
+        .map(decode_draft_list_cursor)
+        .transpose()?;
     let rows = sqlx::query(
         "SELECT
             d.draft_id, d.project_id, d.server_draft_id, d.server_version, d.base_commit_id,
@@ -264,20 +279,57 @@ pub(crate) async fn list_local_drafts(
          FROM local_drafts d
          WHERE ($1 IS NULL OR d.resource_kind = $1)
            AND ($2 IS NULL OR d.status = $2)
+           AND (
+                $3 IS NULL
+                OR d.updated_at < $3
+                OR (d.updated_at = $3 AND d.created_at < $4)
+                OR (d.updated_at = $3 AND d.created_at = $4 AND d.draft_id > $5)
+           )
          ORDER BY d.updated_at DESC, d.created_at DESC, d.draft_id ASC
-         LIMIT $3",
+         LIMIT $6",
     )
     .bind(resource_kind.as_deref())
     .bind(status.as_deref())
-    .bind(limit)
+    .bind(cursor.as_ref().map(|cursor| cursor.updated_at.as_str()))
+    .bind(cursor.as_ref().map(|cursor| cursor.created_at.as_str()))
+    .bind(cursor.as_ref().map(|cursor| cursor.draft_id.as_str()))
+    .bind(limit + 1)
     .fetch_all(pool)
     .await?;
 
+    let has_more = rows.len() as i64 > limit;
     let items = rows
         .iter()
+        .take(limit as usize)
         .map(local_draft_summary_from_row)
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(DaemonDraftListResponse { items })
+    let next_cursor = if has_more {
+        items
+            .last()
+            .map(|draft| {
+                encode_draft_list_cursor(&DraftListCursor {
+                    updated_at: draft.updated_at.clone(),
+                    created_at: draft.created_at.clone(),
+                    draft_id: draft.draft_id.clone(),
+                })
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    Ok(DaemonDraftListResponse { items, next_cursor })
+}
+
+fn encode_draft_list_cursor(cursor: &DraftListCursor) -> Result<String, DaemonError> {
+    Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(cursor)?))
+}
+
+fn decode_draft_list_cursor(cursor: &str) -> Result<DraftListCursor, DaemonError> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| DaemonError::InvalidRequest("Invalid Draft list cursor".to_owned()))?;
+    serde_json::from_slice(&decoded)
+        .map_err(|_| DaemonError::InvalidRequest("Invalid Draft list cursor".to_owned()))
 }
 
 pub(crate) async fn load_local_draft_detail(

--- a/crates/daemon/src/types.rs
+++ b/crates/daemon/src/types.rs
@@ -371,12 +371,14 @@ pub struct McpAdapterStatus {
 pub struct DaemonDraftListQuery {
     pub resource: Option<String>,
     pub status: Option<String>,
+    pub cursor: Option<String>,
     pub limit: Option<i64>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonDraftListResponse {
     pub items: Vec<DaemonDraftSummary>,
+    pub next_cursor: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -2890,6 +2890,7 @@ async fn local_drafts_can_be_listed_and_read_with_operation_history() {
             resource: Some("memory".to_owned()),
             status: Some("open".to_owned()),
             limit: None,
+            cursor: None,
         })
         .await
         .unwrap();
@@ -2941,6 +2942,109 @@ async fn local_drafts_can_be_listed_and_read_with_operation_history() {
     assert!(matches!(
         service.get_draft("missing").await,
         Err(DaemonError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn local_draft_inventory_paginates_past_terminal_history() {
+    let (_root, state, service) = common::test_daemon().await;
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    sqlx::query(
+        "WITH RECURSIVE sequence(value) AS (
+            VALUES(0)
+            UNION ALL
+            SELECT value + 1 FROM sequence WHERE value < 501
+         )
+         INSERT INTO local_drafts (
+            draft_id, project_id, resource_scope, resource_kind, status, created_at, updated_at
+         )
+         SELECT
+            printf('draft-%03d', value),
+            'prj_test',
+            'org',
+            'memory',
+            CASE
+                WHEN value < 500 AND value % 2 = 0 THEN 'discarded'
+                WHEN value < 500 THEN 'merged'
+                WHEN value = 500 THEN 'open'
+                ELSE 'submitted'
+            END,
+            CASE
+                WHEN value < 500 THEN '2026-08-26T12:00:00Z'
+                ELSE '2026-08-25T12:00:00Z'
+            END,
+            CASE
+                WHEN value < 500 THEN '2026-08-26T12:00:00Z'
+                ELSE '2026-08-25T12:00:00Z'
+            END
+         FROM sequence",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let first = service
+        .list_drafts(DaemonDraftListQuery {
+            resource: None,
+            status: None,
+            cursor: None,
+            limit: Some(500),
+        })
+        .await
+        .unwrap();
+    assert_eq!(first.items.len(), 500);
+    assert!(first.items.iter().all(|draft| matches!(
+        draft.status,
+        DaemonLocalDraftStatus::Discarded | DaemonLocalDraftStatus::Merged
+    )));
+    let cursor = first
+        .next_cursor
+        .expect("the full first page must expose a cursor");
+
+    let second = service
+        .list_drafts(DaemonDraftListQuery {
+            resource: None,
+            status: None,
+            cursor: Some(cursor),
+            limit: Some(500),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        second
+            .items
+            .iter()
+            .map(|draft| draft.draft_id.as_str())
+            .collect::<Vec<_>>(),
+        ["draft-500", "draft-501"]
+    );
+    assert_eq!(
+        second
+            .items
+            .iter()
+            .map(|draft| draft.status)
+            .collect::<Vec<_>>(),
+        [
+            DaemonLocalDraftStatus::Open,
+            DaemonLocalDraftStatus::Submitted
+        ]
+    );
+    assert!(second.next_cursor.is_none());
+
+    let invalid = service
+        .list_drafts(DaemonDraftListQuery {
+            resource: None,
+            status: None,
+            cursor: Some("not-a-cursor".to_owned()),
+            limit: Some(500),
+        })
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        invalid,
+        DaemonError::InvalidRequest(message) if message == "Invalid Draft list cursor"
     ));
 }
 


### PR DESCRIPTION
## Summary

- add stable keyset pagination to the daemon Draft inventory using the existing `updated_at DESC, created_at DESC, draft_id ASC` order
- drain every Draft page for both deferred workspace loading and periodic inventory refresh
- keep terminal Draft removal behavior while preventing terminal history from hiding older open/submitted overlays
- align the Swift query model with the daemon `resource` field and add cross-layer regression coverage

## Root cause

The macOS client requested `listDrafts(limit: 500)`, while the daemon sorted and limited all statuses before the client filtered merged/discarded entries. The current local inventory has 751 rows; the seven performance-related open Drafts sit at ranks 534-540, so they remained intact but disappeared from the effective Memory tree after the Ref refreshed.

Native Kanban: ISSUE-070

## Verification

- `cargo test -p daemon`
- `cargo clippy -p daemon --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `bun run test:macos`
- `git diff --check`
- read-only keyset simulation against the current 751-row local database: second page contains 251 rows, 10 active Drafts, and all seven affected performance documents

No production migration, backup restore, or SQLite write was performed.