### PR TITLE
ci: enforce pull request review context

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Pull request policy changes require repository-owner review.
+/.github/workflows/ @lilhammerfun
+/.github/pull_request_template.md @lilhammerfun
+/.github/CODEOWNERS @lilhammerfun
+/dev/validate-pr-template.py @lilhammerfun

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,53 @@
-## Summary
+<!-- Complete every section. Use "None" only where the prompt allows it. -->
 
-<!-- What changed, and why is this the smallest complete change? -->
+## Context and summary
 
-<!-- Use "Closes #123" when this PR should close an issue. -->
+<!-- Link the related Issue or decision. Explain the problem, user impact,
+root cause when applicable, and the chosen solution. -->
 
-## Change type
+## Affected areas
 
-- [ ] Bug fix
-- [ ] Feature
-- [ ] Refactor or maintenance
+<!-- Select every affected surface. -->
+
+- [ ] Rust daemon/runtime
+- [ ] Server/API
+- [ ] macOS app
+- [ ] Web Admin
+- [ ] MCP, CLI, or agent protocol
+- [ ] Storage, configuration, or schema
 - [ ] Documentation
+- [ ] CI, deployment, or release
+
+## Behavior and evidence
+
+<!-- Describe before/after behavior. Add sanitized screenshots, logs, traces,
+performance evidence, or request/response examples where relevant.
+Write "None — no user-visible behavior" only when genuinely applicable. -->
 
 ## Verification
 
-<!-- List exact commands, automated checks, and manual evidence. -->
+<!-- List exact automated commands and manual scenarios with their results.
+Identify anything not run and explain why. -->
 
-## Risk and rollout
+## Compatibility and migration
 
-<!-- Name compatibility, migration, security, privacy, or performance risks. Write "None" when not applicable. -->
+<!-- Cover API, configuration, and data compatibility; upgrade, downgrade, and
+mixed-version behavior; and migration or restore evidence.
+Write "None" when not applicable. -->
 
-- Risk:
+## Risk, security, and privacy
+
+<!-- Cover trust boundaries, permissions, private Memory or Hook payloads,
+reliability, performance, cancellation, concurrency, and platform risks.
+Write "None" when not applicable. -->
+
+## Rollout and rollback
+
+- Rollout:
+- Observability:
 - Rollback:
 
-## Checklist
+## Reviewer focus
 
-- [ ] The PR has one clear purpose and no unrelated changes.
-- [ ] Tests cover behavior changes and pass locally or in CI.
-- [ ] User-facing behavior and operational docs are updated when needed.
-- [ ] Migrations and breaking changes include compatibility and rollback plans.
-- [ ] No credentials, private data, unintended generated/build artifacts, or debug output are included.
+<!-- Name risky code paths, deliberate tradeoffs, known limitations, and linked
+follow-up Issues. Write "None" when not applicable. -->

--- a/.github/workflows/pr-template-event.yml
+++ b/.github/workflows/pr-template-event.yml
@@ -17,7 +17,7 @@ jobs:
     name: pr-template-event
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false

--- a/.github/workflows/pr-template-event.yml
+++ b/.github/workflows/pr-template-event.yml
@@ -22,8 +22,12 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - name: Self-test validator
-        run: python3 dev/validate-pr-template.py --self-test
-
       - name: Validate pull request body
-        run: python3 dev/validate-pr-template.py
+        run: |
+          if [[ ! -f dev/validate-pr-template.py ]]; then
+            echo "Validator is not available on the base branch; bootstrap check passed."
+            exit 0
+          fi
+
+          python3 dev/validate-pr-template.py --self-test
+          python3 dev/validate-pr-template.py

--- a/.github/workflows/pr-template-event.yml
+++ b/.github/workflows/pr-template-event.yml
@@ -1,0 +1,29 @@
+name: PR template event
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-template-event-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: pr-template-event
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Self-test validator
+        run: python3 dev/validate-pr-template.py --self-test
+
+      - name: Validate pull request body
+        run: python3 dev/validate-pr-template.py

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -29,7 +29,7 @@ jobs:
             -f context=pr-template \
             -f description="Validating pull request template"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         id: checkout
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -1,0 +1,71 @@
+name: PR template
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: pr-template-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: validate-pr-template
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Report pending status
+        run: |
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state=pending \
+            -f context=pr-template \
+            -f description="Validating pull request template"
+
+      - uses: actions/checkout@v4
+        id: checkout
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Self-test validator
+        id: self_test
+        run: python3 dev/validate-pr-template.py --self-test
+
+      - name: Validate pull request body
+        id: validate
+        continue-on-error: true
+        run: python3 dev/validate-pr-template.py
+
+      - name: Report validation status
+        if: ${{ always() && !cancelled() }}
+        env:
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          SELF_TEST_OUTCOME: ${{ steps.self_test.outcome }}
+          VALIDATION_OUTCOME: ${{ steps.validate.outcome }}
+        run: |
+          state=failure
+          description="Pull request template is incomplete"
+
+          if [[ "$CHECKOUT_OUTCOME" == "success" &&
+                "$SELF_TEST_OUTCOME" == "success" &&
+                "$VALIDATION_OUTCOME" == "success" ]]; then
+            state=success
+            description="Pull request template is complete"
+          fi
+
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/statuses/${HEAD_SHA}" \
+            -f state="$state" \
+            -f context=pr-template \
+            -f description="$description" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          [[ "$state" == "success" ]]

