### PR TITLE
feat(adapter): install Clumsies as a Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 - **Memory as a Team Asset (Git-Semantic Context)**: Rules, workflows, and project context live as first-class Markdown-backed Organization Memory. A Project selects the Organization resources it uses and carries private Draft overlays; reviewed changes merge atomically into immutable Organization Commit history.
 - **Hybrid Retrieval & Precise Activation**: Combines SQLite FTS5 BM25 text search, local dense vector embeddings, Reciprocal Rank Fusion (RRF), and Cross-Encoder reranking. Agents retrieve task-relevant fragments on demand without exhausting token budgets.
 - **Agent-Native Asynchronous Kanban**: Agents autonomously claim tasks (`begin_work`), build dependency DAGs, evaluate blocking predicates, and record structured verification steps. Human approval gates (`approve_closure`) ensure only verified work transitions to Done.
-- **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.
+- **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Codex is delivered as an Adapter-managed plugin; project-maintained skills remain in Memory Space and are loaded on demand. Restart Codex and start a new task after enabling or updating it, then complete the one-time `/hooks` review before its plugin Hook runs. Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.
 - **Self-Hosted Authority**: Run the Rust Server and PostgreSQL in your own infrastructure with organization OIDC, while the local resident daemon owns fast local state and XPC transport.
 
 ---
