### PR TITLE
macos: ignore cancelled workspace loads

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -1700,6 +1700,8 @@ final class WorkspaceStore: ObservableObject {
                 )
                 guard workspaceReloadGeneration == generation else { return }
             }
+        } catch is CancellationError {
+            return
         } catch {
             guard workspaceReloadGeneration == generation else { return }
             errorMessage = error.localizedDescription
@@ -1944,6 +1946,8 @@ final class WorkspaceStore: ObservableObject {
                 server: server
             ).loadContent(for: resource)
             installLoadedResourceIfCurrent(loaded)
+        } catch is CancellationError {
+            return
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -1083,6 +1083,25 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertTrue(WorkspaceStore.resourceGenerationMatches(current, current))
     }
 
+    func testCancelledDeferredMemoryLoadDoesNotPresentError() async {
+        let store = WorkspaceStore()
+        let resource = orgResource(id: "memory", contentLoaded: false)
+        let item = MemoryListItem(
+            id: resource.id,
+            resource: resource,
+            draft: nil,
+            inherited: false
+        )
+
+        await Task { @MainActor in
+            withUnsafeCurrentTask { $0?.cancel() }
+            await store.loadContentIfNeeded(item)
+        }.value
+
+        XCTAssertNil(store.errorMessage)
+        XCTAssertFalse(store.loadingResourceIds.contains(resource.id))
+    }
+
     func testRenameOnlyDraftDoesNotTreatAnUnloadedOrphanBaselineAsEditableContent() {
         var unloaded = projectResource(
             id: "removed-memory",


### PR DESCRIPTION
## Summary

Switching to Reviews cancels deferred Memory and Bundle loads. Treat those
cancellations as view lifecycle control flow so the global alert no longer
shows `Swift.CancellationError`, while preserving real load failures.

## Change type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor or maintenance
- [ ] Documentation

## Verification

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `bun run api:check`
- [x] `bun run build`
- [x] `bun run test:macos`
- [x] `bun run test:macos:package`
- [x] Deployment scripts, runtime boundary, and retired-term checks

## Risk and rollout

- Risk: Low. Only structured task cancellation bypasses the alert; other load
  failures still use the existing error path.
- Rollback: Revert this commit.

## Checklist

- [x] The PR has one clear purpose and no unrelated changes.
- [x] Tests cover behavior changes and pass locally or in CI.
- [x] User-facing behavior and operational docs are updated when needed.
- [x] Migrations and breaking changes include compatibility and rollback plans.
- [x] No credentials, private data, unintended generated/build artifacts, or
  debug output are included.