--- a/dev/validate-pr-template.py
+++ b/dev/validate-pr-template.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+HEADINGS = (
+    "## Context and summary",
+    "## Affected areas",
+    "## Behavior and evidence",
+    "## Verification",
+    "## Compatibility and migration",
+    "## Risk, security, and privacy",
+    "## Rollout and rollback",
+    "## Reviewer focus",
+)
+REQUIRED_CONTENT = (
+    "## Context and summary",
+    "## Behavior and evidence",
+    "## Verification",
+    "## Compatibility and migration",
+    "## Risk, security, and privacy",
+    "## Reviewer focus",
+)
+AFFECTED_AREAS = (
+    "Rust daemon/runtime",
+    "Server/API",
+    "macOS app",
+    "Web Admin",
+    "MCP, CLI, or agent protocol",
+    "Storage, configuration, or schema",
+    "Documentation",
+    "CI, deployment, or release",
+)
+
+
+def section(body: str, heading: str) -> str | None:
+    match = re.search(
+        rf"(?ms)^{re.escape(heading)}[ \t]*(?:\r?\n|\Z)(.*?)(?=^##[ \t]|\Z)",
+        body,
+    )
+    return match.group(1) if match else None
+
+
+def without_fenced_code(text: str) -> str:
+    output: list[str] = []
+    fence: tuple[str, int] | None = None
+    for line in text.splitlines(keepends=True):
+        marker = re.match(r"^[ \t]{0,3}(`{3,}|~{3,})", line)
+        if fence is None:
+            if marker:
+                fence = (marker.group(1)[0], len(marker.group(1)))
+            else:
+                output.append(line)
+        elif re.fullmatch(
+            rf"[ \t]{{0,3}}{re.escape(fence[0])}{{{fence[1]},}}[ \t]*(?:\r?\n)?",
+            line,
+        ):
+            fence = None
+    return "".join(output)
+
+
+def visible(text: str) -> str:
+    text = re.sub(r"<!--.*?(?:-->|\Z)", "", text, flags=re.DOTALL)
+    text = re.sub(
+        r"(?is)<(pre|code|script|style)\b[^>]*>.*?(?:</\1\s*>|\Z)",
+        "",
+        text,
+    )
+    return without_fenced_code(text).strip()
+
+
+def has_answer(text: str) -> bool:
+    return bool(re.search(r"\w", visible(text)))
+
+
+def is_placeholder(text: str) -> bool:
+    answer = visible(text)
+    answer = re.sub(
+        r"(?mi)^[ \t]*(?:[-*+]|\d+[.)])[ \t]+(?:\[[ x]\][ \t]+)?",
+        "",
+        answer,
+    )
+    answer = re.sub(r"(?mi)^[ \t]*\[[ x]\][ \t]+", "", answer)
+    answer = re.sub(r"[*_`>#]", "", answer)
+    answer = re.sub(r"[\s/_.!?,;:—–-]+", "", answer).casefold()
+    return answer in {"", "none", "na", "notapplicable"}
+
+
+def validate(body: str) -> list[str]:
+    errors: list[str] = []
+    body = visible(body)
+    sections = {heading: section(body, heading) for heading in HEADINGS}
+
+    for heading, content in sections.items():
+        if content is None:
+            errors.append(f"Missing required section: {heading}")
+
+    for heading in REQUIRED_CONTENT:
+        content = sections[heading]
+        if content is not None and not has_answer(content):
+            errors.append(f"Complete the {heading.removeprefix('## ')} section")
+
+    for heading in ("## Context and summary", "## Verification"):
+        if is_placeholder(sections[heading] or ""):
+            errors.append(f"{heading.removeprefix('## ')} cannot be None")
+
+    affected_areas = sections["## Affected areas"] or ""
+    selected = [
+        item
+        for item in AFFECTED_AREAS
+        if re.search(rf"(?mi)^- \[[xX]\] {re.escape(item)}[ \t]*$", affected_areas)
+    ]
+    if not selected:
+        errors.append("Select at least one affected area")
+
+    rollout = visible(sections["## Rollout and rollback"] or "")
+    for label in ("Rollout", "Observability", "Rollback"):
+        match = re.search(rf"(?mi)^- {label}:[ \t]*(.*)$", rollout)
+        if not match or not has_answer(match.group(1)) or is_placeholder(match.group(1)):
+            errors.append(f"Complete the {label} field")
+
+    return errors
+
+
+def valid_sample() -> str:
+    return """## Context and summary
+
+Explain the problem and the smallest complete change.
+
+## Affected areas
+
+- [x] Rust daemon/runtime
+- [ ] Server/API
+- [ ] macOS app
+- [ ] Web Admin
+- [ ] MCP, CLI, or agent protocol
+- [ ] Storage, configuration, or schema
+- [ ] Documentation
+- [ ] CI, deployment, or release
+
+## Behavior and evidence
+
+None — no user-visible behavior.
+
+## Verification
+
+- `python3 dev/validate-pr-template.py --self-test`
+
+## Compatibility and migration
+
+None.
+
+## Risk, security, and privacy
+
+None.
+
+## Rollout and rollback
+
+- Rollout: Merge through the normal pull request flow.
+- Observability: The required status reports pass or fail.
+- Rollback: Revert the commit.
+
+## Reviewer focus
+
+None.
+"""
+
+
+def self_test() -> None:
+    sample = valid_sample()
+    assert not validate(sample)
+
+    unchecked_with_code = sample.replace(
+        "- [x] Rust daemon/runtime",
+        "- [ ] Rust daemon/runtime\n\n```markdown\n- [x] Rust daemon/runtime\n```",
+    )
+    invalid = (
+        sample.replace("## Context and summary", "## Overview", 1),
+        sample.replace("Explain the problem and the smallest complete change.", "<!-- empty -->"),
+        sample.replace("- [x] Rust daemon/runtime", "- [ ] Rust daemon/runtime"),
+        unchecked_with_code,
+        sample.replace("- `python3 dev/validate-pr-template.py --self-test`", "- [x] None."),
+        sample.replace("- `python3 dev/validate-pr-template.py --self-test`", "- N / A"),
+        sample.replace("- `python3 dev/validate-pr-template.py --self-test`", "- Not-applicable"),
+        sample.replace("- Observability: The required status reports pass or fail.", "- Observability:"),
+        sample.replace("- Observability: The required status reports pass or fail.", "- Observability: ✅"),
+        sample.replace("- Rollback: Revert the commit.", "- Rollback: None"),
+        f"<!--\n{sample}\n-->",
+        f"<!--\n{sample}",
+        f"```markdown\n{sample}\n```",
+        f"<pre>\n{sample}\n</pre>",
+    )
+    assert all(validate(body) for body in invalid)
+    print("PR template validator self-test passed.")
+
+
+def event_body() -> str:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return os.environ.get("PR_BODY", "")
+
+    payload = json.loads(Path(event_path).read_text())
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("event payload does not contain a pull_request object")
+    body = pull_request.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        return 0
+    if sys.argv[1:]:
+        print(f"usage: {Path(sys.argv[0]).name} [--self-test]", file=sys.stderr)
+        return 2
+
+    try:
+        errors = validate(event_body())
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        errors = [f"Unable to read the pull request body: {error}"]
+
+    for error in errors:
+        print(f"::error::{error}")
+    if errors:
+        return 1
+
+    print("PR template validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Context and summary

GitHub currently prefills the repository pull request template but does not
enforce it. Replace the generic type-and-checklist form with a Clumsies-specific
review contract. Validate its objective requirements from trusted base-branch
code, report a stable `pr-template` status on the pull request head, and add a
native event check so body edits invalidate the previous result immediately.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [ ] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [x] Documentation
- [x] CI, deployment, or release

## Behavior and evidence

Before this change, authors could remove every prompt and still merge. After
this change, pull requests to `main` must identify affected surfaces, provide
review and verification context, and state rollout, observability, and rollback
plans. Policy files are code-owned. The valid sample and this body pass locally;
blank, hidden, code-fenced, all-unchecked, placeholder verification, and
incomplete rollout cases fail.

## Verification

- [x] `python3 dev/validate-pr-template.py --self-test`
- [x] `actionlint .github/workflows/*.yml`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `cargo test --workspace` (437 passed, 2 ignored)
- [x] `bun run api:check`
- [x] `bun run build`
- [x] `bun run test:macos`
- [x] `bun run test:macos:package`
- [x] `bash deploy/server/server-release-test.sh`
- [x] `sh dev/check-agent-runtime-boundary.sh`
- [x] `sh dev/check-retired-terms.sh`
- [x] `git diff --check`

## Compatibility and migration

None — no runtime API, protocol, configuration, schema, or data changes. The
GitHub ruleset will be activated only after this workflow exists on `main`.

## Risk, security, and privacy

Low. The `pull_request_target` workflow receives status-write permission but
checks out only the trusted base SHA and never executes pull request head code.
A second read-only `pull_request` workflow creates a native check as soon as a
body edit is dispatched. CODEOWNERS protects every workflow, the validator, and
its own policy file. Repository Actions tokens default to read-only. No secrets
or private project data are used. Both checkout invocations are pinned to the
official v7.0.1 commit. GitHub has no atomic merge-time pull request body rule;
the native event check and required review reduce the remaining edit/merge
dispatch race to an administrative edge case.

## Rollout and rollback

- Rollout: Merge this bootstrap PR, verify both template checks on a follow-up
  PR, then activate the `main` ruleset with code-owner review.
- Observability: Inspect both Actions runs plus `pr-template` and
  `pr-template-event` on the pull request.
- Rollback: Disable the ruleset first, then revert the workflow, validator,
  and template.

## Reviewer focus

Review the trusted-base status boundary, native body-edit invalidation,
CODEOWNERS coverage, and whether the validator enforces useful objective fields
without trying to judge prose quality.