@@ -49,7 +49,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 | :--- | :--- | :--- | :--- |
 | **Google Antigravity** | MCP + Lifecycle Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`; no root `Stop` |
 | **Claude Code** | MCP + Lifecycle Hook | `.mcp.json`, `.claude/settings.json` | Prompt, subagent, failure, and session events; no root `Stop` |
-| **OpenAI Codex** | MCP + Config Hook | `.codex/config.toml`, `.codex/hooks.json` | Prompt, subagent, and session events; no root `Stop` |
+| **OpenAI Codex** | Plugin: MCP + Hook + bootstrap Skill | App-managed user plugin; no project files | Prompt, subagent, and session events after Hook trust; no root `Stop` |
 | **opencode** | MCP + Plugin | `opencode.json`, `.opencode/plugins/clumsies.ts` | Prompt, failure, and session events; no normal root `Stop` |
 | **DeepSeek Harness (dsh)** | MCP + Hook Bridge | `.dsh/clumsies.json` | Prompt, failure, and session events; no normal root `Stop` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 - **记忆即团队资产（Git 语义上下文管理）**：将架构规则、工作流规范与项目上下文收敛为统一的 Markdown 组织记忆。Project 只选择要使用的组织记忆并承载项目内可见的 Draft overlay；变更经过团队 Review 后原子合入组织 Commit 历史，杜绝静默覆盖。
 - **混合检索与按需精准激活**：深度融合 SQLite FTS5 BM25 全文检索、本地向量嵌入、倒数排名融合（RRF）与交叉编码器（Cross-Encoder）重排。Agent 通过 `activate` 按需动态召回最相关切片，避免上下文窗口浪费。
 - **面向 Agent 的原生异步看板（Issue DAG）**：Agent 通过类型化 MCP 操作自主认领任务（`begin_work`）、构建有向无环依赖图、评估阻塞谓词并沉淀验证步骤。最终必须由人类通过审批关卡（`approve_closure`）验收完成。
-- **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。
+- **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。Codex 由 Adapter 安装用户级 Plugin，项目维护的 Skill 留在 Memory Space 并按需加载；启用或更新后需重启 Codex 并新建 task，Plugin Hook 首次运行前还需要用户在 `/hooks` 中审查并信任。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。
 - **私有化权威部署**：在自有基础设施中运行 Rust Server 与 PostgreSQL（支持组织 OIDC 鉴权），本地守护进程独立管理高速本地缓存与 XPC 通信。
 
 ---
@@ -49,7 +49,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 | :--- | :--- | :--- | :--- |
 | **Google Antigravity** | MCP + 生命周期 Hook | `.mcp.json`, `.agents/hooks.json` | `PreInvocation`；无根 `Stop` |
 | **Claude Code** | MCP + 生命周期 Hook | `.mcp.json`, `.claude/settings.json` | prompt、subagent、失败与会话事件；无根 `Stop` |
-| **OpenAI Codex** | MCP + 配置 Hook | `.codex/config.toml`, `.codex/hooks.json` | prompt、subagent 与会话事件；无根 `Stop` |
+| **OpenAI Codex** | Plugin：MCP + Hook + 启动 Skill | App 纳管的用户级 Plugin；无项目文件 | Hook 获得信任后的 prompt、subagent 与会话事件；无根 `Stop` |
 | **opencode** | MCP + Plugin | `opencode.json`, `.opencode/plugins/clumsies.ts` | prompt、失败与会话事件；不转发正常根 `Stop` |
 | **DeepSeek Harness (dsh)** | MCP + Hook 桥接 | `.dsh/clumsies.json` | prompt、失败与会话事件；不转发正常根 `Stop` |
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Combine
 import CryptoKit
 import Foundation
@@ -261,6 +262,7 @@ struct ReviewDecisionReadiness: Equatable, Sendable {
 enum ProjectSetupError: LocalizedError, Sendable {
     case noRepositories
     case bundledAgentRuntimeMissing
+    case codexHostMissing
     case bundleNotFound
     case bundleContainsUnavailableMemory
 
@@ -270,6 +272,8 @@ enum ProjectSetupError: LocalizedError, Sendable {
             "Choose at least one local repository."
         case .bundledAgentRuntimeMissing:
             "The clumsiesd Agent runtime is missing from this app build."
+        case .codexHostMissing:
+            "Install or update the Codex app before enabling its Clumsies integration."
         case .bundleNotFound:
             "The selected Bundle is no longer available."
         case .bundleContainsUnavailableMemory:
@@ -1297,6 +1301,9 @@ final class WorkspaceStore: ObservableObject {
         }
         if !adapters.isEmpty {
             let agentRuntimePath = try bundledAgentRuntimePath()
+            let codexHostPath = adapters.contains(.codex)
+                ? try WorkspaceLoader.installedCodexHostBinaryPath()
+                : nil
             for repositoryPath in repositoryPaths {
                 for adapter in adapters.sorted(by: { $0.rawValue < $1.rawValue }) {
                     _ = try await daemon.installProjectAgentAdapter(
@@ -1305,6 +1312,7 @@ final class WorkspaceStore: ObservableObject {
                             workspaceRoot: repositoryPath,
                             adapter: adapter,
                             runtimeBinaryPath: agentRuntimePath,
+                            hostBinaryPath: adapter == .codex ? codexHostPath : nil,
                             expectedRevision: nil
                         )
                     )
@@ -1492,6 +1500,9 @@ final class WorkspaceStore: ObservableObject {
                     workspaceRoot: workspaceRoot,
                     adapter: adapter,
                     runtimeBinaryPath: try bundledAgentRuntimePath(),
+                    hostBinaryPath: adapter == .codex
+                        ? try WorkspaceLoader.installedCodexHostBinaryPath()
+                        : nil,
                     expectedRevision: current?.revision
                 )
             )
@@ -5534,9 +5545,16 @@ struct WorkspaceLoader: Sendable {
         -> LocalAgentAdapterReconciliationResult {
         let runtimePath = try Self.bundledAgentRuntimePath()
         let installed = try await daemon.allProjectAgentAdapters()
+        let codexHostPath = Self.hasReachableCodexAdapter(
+            installed: installed,
+            workspaceExists: { FileManager.default.fileExists(atPath: $0) }
+        )
+            ? try await MainActor.run { try Self.installedCodexHostBinaryPath() }
+            : nil
         let requests = Self.agentAdapterReconciliationPlan(
             installed: installed,
             runtimePath: runtimePath,
+            codexHostPath: codexHostPath,
             workspaceExists: { FileManager.default.fileExists(atPath: $0) }
         )
         for request in requests {
@@ -5605,9 +5623,19 @@ struct WorkspaceLoader: Sendable {
         )
     }
 
+    static func hasReachableCodexAdapter(
+        installed: [DaemonProjectAgentAdapter],
+        workspaceExists: (String) -> Bool
+    ) -> Bool {
+        installed.contains {
+            $0.adapter == .codex && workspaceExists($0.workspaceRoot)
+        }
+    }
+
     static func agentAdapterReconciliationPlan(
         installed: [DaemonProjectAgentAdapter],
         runtimePath: String,
+        codexHostPath: String?,
         workspaceExists: (String) -> Bool
     ) -> [DaemonProjectAgentAdapterInstallRequest] {
         installed
@@ -5624,6 +5652,7 @@ struct WorkspaceLoader: Sendable {
                     workspaceRoot: $0.workspaceRoot,
                     adapter: $0.adapter,
                     runtimeBinaryPath: runtimePath,
+                    hostBinaryPath: $0.adapter == .codex ? codexHostPath : nil,
                     expectedRevision: $0.revision
                 )
             }
@@ -5637,6 +5666,33 @@ struct WorkspaceLoader: Sendable {
         guard let path = bundle.resourceURL?.appending(path: "clumsiesd").path,
               fileManager.isExecutableFile(atPath: path) else {
             throw ProjectSetupError.bundledAgentRuntimeMissing
+        }
+        return path
+    }
+
+    @MainActor
+    static func installedCodexHostBinaryPath(
+        workspace: NSWorkspace = .shared,
+        fileManager: FileManager = .default
+    ) throws -> String {
+        try codexHostBinaryPath(
+            applicationURL: workspace.urlForApplication(
+                withBundleIdentifier: "com.openai.codex"
+            ),
+            fileManager: fileManager
+        )
+    }
+
+    static func codexHostBinaryPath(
+        applicationURL: URL?,
+        fileManager: FileManager = .default
+    ) throws -> String {
+        guard let path = applicationURL?
+            .appending(path: "Contents/Resources/codex")
+            .path,
+            fileManager.isExecutableFile(atPath: path)
+        else {
+            throw ProjectSetupError.codexHostMissing
         }
         return path
     }

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -617,6 +617,13 @@ private struct ProjectLocalSetupSettings: View {
                                 isOn: adapterBinding(adapter, repository: binding)
                             )
                             .disabled(workingKeys.contains(adapterKey(adapter, binding.workspaceRoot)))
+                            if adapter == .codex,
+                               currentAdapter(adapter, binding.workspaceRoot)?.delivery == .hostPlugin {
+                                Text("Restart Codex after enabling or updating this plugin, then start a new task. In that task, open /hooks and trust the current Clumsies Hook to enable AgentRun and run-bound Kanban actions.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
                         }
                     }
                     .padding(.vertical, 2)

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -109,6 +109,11 @@ enum ProjectAgentAdapterKind: String, Codable, CaseIterable, Hashable, Identifia
     }
 }
 
+enum ProjectAgentAdapterDelivery: String, Codable, Sendable {
+    case legacyFiles = "legacy_files"
+    case hostPlugin = "host_plugin"
+}
+
 struct DaemonProjectAgentAdapterListRequest: Codable, Sendable {
     let projectId: String
 }
@@ -118,6 +123,7 @@ struct DaemonProjectAgentAdapterInstallRequest: Codable, Sendable {
     let workspaceRoot: String
     let adapter: ProjectAgentAdapterKind
     let runtimeBinaryPath: String
+    let hostBinaryPath: String?
     let expectedRevision: Int?
 }
 
@@ -140,6 +146,7 @@ struct DaemonProjectAgentAdapter: Codable, Identifiable, Equatable, Sendable {
     let projectId: String
     let workspaceRoot: String
     let adapter: ProjectAgentAdapterKind
+    let delivery: ProjectAgentAdapterDelivery
     let revision: Int
     let managedFiles: [String]
     let createdAt: String

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -10,17 +10,20 @@ final class DaemonContractTests: XCTestCase {
 
     func testAgentAdapterRequestUsesBundledDaemonRuntimePath() throws {
         let runtime = "/Applications/Clumsies.app/Contents/Resources/clumsiesd"
+        let host = "/Applications/Codex.app/Contents/Resources/codex"
         let request = DaemonProjectAgentAdapterInstallRequest(
             projectId: "project-1",
             workspaceRoot: "/tmp/repository",
             adapter: .codex,
             runtimeBinaryPath: runtime,
+            hostBinaryPath: host,
             expectedRevision: nil
         )
 
         let data = try JSONCoding.encoder().encode(request)
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(object["runtime_binary_path"] as? String, runtime)
+        XCTAssertEqual(object["host_binary_path"] as? String, host)
         XCTAssertTrue((object["runtime_binary_path"] as? String)?.hasSuffix("/clumsiesd") == true)
     }
 
@@ -43,6 +46,7 @@ final class DaemonContractTests: XCTestCase {
                 projectId: "project-2",
                 workspaceRoot: "/repos/missing",
                 adapter: .opencode,
+                delivery: .legacyFiles,
                 revision: 4,
                 managedFiles: [],
                 createdAt: "2026-08-01T00:00:00Z",
@@ -53,6 +57,7 @@ final class DaemonContractTests: XCTestCase {
                 projectId: "project-1",
                 workspaceRoot: "/repos/active",
                 adapter: .codex,
+                delivery: .hostPlugin,
                 revision: 7,
                 managedFiles: [],
                 createdAt: "2026-08-01T00:00:00Z",
@@ -63,6 +68,7 @@ final class DaemonContractTests: XCTestCase {
                 projectId: "project-1",
                 workspaceRoot: "/repos/active",
                 adapter: .claudeCode,
+                delivery: .legacyFiles,
                 revision: 3,
                 managedFiles: [],
                 createdAt: "2026-08-01T00:00:00Z",
@@ -73,6 +79,7 @@ final class DaemonContractTests: XCTestCase {
         let planned = WorkspaceLoader.agentAdapterReconciliationPlan(
             installed: adapters,
             runtimePath: "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
+            codexHostPath: "/Applications/Codex.app/Contents/Resources/codex",
             workspaceExists: { $0 == "/repos/active" }
         )
 
@@ -81,6 +88,19 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertTrue(planned.allSatisfy {
             $0.runtimeBinaryPath == "/Applications/Clumsies.app/Contents/Resources/clumsiesd"
         })
+        XCTAssertNil(planned.first { $0.adapter == .claudeCode }?.hostBinaryPath)
+        XCTAssertEqual(
+            planned.first { $0.adapter == .codex }?.hostBinaryPath,
+            "/Applications/Codex.app/Contents/Resources/codex"
+        )
+        XCTAssertTrue(WorkspaceLoader.hasReachableCodexAdapter(
+            installed: adapters,
+            workspaceExists: { $0 == "/repos/active" }
+        ))
+        XCTAssertFalse(WorkspaceLoader.hasReachableCodexAdapter(
+            installed: adapters,
+            workspaceExists: { _ in false }
+        ))
     }
 
     func testWorkspaceCoreReconcilesManagedAdaptersWithoutLegacyInspection() async {

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -23,7 +23,7 @@ sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "sqlite", "uuid"
 thiserror = "2.0.18"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time"] }
+tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "net", "process", "signal", "sync", "time"] }
 toml_edit = "0.25.13"
 uuid = { version = "1.23.4", features = ["v4", "serde"] }
 

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -20,6 +20,7 @@ use crate::{
 #[cfg(target_os = "macos")]
 use crate::config::DAEMON_AGENT_LABEL;
 
+mod codex_plugin;
 mod legacy;
 
 const ISSUE_RUN_EVENT_CODEX: &str =
@@ -46,6 +47,13 @@ pub enum ProjectAgentAdapterKind {
     Opencode,
     Dsh,
     Antigravity,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectAgentAdapterDelivery {
+    LegacyFiles,
+    HostPlugin,
 }
 
 impl ProjectAgentAdapterKind {
@@ -84,6 +92,7 @@ pub struct DaemonProjectAgentAdapterInstallRequest {
     pub workspace_root: String,
     pub adapter: ProjectAgentAdapterKind,
     pub runtime_binary_path: String,
+    pub host_binary_path: Option<String>,
     pub expected_revision: Option<i64>,
 }
 
@@ -100,6 +109,7 @@ pub struct DaemonProjectAgentAdapter {
     pub project_id: String,
     pub workspace_root: String,
     pub adapter: ProjectAgentAdapterKind,
+    pub delivery: ProjectAgentAdapterDelivery,
     pub revision: i64,
     pub managed_files: Vec<String>,
     pub created_at: String,
@@ -144,6 +154,7 @@ pub struct DaemonProjectAgentAdapterRemoveResponse {
 struct AdapterManifest {
     runtime_binary_hash: String,
     runtime_binary_path: String,
+    delivery: ProjectAgentAdapterDelivery,
     managed_files: Vec<ManagedFile>,
 }
 
@@ -518,6 +529,13 @@ pub(crate) async fn migrate(pool: &SqlitePool) -> Result<(), DaemonError> {
     .execute(pool)
     .await?;
     sqlx::query(
+        "UPDATE project_agent_adapters
+         SET manifest_json = json_set(manifest_json, '$.delivery', 'legacy_files')
+         WHERE json_type(manifest_json, '$.delivery') IS NULL",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
         "CREATE INDEX IF NOT EXISTS idx_project_agent_adapters_project
          ON project_agent_adapters (server_url, project_id)",
     )
@@ -538,6 +556,14 @@ pub(crate) async fn migrate(pool: &SqlitePool) -> Result<(), DaemonError> {
             created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
             UNIQUE (server_url, workspace_root, adapter)
         )",
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        "UPDATE adapter_fs_ops
+         SET manifest_json = json_set(manifest_json, '$.delivery', 'legacy_files')
+         WHERE manifest_json IS NOT NULL
+           AND json_type(manifest_json, '$.delivery') IS NULL",
     )
     .execute(pool)
     .await?;
@@ -576,7 +602,7 @@ fn validate_prepared_adapter_fs_op(operation: &PreparedAdapterFsOp) -> Result<()
             "adapter journal workspace is not canonical".to_owned(),
         ));
     }
-    if operation.changes.is_empty() || operation.changes.len() > MAX_ADAPTER_FS_CHANGES {
+    if operation.changes.len() > MAX_ADAPTER_FS_CHANGES {
         return Err(DaemonError::InvalidConfig(
             "adapter journal has an invalid file count".to_owned(),
         ));
@@ -671,43 +697,77 @@ fn validate_prepared_adapter_fs_op(operation: &PreparedAdapterFsOp) -> Result<()
                 "adapter journal runtime identity is invalid".to_owned(),
             ));
         }
-        let desired = operation
-            .changes
-            .iter()
-            .filter_map(|change| {
-                change
-                    .after_content
-                    .as_deref()
-                    .map(|content| (&change.relative_path, change.kind, sha256(content)))
-            })
-            .collect::<Vec<_>>();
-        if manifest.managed_files.len() != desired.len() {
-            return Err(DaemonError::InvalidConfig(
-                "adapter journal manifest does not match its file plan".to_owned(),
-            ));
-        }
-        for managed in &manifest.managed_files {
-            let path = Path::new(&managed.path);
-            validate_manifest_managed_path(&workspace, path, managed.kind)?;
-            let relative = path.strip_prefix(&workspace).map_err(|_| {
-                DaemonError::InvalidConfig(
-                    "adapter journal manifest path escaped its workspace".to_owned(),
-                )
-            })?;
-            let relative = relative.to_str().ok_or_else(|| {
-                DaemonError::InvalidConfig("adapter journal manifest path is not UTF-8".to_owned())
-            })?;
-            let matches = desired.iter().filter(|(candidate, kind, hash)| {
-                candidate.as_str() == relative
-                    && *kind == managed.kind
-                    && hash == &managed.installed_hash
-            });
-            if matches.count() != 1 {
-                return Err(DaemonError::InvalidConfig(
-                    "adapter journal manifest content does not match its file plan".to_owned(),
-                ));
+        match manifest.delivery {
+            ProjectAgentAdapterDelivery::LegacyFiles => {
+                if operation.changes.is_empty() {
+                    return Err(DaemonError::InvalidConfig(
+                        "a legacy adapter install journal cannot have an empty file plan"
+                            .to_owned(),
+                    ));
+                }
+                let desired = operation
+                    .changes
+                    .iter()
+                    .filter_map(|change| {
+                        change
+                            .after_content
+                            .as_deref()
+                            .map(|content| (&change.relative_path, change.kind, sha256(content)))
+                    })
+                    .collect::<Vec<_>>();
+                if manifest.managed_files.len() != desired.len() {
+                    return Err(DaemonError::InvalidConfig(
+                        "adapter journal manifest does not match its file plan".to_owned(),
+                    ));
+                }
+                for managed in &manifest.managed_files {
+                    let path = Path::new(&managed.path);
+                    validate_manifest_managed_path(&workspace, path, managed.kind)?;
+                    let relative = path.strip_prefix(&workspace).map_err(|_| {
+                        DaemonError::InvalidConfig(
+                            "adapter journal manifest path escaped its workspace".to_owned(),
+                        )
+                    })?;
+                    let relative = relative.to_str().ok_or_else(|| {
+                        DaemonError::InvalidConfig(
+                            "adapter journal manifest path is not UTF-8".to_owned(),
+                        )
+                    })?;
+                    let matches = desired.iter().filter(|(candidate, kind, hash)| {
+                        candidate.as_str() == relative
+                            && *kind == managed.kind
+                            && hash == &managed.installed_hash
+                    });
+                    if matches.count() != 1 {
+                        return Err(DaemonError::InvalidConfig(
+                            "adapter journal manifest content does not match its file plan"
+                                .to_owned(),
+                        ));
+                    }
+                }
+            }
+            ProjectAgentAdapterDelivery::HostPlugin => {
+                if operation.adapter != ProjectAgentAdapterKind::Codex
+                    || !manifest.managed_files.is_empty()
+                    || operation.changes.iter().any(|change| match change.kind {
+                        ManagedFileKind::Exclusive => change.after_content.is_some(),
+                        ManagedFileKind::CodexConfig | ManagedFileKind::CodexHooks => {
+                            change.before_content.is_none() && change.after_content.is_some()
+                        }
+                        _ => true,
+                    })
+                {
+                    return Err(DaemonError::InvalidConfig(
+                        "a host-plugin adapter journal is not a Codex legacy cleanup plan"
+                            .to_owned(),
+                    ));
+                }
             }
         }
+    } else if operation.action == AdapterFsAction::Install {
+        return Err(DaemonError::InvalidConfig(
+            "adapter install journal has no manifest".to_owned(),
+        ));
     }
     Ok(())
 }
@@ -1832,6 +1892,36 @@ pub(crate) async fn list_all(
     })
 }
 
+pub(crate) async fn require_runtime_delivery(
+    state: &DaemonState,
+    binding: &crate::DaemonProjectBinding,
+    required: crate::ProjectAgentAdapterRuntimeRequirement,
+) -> Result<(), DaemonError> {
+    let raw_manifest: Option<String> = sqlx::query_scalar(
+        "SELECT manifest_json
+         FROM project_agent_adapters
+         WHERE server_url = $1 AND workspace_root = $2 AND project_id = $3 AND adapter = $4",
+    )
+    .bind(&binding.server_url)
+    .bind(&binding.workspace_root)
+    .bind(&binding.project_id)
+    .bind(required.adapter.as_str())
+    .fetch_optional(&state.inner.pool)
+    .await?;
+    let enabled = raw_manifest
+        .as_deref()
+        .map(serde_json::from_str::<AdapterManifest>)
+        .transpose()?
+        .is_some_and(|manifest| manifest.delivery == required.delivery);
+    if !enabled {
+        return Err(state_error(
+            "project_agent_adapter_not_enabled",
+            "The requested Coding Agent integration is not enabled for this workspace.",
+        ));
+    }
+    Ok(())
+}
+
 pub(crate) async fn inspect_legacy(
     state: &DaemonState,
     request: DaemonLegacyAgentAdapterInspectionRequest,
@@ -1889,28 +1979,57 @@ pub(crate) async fn install(
     verify_code_signature(&runtime_binary)?;
     let runtime_hash = sha256_file(&runtime_binary)?;
     let previous_manifest = existing.as_ref().map(|record| &record.manifest);
-    let mut changes = install_plan_with_project(
-        request.adapter,
-        &workspace_root,
-        &runtime_binary,
-        previous_manifest,
-        Some(&server_url),
-        Some(&project_id),
-    )?;
-    // Retire previously-managed files the new plan no longer includes (the
-    // retired thin skills) instead of silently orphaning them on disk.
-    changes.extend(retire_stale_managed_changes(
-        &changes,
-        previous_manifest,
-        &workspace_root,
-    )?);
+    let (changes, manifest) = if request.adapter == ProjectAgentAdapterKind::Codex {
+        codex_plugin::ensure_installed(
+            &state.inner.config.root_dir,
+            &runtime_binary,
+            &runtime_hash,
+            request.host_binary_path.as_deref(),
+        )
+        .await?;
+        let changes = match previous_manifest {
+            Some(manifest) if manifest.delivery == ProjectAgentAdapterDelivery::LegacyFiles => {
+                remove_plan(manifest, &workspace_root)?
+            }
+            Some(manifest) if !manifest.managed_files.is_empty() => {
+                return Err(DaemonError::InvalidConfig(
+                    "a host-plugin Adapter manifest cannot own workspace files".to_owned(),
+                ));
+            }
+            _ => Vec::new(),
+        };
+        let manifest = AdapterManifest {
+            runtime_binary_hash: runtime_hash,
+            runtime_binary_path: runtime_binary.display().to_string(),
+            delivery: ProjectAgentAdapterDelivery::HostPlugin,
+            managed_files: Vec::new(),
+        };
+        (changes, manifest)
+    } else {
+        let mut changes = install_plan_with_project(
+            request.adapter,
+            &workspace_root,
+            &runtime_binary,
+            previous_manifest,
+            Some(&server_url),
+            Some(&project_id),
+        )?;
+        // Retire previously-managed files the new plan no longer includes
+        // instead of silently orphaning them on disk.
+        changes.extend(retire_stale_managed_changes(
+            &changes,
+            previous_manifest,
+            &workspace_root,
+        )?);
+        let manifest = manifest_for_changes(&changes, &runtime_binary, runtime_hash);
+        (changes, manifest)
+    };
     let files_changed = changes
         .iter()
         .map(change_is_needed)
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .any(|changed| changed);
-    let manifest = manifest_for_changes(&changes, &runtime_binary, runtime_hash);
     let next_revision = match &existing {
         Some(record) if !files_changed && record.manifest == manifest => record.status.revision,
         Some(record) => record.status.revision + 1,
@@ -3528,6 +3647,7 @@ fn manifest_for_changes(
     AdapterManifest {
         runtime_binary_hash,
         runtime_binary_path: runtime_binary.display().to_string(),
+        delivery: ProjectAgentAdapterDelivery::LegacyFiles,
         managed_files: changes
             .iter()
             .filter_map(|change| {
@@ -4231,6 +4351,7 @@ fn adapter_record_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<AdapterRecor
             project_id: row.try_get("project_id")?,
             workspace_root: row.try_get("workspace_root")?,
             adapter,
+            delivery: manifest.delivery,
             revision: row.try_get("revision")?,
             managed_files: manifest
                 .managed_files
@@ -5467,6 +5588,7 @@ name: legacy
         let previous_manifest = AdapterManifest {
             runtime_binary_hash: "helper-hash".to_owned(),
             runtime_binary_path: helper.display().to_string(),
+            delivery: ProjectAgentAdapterDelivery::LegacyFiles,
             managed_files: vec![
                 ManagedFile {
                     path: codex_activate.display().to_string(),
@@ -5552,6 +5674,7 @@ name: legacy
         let previous_manifest = AdapterManifest {
             runtime_binary_hash: "helper-hash".to_owned(),
             runtime_binary_path: helper.display().to_string(),
+            delivery: ProjectAgentAdapterDelivery::LegacyFiles,
             managed_files: vec![ManagedFile {
                 path: skill_path.display().to_string(),
                 kind: ManagedFileKind::Exclusive,
@@ -5885,6 +6008,211 @@ name: legacy
         .await
         .unwrap();
         (pool, server_url, workspace_root, project_id)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn manifest_delivery_migration_rewrites_live_and_pending_records() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (pool, server_url, workspace_root, project_id) =
+            journal_test_pool(workspace.path()).await;
+        let legacy = json!({
+            "runtime_binary_hash": "a".repeat(64),
+            "runtime_binary_path": "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
+            "managed_files": []
+        })
+        .to_string();
+        assert!(serde_json::from_str::<AdapterManifest>(&legacy).is_err());
+        sqlx::query(
+            "INSERT INTO project_agent_adapters
+                 (server_url, workspace_root, project_id, adapter, revision, manifest_json)
+             VALUES ($1, $2, $3, 'codex', 1, $4)",
+        )
+        .bind(&server_url)
+        .bind(&workspace_root)
+        .bind(&project_id)
+        .bind(&legacy)
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO adapter_fs_ops
+                 (operation_id, server_url, workspace_root, project_id, adapter, action,
+                  expected_revision, next_revision, manifest_json, changes_json)
+             VALUES ($1, $2, $3, $4, 'opencode', 'install', NULL, 1, $5, '[]')",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&server_url)
+        .bind(&workspace_root)
+        .bind(&project_id)
+        .bind(&legacy)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        migrate(&pool).await.unwrap();
+        migrate(&pool).await.unwrap();
+        for table in ["project_agent_adapters", "adapter_fs_ops"] {
+            let query = format!("SELECT manifest_json FROM {table} LIMIT 1");
+            let raw: String = sqlx::query_scalar(&query).fetch_one(&pool).await.unwrap();
+            let manifest: AdapterManifest = serde_json::from_str(&raw).unwrap();
+            assert_eq!(manifest.delivery, ProjectAgentAdapterDelivery::LegacyFiles);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn codex_plugin_transition_recovers_cleanup_and_preserves_user_content() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (pool, server_url, workspace_root, project_id) =
+            journal_test_pool(workspace.path()).await;
+        let workspace_root = PathBuf::from(workspace_root);
+        let helper = Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd");
+        let config_path = workspace_root.join(".codex/config.toml");
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, "[model]\nname = \"gpt\"\n").unwrap();
+        let hooks_path = workspace_root.join(".codex/hooks.json");
+        fs::write(
+            &hooks_path,
+            br#"{"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":"lint","timeout":2}]}]}}"#,
+        )
+        .unwrap();
+
+        let legacy_changes = install_plan(
+            ProjectAgentAdapterKind::Codex,
+            &workspace_root,
+            helper,
+            None,
+        )
+        .unwrap();
+        apply_changes(&legacy_changes).unwrap();
+        let legacy_manifest = manifest_for_changes(&legacy_changes, helper, "a".repeat(64));
+        sqlx::query(
+            "INSERT INTO project_agent_adapters
+                 (server_url, workspace_root, project_id, adapter, revision, manifest_json)
+             VALUES ($1, $2, $3, 'codex', 1, $4)",
+        )
+        .bind(&server_url)
+        .bind(workspace_root.display().to_string())
+        .bind(&project_id)
+        .bind(serde_json::to_string(&legacy_manifest).unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let cleanup = remove_plan(&legacy_manifest, &workspace_root).unwrap();
+        let host_manifest = AdapterManifest {
+            runtime_binary_hash: "a".repeat(64),
+            runtime_binary_path: helper.display().to_string(),
+            delivery: ProjectAgentAdapterDelivery::HostPlugin,
+            managed_files: Vec::new(),
+        };
+        let operation = prepared_adapter_fs_op(
+            PreparedAdapterFsOp {
+                operation_id: Uuid::new_v4().to_string(),
+                server_url,
+                workspace_root: workspace_root.clone(),
+                project_id,
+                adapter: ProjectAgentAdapterKind::Codex,
+                action: AdapterFsAction::Install,
+                expected_revision: Some(1),
+                next_revision: Some(2),
+                manifest_json: Some(serde_json::to_string(&host_manifest).unwrap()),
+                changes: Vec::new(),
+            },
+            &cleanup,
+        )
+        .unwrap();
+        persist_prepared_adapter_fs_op(&pool, &operation)
+            .await
+            .unwrap();
+        apply_journal_change_cas(&operation, 0, &operation.changes[0]).unwrap();
+        recover_pending_fs_ops(&pool).await.unwrap();
+
+        let config = fs::read_to_string(&config_path).unwrap();
+        assert!(config.contains("[model]"));
+        assert!(!config.contains("mcp_servers.clumsies"));
+        let hooks: Value = serde_json::from_slice(&fs::read(&hooks_path).unwrap()).unwrap();
+        assert!(hooks["hooks"].get("PreToolUse").is_some());
+        assert!(hooks["hooks"].get("UserPromptSubmit").is_none());
+        assert!(
+            !workspace_root
+                .join(".codex/hooks/issue-run-event.sh")
+                .exists()
+        );
+        assert!(
+            !workspace_root
+                .join(".codex/hooks/resolve-binary.sh")
+                .exists()
+        );
+        let raw: String = sqlx::query_scalar(
+            "SELECT manifest_json FROM project_agent_adapters WHERE adapter = 'codex'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let manifest: AdapterManifest = serde_json::from_str(&raw).unwrap();
+        assert_eq!(manifest.delivery, ProjectAgentAdapterDelivery::HostPlugin);
+        assert!(manifest.managed_files.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_plugin_cleanup_accepts_already_missing_legacy_shared_files() {
+        let workspace = tempfile::tempdir().unwrap();
+        let workspace_root = fs::canonicalize(workspace.path()).unwrap();
+        let helper = Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd");
+        let legacy_manifest = AdapterManifest {
+            runtime_binary_hash: "a".repeat(64),
+            runtime_binary_path: helper.display().to_string(),
+            delivery: ProjectAgentAdapterDelivery::LegacyFiles,
+            managed_files: vec![
+                ManagedFile {
+                    path: workspace_root
+                        .join(".codex/config.toml")
+                        .display()
+                        .to_string(),
+                    kind: ManagedFileKind::CodexConfig,
+                    installed_hash: "b".repeat(64),
+                },
+                ManagedFile {
+                    path: workspace_root
+                        .join(".codex/hooks.json")
+                        .display()
+                        .to_string(),
+                    kind: ManagedFileKind::CodexHooks,
+                    installed_hash: "c".repeat(64),
+                },
+            ],
+        };
+        let cleanup = remove_plan(&legacy_manifest, &workspace_root).unwrap();
+        assert!(
+            cleanup
+                .iter()
+                .all(|change| { change.expected.content.is_none() && change.desired.is_none() })
+        );
+
+        let host_manifest = AdapterManifest {
+            delivery: ProjectAgentAdapterDelivery::HostPlugin,
+            managed_files: Vec::new(),
+            ..legacy_manifest
+        };
+        prepared_adapter_fs_op(
+            PreparedAdapterFsOp {
+                operation_id: Uuid::new_v4().to_string(),
+                server_url: "https://app.clumsies.ai".to_owned(),
+                workspace_root,
+                project_id: "prj_missing_legacy_files".to_owned(),
+                adapter: ProjectAgentAdapterKind::Codex,
+                action: AdapterFsAction::Install,
+                expected_revision: Some(1),
+                next_revision: Some(2),
+                manifest_json: Some(serde_json::to_string(&host_manifest).unwrap()),
+                changes: Vec::new(),
+            },
+            &cleanup,
+        )
+        .unwrap();
     }
 
     #[cfg(unix)]

--- a/crates/daemon/src/agent_adapter/codex_plugin.rs
+++ b/crates/daemon/src/agent_adapter/codex_plugin.rs
@@ -1,0 +1,457 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+
+use crate::DaemonError;
+use crate::project_storage::{ensure_private_directory, write_private_file};
+
+#[cfg(target_os = "macos")]
+use super::code_signature_info;
+use super::{is_executable, shell_single_quote, state_error};
+
+const MARKETPLACE_NAME: &str = "clumsies-local";
+const PLUGIN_ID: &str = "clumsies@clumsies-local";
+#[cfg(target_os = "macos")]
+const CODEX_SIGNING_IDENTIFIER: &str = "codex";
+#[cfg(target_os = "macos")]
+const OPENAI_TEAM_IDENTIFIER: &str = "2DC432GLL2";
+const CLI_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_CLI_OUTPUT_BYTES: usize = 1024 * 1024;
+
+const PLUGIN_MANIFEST: &str =
+    include_str!("../../../../packages/clumsies/.codex-plugin/plugin.json");
+const MCP_TEMPLATE: &str = include_str!("../../../../packages/clumsies/.mcp.json.tpl");
+const HOOKS: &str = include_str!("../../../../packages/clumsies/hooks/hooks.json");
+const HOOK_SCRIPT_TEMPLATE: &str =
+    include_str!("../../../../packages/clumsies/scripts/issue-run-event.sh.tpl");
+const BOOTSTRAP_SKILL: &str =
+    include_str!("../../../../packages/clumsies/skills/clumsies/SKILL.md");
+
+struct MaterializedPlugin {
+    marketplace_root: PathBuf,
+    version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketplaceList {
+    #[serde(default)]
+    marketplaces: Vec<MarketplaceEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketplaceEntry {
+    name: String,
+    #[serde(default)]
+    root: String,
+    #[serde(default, rename = "marketplaceSource")]
+    marketplace_source: Option<MarketplaceSource>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketplaceSource {
+    #[serde(rename = "sourceType")]
+    source_type: String,
+    source: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginList {
+    #[serde(default)]
+    installed: Vec<PluginEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PluginEntry {
+    #[serde(rename = "pluginId")]
+    plugin_id: String,
+    version: String,
+    installed: bool,
+    enabled: bool,
+}
+
+pub(super) async fn ensure_installed(
+    daemon_root: &Path,
+    runtime_binary: &Path,
+    runtime_hash: &str,
+    host_binary_path: Option<&str>,
+) -> Result<(), DaemonError> {
+    let host_binary_path = host_binary_path.ok_or_else(|| {
+        DaemonError::InvalidRequest(
+            "host_binary_path must identify the installed Codex App CLI".to_owned(),
+        )
+    })?;
+    let codex = canonical_codex_cli(host_binary_path)?;
+    verify_codex_cli(&codex)?;
+    let plugin = materialize(daemon_root, runtime_binary, runtime_hash)?;
+    ensure_marketplace(&codex, &plugin.marketplace_root).await?;
+    ensure_plugin(&codex, &plugin.version).await
+}
+
+fn materialize(
+    daemon_root: &Path,
+    runtime_binary: &Path,
+    runtime_hash: &str,
+) -> Result<MaterializedPlugin, DaemonError> {
+    if runtime_hash.len() != 64 || !runtime_hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(DaemonError::InvalidConfig(
+            "Codex plugin runtime identity is invalid".to_owned(),
+        ));
+    }
+    let runtime_path = runtime_binary.to_str().ok_or_else(|| {
+        DaemonError::InvalidRequest("Codex plugin runtime path is not UTF-8".to_owned())
+    })?;
+    let marketplace_root = daemon_root.join("agent-plugins/codex-marketplace");
+    let plugin_root = marketplace_root.join("plugins/clumsies");
+    for directory in [
+        marketplace_root.join(".agents/plugins"),
+        plugin_root.join(".codex-plugin"),
+        plugin_root.join("hooks"),
+        plugin_root.join("scripts"),
+        plugin_root.join("skills/clumsies"),
+    ] {
+        ensure_private_directory(&directory)?;
+    }
+
+    let version = plugin_version(runtime_path, runtime_hash);
+    let mut manifest: Value = serde_json::from_str(PLUGIN_MANIFEST)?;
+    manifest["version"] = Value::String(version.clone());
+    manifest["mcpServers"] = Value::String("./.mcp.json".to_owned());
+    write_json(&plugin_root.join(".codex-plugin/plugin.json"), &manifest)?;
+
+    let mut mcp: Value = serde_json::from_str(MCP_TEMPLATE)?;
+    mcp["mcpServers"]["clumsies"]["command"] = Value::String(runtime_path.to_owned());
+    write_json(&plugin_root.join(".mcp.json"), &mcp)?;
+    write_private_file(&plugin_root.join("hooks/hooks.json"), HOOKS.as_bytes())?;
+    let hook_script = HOOK_SCRIPT_TEMPLATE.replace(
+        "__CLUMSIESD_SHELL_LITERAL_REQUIRED__",
+        &shell_single_quote(runtime_path),
+    );
+    if hook_script.contains("__CLUMSIESD_SHELL_LITERAL_REQUIRED__") {
+        return Err(DaemonError::InvalidConfig(
+            "Codex plugin Hook template was not materialized".to_owned(),
+        ));
+    }
+    write_private_file(
+        &plugin_root.join("scripts/issue-run-event.sh"),
+        hook_script.as_bytes(),
+    )?;
+    write_private_file(
+        &plugin_root.join("skills/clumsies/SKILL.md"),
+        BOOTSTRAP_SKILL.as_bytes(),
+    )?;
+
+    write_json(
+        &marketplace_root.join(".agents/plugins/marketplace.json"),
+        &json!({
+            "name": MARKETPLACE_NAME,
+            "interface": { "displayName": "Clumsies Local" },
+            "plugins": [{
+                "name": "clumsies",
+                "source": { "source": "local", "path": "./plugins/clumsies" },
+                "policy": {
+                    "installation": "AVAILABLE",
+                    "authentication": "ON_INSTALL"
+                },
+                "category": "Productivity"
+            }]
+        }),
+    )?;
+
+    Ok(MaterializedPlugin {
+        marketplace_root,
+        version,
+    })
+}
+
+fn plugin_version(runtime_path: &str, runtime_hash: &str) -> String {
+    let mut digest = Sha256::new();
+    for component in [
+        b"clumsies-codex-plugin-v1".as_slice(),
+        runtime_hash.as_bytes(),
+        runtime_path.as_bytes(),
+        PLUGIN_MANIFEST.as_bytes(),
+        MCP_TEMPLATE.as_bytes(),
+        HOOKS.as_bytes(),
+        HOOK_SCRIPT_TEMPLATE.as_bytes(),
+        BOOTSTRAP_SKILL.as_bytes(),
+    ] {
+        digest.update((component.len() as u64).to_be_bytes());
+        digest.update(component);
+    }
+    let identity = hex::encode(digest.finalize());
+    format!("0.1.0+codex.{}", &identity[..16])
+}
+
+fn write_json(path: &Path, value: &Value) -> Result<(), DaemonError> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    write_private_file(path, &bytes)
+}
+
+async fn ensure_marketplace(codex: &Path, marketplace_root: &Path) -> Result<(), DaemonError> {
+    let observed = marketplace_list(codex).await?;
+    match observed
+        .marketplaces
+        .iter()
+        .find(|entry| entry.name == MARKETPLACE_NAME)
+    {
+        Some(entry) if marketplace_matches(entry, marketplace_root) => return Ok(()),
+        Some(_) => {
+            return Err(state_error(
+                "project_agent_adapter_plugin_conflict",
+                "Codex already has a different marketplace named clumsies-local.",
+            ));
+        }
+        None => {}
+    }
+
+    let source = marketplace_root.to_str().ok_or_else(|| {
+        DaemonError::InvalidRequest("Codex plugin marketplace path is not UTF-8".to_owned())
+    })?;
+    run_cli_json(codex, &["plugin", "marketplace", "add", source, "--json"]).await?;
+    let observed = marketplace_list(codex).await?;
+    if observed
+        .marketplaces
+        .iter()
+        .any(|entry| entry.name == MARKETPLACE_NAME && marketplace_matches(entry, marketplace_root))
+    {
+        Ok(())
+    } else {
+        Err(state_error(
+            "project_agent_adapter_plugin_install_failed",
+            "Codex did not retain the Clumsies marketplace after installation.",
+        ))
+    }
+}
+
+async fn marketplace_list(codex: &Path) -> Result<MarketplaceList, DaemonError> {
+    serde_json::from_value(run_cli_json(codex, &["plugin", "marketplace", "list", "--json"]).await?)
+        .map_err(Into::into)
+}
+
+async fn ensure_plugin(codex: &Path, version: &str) -> Result<(), DaemonError> {
+    if plugin_installed_and_enabled(&plugin_list(codex).await?, version) {
+        return Ok(());
+    }
+    run_cli_json(codex, &["plugin", "add", PLUGIN_ID, "--json"]).await?;
+    if plugin_installed_and_enabled(&plugin_list(codex).await?, version) {
+        Ok(())
+    } else {
+        Err(state_error(
+            "project_agent_adapter_plugin_install_failed",
+            "Codex did not enable the expected Clumsies plugin version.",
+        ))
+    }
+}
+
+async fn plugin_list(codex: &Path) -> Result<PluginList, DaemonError> {
+    serde_json::from_value(
+        run_cli_json(
+            codex,
+            &[
+                "plugin",
+                "list",
+                "--marketplace",
+                MARKETPLACE_NAME,
+                "--available",
+                "--json",
+            ],
+        )
+        .await?,
+    )
+    .map_err(Into::into)
+}
+
+fn plugin_installed_and_enabled(list: &PluginList, version: &str) -> bool {
+    list.installed.iter().any(|entry| {
+        entry.plugin_id == PLUGIN_ID && entry.version == version && entry.installed && entry.enabled
+    })
+}
+
+async fn run_cli_json(codex: &Path, args: &[&str]) -> Result<Value, DaemonError> {
+    let mut command = tokio::process::Command::new(codex);
+    command
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let output = tokio::time::timeout(CLI_TIMEOUT, command.output())
+        .await
+        .map_err(|_| {
+            state_error(
+                "project_agent_adapter_plugin_timeout",
+                "Codex did not finish the plugin operation in time.",
+            )
+        })??;
+    if output.stdout.len() > MAX_CLI_OUTPUT_BYTES || output.stderr.len() > MAX_CLI_OUTPUT_BYTES {
+        return Err(state_error(
+            "project_agent_adapter_plugin_output_too_large",
+            "Codex returned an unexpectedly large plugin response.",
+        ));
+    }
+    if !output.status.success() {
+        return Err(state_error(
+            "project_agent_adapter_plugin_install_failed",
+            "Codex could not install the Clumsies plugin. Open Codex once, then retry the integration.",
+        ));
+    }
+    serde_json::from_slice(&output.stdout).map_err(|_| {
+        state_error(
+            "project_agent_adapter_plugin_invalid_response",
+            "Codex returned an invalid plugin response.",
+        )
+    })
+}
+
+fn canonical_paths_match(left: &Path, right: &Path) -> bool {
+    fs::canonicalize(left)
+        .ok()
+        .zip(fs::canonicalize(right).ok())
+        .is_some_and(|(left, right)| left == right)
+}
+
+fn marketplace_matches(entry: &MarketplaceEntry, marketplace_root: &Path) -> bool {
+    match &entry.marketplace_source {
+        Some(source) => {
+            source.source_type == "local"
+                && canonical_paths_match(Path::new(&source.source), marketplace_root)
+        }
+        None => canonical_paths_match(Path::new(&entry.root), marketplace_root),
+    }
+}
+
+fn canonical_codex_cli(path: &str) -> Result<PathBuf, DaemonError> {
+    let path = path.trim();
+    if path.is_empty() {
+        return Err(DaemonError::InvalidRequest(
+            "host_binary_path must identify the installed Codex App CLI".to_owned(),
+        ));
+    }
+    let canonical = fs::canonicalize(path).map_err(|error| {
+        DaemonError::InvalidRequest(format!("Codex CLI path {path} cannot be resolved: {error}"))
+    })?;
+    if !canonical.is_file()
+        || !canonical.ends_with("Contents/Resources/codex")
+        || !is_executable(&canonical)?
+    {
+        return Err(DaemonError::InvalidRequest(format!(
+            "Codex CLI path {} is not an App-bundled executable",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+#[cfg(target_os = "macos")]
+fn verify_codex_cli(path: &Path) -> Result<(), DaemonError> {
+    let output = std::process::Command::new("/usr/bin/codesign")
+        .arg("--verify")
+        .arg("--strict")
+        .arg(path)
+        .output()?;
+    let info = code_signature_info(path)?;
+    if !output.status.success()
+        || info.identifier != CODEX_SIGNING_IDENTIFIER
+        || info.team_identifier.as_deref() != Some(OPENAI_TEAM_IDENTIFIER)
+        || info.ad_hoc
+        || !info.hardened_runtime
+    {
+        return Err(state_error(
+            "project_agent_adapter_invalid_host",
+            "The selected Codex CLI does not have the required OpenAI signing identity.",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn verify_codex_cli(_path: &Path) -> Result<(), DaemonError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialized_plugin_pins_runtime_and_keeps_memory_skills_remote() {
+        let root = tempfile::tempdir().unwrap();
+        let runtime = Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd");
+        let plugin = materialize(root.path(), runtime, &"a".repeat(64)).unwrap();
+        assert!(plugin.version.starts_with("0.1.0+codex."));
+        let moved_root = tempfile::tempdir().unwrap();
+        let moved = materialize(
+            moved_root.path(),
+            Path::new("/Users/test/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
+            &"a".repeat(64),
+        )
+        .unwrap();
+        assert_ne!(plugin.version, moved.version);
+
+        let plugin_root = plugin.marketplace_root.join("plugins/clumsies");
+        let mcp: Value =
+            serde_json::from_slice(&fs::read(plugin_root.join(".mcp.json")).unwrap()).unwrap();
+        assert_eq!(
+            mcp["mcpServers"]["clumsies"]["command"],
+            runtime.display().to_string()
+        );
+        assert_eq!(
+            mcp["mcpServers"]["clumsies"]["args"],
+            json!([
+                "mcp",
+                "serve",
+                "--host",
+                "codex",
+                "--delivery",
+                "host-plugin"
+            ])
+        );
+        let skill = fs::read_to_string(plugin_root.join("skills/clumsies/SKILL.md")).unwrap();
+        assert!(skill.contains("skill stored in Memory as ordinary Memory content"));
+        assert!(!plugin_root.join("skills/coding").exists());
+        let hooks = fs::read_to_string(plugin_root.join("hooks/hooks.json")).unwrap();
+        assert!(hooks.contains("${PLUGIN_ROOT}/scripts/issue-run-event.sh"));
+    }
+
+    #[test]
+    fn exact_installed_plugin_state_is_required() {
+        let ready = PluginList {
+            installed: vec![PluginEntry {
+                plugin_id: PLUGIN_ID.to_owned(),
+                version: "0.1.0+codex.abc".to_owned(),
+                installed: true,
+                enabled: true,
+            }],
+        };
+        assert!(plugin_installed_and_enabled(&ready, "0.1.0+codex.abc"));
+        assert!(!plugin_installed_and_enabled(&ready, "0.1.0+codex.def"));
+    }
+
+    #[test]
+    fn marketplace_source_is_authoritative_when_reported() {
+        let expected = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+        let entry = MarketplaceEntry {
+            name: MARKETPLACE_NAME.to_owned(),
+            root: expected.path().display().to_string(),
+            marketplace_source: Some(MarketplaceSource {
+                source_type: "local".to_owned(),
+                source: other.path().display().to_string(),
+            }),
+        };
+        assert!(!marketplace_matches(&entry, expected.path()));
+
+        let legacy_entry = MarketplaceEntry {
+            name: MARKETPLACE_NAME.to_owned(),
+            root: expected.path().display().to_string(),
+            marketplace_source: None,
+        };
+        assert!(marketplace_matches(&legacy_entry, expected.path()));
+    }
+}

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -25,7 +25,7 @@ pub use agent_adapter::{
     DaemonLegacyAgentAdapterInspectionResponse, DaemonProjectAgentAdapter,
     DaemonProjectAgentAdapterInstallRequest, DaemonProjectAgentAdapterListRequest,
     DaemonProjectAgentAdapterListResponse, DaemonProjectAgentAdapterRemoveRequest,
-    DaemonProjectAgentAdapterRemoveResponse, ProjectAgentAdapterKind,
+    DaemonProjectAgentAdapterRemoveResponse, ProjectAgentAdapterDelivery, ProjectAgentAdapterKind,
 };
 pub use commit_sync::{
     DaemonMemoryCacheRequest, DaemonMemoryCacheState, DaemonMemoryCacheStatus,
@@ -104,8 +104,8 @@ pub use types::{
     DaemonProjectBindingResolveRequest, DaemonProjectConfig, DaemonProjectConfigUpdateRequest,
     DaemonProjectSelectionRequest, DaemonRetryResponse, DaemonServerRequest, DaemonServerResponse,
     DaemonSyncRetryRequest, DaemonSyncStatus, DraftOperationSyncStatus, ErrorEnvelope,
-    LaunchAgentRuntimeStatus, LocalDbStatus, McpAdapterStatus, SyncChannelStatus, SyncRetryChannel,
-    SyncState,
+    LaunchAgentRuntimeStatus, LocalDbStatus, McpAdapterStatus,
+    ProjectAgentAdapterRuntimeRequirement, SyncChannelStatus, SyncRetryChannel, SyncState,
 };
 pub use types::{
     DaemonContentDraftUpdate, DaemonCreateDraftOperation, DaemonDeleteDraftOperation,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -6,11 +6,13 @@ use daemon::agent_runtime::hook::{
     HookEventName, HookHost, MAX_HOOK_INPUT_BYTES, NormalizedHookEvent, normalize_hook_event,
 };
 use daemon::agent_runtime::mcp::McpServer;
+use daemon::agent_runtime::{AgentRuntimeBackend, mcp_contract::AgentRuntimeRequest};
 use daemon::{
     AgentRunKind, CredentialStore, CredentialStoreError, DAEMON_MACH_SERVICE_NAME, DaemonConfig,
-    DaemonError, DaemonIpcClient, DaemonIpcServer, DaemonIpcService,
+    DaemonError, DaemonIpcClient, DaemonIpcResponse, DaemonIpcServer, DaemonIpcService,
     DaemonProjectBindingResolveRequest, DaemonState, IssueBoardState, IssueDetailRequest,
-    LaunchAgentConfig, LaunchAgentController, RecordAgentRunEventResponse, ServerCredentials,
+    LaunchAgentConfig, LaunchAgentController, ProjectAgentAdapterDelivery, ProjectAgentAdapterKind,
+    ProjectAgentAdapterRuntimeRequirement, RecordAgentRunEventResponse, ServerCredentials,
 };
 use serde_json::{Value, json};
 use tracing_subscriber::EnvFilter;
@@ -19,8 +21,11 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ProcessMode {
-    McpServe,
-    AgentIssueRunEvent(HookHost),
+    McpServe(Option<ProjectAgentAdapterRuntimeRequirement>),
+    AgentIssueRunEvent {
+        host: HookHost,
+        required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
+    },
     Daemon,
 }
 
@@ -35,6 +40,42 @@ const AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV: &str =
 const AGENT_RUNTIME_STARTUP_IPC_TIMEOUT: Duration = Duration::from_secs(30);
 const AGENT_RUNTIME_MCP_IPC_TIMEOUT: Duration = Duration::from_secs(65);
 const AGENT_RUNTIME_HOOK_IPC_TIMEOUT: Duration = Duration::from_secs(3);
+
+struct DeliveryCheckedBackend {
+    client: DaemonIpcClient,
+    workspace_path: String,
+    project_id: String,
+    required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
+}
+
+impl AgentRuntimeBackend for DeliveryCheckedBackend {
+    fn execute(&self, request: AgentRuntimeRequest) -> Result<DaemonIpcResponse, DaemonError> {
+        if let Some(required_adapter) = self.required_adapter {
+            let binding =
+                self.client
+                    .resolve_project_binding(DaemonProjectBindingResolveRequest {
+                        workspace_path: self.workspace_path.clone(),
+                        required_adapter: Some(required_adapter),
+                    })?;
+            if binding.project_id != self.project_id {
+                return Err(DaemonError::State {
+                    code: "project_binding_changed",
+                    message: "The Project binding changed after this Agent runtime started; start a new Agent task."
+                        .to_owned(),
+                });
+            }
+        }
+        self.client.execute(request)
+    }
+
+    fn guidelines_path(&self) -> Result<Option<String>, DaemonError> {
+        self.client.guidelines_path()
+    }
+
+    fn active_project_id(&self) -> Result<Option<String>, DaemonError> {
+        self.client.active_project_id()
+    }
+}
 
 #[derive(Debug)]
 struct IsolatedTestCredentialStore;
@@ -60,12 +101,15 @@ impl CredentialStore for IsolatedTestCredentialStore {
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
     match process_mode(&args)? {
-        ProcessMode::McpServe => run_mcp_proxy(),
-        ProcessMode::AgentIssueRunEvent(host) => {
+        ProcessMode::McpServe(required_adapter) => run_mcp_proxy(required_adapter),
+        ProcessMode::AgentIssueRunEvent {
+            host,
+            required_adapter,
+        } => {
             // Lifecycle observation is fail-open. The managed wrapper records
             // bounded diagnostics, while raw Hook input is never echoed here.
             init_hook_tracing();
-            if run_hook_proxy(host).is_err() {
+            if run_hook_proxy(host, required_adapter).is_err() {
                 tracing::error!("clumsiesd Hook proxy could not record this lifecycle event");
             }
             Ok(())
@@ -105,34 +149,83 @@ fn init_hook_tracing() {
 
 fn process_mode(args: &[String]) -> Result<ProcessMode, Box<dyn std::error::Error>> {
     match args {
-        [first, second] if first == "mcp" && second == "serve" => Ok(ProcessMode::McpServe),
+        [first, second] if first == "mcp" && second == "serve" => Ok(ProcessMode::McpServe(None)),
+        [first, second, host_flag, host, delivery_flag, delivery]
+            if first == "mcp"
+                && second == "serve"
+                && host_flag == "--host"
+                && delivery_flag == "--delivery" =>
+        {
+            let (_, required_adapter) = agent_runtime_requirement(host, delivery)?;
+            Ok(ProcessMode::McpServe(Some(required_adapter)))
+        }
         [agent, command, flag, host]
             if agent == "_agent" && command == "issue-run-event" && flag == "--host" =>
         {
-            let host = match host.as_str() {
-                "codex" => HookHost::Codex,
-                "claude-code" => HookHost::ClaudeCode,
-                "opencode" => HookHost::Opencode,
-                "dsh" => HookHost::Dsh,
-                "antigravity" => HookHost::Antigravity,
-                _ => return Err("unsupported Agent Hook host".into()),
-            };
-            Ok(ProcessMode::AgentIssueRunEvent(host))
+            let (host, _) = agent_runtime_requirement(host, "legacy-files")?;
+            Ok(ProcessMode::AgentIssueRunEvent {
+                host,
+                required_adapter: None,
+            })
+        }
+        [agent, command, host_flag, host, delivery_flag, delivery]
+            if agent == "_agent"
+                && command == "issue-run-event"
+                && host_flag == "--host"
+                && delivery_flag == "--delivery" =>
+        {
+            let (host, required_adapter) = agent_runtime_requirement(host, delivery)?;
+            Ok(ProcessMode::AgentIssueRunEvent {
+                host,
+                required_adapter: Some(required_adapter),
+            })
         }
         _ => Ok(ProcessMode::Daemon),
     }
 }
 
-fn run_mcp_proxy() -> Result<(), Box<dyn std::error::Error>> {
+fn agent_runtime_requirement(
+    host: &str,
+    delivery: &str,
+) -> Result<(HookHost, ProjectAgentAdapterRuntimeRequirement), Box<dyn std::error::Error>> {
+    let (host, adapter) = match host {
+        "codex" => (HookHost::Codex, ProjectAgentAdapterKind::Codex),
+        "claude-code" => (HookHost::ClaudeCode, ProjectAgentAdapterKind::ClaudeCode),
+        "opencode" => (HookHost::Opencode, ProjectAgentAdapterKind::Opencode),
+        "dsh" => (HookHost::Dsh, ProjectAgentAdapterKind::Dsh),
+        "antigravity" => (HookHost::Antigravity, ProjectAgentAdapterKind::Antigravity),
+        _ => return Err("unsupported Agent runtime host".into()),
+    };
+    let delivery = match delivery {
+        "legacy-files" => ProjectAgentAdapterDelivery::LegacyFiles,
+        "host-plugin" => ProjectAgentAdapterDelivery::HostPlugin,
+        _ => return Err("unsupported Agent runtime delivery".into()),
+    };
+    Ok((
+        host,
+        ProjectAgentAdapterRuntimeRequirement { adapter, delivery },
+    ))
+}
+
+fn run_mcp_proxy(
+    required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let client = agent_runtime_client(AGENT_RUNTIME_STARTUP_IPC_TIMEOUT)?;
     verify_agent_runtime(&client)?;
     let workspace_path = std::env::current_dir()?.to_string_lossy().into_owned();
-    let project_id = client
-        .resolve_project_binding(DaemonProjectBindingResolveRequest { workspace_path })
-        .ok()
-        .map(|binding| binding.project_id)
-        .or_else(|| client.project_config().ok().and_then(|cfg| cfg.project_id))
-        .unwrap_or_default();
+    let binding = client.resolve_project_binding(DaemonProjectBindingResolveRequest {
+        workspace_path: workspace_path.clone(),
+        required_adapter,
+    });
+    let project_id = match (binding, required_adapter) {
+        (Ok(binding), _) => binding.project_id,
+        (Err(error), Some(_)) => return Err(error.into()),
+        (Err(_), None) => client
+            .project_config()
+            .ok()
+            .and_then(|cfg| cfg.project_id)
+            .unwrap_or_default(),
+    };
     // The debug-only test seam changes the backend identity only after the
     // startup health and binding requests. This models a resident replacement
     // between MCP initialize and the next tools/call over real XPC.
@@ -141,6 +234,12 @@ fn run_mcp_proxy() -> Result<(), Box<dyn std::error::Error>> {
             .with_timeout(AGENT_RUNTIME_MCP_IPC_TIMEOUT),
         None => client.with_timeout(AGENT_RUNTIME_MCP_IPC_TIMEOUT),
     };
+    let backend = DeliveryCheckedBackend {
+        client: backend,
+        workspace_path,
+        project_id: project_id.clone(),
+        required_adapter,
+    };
     let mut server = McpServer::new(backend, project_id, env!("CARGO_PKG_VERSION"));
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
@@ -148,7 +247,10 @@ fn run_mcp_proxy() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn run_hook_proxy(host: HookHost) -> Result<(), Box<dyn std::error::Error>> {
+fn run_hook_proxy(
+    host: HookHost,
+    required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut raw = Vec::new();
     std::io::stdin()
         .take((MAX_HOOK_INPUT_BYTES + 1) as u64)
@@ -161,8 +263,10 @@ fn run_hook_proxy(host: HookHost) -> Result<(), Box<dyn std::error::Error>> {
     };
     let client = agent_runtime_client(AGENT_RUNTIME_HOOK_IPC_TIMEOUT)?;
     verify_agent_runtime(&client)?;
-    let binding =
-        client.resolve_project_binding(DaemonProjectBindingResolveRequest { workspace_path })?;
+    let binding = client.resolve_project_binding(DaemonProjectBindingResolveRequest {
+        workspace_path,
+        required_adapter,
+    })?;
     let response = client.record_agent_run_event(event.to_record_request(&binding.project_id))?;
     if response.duplicate {
         return Ok(());
@@ -494,7 +598,7 @@ mod tests {
     fn proxy_modes_are_parsed_before_daemon_initialization() {
         assert_eq!(
             process_mode(&["mcp".to_owned(), "serve".to_owned()]).unwrap(),
-            ProcessMode::McpServe
+            ProcessMode::McpServe(None)
         );
         assert_eq!(
             process_mode(&[
@@ -504,7 +608,41 @@ mod tests {
                 "codex".to_owned(),
             ])
             .unwrap(),
-            ProcessMode::AgentIssueRunEvent(HookHost::Codex)
+            ProcessMode::AgentIssueRunEvent {
+                host: HookHost::Codex,
+                required_adapter: None,
+            }
+        );
+        let plugin_requirement = ProjectAgentAdapterRuntimeRequirement {
+            adapter: ProjectAgentAdapterKind::Codex,
+            delivery: ProjectAgentAdapterDelivery::HostPlugin,
+        };
+        assert_eq!(
+            process_mode(&[
+                "mcp".to_owned(),
+                "serve".to_owned(),
+                "--host".to_owned(),
+                "codex".to_owned(),
+                "--delivery".to_owned(),
+                "host-plugin".to_owned(),
+            ])
+            .unwrap(),
+            ProcessMode::McpServe(Some(plugin_requirement))
+        );
+        assert_eq!(
+            process_mode(&[
+                "_agent".to_owned(),
+                "issue-run-event".to_owned(),
+                "--host".to_owned(),
+                "codex".to_owned(),
+                "--delivery".to_owned(),
+                "host-plugin".to_owned(),
+            ])
+            .unwrap(),
+            ProcessMode::AgentIssueRunEvent {
+                host: HookHost::Codex,
+                required_adapter: Some(plugin_requirement),
+            }
         );
         assert_eq!(process_mode(&[]).unwrap(), ProcessMode::Daemon);
     }

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -483,6 +483,7 @@ impl DaemonState {
         &self,
         request: DaemonProjectBindingResolveRequest,
     ) -> Result<DaemonProjectBinding, DaemonError> {
+        let required_adapter = request.required_adapter;
         let workspace_path = canonical_workspace_directory(&request.workspace_path)?;
         let server_url = canonical_server_url(&self.project_config().server_url)?;
         let rows = sqlx::query(
@@ -526,14 +527,19 @@ impl DaemonState {
             }
         }
 
-        best.map(|(_, binding)| binding)
+        let binding = best
+            .map(|(_, binding)| binding)
             .ok_or_else(|| DaemonError::State {
                 code: "project_binding_not_found",
                 message: format!(
                     "No Project is bound to workspace path {} on {server_url}",
                     workspace_path.display()
                 ),
-            })
+            })?;
+        if let Some(required) = required_adapter {
+            agent_adapter::require_runtime_delivery(self, &binding, required).await?;
+        }
+        Ok(binding)
     }
 
     pub async fn list_project_bindings(

--- a/crates/daemon/src/types.rs
+++ b/crates/daemon/src/types.rs
@@ -207,6 +207,14 @@ pub struct DaemonProjectSelectionRequest {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonProjectBindingResolveRequest {
     pub workspace_path: String,
+    #[serde(default)]
+    pub required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ProjectAgentAdapterRuntimeRequirement {
+    pub adapter: crate::ProjectAgentAdapterKind,
+    pub delivery: crate::ProjectAgentAdapterDelivery,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/daemon/tests/agent_runtime_xpc_e2e.rs
+++ b/crates/daemon/tests/agent_runtime_xpc_e2e.rs
@@ -1,8 +1,8 @@
 #![cfg(target_os = "macos")]
 
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
+use std::process::{Child, Command, Output, Stdio};
 use std::time::{Duration, Instant};
 
 use daemon::{DaemonHealth, DaemonIpcClient, DaemonProjectBindingResolveRequest};
@@ -160,6 +160,53 @@ async fn real_clumsiesd_process_proxies_use_xpc_and_reject_stale_identity() {
         );
     }
 
+    let mut plugin_mcp = spawn_proxy(
+        &binary,
+        &[
+            "mcp",
+            "serve",
+            "--host",
+            "codex",
+            "--delivery",
+            "host-plugin",
+        ],
+        &workspace,
+        &service_name,
+        &[],
+    );
+    let mut plugin_stdin = plugin_mcp.stdin.take().unwrap();
+    let mut plugin_stdout = BufReader::new(plugin_mcp.stdout.take().unwrap());
+    plugin_stdin
+        .write_all(
+            concat!(
+                "{\"jsonrpc\":\"2.0\",\"id\":20,\"method\":\"initialize\"}\n",
+                "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n",
+                "{\"jsonrpc\":\"2.0\",\"id\":21,\"method\":\"tools/call\",\"params\":{\"name\":\"kanban\",\"arguments\":{\"op\":{\"list\":{}}}}}\n"
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    plugin_stdin.flush().unwrap();
+    assert_eq!(read_proxy_json_line(&mut plugin_stdout)["id"], 20);
+    let before_remove = read_proxy_json_line(&mut plugin_stdout);
+    assert_eq!(before_remove["id"], 21);
+    assert_eq!(before_remove["result"]["isError"], false, "{before_remove}");
+
+    remove_codex_adapter(&daemon_root.join("local.db")).await;
+    plugin_stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tools/call\",\"params\":{\"name\":\"kanban\",\"arguments\":{\"op\":{\"list\":{}}}}}\n",
+        )
+        .unwrap();
+    plugin_stdin.flush().unwrap();
+    let after_remove = read_proxy_json_line(&mut plugin_stdout);
+    assert_eq!(after_remove["id"], 22);
+    assert_eq!(after_remove["result"]["isError"], true, "{after_remove}");
+    drop(plugin_stdin);
+    drop(plugin_stdout);
+    let plugin_output = plugin_mcp.wait_with_output().unwrap();
+    assert_process_succeeded("delivery-gated MCP proxy", &plugin_output);
+
     let hook_fixture = json!({
         "session_id": "issue049-e2e-session",
         "turn_id": "issue049-e2e-turn",
@@ -220,6 +267,7 @@ async fn real_clumsiesd_process_proxies_use_xpc_and_reject_stale_identity() {
     let missing_identity = ordinary_client
         .resolve_project_binding(DaemonProjectBindingResolveRequest {
             workspace_path: workspace.display().to_string(),
+            required_adapter: None,
         })
         .unwrap_err();
     assert!(
@@ -312,6 +360,38 @@ async fn seed_project_fixture(local_db: &Path, workspace: &Path) {
         .execute(&pool)
         .await
         .unwrap();
+    sqlx::query(
+        "INSERT INTO project_agent_adapters
+             (server_url, workspace_root, project_id, adapter, revision, manifest_json)
+         VALUES ($1, $2, $3, 'codex', 1, $4)",
+    )
+    .bind(SERVER_URL)
+    .bind(workspace.display().to_string())
+    .bind(PROJECT_ID)
+    .bind(
+        json!({
+            "runtime_binary_hash": "a".repeat(64),
+            "runtime_binary_path": "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
+            "delivery": "host_plugin",
+            "managed_files": []
+        })
+        .to_string(),
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+}
+
+async fn remove_codex_adapter(local_db: &Path) {
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", local_db.display()))
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM project_agent_adapters WHERE project_id = $1 AND adapter = 'codex'")
+        .bind(PROJECT_ID)
+        .execute(&pool)
+        .await
+        .unwrap();
     pool.close().await;
 }
 
@@ -358,16 +438,7 @@ fn run_proxy(
     input: &str,
     extra_env: &[(&str, &str)],
 ) -> Output {
-    let mut child = Command::new(binary)
-        .args(args)
-        .current_dir(workspace)
-        .env(TEST_SERVICE_ENV, service_name)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .envs(extra_env.iter().copied())
-        .spawn()
-        .unwrap();
+    let mut child = spawn_proxy(binary, args, workspace, service_name, extra_env);
     child
         .stdin
         .take()
@@ -388,6 +459,31 @@ fn run_proxy(
         "proxy did not exit; stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn spawn_proxy(
+    binary: &Path,
+    args: &[&str],
+    workspace: &Path,
+    service_name: &str,
+    extra_env: &[(&str, &str)],
+) -> Child {
+    Command::new(binary)
+        .args(args)
+        .current_dir(workspace)
+        .env(TEST_SERVICE_ENV, service_name)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .envs(extra_env.iter().copied())
+        .spawn()
+        .unwrap()
+}
+
+fn read_proxy_json_line(reader: &mut impl BufRead) -> Value {
+    let mut line = String::new();
+    assert!(reader.read_line(&mut line).unwrap() > 0);
+    serde_json::from_str(&line).unwrap()
 }
 
 fn assert_process_succeeded(name: &str, output: &Output) {

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -26,8 +26,8 @@ use daemon::{
     DaemonProjectStorageRequest, DaemonProjectStorageResetRequest, DaemonServerRequest,
     DaemonState, DaemonSyncRetryRequest, DaemonUpdateDraftOperation, DraftOperationSyncStatus,
     IDENTIFIER_NAMESPACE, LaunchAgentConfig, LaunchAgentController, LaunchAgentRuntimeStatus,
-    ProjectAgentAdapterKind, RecordAgentRunEventResponse, ServerCredentials, SyncRetryChannel,
-    SyncState,
+    ProjectAgentAdapterDelivery, ProjectAgentAdapterKind, ProjectAgentAdapterRuntimeRequirement,
+    RecordAgentRunEventResponse, ServerCredentials, SyncRetryChannel, SyncState,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -3272,9 +3272,11 @@ async fn project_bindings_resolve_by_canonical_root_and_persist_across_restarts(
 
     let first_resolution = service.resolve_project_binding(DaemonProjectBindingResolveRequest {
         workspace_path: first_nested.display().to_string(),
+        required_adapter: None,
     });
     let second_resolution = service.resolve_project_binding(DaemonProjectBindingResolveRequest {
         workspace_path: second_root.display().to_string(),
+        required_adapter: None,
     });
     let (first_resolution, second_resolution) = tokio::join!(first_resolution, second_resolution);
     assert_eq!(first_resolution.unwrap().project_id, "prj_first");
@@ -3284,6 +3286,7 @@ async fn project_bindings_resolve_by_canonical_root_and_persist_across_restarts(
     let persisted = restarted
         .resolve_project_binding(DaemonProjectBindingResolveRequest {
             workspace_path: first_nested.display().to_string(),
+            required_adapter: None,
         })
         .await
         .unwrap();
@@ -3358,6 +3361,7 @@ async fn project_bindings_resolve_when_the_workspace_root_is_replaced_by_a_symli
     let resolved = service
         .resolve_project_binding(DaemonProjectBindingResolveRequest {
             workspace_path: bound_root.display().to_string(),
+            required_adapter: None,
         })
         .await
         .unwrap();
@@ -3409,8 +3413,9 @@ async fn adapter_install_normalizes_an_empty_binding_after_a_workspace_symlink_m
         .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
             project_id: "prj_moved_adapter".to_owned(),
             workspace_root: bound_root.display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::Dsh,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
@@ -3436,7 +3441,7 @@ async fn adapter_install_normalizes_an_empty_binding_after_a_workspace_symlink_m
     service
         .remove_project_agent_adapter(DaemonProjectAgentAdapterRemoveRequest {
             workspace_root: bound_root.display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::Dsh,
             expected_revision: installed.revision,
         })
         .await
@@ -3462,9 +3467,8 @@ async fn project_agent_adapter_install_is_reversible_and_repository_binding_can_
 
     let daemon_root = tempfile::tempdir().unwrap();
     let repository_root = tempfile::tempdir().unwrap();
-    let codex_config = repository_root.path().join(".codex/config.toml");
-    std::fs::create_dir_all(codex_config.parent().unwrap()).unwrap();
-    std::fs::write(&codex_config, "[model]\nname = \"gpt\"\n").unwrap();
+    let agent_config = repository_root.path().join("opencode.json");
+    std::fs::write(&agent_config, r#"{"model":"gpt"}"#).unwrap();
     let mut config = DaemonConfig::for_root(daemon_root.path());
     config.project.server_url = format!("http://{address}");
     let credential_store = common::TestCredentialStore::new(Some(ServerCredentials {
@@ -3488,16 +3492,17 @@ async fn project_agent_adapter_install_is_reversible_and_repository_binding_can_
         .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
             project_id: "prj_adapter".to_owned(),
             workspace_root: repository_root.path().display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::Opencode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
         .unwrap();
     assert_eq!(installed.revision, 1);
-    let rendered_config = std::fs::read_to_string(&codex_config).unwrap();
-    assert!(rendered_config.contains("[model]"));
-    assert!(rendered_config.contains("[mcp_servers.clumsies]"));
+    let rendered_config = std::fs::read_to_string(&agent_config).unwrap();
+    assert!(rendered_config.contains("\"model\""));
+    assert!(rendered_config.contains("\"clumsies\""));
     assert!(
         rendered_config.contains(
             &std::fs::canonicalize(&helper)
@@ -3519,8 +3524,9 @@ async fn project_agent_adapter_install_is_reversible_and_repository_binding_can_
         .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
             project_id: "prj_adapter".to_owned(),
             workspace_root: repository_root.path().display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::Opencode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
@@ -3537,14 +3543,14 @@ async fn project_agent_adapter_install_is_reversible_and_repository_binding_can_
     service
         .remove_project_agent_adapter(DaemonProjectAgentAdapterRemoveRequest {
             workspace_root: repository_root.path().display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::Opencode,
             expected_revision: installed.revision,
         })
         .await
         .unwrap();
-    let restored_config = std::fs::read_to_string(&codex_config).unwrap();
-    assert!(restored_config.contains("[model]"));
-    assert!(!restored_config.contains("mcp_servers.clumsies"));
+    let restored_config = std::fs::read_to_string(&agent_config).unwrap();
+    assert!(restored_config.contains("\"model\""));
+    assert!(!restored_config.contains("\"clumsies\""));
     assert!(
         !repository_root
             .path()
@@ -3608,8 +3614,9 @@ async fn adapter_update_retires_stale_managed_skill_files() {
         .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
             project_id: "prj_adapter".to_owned(),
             workspace_root: repository_root.path().display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::ClaudeCode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
@@ -3620,8 +3627,8 @@ async fn adapter_update_retires_stale_managed_skill_files() {
     // the stored manifest still manages them (as older releases wrote it).
     let activate = repository_root
         .path()
-        .join(".agents/skills/activate/SKILL.md");
-    let ntmd = repository_root.path().join(".agents/skills/ntmd/SKILL.md");
+        .join(".claude/skills/activate/SKILL.md");
+    let ntmd = repository_root.path().join(".claude/skills/ntmd/SKILL.md");
     std::fs::create_dir_all(activate.parent().unwrap()).unwrap();
     std::fs::create_dir_all(ntmd.parent().unwrap()).unwrap();
     let content = b"---\nname: legacy\n---\n";
@@ -3637,7 +3644,7 @@ async fn adapter_update_retires_stale_managed_skill_files() {
     let canonical_root = std::fs::canonicalize(repository_root.path()).unwrap();
     let manifest_json: String = sqlx::query_scalar(
         "SELECT manifest_json FROM project_agent_adapters
-         WHERE workspace_root = $1 AND adapter = 'codex'",
+         WHERE workspace_root = $1 AND adapter = 'claude-code'",
     )
     .bind(canonical_root.display().to_string())
     .fetch_one(&db)
@@ -3646,8 +3653,8 @@ async fn adapter_update_retires_stale_managed_skill_files() {
     let mut manifest: serde_json::Value = serde_json::from_str(&manifest_json).unwrap();
     let hash = format!("{:x}", Sha256::digest(content));
     for relative in [
-        ".agents/skills/activate/SKILL.md",
-        ".agents/skills/ntmd/SKILL.md",
+        ".claude/skills/activate/SKILL.md",
+        ".claude/skills/ntmd/SKILL.md",
     ] {
         manifest["managed_files"]
             .as_array_mut()
@@ -3669,8 +3676,9 @@ async fn adapter_update_retires_stale_managed_skill_files() {
         .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
             project_id: "prj_adapter".to_owned(),
             workspace_root: repository_root.path().display().to_string(),
-            adapter: ProjectAgentAdapterKind::Codex,
+            adapter: ProjectAgentAdapterKind::ClaudeCode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: Some(installed.revision),
         })
         .await
@@ -3678,11 +3686,11 @@ async fn adapter_update_retires_stale_managed_skill_files() {
     assert_eq!(updated.revision, 2);
     assert!(!activate.exists());
     assert!(!ntmd.exists());
-    assert!(!repository_root.path().join(".agents").exists());
+    assert!(!repository_root.path().join(".claude/skills").exists());
 
     let manifest_json: String = sqlx::query_scalar(
         "SELECT manifest_json FROM project_agent_adapters
-         WHERE workspace_root = $1 AND adapter = 'codex'",
+         WHERE workspace_root = $1 AND adapter = 'claude-code'",
     )
     .bind(canonical_root.display().to_string())
     .fetch_one(&db)
@@ -3740,6 +3748,7 @@ async fn opencode_project_agent_adapter_install_is_reversible_and_preserves_user
             workspace_root: repository_root.path().display().to_string(),
             adapter: ProjectAgentAdapterKind::Opencode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
@@ -3784,6 +3793,7 @@ async fn opencode_project_agent_adapter_install_is_reversible_and_preserves_user
             workspace_root: repository_root.path().display().to_string(),
             adapter: ProjectAgentAdapterKind::Opencode,
             runtime_binary_path: helper.display().to_string(),
+            host_binary_path: None,
             expected_revision: None,
         })
         .await
@@ -3836,6 +3846,77 @@ async fn opencode_project_agent_adapter_install_is_reversible_and_preserves_user
 }
 
 #[tokio::test]
+async fn host_plugin_runtime_requires_exact_adapter_delivery() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let daemon_root = root.path().join("daemon");
+    let mut config = DaemonConfig::for_root(&daemon_root);
+    config.project.server_url = "https://app.clumsies.ai".to_owned();
+    let state = common::initialize_daemon(config, common::TestCredentialStore::default()).await;
+    let workspace_root = std::fs::canonicalize(workspace.path())
+        .unwrap()
+        .display()
+        .to_string();
+    let db = sqlx::SqlitePool::connect(&format!(
+        "sqlite://{}",
+        daemon_root.join("local.db").display()
+    ))
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO project_bindings
+             (server_url, workspace_root, project_id, revision)
+         VALUES ('https://app.clumsies.ai', $1, 'prj_plugin_gate', 1)",
+    )
+    .bind(&workspace_root)
+    .execute(&db)
+    .await
+    .unwrap();
+    let manifest = |delivery: &str| {
+        json!({
+            "runtime_binary_hash": "a".repeat(64),
+            "runtime_binary_path": "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
+            "delivery": delivery,
+            "managed_files": []
+        })
+        .to_string()
+    };
+    sqlx::query(
+        "INSERT INTO project_agent_adapters
+             (server_url, workspace_root, project_id, adapter, revision, manifest_json)
+         VALUES ('https://app.clumsies.ai', $1, 'prj_plugin_gate', 'codex', 1, $2)",
+    )
+    .bind(&workspace_root)
+    .bind(manifest("legacy_files"))
+    .execute(&db)
+    .await
+    .unwrap();
+    let request = || DaemonProjectBindingResolveRequest {
+        workspace_path: workspace.path().display().to_string(),
+        required_adapter: Some(ProjectAgentAdapterRuntimeRequirement {
+            adapter: ProjectAgentAdapterKind::Codex,
+            delivery: ProjectAgentAdapterDelivery::HostPlugin,
+        }),
+    };
+    let rejected = state.resolve_project_binding(request()).await.unwrap_err();
+    assert!(matches!(
+        rejected,
+        DaemonError::State {
+            code: "project_agent_adapter_not_enabled",
+            ..
+        }
+    ));
+
+    sqlx::query("UPDATE project_agent_adapters SET manifest_json = $1 WHERE adapter = 'codex'")
+        .bind(manifest("host_plugin"))
+        .execute(&db)
+        .await
+        .unwrap();
+    let accepted = state.resolve_project_binding(request()).await.unwrap();
+    assert_eq!(accepted.project_id, "prj_plugin_gate");
+}
+
+#[tokio::test]
 async fn resolving_an_unbound_workspace_reports_project_binding_not_found() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("unbound");
@@ -3846,6 +3927,7 @@ async fn resolving_an_unbound_workspace_reports_project_binding_not_found() {
     let error = state
         .resolve_project_binding(DaemonProjectBindingResolveRequest {
             workspace_path: workspace.display().to_string(),
+            required_adapter: None,
         })
         .await
         .unwrap_err();

--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -1,10 +1,11 @@
 # Adapter
 
 Adapter is the daemon-owned integration layer that makes the Clumsies Agent
-runtime usable inside Codex, Claude Code, opencode, dsh, and Antigravity. It
-installs each host's MCP registration, non-blocking lifecycle bridge, and
-necessary configuration without creating a second memory or runtime
-implementation.
+runtime usable inside Codex, Claude Code, opencode, dsh, and Antigravity. For
+Codex it installs and reconciles one user-level Clumsies plugin; the other
+hosts retain their direct-file integrations. Both delivery forms provide the
+MCP registration and non-blocking lifecycle bridge without creating a second
+memory or runtime implementation.
 
 ## Runtime boundary
 
@@ -20,7 +21,9 @@ one of two short-lived proxy modes:
 
 ```text
 clumsiesd mcp serve
+clumsiesd mcp serve --host codex --delivery host-plugin
 clumsiesd _agent issue-run-event --host codex|claude-code|opencode|dsh|antigravity
+clumsiesd _agent issue-run-event --host codex --delivery host-plugin
 ```
 
 The installer requires an executable whose canonical path ends in
@@ -42,31 +45,48 @@ workspace root, and host.
 
 | Host | MCP registration | Lifecycle integration |
 | --- | --- | --- |
-| Codex | `.codex/config.toml` → `mcp_servers.clumsies` | `.codex/hooks.json`, `hooks/resolve-binary.sh`, `hooks/issue-run-event.sh` |
+| Codex | `clumsies@clumsies-local` plugin → pinned MCP server | plugin Hooks; no project files |
 | Claude Code | `.mcp.json` → `mcpServers.clumsies` | `.claude/settings.json`, `hooks/resolve-binary.sh`, `hooks/issue-run-event.sh` |
 | opencode | `opencode.json` → `mcp.clumsies` | `.opencode/plugins/clumsies.ts` |
 | dsh | profile-managed MCP registration | `.dsh/clumsies.json` routes the separately installed client bridge |
 | Antigravity | `.mcp.json` → `mcpServers.clumsies` | `.agents/hooks.json`, `.agents/hooks/resolve-binary.sh`, `.agents/hooks/issue-run-event.sh` |
 
-Every host consumes the MCP tools directly; the thin host-native skills that
-older releases installed for Codex and Claude Code
-(`.agents/skills/activate|ntmd`, `.claude/skills/activate|ntmd`) are
-retired. The adapter update path deletes those previously-managed skill files
-instead of leaving them behind.
+Every host consumes the MCP tools directly. The Codex plugin carries one thin
+`clumsies` bootstrap Skill that tells the harness when to activate Memory and
+how to use Kanban. Project-maintained skills such as `coding` are ordinary
+resources in Memory Space: the bootstrap loads them through `memory.load` when
+relevant and never copies or installs them into a host skill directory.
 
-Codex and Claude Code MCP entries execute the pinned binary with arguments
-`mcp`, `serve`. The opencode local MCP entry executes the equivalent command
-array. The opencode plugin embeds the same pinned path for lifecycle events.
+The unrelated host-native `activate` / `ntmd` skills installed by older Codex
+and Claude Code releases are retired. Codex plugin migration removes the exact
+legacy `.codex/config.toml`, `.codex/hooks.json`, and managed Hook fragments;
+the direct-file update paths likewise delete previously managed retired skill
+files without touching user-owned content.
+
+The Codex plugin executes the pinned binary as `mcp serve --host codex
+--delivery host-plugin`. The delivery marker requires an exact, enabled Codex
+Adapter record at startup and again before every `tools/call`; a removal,
+delivery change, or Project rebind therefore fails the next call closed. Claude
+Code and the remaining direct-file hosts retain their existing commands. The
+opencode plugin embeds the same pinned path for lifecycle events.
 
 ## Lifecycle bridge
 
-Codex and Claude Code register one managed `issue-run-event.sh` for prompt,
-subagent, and session lifecycle. Claude Code additionally registers
-`StopFailure`. Antigravity registers `PreInvocation`. None of these adapters
-registers a normal root `Stop`. The opencode plugin forwards user messages,
-failed assistant completions, and session deletion, but does not turn a normal
-assistant completion into `Stop`. The dsh client bridge follows the same
-non-blocking boundary.
+The Codex plugin and Claude Code direct-file adapter each register an
+`issue-run-event.sh` for prompt, subagent, and session lifecycle. Codex forwards
+the same `host-plugin` delivery marker used by MCP; a stale global plugin is
+therefore inert for Projects without an enabled matching Adapter record.
+Codex treats plugin Hooks as non-managed code and skips a new or changed Hook
+until the user reviews and trusts its current hash in `/hooks`. Adapter never
+bypasses that trust boundary. Plugin changes do not hot-load into an already
+open Codex task: restart Codex after install or update, then start a new task.
+MCP and Memory are then available; AgentRun injection and run-bound Kanban
+actions begin after Hook trust.
+Claude Code additionally registers `StopFailure`. Antigravity registers
+`PreInvocation`. None of these adapters registers a normal root `Stop`. The
+opencode plugin forwards user messages, failed assistant completions, and
+session deletion, but does not turn a normal assistant completion into `Stop`.
+The dsh client bridge follows the same non-blocking boundary.
 
 ```text
 host event
@@ -100,11 +120,23 @@ authority boundary.
 
 ## Safe install, update, and remove
 
-Adapter merges shared host configuration while treating generated scripts
-and plugins as exclusive managed files. Its manifest records the installed
-hash of every managed file, and the update path retires previously-managed
-files the current plan no longer includes (for example the retired thin
-skills).
+Direct-file adapters merge shared host configuration while treating generated
+scripts and plugins as exclusive managed files. Their manifests record the
+installed hash of every managed file, and update retires managed files that the
+current plan no longer includes.
+
+Codex uses a distinct `host_plugin` delivery. The daemon verifies the explicit
+Codex App CLI, materializes an App-owned local marketplace, and reconciles the
+exact enabled plugin version through the Codex plugin CLI. Only after that
+succeeds does its journal remove exact legacy project fragments and flip the
+Project Adapter record from `legacy_files` to `host_plugin`. Disabling Codex in
+v1 deletes the Project Adapter record but deliberately leaves the global plugin
+installed; the runtime delivery gate makes it inert for that Project. Installed
+and enabled describes plugin delivery, not Hook trust. Project settings keep a
+visible `/hooks` reminder because Codex owns that explicit user decision.
+The same reminder requires a Codex restart and a new task after install or
+update; an existing task is not a valid convergence probe for the new plugin
+snapshot and may still own a retired legacy proxy until it exits.
 
 The App refuses to bootstrap `clumsiesd` or persist an Agent runtime path while
 macOS is running it from an App Translocation mount. Move the released App to
@@ -129,7 +161,8 @@ temporary quarantine UUID from entering LaunchAgent and host configuration.
   refuses foreign or drifted entries instead of silently adopting them.
 - Remove deletes only exact managed entries and files; drift becomes a conflict
   instead of an overwrite.
-- Filesystem changes are rolled back if the adapter record cannot be committed.
+- Filesystem and record changes are journaled so an interrupted install or
+  migration is recovered deterministically on the next reconciliation pass.
 
 This keeps unrelated host configuration intact and prevents an old worktree or
 helper copy from silently taking over the Agent runtime.
@@ -139,10 +172,13 @@ helper copy from silently taking over the Agent runtime.
 | Concern | Active path |
 | --- | --- |
 | Native installer, merge rules, and legacy discovery | `crates/daemon/src/agent_adapter.rs` |
+| Codex plugin materialization and CLI reconciliation | `crates/daemon/src/agent_adapter/codex_plugin.rs` |
+| Codex plugin source bundle | `packages/clumsies/` |
 | MCP and Hook proxy modes | `crates/daemon/src/main.rs` |
 | Typed MCP contract | `crates/daemon/src/agent_runtime/mcp_contract.rs` |
 | Hook normalization | `crates/daemon/src/agent_runtime/hook.rs` |
-| Codex and Claude Code Hook templates | `assets/adapters/*/runtime/hooks/issue-run-event.sh.tpl` |
+| Codex plugin Hook template | `packages/clumsies/scripts/issue-run-event.sh.tpl` |
+| Direct-file Hook templates | `assets/adapters/*/runtime/hooks/issue-run-event.sh.tpl` |
 | opencode lifecycle plugin | `assets/adapters/opencode/runtime/plugin.ts` |
 
 The retired Zig adapter implementation is historical source under

--- a/docs/guides/agent-run-injection.md
+++ b/docs/guides/agent-run-injection.md
@@ -41,7 +41,7 @@ unbound, and one active Issue cannot be claimed by a second active run.
 
 | Host | Observed events | Integration surface |
 | --- | --- | --- |
-| Codex | `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `SessionEnd` | `.codex/hooks.json` → managed shell Hook; no root `Stop` registration |
+| Codex | `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `SessionEnd` | Adapter-installed Clumsies plugin Hook with exact `host_plugin` gate after the user trusts its current hash in `/hooks`; no project Hook files and no root `Stop` registration |
 | Claude Code | the Codex set plus `StopFailure` | `.claude/settings.json` → managed shell Hook; no root `Stop` registration |
 | Antigravity | `PreInvocation` | `.agents/hooks.json` → managed shell Hook; no root `Stop` registration |
 | opencode | user message, failed assistant message, deleted session | managed plugin maps them to `UserPromptSubmit`, `StopFailure`, and `SessionEnd`; successful completion emits no `Stop` |
@@ -111,6 +111,11 @@ Hook lifecycle event        -> record_agent_run_event -> AgentRun observation
 Skill/manual Agent judgment -> MCP kanban operation   -> Issue transition
 ```
 
+Codex skips a new or changed plugin Hook until the user reviews and trusts it
+through `/hooks`. Clumsies never bypasses that decision. Memory and non-run-bound
+Kanban reads remain available, while `begin_work` and closure must wait for a
+real Hook-injected run ID.
+
 The private bridge is not an MCP tool. Conversely, `kanban.begin_work`, pause,
 resume, unclaim, and `request_closure` do not pretend to be host lifecycle
 events. This keeps transport telemetry from becoming product intent.
@@ -123,5 +128,6 @@ events. This keeps transport telemetry from becoming product intent.
 | Host payload normalization | `crates/daemon/src/agent_runtime/hook.rs` |
 | AgentRun persistence and Issue transitions | `crates/daemon/src/work_tracking.rs` |
 | Adapter rendering and migration | `crates/daemon/src/agent_adapter.rs` |
-| Codex / Claude Code Hook templates | `assets/adapters/*/runtime/hooks/issue-run-event.sh.tpl` |
+| Codex plugin reconciliation and Hook template | `crates/daemon/src/agent_adapter/codex_plugin.rs`, `packages/clumsies/scripts/issue-run-event.sh.tpl` |
+| Direct-file Hook templates | `assets/adapters/*/runtime/hooks/issue-run-event.sh.tpl` |
 | opencode plugin | `assets/adapters/opencode/runtime/plugin.ts` |

--- a/docs/guides/agent-runtime.md
+++ b/docs/guides/agent-runtime.md
@@ -4,20 +4,34 @@ This page describes the host runtime path, not the human member workflow.
 
 ## Entrypoint
 
-Supported adapters register the App-bundled runtime as:
+Direct-file adapters register the App-bundled runtime as:
 
 ```bash
 /path/to/Clumsies.app/Contents/Resources/clumsiesd mcp serve
 ```
 
-This is an adapter-managed command, not a general-purpose CLI. The repository
+Codex receives the same runtime through the Adapter-installed Clumsies plugin:
+
+```bash
+/path/to/Clumsies.app/Contents/Resources/clumsiesd \
+  mcp serve --host codex --delivery host-plugin
+```
+
+These are adapter-managed commands, not a general-purpose CLI. The repository
 must already have a daemon-owned Project binding, the resident macOS daemon must
-be running, and the matching Project Commit generation must be ready. Adapters
-also register the private lifecycle bridge:
+be running, and the matching Project Commit generation must be ready. A
+direct-file Hook invokes the private lifecycle bridge as:
 
 ```bash
 /path/to/Clumsies.app/Contents/Resources/clumsiesd \
   _agent issue-run-event --host codex|claude-code|opencode
+```
+
+The Codex plugin Hook instead invokes the exact gated form:
+
+```bash
+/path/to/Clumsies.app/Contents/Resources/clumsiesd \
+  _agent issue-run-event --host codex --delivery host-plugin
 ```
 
 Both modes are short-lived proxies. They are parsed before daemon
@@ -97,11 +111,26 @@ context.
 
 ## Adapter boundary
 
-Adapters make a concrete host launch the MCP server; hosts consume the MCP
-tools directly, so no host-native skill layer is installed. Adapters manage
-host-specific hooks for lifecycle observation outside the MCP memory contract,
-but those hooks must not reimplement retrieval or inject a second bootstrap
-protocol.
+Adapters make a concrete host launch the MCP server. Codex receives one thin
+bootstrap Skill inside the plugin; it coordinates `memory.activate`, loads
+relevant project-maintained skills from Memory Space with `memory.load`, and
+uses Kanban when durable work exists. The project skills themselves remain
+ordinary Memory resources and are never installed into a host skill directory.
+Other hosts consume the MCP tools directly. Host-specific Hooks observe
+lifecycle outside the MCP memory contract and must not reimplement retrieval or
+inject a second bootstrap protocol.
+
+Codex plugin proxies identify both `host=codex` and `delivery=host-plugin`.
+After resolving the canonical Project, the resident daemon requires the exact
+enabled Adapter delivery at startup and before every `tools/call`. Removing the
+Adapter, changing its delivery, or rebinding the workspace makes an already
+running plugin proxy fail its next call closed. This makes a globally installed
+plugin harmless when the integration is disabled for a Project. Plugin
+installation does not grant Hook trust: the user must review the current
+Clumsies Hook in `/hooks` before AgentRun injection and run-bound Kanban actions
+become available. Installation also does not hot-load the plugin into an
+existing Codex task; restart Codex after install or update, then start a new
+task with the new plugin snapshot.
 
 The native daemon installer writes the exact code-signed App-bundled
 `clumsiesd` path into host configuration and its managed resolver. It does not

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -83,11 +83,12 @@ MCP keeps the public `memory` (`op.store`) tool shape. Internally it adds the
 current bound Project as the Draft carrier and marks Organization authority as
 the proposal target. These are separate axes: the Project owns the pre-merge
 overlay; `org` describes the Ref an approved Review may eventually move. At
-process startup, MCP gives its current working directory to daemon;
-daemon canonicalizes the path and resolves the nearest bound ancestor in
-SQLite. MCP never treats a legacy Workspace ID as a Project ID. The Rust MCP
-contract tests exercise the exact Agent-facing envelopes before they are mapped
-to typed daemon requests.
+process startup, MCP gives its current working directory to daemon; daemon
+canonicalizes the path and resolves the nearest bound ancestor in SQLite. A
+Codex host-plugin proxy repeats that resolution and its exact Adapter-delivery
+check before every `tools/call`. MCP never treats a legacy Workspace ID as a
+Project ID. The Rust MCP contract tests exercise the exact Agent-facing
+envelopes before they are mapped to typed daemon requests.
 
 Agent-originated updates are exact text replacements, not complete-document
 writes. MCP forwards the resource ID, the complete-resource hash returned by

--- a/docs/unified-memory-model.md
+++ b/docs/unified-memory-model.md
@@ -126,14 +126,13 @@ Memory {
 - Workflow Skill generation is explicitly retired: it lived in the archived
   Zig CLI (`archive/zig-cli/src/client/adapter/workflow_skills.zig`), which
   is outside the active build boundary.
-- The thin host-native skills layer is retired as well (ISSUE-064): the Rust
-  Agent Adapter no longer installs or manages `activate` / `ntmd` (or any
-  other) host skills; every host uses the MCP tools directly, and the adapter
-  update path deletes previously-installed skill files. All host-skill
-  templates were removed from `assets/adapters/` and their archived mirrors,
-  and the `.agents/skills` / `.claude/skills` artifacts are cleaned up. A
-  documented decision records the retirement rather than a silent
-  disappearance.
+- The former `activate` / `ntmd` host-native layer is retired (ISSUE-064).
+  Direct-file adapters no longer install project guidance as host skills and
+  clean up their old `.agents/skills` / `.claude/skills` artifacts. The Codex
+  plugin adds only a generic Clumsies bootstrap Skill: it uses MCP to activate
+  Memory and dynamically load relevant project-maintained skills. Those skills
+  remain ordinary resources in Memory Space, are governed by the unified
+  Memory contract, and are never copied into Codex's skill directories.
 
 ## macOS
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -105,4 +105,7 @@ The adapter starts the App-bundled `clumsiesd mcp serve` proxy from the
 repository. At startup the proxy verifies the resident daemon release identity,
 resolves the current directory through the binding registry, and fixes that
 canonical `project_id` for the process. Agent input cannot select another
-Project or reuse Desktop's current selection.
+Project or reuse Desktop's current selection. A Codex host-plugin proxy repeats
+the canonical binding and exact Adapter-delivery check before every
+`tools/call`, so a removal, delivery flip, or rebind revokes the running proxy
+on its next call.

--- a/packages/clumsies/.codex-plugin/plugin.json
+++ b/packages/clumsies/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "clumsies",
+  "version": "0.1.0",
+  "description": "Use project Memory and Kanban through Clumsies from Codex.",
+  "author": {
+    "name": "Clumsies Lab"
+  },
+  "repository": "https://github.com/lilhammerfun/clumsies",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "kanban",
+    "coding-agent"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Clumsies",
+    "shortDescription": "Project Memory and Kanban for Codex",
+    "longDescription": "Activate project knowledge, load project-maintained skills from Memory, and coordinate durable work through the Clumsies Kanban.",
+    "developerName": "Clumsies Lab",
+    "category": "Productivity",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Activate Clumsies Memory for this project."
+    ]
+  }
+}

--- a/packages/clumsies/.mcp.json.tpl
+++ b/packages/clumsies/.mcp.json.tpl
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "clumsies": {
+      "command": "__CLUMSIESD_ABSOLUTE_PATH_REQUIRED__",
+      "args": [
+        "mcp",
+        "serve",
+        "--host",
+        "codex",
+        "--delivery",
+        "host-plugin"
+      ]
+    }
+  }
+}

--- a/packages/clumsies/hooks/hooks.json
+++ b/packages/clumsies/hooks/hooks.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/scripts/issue-run-event.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/scripts/issue-run-event.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/scripts/issue-run-event.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${PLUGIN_ROOT}/scripts/issue-run-event.sh\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/clumsies/scripts/issue-run-event.sh.tpl
+++ b/packages/clumsies/scripts/issue-run-event.sh.tpl
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Forward a Codex lifecycle event to the signed App-bundled Clumsies runtime.
+# Best effort only: lifecycle observation must never block Codex.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CLUMSIES=__CLUMSIESD_SHELL_LITERAL_REQUIRED__
+[ -x "$CLUMSIES" ] || exit 0
+
+cd "$PROJECT_ROOT" 2>/dev/null || exit 0
+"$CLUMSIES" _agent issue-run-event --host codex --delivery host-plugin 2>/dev/null || true
+exit 0

--- a/packages/clumsies/skills/clumsies/SKILL.md
+++ b/packages/clumsies/skills/clumsies/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: clumsies
+description: Use Clumsies in a bound project to retrieve relevant Memory, including project-maintained skills and procedures, and coordinate durable work through Kanban. Use for substantive project tasks when the Clumsies memory and kanban MCP tools are available; skills stored in Memory remain ordinary project guidance.
+---
+
+# Clumsies
+
+Clumsies connects the current project to durable knowledge and work tracking. Its MCP surface exposes `memory` and `kanban`; operations such as `activate`, `load`, and `store` belong to `memory`.
+
+## Memory
+
+- Call `memory.activate` once before planning or editing for each substantive task. Reuse an activation already made for the same task. Describe the user's goal and the project guidance needed; when the user names a project skill, such as `coding`, include that skill name in the activation query.
+- Apply relevant returned fragments as project guidance. When a fragment identifies a project-maintained skill or procedure, call `memory.load` with its exact resource ID or path and read the complete resource before following it. Load only resources needed for the task.
+- Treat a skill stored in Memory as ordinary Memory content. Do not look for it in a harness skill directory, copy it there, claim it is installed, or grant it extra authority. Follow it only when relevant and within the current instruction hierarchy, user scope, permissions, and available tools.
+- Call `memory.store` only when the user explicitly asks to maintain Memory. Load an existing target and the project's applicable Memory guidance before changing it.
+
+## Kanban
+
+- Keep transient work off the board. Before creating or mutating a durable Issue, call `kanban.list`; inspect a supplied Issue ID or key with `kanban.get`.
+- Call `kanban.begin_work` before starting active Issue work, using the exact hook-injected run ID and revision. Never invent a run or infer one by recency. Do not begin blocked work unless the user explicitly overrides the block; create unrelated durable follow-up work as Todo without switching the current run.
+- If no hook-injected run is present, Memory and non-run-bound Kanban operations remain available, but run-bound mutations do not. Tell the user to open `/hooks` in Codex and review and trust the current Clumsies plugin Hook; never bypass Hook trust or fabricate a run.
+- Verify the Issue's acceptance criteria and required evidence. Only the root agent may call `kanban.request_closure`, using `run.revision` returned by `begin_work` or a later run-changing operation, never the Issue revision. Closure moves the Issue to In Review, not Done; subagents report evidence to the root agent.
+
+If Clumsies is unavailable or the workspace is unbound, state that plainly and do not invent Memory, Kanban, or AgentRun state.


### PR DESCRIPTION
## Summary

- package Clumsies as a Codex plugin with a generic bootstrap skill, MCP configuration, and lifecycle Hooks
- keep project-maintained skills such as coding exclusively in Memory Space and load them dynamically with memory.activate and memory.load
- reconcile the user plugin from the project Adapter, migrate legacy direct files, and preserve explicit Hook trust
- add an exact delivery gate on every host-plugin MCP tool call so disabling or rebinding the Adapter revokes a live process
- discover and verify the signed Codex host from the macOS app and show restart, new-task, and /hooks guidance

## Validation

- cargo test -p daemon --lib: 274 passed, 2 ignored
- cargo test -p daemon --test daemon_lifecycle: 66 passed
- cargo test -p daemon --test agent_runtime_xpc_e2e: passed
- bun run test:macos: passed
- cargo fmt --check: passed
- cargo clippy -p daemon --all-targets with warnings denied: passed
- plugin and bootstrap skill validators: passed
- JSON, Hook shell syntax, and git diff checks: passed

## Manual App test

1. Build and launch this branch of Clumsies.
2. Open a registered project and enable the Codex Adapter.
3. Restart Codex, then start a new task in that project.
4. Open /hooks and trust the current Clumsies Hook.
5. Ask Codex to activate project Memory, load a project skill such as coding from Memory Space, and inspect Kanban.
6. Disable the Codex Adapter in Clumsies and confirm the next plugin tool call is rejected.

Project skills must remain Memory resources; the plugin must not copy or install them into a host skill directory.