### PR TITLE
feat(adapter): manage Codex plugin globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 - **Memory as a Team Asset (Git-Semantic Context)**: Rules, workflows, and project context live as first-class Markdown-backed Organization Memory. A Project selects the Organization resources it uses and carries private Draft overlays; reviewed changes merge atomically into immutable Organization Commit history.
 - **Hybrid Retrieval & Precise Activation**: Combines SQLite FTS5 BM25 text search, local dense vector embeddings, Reciprocal Rank Fusion (RRF), and Cross-Encoder reranking. Agents retrieve task-relevant fragments on demand without exhausting token budgets.
 - **Agent-Native Asynchronous Kanban**: Agents autonomously claim tasks (`begin_work`), build dependency DAGs, evaluate blocking predicates, and record structured verification steps. Human approval gates (`approve_closure`) ensure only verified work transitions to Done.
-- **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Codex is delivered as an Adapter-managed plugin; project-maintained skills remain in Memory Space and are loaded on demand. Restart Codex and start a new task after enabling or updating it, then complete the one-time `/hooks` review before its plugin Hook runs. Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.
+- **MCP & Non-Blocking Lifecycle Integration**: Out-of-the-box integration for Google Antigravity, Claude Code, OpenAI Codex, opencode, and DeepSeek Harness (dsh) via a single signed Rust daemon (`clumsiesd`). Codex is delivered as an automatically managed user-level plugin; project-maintained skills remain in Memory Space and are loaded on demand. Restart Codex and start a new task after plugin changes, then complete the one-time `/hooks` review before its plugin Hook runs. Managed adapters do not install normal root Stop hooks; Issue closure remains explicit in an opt-in skill or manually maintained workflow.
 - **Self-Hosted Authority**: Run the Rust Server and PostgreSQL in your own infrastructure with organization OIDC, while the local resident daemon owns fast local state and XPC transport.
 
 ---
@@ -62,7 +62,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 1. Download the latest release from [Releases](https://github.com/lilhammerfun/clumsies/releases).
 2. Move `Clumsies.app` to `/Applications` or `~/Applications`.
 3. Open `Clumsies.app`. It automatically provisions the resident launchd daemon (`ai.clumsies.daemon`) and connects to your organization server.
-4. Toggle your desired Coding Agent adapters in **Project Settings → Coding Agents**.
+4. Bind a repository to its Project. Codex uses the global Plugin automatically; configure optional repository-writing hosts in **Project Settings → Agent**.
 
 ### Development from Source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 - **记忆即团队资产（Git 语义上下文管理）**：将架构规则、工作流规范与项目上下文收敛为统一的 Markdown 组织记忆。Project 只选择要使用的组织记忆并承载项目内可见的 Draft overlay；变更经过团队 Review 后原子合入组织 Commit 历史，杜绝静默覆盖。
 - **混合检索与按需精准激活**：深度融合 SQLite FTS5 BM25 全文检索、本地向量嵌入、倒数排名融合（RRF）与交叉编码器（Cross-Encoder）重排。Agent 通过 `activate` 按需动态召回最相关切片，避免上下文窗口浪费。
 - **面向 Agent 的原生异步看板（Issue DAG）**：Agent 通过类型化 MCP 操作自主认领任务（`begin_work`）、构建有向无环依赖图、评估阻塞谓词并沉淀验证步骤。最终必须由人类通过审批关卡（`approve_closure`）验收完成。
-- **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。Codex 由 Adapter 安装用户级 Plugin，项目维护的 Skill 留在 Memory Space 并按需加载；启用或更新后需重启 Codex 并新建 task，Plugin Hook 首次运行前还需要用户在 `/hooks` 中审查并信任。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。
+- **MCP + 非阻塞生命周期集成**：原生支持 Google Antigravity、Claude Code、OpenAI Codex、opencode 与 DeepSeek Harness (dsh)，由统一签名的 Rust 守护进程（`clumsiesd`）提供代理。Codex 使用 App 自动维护的用户级 Plugin，项目维护的 Skill 留在 Memory Space 并按需加载；Plugin 变化后需重启 Codex 并新建 task，Plugin Hook 首次运行前还需要用户在 `/hooks` 中审查并信任。纳管适配器不安装正常根 `Stop` Hook；Issue 关闭由可选 skill 或人工维护的工作流显式决定。
 - **私有化权威部署**：在自有基础设施中运行 Rust Server 与 PostgreSQL（支持组织 OIDC 鉴权），本地守护进程独立管理高速本地缓存与 XPC 通信。
 
 ---
@@ -62,7 +62,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 1. 在 [Releases 发布页面](https://github.com/lilhammerfun/clumsies/releases) 下载最新的安装包。
 2. 将 `Clumsies.app` 拖入 `/Applications` 或 `~/Applications` 目录。
 3. 打开 `Clumsies.app`，系统将自动配置常驻后台守护进程（`ai.clumsies.daemon`）并连接至组织服务器。
-4. 在 **Project Settings → Coding Agents** 中勾选需要激活的 Coding Agent 即可开箱即用。
+4. 将仓库绑定到对应 Project。Codex 会自动使用全局 Plugin；需要写入仓库的其他 Agent 可在 **Project Settings → Agent** 中配置。
 
 ### 源码构建与本地开发
 

--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -13,7 +13,20 @@ enum SettingsWindowLayout {
     static let defaultContentSize = NSSize(width: 620, height: 470)
     static let minimumContentSize = NSSize(width: 520, height: 400)
 
-    static func normalize(_ window: NSWindow) {
+    static func configure(_ window: NSWindow, pane: SettingsPane) {
+        window.styleMask.remove(.miniaturizable)
+        window.styleMask.remove(.resizable)
+        window.title = pane.title
+        window.toolbarStyle = .preference
+        window.toolbar?.allowsUserCustomization = false
+        window.toolbar?.autosavesConfiguration = false
+        window.toolbar?.displayMode = .iconAndLabel
+        window.standardWindowButton(.miniaturizeButton)?.isEnabled = false
+        window.standardWindowButton(.zoomButton)?.isEnabled = false
+    }
+
+    static func normalize(_ window: NSWindow, pane: SettingsPane) {
+        configure(window, pane: pane)
         window.contentMinSize = minimumContentSize
         let contentSize = window.contentLayoutRect.size
         guard contentSize.width < minimumContentSize.width
@@ -22,6 +35,53 @@ enum SettingsWindowLayout {
             return
         }
         window.setContentSize(defaultContentSize)
+    }
+}
+
+@MainActor
+final class SettingsTabViewController: NSTabViewController {
+    private let panes: [SettingsPane]
+    private let defaults: UserDefaults
+
+    init(
+        items: [(SettingsPane, NSViewController)],
+        selectedPane: SettingsPane,
+        defaults: UserDefaults = .standard
+    ) {
+        panes = items.map(\.0)
+        self.defaults = defaults
+        super.init(nibName: nil, bundle: nil)
+        tabStyle = .toolbar
+        for (pane, controller) in items {
+            controller.title = pane.title
+            let item = NSTabViewItem(viewController: controller)
+            item.identifier = pane.rawValue
+            item.label = pane.title
+            item.image = NSImage(systemSymbolName: pane.systemImage, accessibilityDescription: pane.title)
+            addTabViewItem(item)
+        }
+        selectedTabViewItemIndex = panes.firstIndex(of: selectedPane) ?? 0
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    var selectedPane: SettingsPane {
+        panes.indices.contains(selectedTabViewItemIndex)
+            ? panes[selectedTabViewItemIndex]
+            : .general
+    }
+
+    override func tabView(_ tabView: NSTabView, didSelect tabViewItem: NSTabViewItem?) {
+        super.tabView(tabView, didSelect: tabViewItem)
+        guard let rawValue = tabViewItem?.identifier as? String,
+              let pane = SettingsPane(rawValue: rawValue) else {
+            return
+        }
+        pane.persist(in: defaults)
+        view.window?.title = pane.title
     }
 }
 
@@ -270,26 +330,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
 
     private func presentSettingsWindow() {
         if let settingsWindow {
-            SettingsWindowLayout.normalize(settingsWindow)
+            let pane = (settingsWindow.contentViewController as? SettingsTabViewController)?
+                .selectedPane ?? .general
+            SettingsWindowLayout.normalize(settingsWindow, pane: pane)
             settingsWindow.makeKeyAndOrderFront(nil)
             return
         }
-        let controller = NSHostingController(
-            rootView: NativeSettingsView(
-                store: store,
-                softwareUpdateController: softwareUpdateController
+        let selectedPane = SettingsPane.restored()
+        let items = SettingsPane.allCases.map { pane in
+            let controller = NSHostingController(
+                rootView: NativeSettingsView(
+                    store: store,
+                    softwareUpdateController: softwareUpdateController,
+                    pane: pane,
+                    onOpenDiagnostics: { [weak self] in
+                        self?.presentDiagnosticsWindow(.runtime)
+                    },
+                    onShowLogs: { [weak self] in self?.showLogsInFinder() }
+                )
             )
-        )
-        controller.sizingOptions = []
+            controller.sizingOptions = []
+            return (pane, controller as NSViewController)
+        }
+        let controller = SettingsTabViewController(items: items, selectedPane: selectedPane)
         let window = NSWindow(
             contentRect: NSRect(origin: .zero, size: SettingsWindowLayout.defaultContentSize),
-            styleMask: [.titled, .closable, .resizable],
+            styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
-        window.title = "Settings"
         window.contentViewController = controller
-        SettingsWindowLayout.normalize(window)
+        SettingsWindowLayout.normalize(window, pane: selectedPane)
         window.isReleasedWhenClosed = false
         window.center()
         window.makeKeyAndOrderFront(nil)

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -273,7 +273,7 @@ enum ProjectSetupError: LocalizedError, Sendable {
         case .bundledAgentRuntimeMissing:
             "The clumsiesd Agent runtime is missing from this app build."
         case .codexHostMissing:
-            "Install or update the Codex app before enabling its Clumsies integration."
+            "Install or update the Codex app before repairing its Clumsies Plugin."
         case .bundleNotFound:
             "The selected Bundle is no longer available."
         case .bundleContainsUnavailableMemory:
@@ -1259,6 +1259,7 @@ final class WorkspaceStore: ObservableObject {
         adapters: Set<ProjectAgentAdapterKind>
     ) async throws {
         let repositoryPaths = normalizedRepositoryPaths(repositoryPaths)
+        let adapters = adapters.filter { $0 != .codex }
         guard !repositoryPaths.isEmpty else { throw ProjectSetupError.noRepositories }
         let created: ProjectRecord = try await server.send(
             method: "POST",
@@ -1301,9 +1302,6 @@ final class WorkspaceStore: ObservableObject {
         }
         if !adapters.isEmpty {
             let agentRuntimePath = try bundledAgentRuntimePath()
-            let codexHostPath = adapters.contains(.codex)
-                ? try WorkspaceLoader.installedCodexHostBinaryPath()
-                : nil
             for repositoryPath in repositoryPaths {
                 for adapter in adapters.sorted(by: { $0.rawValue < $1.rawValue }) {
                     _ = try await daemon.installProjectAgentAdapter(
@@ -1312,7 +1310,7 @@ final class WorkspaceStore: ObservableObject {
                             workspaceRoot: repositoryPath,
                             adapter: adapter,
                             runtimeBinaryPath: agentRuntimePath,
-                            hostBinaryPath: adapter == .codex ? codexHostPath : nil,
+                            hostBinaryPath: nil,
                             expectedRevision: nil
                         )
                     )
@@ -1486,6 +1484,25 @@ final class WorkspaceStore: ObservableObject {
         try await daemon.projectAgentAdapters(projectId)
     }
 
+    func codexPluginStatus() async throws -> DaemonCodexPluginStatus {
+        try await daemon.inspectCodexPlugin(
+            .init(
+                runtimeBinaryPath: try bundledAgentRuntimePath(),
+                hostBinaryPath: try? WorkspaceLoader.installedCodexHostBinaryPath()
+            )
+        )
+    }
+
+    func repairCodexPlugin() async throws -> DaemonCodexPluginStatus {
+        let hostBinaryPath = try WorkspaceLoader.installedCodexHostBinaryPath()
+        return try await daemon.reconcileCodexPlugin(
+            .init(
+                runtimeBinaryPath: try bundledAgentRuntimePath(),
+                hostBinaryPath: hostBinaryPath
+            )
+        )
+    }
+
     func setProjectAgentAdapter(
         _ adapter: ProjectAgentAdapterKind,
         enabled: Bool,
@@ -1493,6 +1510,7 @@ final class WorkspaceStore: ObservableObject {
         workspaceRoot: String,
         current: DaemonProjectAgentAdapter?
     ) async throws {
+        guard adapter != .codex else { return }
         if enabled {
             _ = try await daemon.installProjectAgentAdapter(
                 .init(
@@ -1500,9 +1518,7 @@ final class WorkspaceStore: ObservableObject {
                     workspaceRoot: workspaceRoot,
                     adapter: adapter,
                     runtimeBinaryPath: try bundledAgentRuntimePath(),
-                    hostBinaryPath: adapter == .codex
-                        ? try WorkspaceLoader.installedCodexHostBinaryPath()
-                        : nil,
+                    hostBinaryPath: nil,
                     expectedRevision: current?.revision
                 )
             )
@@ -4618,7 +4634,13 @@ final class WorkspaceStore: ObservableObject {
                   !Task.isCancelled else {
                 return
             }
-            self.applyLocalAgentAdapterResult(result)
+            self.applyLocalAgentAdapterResult(.init(
+                conflicts: result.conflicts,
+                inspectionWarning: Self.combinedAgentAdapterWarning(
+                    self.legacyAgentAdapterInspectionWarning,
+                    result.inspectionWarning
+                )
+            ))
         }
 
         draftInventoryLoadTask = Task { @MainActor [weak self] in
@@ -4844,6 +4866,14 @@ final class WorkspaceStore: ObservableObject {
             messages.append("\(result.conflicts.count - visible.count) more legacy integrations need review.")
         }
         return messages.isEmpty ? nil : messages.joined(separator: "\n")
+    }
+
+    nonisolated static func combinedAgentAdapterWarning(
+        _ managedWarning: String?,
+        _ legacyWarning: String?
+    ) -> String? {
+        let warnings = [managedWarning, legacyWarning].compactMap { $0 }
+        return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
     }
 
     private func refreshDraft(_ draftId: String) async throws {
@@ -5581,23 +5611,32 @@ struct WorkspaceLoader: Sendable {
     private func reconcileManagedAgentAdapters() async throws
         -> LocalAgentAdapterReconciliationResult {
         let runtimePath = try Self.bundledAgentRuntimePath()
+        let codexHostPath = await MainActor.run { try? Self.installedCodexHostBinaryPath() }
+        var codexWarning: String?
+        if let codexHostPath {
+            let request = DaemonCodexPluginRequest(
+                runtimeBinaryPath: runtimePath,
+                hostBinaryPath: codexHostPath
+            )
+            do {
+                let status = try await daemon.inspectCodexPlugin(request)
+                if !status.ready {
+                    _ = try await daemon.reconcileCodexPlugin(request)
+                }
+            } catch {
+                codexWarning = "Clumsies could not repair the global Codex plugin. Open Settings > Agent to try again. \(error.localizedDescription)"
+            }
+        }
         let installed = try await daemon.allProjectAgentAdapters()
-        let codexHostPath = Self.hasReachableCodexAdapter(
-            installed: installed,
-            workspaceExists: { FileManager.default.fileExists(atPath: $0) }
-        )
-            ? try await MainActor.run { try Self.installedCodexHostBinaryPath() }
-            : nil
         let requests = Self.agentAdapterReconciliationPlan(
             installed: installed,
             runtimePath: runtimePath,
-            codexHostPath: codexHostPath,
             workspaceExists: { FileManager.default.fileExists(atPath: $0) }
         )
         for request in requests {
             _ = try await daemon.installProjectAgentAdapter(request)
         }
-        return .init(conflicts: [], inspectionWarning: nil)
+        return .init(conflicts: [], inspectionWarning: codexWarning)
     }
 
     func inspectLegacyAgentAdapters() async -> LocalAgentAdapterReconciliationResult {
@@ -5660,23 +5699,13 @@ struct WorkspaceLoader: Sendable {
         )
     }
 
-    static func hasReachableCodexAdapter(
-        installed: [DaemonProjectAgentAdapter],
-        workspaceExists: (String) -> Bool
-    ) -> Bool {
-        installed.contains {
-            $0.adapter == .codex && workspaceExists($0.workspaceRoot)
-        }
-    }
-
     static func agentAdapterReconciliationPlan(
         installed: [DaemonProjectAgentAdapter],
         runtimePath: String,
-        codexHostPath: String?,
         workspaceExists: (String) -> Bool
     ) -> [DaemonProjectAgentAdapterInstallRequest] {
         installed
-            .filter { workspaceExists($0.workspaceRoot) }
+            .filter { $0.adapter != .codex && workspaceExists($0.workspaceRoot) }
             .sorted {
                 if $0.workspaceRoot != $1.workspaceRoot {
                     return $0.workspaceRoot < $1.workspaceRoot
@@ -5689,7 +5718,7 @@ struct WorkspaceLoader: Sendable {
                     workspaceRoot: $0.workspaceRoot,
                     adapter: $0.adapter,
                     runtimeBinaryPath: runtimePath,
-                    hostBinaryPath: $0.adapter == .codex ? codexHostPath : nil,
+                    hostBinaryPath: nil,
                     expectedRevision: $0.revision
                 )
             }

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -97,8 +97,8 @@ struct ProjectCreationSheet: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Section("Coding Agents") {
-                    ForEach(ProjectAgentAdapterKind.allCases) { adapter in
+                Section("Agent") {
+                    ForEach(ProjectAgentAdapterKind.projectScopedCases) { adapter in
                         Toggle(
                             adapter.title,
                             isOn: Binding(
@@ -600,9 +600,9 @@ private struct ProjectLocalSetupSettings: View {
             }
         }
 
-        Section("Coding Agents") {
+        Section("Agent") {
             if bindings.isEmpty {
-                Text("Add a repository before configuring a Coding Agent.")
+                Text("Add a repository before configuring an Agent.")
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(bindings) { binding in
@@ -611,19 +611,12 @@ private struct ProjectLocalSetupSettings: View {
                             Text(URL(fileURLWithPath: binding.workspaceRoot).lastPathComponent)
                                 .fontWeight(.medium)
                         }
-                        ForEach(ProjectAgentAdapterKind.allCases) { adapter in
+                        ForEach(ProjectAgentAdapterKind.projectScopedCases) { adapter in
                             Toggle(
                                 adapter.title,
                                 isOn: adapterBinding(adapter, repository: binding)
                             )
                             .disabled(workingKeys.contains(adapterKey(adapter, binding.workspaceRoot)))
-                            if adapter == .codex,
-                               currentAdapter(adapter, binding.workspaceRoot)?.delivery == .hostPlugin {
-                                Text("Restart Codex after enabling or updating this plugin, then start a new task. In that task, open /hooks and trust the current Clumsies Hook to enable AgentRun and run-bound Kanban actions.")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
                         }
                     }
                     .padding(.vertical, 2)
@@ -650,7 +643,7 @@ private struct ProjectLocalSetupSettings: View {
                 bindingToRemove = nil
             }
         } message: {
-            Text("Clumsies will remove its Coding Agent configuration from this repository and stop resolving it to the Project.")
+            Text("Clumsies will remove its Agent configuration from this repository and stop resolving it to the Project.")
         }
     }
 

--- a/apps/macos/Sources/Features/SettingsView.swift
+++ b/apps/macos/Sources/Features/SettingsView.swift
@@ -1,9 +1,66 @@
 import AppKit
 import SwiftUI
 
+enum SettingsPane: String, CaseIterable {
+    case general
+    case agent
+    case advanced
+
+    static let defaultsKey = "ClumsiesSettingsPane"
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .agent: "Agent"
+        case .advanced: "Advanced"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .general: "gearshape"
+        case .agent: "person.2"
+        case .advanced: "wrench.and.screwdriver"
+        }
+    }
+
+    static func restored(from defaults: UserDefaults = .standard) -> Self {
+        defaults.string(forKey: defaultsKey).flatMap(Self.init(rawValue:)) ?? .general
+    }
+
+    func persist(in defaults: UserDefaults = .standard) {
+        defaults.set(rawValue, forKey: Self.defaultsKey)
+    }
+}
+
 struct NativeSettingsView: View {
     @ObservedObject var store: WorkspaceStore
-    let softwareUpdateController: SoftwareUpdateController
+    @ObservedObject var softwareUpdateController: SoftwareUpdateController
+    let pane: SettingsPane
+    let onOpenDiagnostics: () -> Void
+    let onShowLogs: () -> Void
+
+    var body: some View {
+        Group {
+            switch pane {
+            case .general:
+                GeneralSettingsView(softwareUpdateController: softwareUpdateController)
+            case .agent:
+                AgentsSettingsView(store: store)
+            case .advanced:
+                AdvancedSettingsView(
+                    store: store,
+                    onOpenDiagnostics: onOpenDiagnostics,
+                    onShowLogs: onShowLogs
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+private struct GeneralSettingsView: View {
+    @ObservedObject var softwareUpdateController: SoftwareUpdateController
 
     private var version: String {
         let short = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
@@ -13,18 +70,138 @@ struct NativeSettingsView: View {
 
     var body: some View {
         Form {
-            Section("Application") {
-                LabeledContent("Version", value: version)
+            Section("Updates") {
+                Toggle(
+                    "Automatically check for updates",
+                    isOn: Binding(
+                        get: { softwareUpdateController.automaticallyChecksForUpdates },
+                        set: { softwareUpdateController.automaticallyChecksForUpdates = $0 }
+                    )
+                )
+                Toggle(
+                    "Automatically download updates",
+                    isOn: Binding(
+                        get: { softwareUpdateController.automaticallyDownloadsUpdates },
+                        set: { softwareUpdateController.automaticallyDownloadsUpdates = $0 }
+                    )
+                )
+                .disabled(!softwareUpdateController.allowsAutomaticUpdates)
                 Button("Check for Updates...") { softwareUpdateController.checkForUpdates() }
+                    .disabled(!softwareUpdateController.canCheckForUpdates)
             }
-            Section("Connection") {
+            Section("About") {
+                LabeledContent("Version", value: version)
+            }
+        }
+        .formStyle(.grouped)
+        .padding(12)
+    }
+}
+
+private struct AgentsSettingsView: View {
+    @ObservedObject var store: WorkspaceStore
+    @State private var status: DaemonCodexPluginStatus?
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+    @State private var repairMessage: String?
+
+    var body: some View {
+        Form {
+            Section("Codex") {
+                if let status {
+                    LabeledContent("Host", value: status.hostInstalled ? "Installed" : "Not installed")
+                    LabeledContent("Marketplace", value: marketplaceLabel(status))
+                    LabeledContent("Plugin installed", value: status.pluginInstalled ? "Yes" : "No")
+                    LabeledContent("Plugin enabled", value: status.pluginEnabled ? "Yes" : "No")
+                    LabeledContent("Installed version", value: status.installedVersion ?? "Not installed")
+                    LabeledContent("Expected version", value: status.expectedVersion)
+                    LabeledContent("Status", value: status.ready ? "Ready" : "Needs repair")
+                } else if errorMessage == nil {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                Text("Clumsies installs and keeps this user-level Plugin enabled automatically. Repository bindings only choose the Project used by Memory and Kanban.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .textSelection(.enabled)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                if let repairMessage {
+                    Text(repairMessage)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button("Repair") { Task { await repair() } }
+                    .disabled(isWorking || status?.hostInstalled == false)
+            }
+
+            Section("After Plugin Changes") {
+                Text("Restart Codex and start a new task. In that task, open /hooks and review the current Clumsies Hook. Plugin Enabled does not mean Hook Trusted or AgentRun Ready.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .formStyle(.grouped)
+        .padding(12)
+        .task { await load() }
+    }
+
+    private func marketplaceLabel(_ status: DaemonCodexPluginStatus) -> String {
+        if status.marketplaceConflict { return "Conflict" }
+        return status.marketplaceInstalled ? "Installed" : "Not installed"
+    }
+
+    private func load() async {
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+        do {
+            status = try await store.codexPluginStatus()
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func repair() async {
+        isWorking = true
+        errorMessage = nil
+        repairMessage = nil
+        defer { isWorking = false }
+        do {
+            status = try await store.repairCodexPlugin()
+            repairMessage = "Repair completed. Restart Codex and start a new task."
+        } catch is CancellationError {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct AdvancedSettingsView: View {
+    @ObservedObject var store: WorkspaceStore
+    let onOpenDiagnostics: () -> Void
+    let onShowLogs: () -> Void
+
+    var body: some View {
+        Form {
+            Section("Runtime") {
                 LabeledContent("Server", value: store.runtime?.health.serverUrl ?? "Unavailable")
-                LabeledContent("Project", value: store.activeProject?.name ?? "Not selected")
-                LabeledContent("Organization", value: store.organization?.name ?? "Unavailable")
-            }
-            Section("Local Runtime") {
-                LabeledContent("Draft synchronization", value: "Automatic")
+                LabeledContent("Daemon", value: store.runtime?.health.daemonVersion ?? "Unavailable")
                 LabeledContent("Background service", value: "LaunchAgent")
+            }
+            Section {
+                Button("Open Runtime Status...") { onOpenDiagnostics() }
+                Button("Show Logs in Finder") { onShowLogs() }
             }
         }
         .formStyle(.grouped)

--- a/apps/macos/Sources/Infrastructure/AppBundleRuntimeLocation.swift
+++ b/apps/macos/Sources/Infrastructure/AppBundleRuntimeLocation.swift
@@ -6,7 +6,7 @@ enum AppBundleRuntimeLocationError: LocalizedError, Sendable {
     var errorDescription: String? {
         switch self {
         case .translocated:
-            "Clumsies is running from a temporary macOS App Translocation path. Quit the App, move Clumsies.app to /Applications or ~/Applications, then open it again. No daemon or Coding Agent integration was changed."
+            "Clumsies is running from a temporary macOS App Translocation path. Quit the App, move Clumsies.app to /Applications or ~/Applications, then open it again. No daemon or Agent integration was changed."
         }
     }
 }

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -98,6 +98,10 @@ enum ProjectAgentAdapterKind: String, Codable, CaseIterable, Hashable, Identifia
 
     var id: String { rawValue }
 
+    static var projectScopedCases: [Self] {
+        allCases.filter { $0 != .codex }
+    }
+
     var title: String {
         switch self {
         case .codex: "Codex"
@@ -107,6 +111,22 @@ enum ProjectAgentAdapterKind: String, Codable, CaseIterable, Hashable, Identifia
         case .antigravity: "Antigravity"
         }
     }
+}
+
+struct DaemonCodexPluginRequest: Codable, Sendable {
+    let runtimeBinaryPath: String
+    let hostBinaryPath: String?
+}
+
+struct DaemonCodexPluginStatus: Codable, Equatable, Sendable {
+    let hostInstalled: Bool
+    let marketplaceInstalled: Bool
+    let marketplaceConflict: Bool
+    let pluginInstalled: Bool
+    let pluginEnabled: Bool
+    let installedVersion: String?
+    let expectedVersion: String
+    let ready: Bool
 }
 
 enum ProjectAgentAdapterDelivery: String, Codable, Sendable {

--- a/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
@@ -106,6 +106,16 @@ struct DaemonXPCClient: Sendable {
         )
     }
 
+    func inspectCodexPlugin(_ request: DaemonCodexPluginRequest) async throws
+        -> DaemonCodexPluginStatus {
+        try await call(method: "inspect_codex_plugin", payload: request, timeout: 40)
+    }
+
+    func reconcileCodexPlugin(_ request: DaemonCodexPluginRequest) async throws
+        -> DaemonCodexPluginStatus {
+        try await call(method: "reconcile_codex_plugin", payload: request, timeout: 130)
+    }
+
     func installProjectAgentAdapter(_ request: DaemonProjectAgentAdapterInstallRequest) async throws
         -> DaemonProjectAgentAdapter {
         try await call(method: "install_project_agent_adapter", payload: request)

--- a/apps/macos/Sources/Infrastructure/SoftwareUpdateController.swift
+++ b/apps/macos/Sources/Infrastructure/SoftwareUpdateController.swift
@@ -1,7 +1,8 @@
+import Combine
 import Sparkle
 
 @MainActor
-final class SoftwareUpdateController {
+final class SoftwareUpdateController: ObservableObject {
     private let controller: SPUStandardUpdaterController
 
     init() {
@@ -14,5 +15,29 @@ final class SoftwareUpdateController {
 
     func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    var automaticallyChecksForUpdates: Bool {
+        get { controller.updater.automaticallyChecksForUpdates }
+        set {
+            objectWillChange.send()
+            controller.updater.automaticallyChecksForUpdates = newValue
+        }
+    }
+
+    var automaticallyDownloadsUpdates: Bool {
+        get { controller.updater.automaticallyDownloadsUpdates }
+        set {
+            objectWillChange.send()
+            controller.updater.automaticallyDownloadsUpdates = newValue
+        }
+    }
+
+    var allowsAutomaticUpdates: Bool {
+        controller.updater.allowsAutomaticUpdates
+    }
+
+    var canCheckForUpdates: Bool {
+        controller.updater.canCheckForUpdates
     }
 }

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -8,23 +8,36 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(DaemonXPCClient.serviceName, "ai.clumsies.daemon")
     }
 
-    func testAgentAdapterRequestUsesBundledDaemonRuntimePath() throws {
+    func testCodexPluginRequestIsGlobalAndUsesBundledRuntimePath() throws {
         let runtime = "/Applications/Clumsies.app/Contents/Resources/clumsiesd"
         let host = "/Applications/Codex.app/Contents/Resources/codex"
-        let request = DaemonProjectAgentAdapterInstallRequest(
-            projectId: "project-1",
-            workspaceRoot: "/tmp/repository",
-            adapter: .codex,
+        let request = DaemonCodexPluginRequest(
             runtimeBinaryPath: runtime,
-            hostBinaryPath: host,
-            expectedRevision: nil
+            hostBinaryPath: host
         )
 
         let data = try JSONCoding.encoder().encode(request)
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         XCTAssertEqual(object["runtime_binary_path"] as? String, runtime)
         XCTAssertEqual(object["host_binary_path"] as? String, host)
+        XCTAssertNil(object["project_id"])
+        XCTAssertNil(object["workspace_root"])
         XCTAssertTrue((object["runtime_binary_path"] as? String)?.hasSuffix("/clumsiesd") == true)
+    }
+
+    func testCodexPluginStatusKeepsReadinessDimensionsSeparate() throws {
+        let json = #"{"host_installed":true,"marketplace_installed":true,"marketplace_conflict":false,"plugin_installed":true,"plugin_enabled":false,"installed_version":"0.1.0+codex.old","expected_version":"0.1.0+codex.new","ready":false}"#
+        let status = try JSONCoding.decoder().decode(
+            DaemonCodexPluginStatus.self,
+            from: Data(json.utf8)
+        )
+
+        XCTAssertTrue(status.hostInstalled)
+        XCTAssertTrue(status.marketplaceInstalled)
+        XCTAssertTrue(status.pluginInstalled)
+        XCTAssertFalse(status.pluginEnabled)
+        XCTAssertNotEqual(status.installedVersion, status.expectedVersion)
+        XCTAssertFalse(status.ready)
     }
 
     func testLegacyAdapterInspectionResponseDecodesDeferredTargets() throws {
@@ -39,7 +52,7 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertTrue(response.conflicts.isEmpty)
     }
 
-    func testWorkspaceStartupPlansEveryReachableAdapterUpgrade() {
+    func testWorkspaceStartupPlansOnlyReachableProjectScopedAdapterUpgrades() {
         let adapters = [
             DaemonProjectAgentAdapter(
                 serverUrl: "https://app.clumsies.ai",
@@ -79,28 +92,15 @@ final class DaemonContractTests: XCTestCase {
         let planned = WorkspaceLoader.agentAdapterReconciliationPlan(
             installed: adapters,
             runtimePath: "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
-            codexHostPath: "/Applications/Codex.app/Contents/Resources/codex",
             workspaceExists: { $0 == "/repos/active" }
         )
 
-        XCTAssertEqual(planned.map(\.adapter), [.claudeCode, .codex])
-        XCTAssertEqual(planned.map(\.expectedRevision), [3, 7])
+        XCTAssertEqual(planned.map(\.adapter), [.claudeCode])
+        XCTAssertEqual(planned.map(\.expectedRevision), [3])
         XCTAssertTrue(planned.allSatisfy {
             $0.runtimeBinaryPath == "/Applications/Clumsies.app/Contents/Resources/clumsiesd"
         })
-        XCTAssertNil(planned.first { $0.adapter == .claudeCode }?.hostBinaryPath)
-        XCTAssertEqual(
-            planned.first { $0.adapter == .codex }?.hostBinaryPath,
-            "/Applications/Codex.app/Contents/Resources/codex"
-        )
-        XCTAssertTrue(WorkspaceLoader.hasReachableCodexAdapter(
-            installed: adapters,
-            workspaceExists: { $0 == "/repos/active" }
-        ))
-        XCTAssertFalse(WorkspaceLoader.hasReachableCodexAdapter(
-            installed: adapters,
-            workspaceExists: { _ in false }
-        ))
+        XCTAssertNil(planned.first?.hostBinaryPath)
     }
 
     func testWorkspaceCoreReconcilesManagedAdaptersWithoutLegacyInspection() async {
@@ -669,6 +669,20 @@ final class DaemonContractTests: XCTestCase {
                 next: next
             ),
             "Next adapter warning"
+        )
+    }
+
+    func testLegacyInspectionDoesNotClearManagedPluginWarning() {
+        XCTAssertEqual(
+            WorkspaceStore.combinedAgentAdapterWarning("Codex repair failed", nil),
+            "Codex repair failed"
+        )
+        XCTAssertEqual(
+            WorkspaceStore.combinedAgentAdapterWarning(
+                "Codex repair failed",
+                "Legacy inspection failed"
+            ),
+            "Codex repair failed\nLegacy inspection failed"
         )
     }
 

--- a/apps/macos/Tests/ProjectManagementTests.swift
+++ b/apps/macos/Tests/ProjectManagementTests.swift
@@ -2,6 +2,13 @@ import XCTest
 @testable import Clumsies
 
 final class ProjectManagementTests: XCTestCase {
+    func testProjectScopedAgentsExcludeGlobalCodexPlugin() {
+        XCTAssertEqual(
+            ProjectAgentAdapterKind.projectScopedCases,
+            [.claudeCode, .opencode, .dsh, .antigravity]
+        )
+    }
+
     func testProjectMetadataRequiresANonEmptyName() {
         XCTAssertFalse(ProjectMetadataValidation.isValid(name: "   ", description: "Description"))
         XCTAssertTrue(ProjectMetadataValidation.isValid(name: " Project ", description: "Description"))

--- a/apps/macos/Tests/SettingsWindowLayoutTests.swift
+++ b/apps/macos/Tests/SettingsWindowLayoutTests.swift
@@ -21,7 +21,7 @@ final class SettingsWindowLayoutTests: XCTestCase {
             SettingsWindowLayout.minimumContentSize.width
         )
 
-        SettingsWindowLayout.normalize(window)
+        SettingsWindowLayout.normalize(window, pane: .general)
 
         XCTAssertEqual(window.contentLayoutRect.size, SettingsWindowLayout.defaultContentSize)
         XCTAssertEqual(window.contentMinSize, SettingsWindowLayout.minimumContentSize)
@@ -36,9 +36,56 @@ final class SettingsWindowLayoutTests: XCTestCase {
             defer: false
         )
 
-        SettingsWindowLayout.normalize(window)
+        SettingsWindowLayout.normalize(window, pane: .advanced)
 
         XCTAssertEqual(window.contentLayoutRect.size, selectedSize)
         XCTAssertEqual(window.contentMinSize, SettingsWindowLayout.minimumContentSize)
+        XCTAssertEqual(window.title, "Advanced")
+        XCTAssertFalse(window.styleMask.contains(.miniaturizable))
+        XCTAssertFalse(window.styleMask.contains(.resizable))
+    }
+
+    func testPaneRestorationDefaultsToGeneralAndRejectsUnknownValues() {
+        let suite = "SettingsWindowLayoutTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(SettingsPane.restored(from: defaults), .general)
+        SettingsPane.agent.persist(in: defaults)
+        XCTAssertEqual(SettingsPane.restored(from: defaults), .agent)
+        defaults.set("unknown", forKey: SettingsPane.defaultsKey)
+        XCTAssertEqual(SettingsPane.restored(from: defaults), .general)
+    }
+
+    func testNativePreferenceToolbarSelectsAndPersistsPane() {
+        let suite = "SettingsWindowLayoutTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let controller = SettingsTabViewController(
+            items: SettingsPane.allCases.map { ($0, NSViewController()) },
+            selectedPane: .agent,
+            defaults: defaults
+        )
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: SettingsWindowLayout.defaultContentSize),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.contentViewController = controller
+        SettingsWindowLayout.configure(window, pane: controller.selectedPane)
+
+        XCTAssertEqual(controller.tabStyle, .toolbar)
+        XCTAssertEqual(window.toolbarStyle, .preference)
+        XCTAssertEqual(window.toolbar?.allowsUserCustomization, false)
+        XCTAssertEqual(window.title, "Agent")
+        XCTAssertFalse(window.styleMask.contains(.miniaturizable))
+        XCTAssertFalse(window.styleMask.contains(.resizable))
+
+        controller.selectedTabViewItemIndex = 2
+        XCTAssertEqual(controller.selectedPane, .advanced)
+        XCTAssertEqual(window.title, "Advanced")
+        XCTAssertEqual(SettingsPane.restored(from: defaults), .advanced)
     }
 }

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -151,6 +151,24 @@ pub struct DaemonProjectAgentAdapterRemoveResponse {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonCodexPluginRequest {
+    pub runtime_binary_path: String,
+    pub host_binary_path: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonCodexPluginStatus {
+    pub host_installed: bool,
+    pub marketplace_installed: bool,
+    pub marketplace_conflict: bool,
+    pub plugin_installed: bool,
+    pub plugin_enabled: bool,
+    pub installed_version: Option<String>,
+    pub expected_version: String,
+    pub ready: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 struct AdapterManifest {
     runtime_binary_hash: String,
     runtime_binary_path: String,
@@ -1897,6 +1915,11 @@ pub(crate) async fn require_runtime_delivery(
     binding: &crate::DaemonProjectBinding,
     required: crate::ProjectAgentAdapterRuntimeRequirement,
 ) -> Result<(), DaemonError> {
+    if required.adapter == ProjectAgentAdapterKind::Codex
+        && required.delivery == ProjectAgentAdapterDelivery::HostPlugin
+    {
+        return Ok(());
+    }
     let raw_manifest: Option<String> = sqlx::query_scalar(
         "SELECT manifest_json
          FROM project_agent_adapters
@@ -1929,10 +1952,59 @@ pub(crate) async fn inspect_legacy(
     legacy::inspect(state, request).await
 }
 
+pub(crate) async fn inspect_codex_plugin(
+    state: &DaemonState,
+    request: DaemonCodexPluginRequest,
+) -> Result<DaemonCodexPluginStatus, DaemonError> {
+    let _guard = state.inner.local_setup_lock.lock().await;
+    let runtime_binary = canonical_agent_runtime_binary(&request.runtime_binary_path)?;
+    #[cfg(target_os = "macos")]
+    verify_code_signature(&runtime_binary)?;
+    let runtime_hash = sha256_file(&runtime_binary)?;
+    codex_plugin::inspect(
+        &state.inner.config.root_dir,
+        &runtime_binary,
+        &runtime_hash,
+        request.host_binary_path.as_deref(),
+    )
+    .await
+}
+
+pub(crate) async fn reconcile_codex_plugin(
+    state: &DaemonState,
+    request: DaemonCodexPluginRequest,
+) -> Result<DaemonCodexPluginStatus, DaemonError> {
+    let _guard = state.inner.local_setup_lock.lock().await;
+    let runtime_binary = canonical_agent_runtime_binary(&request.runtime_binary_path)?;
+    #[cfg(target_os = "macos")]
+    verify_code_signature(&runtime_binary)?;
+    let runtime_hash = sha256_file(&runtime_binary)?;
+    codex_plugin::ensure_installed(
+        &state.inner.config.root_dir,
+        &runtime_binary,
+        &runtime_hash,
+        request.host_binary_path.as_deref(),
+    )
+    .await?;
+    codex_plugin::inspect(
+        &state.inner.config.root_dir,
+        &runtime_binary,
+        &runtime_hash,
+        request.host_binary_path.as_deref(),
+    )
+    .await
+}
+
 pub(crate) async fn install(
     state: &DaemonState,
     request: DaemonProjectAgentAdapterInstallRequest,
 ) -> Result<DaemonProjectAgentAdapter, DaemonError> {
+    if request.adapter == ProjectAgentAdapterKind::Codex {
+        return Err(DaemonError::InvalidRequest(
+            "The Codex Plugin is managed globally; Project Agent settings cannot install it."
+                .to_owned(),
+        ));
+    }
     let _guard = state.inner.local_setup_lock.lock().await;
     let project_id = required_value("project_id", request.project_id)?;
     let workspace_root = canonical_workspace_directory(&request.workspace_root)?;
@@ -1979,51 +2051,22 @@ pub(crate) async fn install(
     verify_code_signature(&runtime_binary)?;
     let runtime_hash = sha256_file(&runtime_binary)?;
     let previous_manifest = existing.as_ref().map(|record| &record.manifest);
-    let (changes, manifest) = if request.adapter == ProjectAgentAdapterKind::Codex {
-        codex_plugin::ensure_installed(
-            &state.inner.config.root_dir,
-            &runtime_binary,
-            &runtime_hash,
-            request.host_binary_path.as_deref(),
-        )
-        .await?;
-        let changes = match previous_manifest {
-            Some(manifest) if manifest.delivery == ProjectAgentAdapterDelivery::LegacyFiles => {
-                remove_plan(manifest, &workspace_root)?
-            }
-            Some(manifest) if !manifest.managed_files.is_empty() => {
-                return Err(DaemonError::InvalidConfig(
-                    "a host-plugin Adapter manifest cannot own workspace files".to_owned(),
-                ));
-            }
-            _ => Vec::new(),
-        };
-        let manifest = AdapterManifest {
-            runtime_binary_hash: runtime_hash,
-            runtime_binary_path: runtime_binary.display().to_string(),
-            delivery: ProjectAgentAdapterDelivery::HostPlugin,
-            managed_files: Vec::new(),
-        };
-        (changes, manifest)
-    } else {
-        let mut changes = install_plan_with_project(
-            request.adapter,
-            &workspace_root,
-            &runtime_binary,
-            previous_manifest,
-            Some(&server_url),
-            Some(&project_id),
-        )?;
-        // Retire previously-managed files the new plan no longer includes
-        // instead of silently orphaning them on disk.
-        changes.extend(retire_stale_managed_changes(
-            &changes,
-            previous_manifest,
-            &workspace_root,
-        )?);
-        let manifest = manifest_for_changes(&changes, &runtime_binary, runtime_hash);
-        (changes, manifest)
-    };
+    let mut changes = install_plan_with_project(
+        request.adapter,
+        &workspace_root,
+        &runtime_binary,
+        previous_manifest,
+        Some(&server_url),
+        Some(&project_id),
+    )?;
+    // Retire previously-managed files the new plan no longer includes
+    // instead of silently orphaning them on disk.
+    changes.extend(retire_stale_managed_changes(
+        &changes,
+        previous_manifest,
+        &workspace_root,
+    )?);
+    let manifest = manifest_for_changes(&changes, &runtime_binary, runtime_hash);
     let files_changed = changes
         .iter()
         .map(change_is_needed)

--- a/crates/daemon/src/agent_adapter/codex_plugin.rs
+++ b/crates/daemon/src/agent_adapter/codex_plugin.rs
@@ -12,7 +12,7 @@ use crate::project_storage::{ensure_private_directory, write_private_file};
 
 #[cfg(target_os = "macos")]
 use super::code_signature_info;
-use super::{is_executable, shell_single_quote, state_error};
+use super::{DaemonCodexPluginStatus, is_executable, shell_single_quote, state_error};
 
 const MARKETPLACE_NAME: &str = "clumsies-local";
 const PLUGIN_ID: &str = "clumsies@clumsies-local";
@@ -90,6 +90,77 @@ pub(super) async fn ensure_installed(
     let plugin = materialize(daemon_root, runtime_binary, runtime_hash)?;
     ensure_marketplace(&codex, &plugin.marketplace_root).await?;
     ensure_plugin(&codex, &plugin.version).await
+}
+
+pub(super) async fn inspect(
+    daemon_root: &Path,
+    runtime_binary: &Path,
+    runtime_hash: &str,
+    host_binary_path: Option<&str>,
+) -> Result<DaemonCodexPluginStatus, DaemonError> {
+    let expected_version = plugin_version(
+        runtime_binary.to_str().ok_or_else(|| {
+            DaemonError::InvalidRequest("Codex plugin runtime path is not UTF-8".to_owned())
+        })?,
+        runtime_hash,
+    );
+    let Some(host_binary_path) = host_binary_path else {
+        return Ok(DaemonCodexPluginStatus {
+            host_installed: false,
+            marketplace_installed: false,
+            marketplace_conflict: false,
+            plugin_installed: false,
+            plugin_enabled: false,
+            installed_version: None,
+            expected_version,
+            ready: false,
+        });
+    };
+    let codex = canonical_codex_cli(host_binary_path)?;
+    verify_codex_cli(&codex)?;
+    let marketplace_root = daemon_root.join("agent-plugins/codex-marketplace");
+    inspect_verified(&codex, &marketplace_root, expected_version).await
+}
+
+async fn inspect_verified(
+    codex: &Path,
+    marketplace_root: &Path,
+    expected_version: String,
+) -> Result<DaemonCodexPluginStatus, DaemonError> {
+    let marketplaces = marketplace_list(codex).await?;
+    let marketplace = marketplaces
+        .marketplaces
+        .iter()
+        .find(|entry| entry.name == MARKETPLACE_NAME);
+    let marketplace_installed =
+        marketplace.is_some_and(|entry| marketplace_matches(entry, marketplace_root));
+    let marketplace_conflict = marketplace.is_some() && !marketplace_installed;
+    let plugin = if marketplace_installed {
+        plugin_list(codex)
+            .await?
+            .installed
+            .into_iter()
+            .find(|entry| entry.plugin_id == PLUGIN_ID)
+    } else {
+        None
+    };
+    let plugin_installed = plugin.as_ref().is_some_and(|entry| entry.installed);
+    let plugin_enabled = plugin.as_ref().is_some_and(|entry| entry.enabled);
+    let installed_version = plugin.map(|entry| entry.version);
+    let ready = marketplace_installed
+        && plugin_installed
+        && plugin_enabled
+        && installed_version.as_deref() == Some(expected_version.as_str());
+    Ok(DaemonCodexPluginStatus {
+        host_installed: true,
+        marketplace_installed,
+        marketplace_conflict,
+        plugin_installed,
+        plugin_enabled,
+        installed_version,
+        expected_version,
+        ready,
+    })
 }
 
 fn materialize(
@@ -203,7 +274,7 @@ async fn ensure_marketplace(codex: &Path, marketplace_root: &Path) -> Result<(),
         Some(entry) if marketplace_matches(entry, marketplace_root) => return Ok(()),
         Some(_) => {
             return Err(state_error(
-                "project_agent_adapter_plugin_conflict",
+                "codex_plugin_conflict",
                 "Codex already has a different marketplace named clumsies-local.",
             ));
         }
@@ -223,7 +294,7 @@ async fn ensure_marketplace(codex: &Path, marketplace_root: &Path) -> Result<(),
         Ok(())
     } else {
         Err(state_error(
-            "project_agent_adapter_plugin_install_failed",
+            "codex_plugin_install_failed",
             "Codex did not retain the Clumsies marketplace after installation.",
         ))
     }
@@ -243,7 +314,7 @@ async fn ensure_plugin(codex: &Path, version: &str) -> Result<(), DaemonError> {
         Ok(())
     } else {
         Err(state_error(
-            "project_agent_adapter_plugin_install_failed",
+            "codex_plugin_install_failed",
             "Codex did not enable the expected Clumsies plugin version.",
         ))
     }
@@ -285,25 +356,25 @@ async fn run_cli_json(codex: &Path, args: &[&str]) -> Result<Value, DaemonError>
         .await
         .map_err(|_| {
             state_error(
-                "project_agent_adapter_plugin_timeout",
+                "codex_plugin_timeout",
                 "Codex did not finish the plugin operation in time.",
             )
         })??;
     if output.stdout.len() > MAX_CLI_OUTPUT_BYTES || output.stderr.len() > MAX_CLI_OUTPUT_BYTES {
         return Err(state_error(
-            "project_agent_adapter_plugin_output_too_large",
+            "codex_plugin_output_too_large",
             "Codex returned an unexpectedly large plugin response.",
         ));
     }
     if !output.status.success() {
         return Err(state_error(
-            "project_agent_adapter_plugin_install_failed",
+            "codex_plugin_install_failed",
             "Codex could not install the Clumsies plugin. Open Codex once, then retry the integration.",
         ));
     }
     serde_json::from_slice(&output.stdout).map_err(|_| {
         state_error(
-            "project_agent_adapter_plugin_invalid_response",
+            "codex_plugin_invalid_response",
             "Codex returned an invalid plugin response.",
         )
     })
@@ -363,7 +434,7 @@ fn verify_codex_cli(path: &Path) -> Result<(), DaemonError> {
         || !info.hardened_runtime
     {
         return Err(state_error(
-            "project_agent_adapter_invalid_host",
+            "codex_plugin_invalid_host",
             "The selected Codex CLI does not have the required OpenAI signing identity.",
         ));
     }
@@ -431,6 +502,126 @@ mod tests {
         };
         assert!(plugin_installed_and_enabled(&ready, "0.1.0+codex.abc"));
         assert!(!plugin_installed_and_enabled(&ready, "0.1.0+codex.def"));
+    }
+
+    #[tokio::test]
+    async fn inspection_without_codex_is_read_only() {
+        let root = tempfile::tempdir().unwrap();
+        let status = inspect(
+            root.path(),
+            Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
+            &"a".repeat(64),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(!status.host_installed);
+        assert!(!status.ready);
+        assert!(root.path().read_dir().unwrap().next().is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn inspection_with_codex_lists_state_without_materializing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let host = tempfile::tempdir().unwrap();
+        let codex = host.path().join("Codex.app/Contents/Resources/codex");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        fs::write(&codex, "#!/bin/sh\necho '{\"marketplaces\":[]}'\n").unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+        let daemon = tempfile::tempdir().unwrap();
+        let marketplace = daemon.path().join("agent-plugins/codex-marketplace");
+
+        let status = inspect_verified(&codex, &marketplace, "0.1.0+codex.expected".to_owned())
+            .await
+            .unwrap();
+
+        assert!(status.host_installed);
+        assert!(!status.marketplace_installed);
+        assert!(!status.ready);
+        assert!(!marketplace.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn reconciliation_repairs_missing_stale_and_disabled_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let daemon = tempfile::tempdir().unwrap();
+        let plugin = materialize(
+            daemon.path(),
+            Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
+            &"a".repeat(64),
+        )
+        .unwrap();
+        let host = tempfile::tempdir().unwrap();
+        let state = host.path().join("state");
+        fs::create_dir_all(&state).unwrap();
+        let marketplace_marker = state.join("marketplace");
+        let plugin_marker = state.join("plugin");
+        let marketplace_ready = json!({
+            "marketplaces": [{
+                "name": MARKETPLACE_NAME,
+                "root": plugin.marketplace_root.display().to_string()
+            }]
+        })
+        .to_string();
+        let plugin_stale = json!({
+            "installed": [{
+                "pluginId": PLUGIN_ID,
+                "version": "0.1.0+codex.old",
+                "installed": true,
+                "enabled": false
+            }]
+        })
+        .to_string();
+        let plugin_ready = json!({
+            "installed": [{
+                "pluginId": PLUGIN_ID,
+                "version": plugin.version,
+                "installed": true,
+                "enabled": true
+            }]
+        })
+        .to_string();
+        let codex = host.path().join("Codex.app/Contents/Resources/codex");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        fs::write(
+            &codex,
+            format!(
+                "#!/bin/sh\n\
+                 if [ \"$1\" = plugin ] && [ \"$2\" = marketplace ] && [ \"$3\" = list ]; then\n\
+                   if [ -f {marketplace_marker} ]; then printf '%s\\n' {marketplace_ready}; else printf '%s\\n' '{{\"marketplaces\":[]}}'; fi\n\
+                 elif [ \"$1\" = plugin ] && [ \"$2\" = marketplace ] && [ \"$3\" = add ]; then\n\
+                   touch {marketplace_marker}; printf '%s\\n' '{{}}'\n\
+                 elif [ \"$1\" = plugin ] && [ \"$2\" = list ]; then\n\
+                   if [ -f {plugin_marker} ]; then printf '%s\\n' {plugin_ready}; else printf '%s\\n' {plugin_stale}; fi\n\
+                 elif [ \"$1\" = plugin ] && [ \"$2\" = add ]; then\n\
+                   touch {plugin_marker}; printf '%s\\n' '{{}}'\n\
+                 else exit 1; fi\n",
+                marketplace_marker = shell_single_quote(&marketplace_marker.display().to_string()),
+                marketplace_ready = shell_single_quote(&marketplace_ready),
+                plugin_marker = shell_single_quote(&plugin_marker.display().to_string()),
+                plugin_ready = shell_single_quote(&plugin_ready),
+                plugin_stale = shell_single_quote(&plugin_stale),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&codex, fs::Permissions::from_mode(0o755)).unwrap();
+
+        ensure_marketplace(&codex, &plugin.marketplace_root)
+            .await
+            .unwrap();
+        ensure_plugin(&codex, &plugin.version).await.unwrap();
+        let status = inspect_verified(&codex, &plugin.marketplace_root, plugin.version)
+            .await
+            .unwrap();
+
+        assert!(marketplace_marker.exists());
+        assert!(plugin_marker.exists());
+        assert!(status.ready);
     }
 
     #[test]

--- a/crates/daemon/src/ipc.rs
+++ b/crates/daemon/src/ipc.rs
@@ -1,9 +1,10 @@
 use crate::{
     ActivateMemoryRequest, ActivateMemoryResponse, AgentRuntimeIdentity, ApplyIssueGateRequest,
     ClearRetrievalRunsRequest, ClearRetrievalRunsResponse, CreateEvaluationCaseRequest,
-    CreateIssueRequest, DaemonDraftDetail, DaemonDraftDetailRequest, DaemonDraftListQuery,
-    DaemonDraftListResponse, DaemonDraftOperationRequest, DaemonDraftOperationResponse,
-    DaemonError, DaemonHealth, DaemonIpcRequest, DaemonIpcResponse, DaemonIpcService,
+    CreateIssueRequest, DaemonCodexPluginRequest, DaemonCodexPluginStatus, DaemonDraftDetail,
+    DaemonDraftDetailRequest, DaemonDraftListQuery, DaemonDraftListResponse,
+    DaemonDraftOperationRequest, DaemonDraftOperationResponse, DaemonError, DaemonHealth,
+    DaemonIpcRequest, DaemonIpcResponse, DaemonIpcService,
     DaemonLegacyAgentAdapterInspectionRequest, DaemonLegacyAgentAdapterInspectionResponse,
     DaemonMcpStatus, DaemonProjectAgentAdapter, DaemonProjectAgentAdapterInstallRequest,
     DaemonProjectAgentAdapterListRequest, DaemonProjectAgentAdapterListResponse,
@@ -184,6 +185,28 @@ impl DaemonIpcClient {
     ) -> Result<DaemonLegacyAgentAdapterInspectionResponse, DaemonError> {
         self.call(DaemonIpcRequest::new(
             "inspect_legacy_agent_adapters",
+            serde_json::to_value(request)?,
+        ))?
+        .into_payload()
+    }
+
+    pub fn inspect_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        self.call(DaemonIpcRequest::new(
+            "inspect_codex_plugin",
+            serde_json::to_value(request)?,
+        ))?
+        .into_payload()
+    }
+
+    pub fn reconcile_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        self.call(DaemonIpcRequest::new(
+            "reconcile_codex_plugin",
             serde_json::to_value(request)?,
         ))?
         .into_payload()

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -21,11 +21,12 @@ mod util;
 mod work_tracking;
 
 pub use agent_adapter::{
-    DaemonLegacyAgentAdapterConflict, DaemonLegacyAgentAdapterInspectionRequest,
-    DaemonLegacyAgentAdapterInspectionResponse, DaemonProjectAgentAdapter,
-    DaemonProjectAgentAdapterInstallRequest, DaemonProjectAgentAdapterListRequest,
-    DaemonProjectAgentAdapterListResponse, DaemonProjectAgentAdapterRemoveRequest,
-    DaemonProjectAgentAdapterRemoveResponse, ProjectAgentAdapterDelivery, ProjectAgentAdapterKind,
+    DaemonCodexPluginRequest, DaemonCodexPluginStatus, DaemonLegacyAgentAdapterConflict,
+    DaemonLegacyAgentAdapterInspectionRequest, DaemonLegacyAgentAdapterInspectionResponse,
+    DaemonProjectAgentAdapter, DaemonProjectAgentAdapterInstallRequest,
+    DaemonProjectAgentAdapterListRequest, DaemonProjectAgentAdapterListResponse,
+    DaemonProjectAgentAdapterRemoveRequest, DaemonProjectAgentAdapterRemoveResponse,
+    ProjectAgentAdapterDelivery, ProjectAgentAdapterKind,
 };
 pub use commit_sync::{
     DaemonMemoryCacheRequest, DaemonMemoryCacheState, DaemonMemoryCacheStatus,

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -749,6 +749,20 @@ impl DaemonState {
         agent_adapter::inspect_legacy(self, request).await
     }
 
+    pub async fn inspect_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        agent_adapter::inspect_codex_plugin(self, request).await
+    }
+
+    pub async fn reconcile_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        agent_adapter::reconcile_codex_plugin(self, request).await
+    }
+
     pub async fn install_project_agent_adapter(
         &self,
         request: DaemonProjectAgentAdapterInstallRequest,
@@ -2579,6 +2593,20 @@ impl DaemonIpcService {
         self.state.inspect_legacy_agent_adapters(request).await
     }
 
+    pub async fn inspect_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        self.state.inspect_codex_plugin(request).await
+    }
+
+    pub async fn reconcile_codex_plugin(
+        &self,
+        request: DaemonCodexPluginRequest,
+    ) -> Result<DaemonCodexPluginStatus, DaemonError> {
+        self.state.reconcile_codex_plugin(request).await
+    }
+
     pub async fn install_project_agent_adapter(
         &self,
         request: DaemonProjectAgentAdapterInstallRequest,
@@ -2899,6 +2927,12 @@ impl DaemonIpcService {
             }
             "inspect_legacy_agent_adapters" => {
                 dispatch_async!(self, request.payload, inspect_legacy_agent_adapters)
+            }
+            "inspect_codex_plugin" => {
+                dispatch_async!(self, request.payload, inspect_codex_plugin)
+            }
+            "reconcile_codex_plugin" => {
+                dispatch_async!(self, request.payload, reconcile_codex_plugin)
             }
             "install_project_agent_adapter" => {
                 dispatch_async!(self, request.payload, install_project_agent_adapter)

--- a/crates/daemon/src/work_tracking.rs
+++ b/crates/daemon/src/work_tracking.rs
@@ -5809,7 +5809,7 @@ mod tests {
                 verification_level: VerificationLevel::HumanRequired,
                 verification_steps: vec![
                     VerificationStep {
-                        text: "Open Settings > Coding Agents".to_owned(),
+                        text: "Open Settings > Agent".to_owned(),
                         completed: false,
                     },
                     VerificationStep {

--- a/crates/daemon/tests/agent_runtime_xpc_e2e.rs
+++ b/crates/daemon/tests/agent_runtime_xpc_e2e.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 const SERVER_URL: &str = "http://127.0.0.1:9";
 const PROJECT_ID: &str = "prj_agent_runtime_e2e";
+const REBOUND_PROJECT_ID: &str = "prj_agent_runtime_rebound";
 const TEST_SERVICE_ENV: &str = "CLUMSIES_AGENT_RUNTIME_TEST_MACH_SERVICE";
 const STALE_TOOL_BUILD_ENV: &str = "CLUMSIES_AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ID";
 
@@ -188,20 +189,20 @@ async fn real_clumsiesd_process_proxies_use_xpc_and_reject_stale_identity() {
         .unwrap();
     plugin_stdin.flush().unwrap();
     assert_eq!(read_proxy_json_line(&mut plugin_stdout)["id"], 20);
-    let before_remove = read_proxy_json_line(&mut plugin_stdout);
-    assert_eq!(before_remove["id"], 21);
-    assert_eq!(before_remove["result"]["isError"], false, "{before_remove}");
+    let before_rebind = read_proxy_json_line(&mut plugin_stdout);
+    assert_eq!(before_rebind["id"], 21);
+    assert_eq!(before_rebind["result"]["isError"], false, "{before_rebind}");
 
-    remove_codex_adapter(&daemon_root.join("local.db")).await;
+    rebind_project(&daemon_root.join("local.db")).await;
     plugin_stdin
         .write_all(
             b"{\"jsonrpc\":\"2.0\",\"id\":22,\"method\":\"tools/call\",\"params\":{\"name\":\"kanban\",\"arguments\":{\"op\":{\"list\":{}}}}}\n",
         )
         .unwrap();
     plugin_stdin.flush().unwrap();
-    let after_remove = read_proxy_json_line(&mut plugin_stdout);
-    assert_eq!(after_remove["id"], 22);
-    assert_eq!(after_remove["result"]["isError"], true, "{after_remove}");
+    let after_rebind = read_proxy_json_line(&mut plugin_stdout);
+    assert_eq!(after_rebind["id"], 22);
+    assert_eq!(after_rebind["result"]["isError"], true, "{after_rebind}");
     drop(plugin_stdin);
     drop(plugin_stdout);
     let plugin_output = plugin_mcp.wait_with_output().unwrap();
@@ -360,35 +361,15 @@ async fn seed_project_fixture(local_db: &Path, workspace: &Path) {
         .execute(&pool)
         .await
         .unwrap();
-    sqlx::query(
-        "INSERT INTO project_agent_adapters
-             (server_url, workspace_root, project_id, adapter, revision, manifest_json)
-         VALUES ($1, $2, $3, 'codex', 1, $4)",
-    )
-    .bind(SERVER_URL)
-    .bind(workspace.display().to_string())
-    .bind(PROJECT_ID)
-    .bind(
-        json!({
-            "runtime_binary_hash": "a".repeat(64),
-            "runtime_binary_path": "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
-            "delivery": "host_plugin",
-            "managed_files": []
-        })
-        .to_string(),
-    )
-    .execute(&pool)
-    .await
-    .unwrap();
     pool.close().await;
 }
 
-async fn remove_codex_adapter(local_db: &Path) {
+async fn rebind_project(local_db: &Path) {
     let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", local_db.display()))
         .await
         .unwrap();
-    sqlx::query("DELETE FROM project_agent_adapters WHERE project_id = $1 AND adapter = 'codex'")
-        .bind(PROJECT_ID)
+    sqlx::query("UPDATE project_bindings SET project_id = $1")
+        .bind(REBOUND_PROJECT_ID)
         .execute(&pool)
         .await
         .unwrap();
@@ -406,7 +387,7 @@ async fn assert_hook_fixture_persisted(local_db: &Path) {
     .fetch_one(&pool)
     .await
     .unwrap();
-    assert_eq!(run.get::<String, _>("project_id"), PROJECT_ID);
+    assert_eq!(run.get::<String, _>("project_id"), REBOUND_PROJECT_ID);
     assert_eq!(run.get::<String, _>("host"), "codex");
     assert_eq!(
         run.get::<String, _>("host_run_key"),

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -3950,7 +3950,7 @@ async fn opencode_project_agent_adapter_install_is_reversible_and_preserves_user
 }
 
 #[tokio::test]
-async fn host_plugin_runtime_requires_exact_adapter_delivery() {
+async fn codex_host_plugin_runtime_requires_only_a_project_binding() {
     let root = tempfile::tempdir().unwrap();
     let workspace = tempfile::tempdir().unwrap();
     let daemon_root = root.path().join("daemon");
@@ -3976,25 +3976,18 @@ async fn host_plugin_runtime_requires_exact_adapter_delivery() {
     .execute(&db)
     .await
     .unwrap();
-    let manifest = |delivery: &str| {
-        json!({
-            "runtime_binary_hash": "a".repeat(64),
-            "runtime_binary_path": "/Applications/Clumsies.app/Contents/Resources/clumsiesd",
-            "delivery": delivery,
-            "managed_files": []
+    let install_error = state
+        .install_project_agent_adapter(DaemonProjectAgentAdapterInstallRequest {
+            project_id: "prj_plugin_gate".to_owned(),
+            workspace_root: workspace_root.clone(),
+            adapter: ProjectAgentAdapterKind::Codex,
+            runtime_binary_path: "/missing/clumsiesd".to_owned(),
+            host_binary_path: None,
+            expected_revision: None,
         })
-        .to_string()
-    };
-    sqlx::query(
-        "INSERT INTO project_agent_adapters
-             (server_url, workspace_root, project_id, adapter, revision, manifest_json)
-         VALUES ('https://app.clumsies.ai', $1, 'prj_plugin_gate', 'codex', 1, $2)",
-    )
-    .bind(&workspace_root)
-    .bind(manifest("legacy_files"))
-    .execute(&db)
-    .await
-    .unwrap();
+        .await
+        .unwrap_err();
+    assert!(matches!(install_error, DaemonError::InvalidRequest(_)));
     let request = || DaemonProjectBindingResolveRequest {
         workspace_path: workspace.path().display().to_string(),
         required_adapter: Some(ProjectAgentAdapterRuntimeRequirement {
@@ -4002,22 +3995,26 @@ async fn host_plugin_runtime_requires_exact_adapter_delivery() {
             delivery: ProjectAgentAdapterDelivery::HostPlugin,
         }),
     };
-    let rejected = state.resolve_project_binding(request()).await.unwrap_err();
+    let accepted = state.resolve_project_binding(request()).await.unwrap();
+    assert_eq!(accepted.project_id, "prj_plugin_gate");
+
+    let other_host = state
+        .resolve_project_binding(DaemonProjectBindingResolveRequest {
+            workspace_path: workspace.path().display().to_string(),
+            required_adapter: Some(ProjectAgentAdapterRuntimeRequirement {
+                adapter: ProjectAgentAdapterKind::ClaudeCode,
+                delivery: ProjectAgentAdapterDelivery::LegacyFiles,
+            }),
+        })
+        .await
+        .unwrap_err();
     assert!(matches!(
-        rejected,
+        other_host,
         DaemonError::State {
             code: "project_agent_adapter_not_enabled",
             ..
         }
     ));
-
-    sqlx::query("UPDATE project_agent_adapters SET manifest_json = $1 WHERE adapter = 'codex'")
-        .bind(manifest("host_plugin"))
-        .execute(&db)
-        .await
-        .unwrap();
-    let accepted = state.resolve_project_binding(request()).await.unwrap();
-    assert_eq!(accepted.project_id, "prj_plugin_gate");
 }
 
 #[tokio::test]
@@ -4031,7 +4028,10 @@ async fn resolving_an_unbound_workspace_reports_project_binding_not_found() {
     let error = state
         .resolve_project_binding(DaemonProjectBindingResolveRequest {
             workspace_path: workspace.display().to_string(),
-            required_adapter: None,
+            required_adapter: Some(ProjectAgentAdapterRuntimeRequirement {
+                adapter: ProjectAgentAdapterKind::Codex,
+                delivery: ProjectAgentAdapterDelivery::HostPlugin,
+            }),
         })
         .await
         .unwrap_err();

--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -2,7 +2,7 @@
 
 Adapter is the daemon-owned integration layer that makes the Clumsies Agent
 runtime usable inside Codex, Claude Code, opencode, dsh, and Antigravity. For
-Codex it installs and reconciles one user-level Clumsies plugin; the other
+Codex it automatically installs and reconciles one user-level Clumsies plugin; the other
 hosts retain their direct-file integrations. Both delivery forms provide the
 MCP registration and non-blocking lifecycle bridge without creating a second
 memory or runtime implementation.
@@ -38,10 +38,11 @@ release is detected and must be restarted.
 
 ## Managed host surfaces
 
-Adapter is installed and removed from native Project Management. The resident
-daemon requires the repository's canonical Project binding first, serializes
-local setup, and persists one revisioned adapter record per Server authority,
-workspace root, and host.
+Codex is a global host integration managed from **Settings → Agent**. It is
+installed and enabled by default when the Codex App is available, and it never
+writes files into a repository. The other hosts are installed and removed from
+native Project Management; their direct-file integrations retain one revisioned
+adapter record per Server authority, workspace root, and host.
 
 | Host | MCP registration | Lifecycle integration |
 | --- | --- | --- |
@@ -58,24 +59,28 @@ resources in Memory Space: the bootstrap loads them through `memory.load` when
 relevant and never copies or installs them into a host skill directory.
 
 The unrelated host-native `activate` / `ntmd` skills installed by older Codex
-and Claude Code releases are retired. Codex plugin migration removes the exact
-legacy `.codex/config.toml`, `.codex/hooks.json`, and managed Hook fragments;
-the direct-file update paths likewise delete previously managed retired skill
-files without touching user-owned content.
+and Claude Code releases are retired. Historical Codex Adapter rows retain
+enough ownership metadata to remove exact legacy `.codex/config.toml`,
+`.codex/hooks.json`, and managed Hook fragments when that repository is
+removed. Direct-file update paths likewise delete previously managed retired
+skill files without touching user-owned content.
 
 The Codex plugin executes the pinned binary as `mcp serve --host codex
---delivery host-plugin`. The delivery marker requires an exact, enabled Codex
-Adapter record at startup and again before every `tools/call`; a removal,
-delivery change, or Project rebind therefore fails the next call closed. Claude
-Code and the remaining direct-file hosts retain their existing commands. The
-opencode plugin embeds the same pinned path for lifecycle events.
+--delivery host-plugin`. The marker identifies the global plugin delivery; it
+does not select or authorize a Project. At startup and again before every
+`tools/call`, daemon resolves the repository's canonical Project binding and
+requires it to remain the same Project. A missing or changed binding therefore
+fails closed without consulting a Codex project Adapter row. Claude Code and
+the remaining direct-file hosts retain their existing commands and Adapter
+delivery checks. The opencode plugin embeds the same pinned path for lifecycle
+events.
 
 ## Lifecycle bridge
 
 The Codex plugin and Claude Code direct-file adapter each register an
 `issue-run-event.sh` for prompt, subagent, and session lifecycle. Codex forwards
-the same `host-plugin` delivery marker used by MCP; a stale global plugin is
-therefore inert for Projects without an enabled matching Adapter record.
+the same `host-plugin` delivery marker used by MCP; the Hook resolves its
+repository binding rather than a project-level Codex switch.
 Codex treats plugin Hooks as non-managed code and skips a new or changed Hook
 until the user reviews and trusts its current hash in `/hooks`. Adapter never
 bypasses that trust boundary. Plugin changes do not hot-load into an already
@@ -125,18 +130,21 @@ scripts and plugins as exclusive managed files. Their manifests record the
 installed hash of every managed file, and update retires managed files that the
 current plan no longer includes.
 
-Codex uses a distinct `host_plugin` delivery. The daemon verifies the explicit
-Codex App CLI, materializes an App-owned local marketplace, and reconciles the
-exact enabled plugin version through the Codex plugin CLI. Only after that
-succeeds does its journal remove exact legacy project fragments and flip the
-Project Adapter record from `legacy_files` to `host_plugin`. Disabling Codex in
-v1 deletes the Project Adapter record but deliberately leaves the global plugin
-installed; the runtime delivery gate makes it inert for that Project. Installed
-and enabled describes plugin delivery, not Hook trust. Project settings keep a
-visible `/hooks` reminder because Codex owns that explicit user decision.
-The same reminder requires a Codex restart and a new task after install or
-update; an existing task is not a valid convergence probe for the new plugin
-snapshot and may still own a retired legacy proxy until it exits.
+Codex uses a distinct `host_plugin` delivery. Before authentication, the App
+inspects the Codex host, App-owned local marketplace, installed/enabled state,
+and expected plugin version. Missing or stale managed state is reconciled
+through the signed Codex CLI. Inspection is read-only; automatic reconciliation
+and the explicit **Repair** action in **Settings → Agent** materialize the
+marketplace and install or update the plugin. Neither operation writes a
+`project_agent_adapters` row or repository file.
+
+Installed and enabled describes plugin delivery, not Hook trust or AgentRun
+readiness. Settings therefore keeps the `/hooks` reminder and requires a Codex
+restart and a new task after plugin changes; an existing task is not a valid
+convergence probe for the new plugin snapshot and may still own a retired
+legacy proxy until it exits. Historical Codex Adapter rows remain readable only
+so repository removal and legacy-file cleanup can retire them safely; current
+installation and runtime routing ignore them.
 
 The App refuses to bootstrap `clumsiesd` or persist an Agent runtime path while
 macOS is running it from an App Translocation mount. Move the released App to
@@ -152,11 +160,9 @@ temporary quarantine UUID from entering LaunchAgent and host configuration.
   best-effort, has a short App-side deadline, and never blocks reconciliation
   of daemon-owned integrations, including while signed out or offline. Their external
   manifests are not accepted as native ownership proof.
-- Archived `repo`-scope generations are reported as unsupported. For a
-  workspace install, remove its old Clumsies MCP/Hook entries and reinstall in
-  Project settings. For a user-wide install, remove the global entries and
-  enable the integration separately for each repository; the App deliberately
-  has no global-install ownership mode.
+- Archived `repo`-scope generations are reported as unsupported. Remove their
+  old Clumsies MCP/Hook entries; the App-owned global Codex Plugin replaces
+  repository-local Codex integration, while other hosts remain project-scoped.
 - Reinstalling from the App is the explicit handoff: the native installer
   refuses foreign or drifted entries instead of silently adopting them.
 - Remove deletes only exact managed entries and files; drift becomes a conflict

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -119,6 +119,8 @@ source is preserved under `archive/zig-cli/` only.
 Adapter is the host integration layer. It connects clumsies to coding agents
 such as Codex, Claude Code, opencode, and the DeepSeek Harness by installing
 the hooks, config, and runtime glue needed for the protocol to actually run.
+Codex uses one App-managed user-global Plugin; repository-writing hosts use
+project-scoped adapters.
 Hosts consume the MCP tools directly; the former thin host-native skill layer
 is retired.
 

--- a/docs/guides/agent-run-injection.md
+++ b/docs/guides/agent-run-injection.md
@@ -41,7 +41,7 @@ unbound, and one active Issue cannot be claimed by a second active run.
 
 | Host | Observed events | Integration surface |
 | --- | --- | --- |
-| Codex | `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `SessionEnd` | Adapter-installed Clumsies plugin Hook with exact `host_plugin` gate after the user trusts its current hash in `/hooks`; no project Hook files and no root `Stop` registration |
+| Codex | `UserPromptSubmit`, `SubagentStart`, `SubagentStop`, `SessionEnd` | App-managed global Clumsies Plugin Hook after the user trusts its current hash in `/hooks`; repository binding supplies the Project, with no project Hook files or root `Stop` registration |
 | Claude Code | the Codex set plus `StopFailure` | `.claude/settings.json` → managed shell Hook; no root `Stop` registration |
 | Antigravity | `PreInvocation` | `.agents/hooks.json` → managed shell Hook; no root `Stop` registration |
 | opencode | user message, failed assistant message, deleted session | managed plugin maps them to `UserPromptSubmit`, `StopFailure`, and `SessionEnd`; successful completion emits no `Stop` |

--- a/docs/guides/agent-runtime.md
+++ b/docs/guides/agent-runtime.md
@@ -10,7 +10,7 @@ Direct-file adapters register the App-bundled runtime as:
 /path/to/Clumsies.app/Contents/Resources/clumsiesd mcp serve
 ```
 
-Codex receives the same runtime through the Adapter-installed Clumsies plugin:
+Codex receives the same runtime through the App-managed global Clumsies plugin:
 
 ```bash
 /path/to/Clumsies.app/Contents/Resources/clumsiesd \
@@ -27,7 +27,7 @@ direct-file Hook invokes the private lifecycle bridge as:
   _agent issue-run-event --host codex|claude-code|opencode
 ```
 
-The Codex plugin Hook instead invokes the exact gated form:
+The Codex plugin Hook invokes the host-plugin form:
 
 ```bash
 /path/to/Clumsies.app/Contents/Resources/clumsiesd \
@@ -121,12 +121,12 @@ lifecycle outside the MCP memory contract and must not reimplement retrieval or
 inject a second bootstrap protocol.
 
 Codex plugin proxies identify both `host=codex` and `delivery=host-plugin`.
-After resolving the canonical Project, the resident daemon requires the exact
-enabled Adapter delivery at startup and before every `tools/call`. Removing the
-Adapter, changing its delivery, or rebinding the workspace makes an already
-running plugin proxy fail its next call closed. This makes a globally installed
-plugin harmless when the integration is disabled for a Project. Plugin
-installation does not grant Hook trust: the user must review the current
+The Plugin is installed and enabled globally, but it can operate only inside a
+repository with a canonical Project binding. The resident daemon resolves that
+binding at startup and before every `tools/call`; removing or changing the
+binding makes an already running plugin proxy fail its next call closed. There
+is no per-Project Codex enable/disable row. Plugin installation does not grant
+Hook trust: the user must review the current
 Clumsies Hook in `/hooks` before AgentRun injection and run-bound Kanban actions
 become available. Installation also does not hot-load the plugin into an
 existing Codex task; restart Codex after install or update, then start a new

--- a/docs/guides/dsh-integration.md
+++ b/docs/guides/dsh-integration.md
@@ -35,11 +35,11 @@ Register the Clumsies MCP server in the dsh profile patch layer
 by the hook (see below) — the daemon never lets an agent mint its own
 identity.
 
-## Coding Agents adapter (project settings)
+## Agent adapter (project settings)
 
-dsh is a first-class Coding Agent adapter. In the macOS app, Project Settings
-→ Coding Agents (and the New Project sheet) list **DeepSeek Harness (dsh)**
-next to Codex, Claude Code, and opencode. Enabling the toggle installs a
+dsh is a first-class Agent adapter. In the macOS app, Project Settings
+→ Agent (and the New Project sheet) lists **DeepSeek Harness (dsh)**
+next to Claude Code, opencode, and Antigravity. Enabling the toggle installs a
 workspace marker the dsh side reads:
 
 ```json
@@ -56,7 +56,7 @@ like the other adapters' files. Disabling the toggle removes it.
 
 The marker is per-machine state (the App-bundled clumsiesd path and the
 daemon's server URL), so repositories using the dsh adapter should ignore it
-in git, same as `.codex/`, `.claude/`, and `.opencode/`:
+in git, like the other project-scoped Agent files:
 
 ```gitignore
 .dsh/

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -85,9 +85,10 @@ the proposal target. These are separate axes: the Project owns the pre-merge
 overlay; `org` describes the Ref an approved Review may eventually move. At
 process startup, MCP gives its current working directory to daemon; daemon
 canonicalizes the path and resolves the nearest bound ancestor in SQLite. A
-Codex host-plugin proxy repeats that resolution and its exact Adapter-delivery
-check before every `tools/call`. MCP never treats a legacy Workspace ID as a
-Project ID. The Rust MCP contract tests exercise the exact Agent-facing
+Codex host-plugin proxy repeats that resolution before every `tools/call` and
+requires it to remain the same Project; the global Plugin does not require a
+project Adapter row. MCP never treats a legacy Workspace ID as a Project ID.
+The Rust MCP contract tests exercise the exact Agent-facing
 envelopes before they are mapped to typed daemon requests.
 
 Agent-originated updates are exact text replacements, not complete-document

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -106,6 +106,6 @@ repository. At startup the proxy verifies the resident daemon release identity,
 resolves the current directory through the binding registry, and fixes that
 canonical `project_id` for the process. Agent input cannot select another
 Project or reuse Desktop's current selection. A Codex host-plugin proxy repeats
-the canonical binding and exact Adapter-delivery check before every
-`tools/call`, so a removal, delivery flip, or rebind revokes the running proxy
-on its next call.
+the canonical binding before every `tools/call`, so a missing binding or rebind
+revokes the running proxy on its next call. The global Plugin does not create or
+require a per-repository Codex Adapter row.


### PR DESCRIPTION
## Context and summary

Codex installs Plugins at user scope, but Clumsies previously modeled the
managed Plugin as a per-project Adapter. That made Project Settings look like
an authorization boundary even though the Plugin lived outside the repository,
and it coupled runtime availability to a `project_agent_adapters` row.

Manage the Codex Plugin globally through the macOS App instead. The App now
inspects and repairs the signed user-level Plugin before authentication, while
repository bindings remain the sole Memory and Kanban routing boundary.

## Affected areas

- [x] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [x] MCP, CLI, or agent protocol
- [x] Storage, configuration, or schema
- [x] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before this change, Project creation and Project Settings exposed a Codex
switch, installation persisted a Codex Adapter row, and the runtime required
that row even though delivery used a global Plugin.

After this change, the App automatically reconciles the user-level Plugin and
offers read-only status plus Repair under native General, Agent, and Advanced
preference panes. Project UI no longer exposes Codex, project installation is
rejected by the daemon, and no repository `.codex` files are created. Codex
still resolves the repository binding at startup and before every tool call,
so a missing or changed binding fails closed without consulting a Codex
Adapter row. Other project-scoped Agents keep their existing behavior.

Rust tests cover read-only inspection, missing/stale/disabled reconciliation,
the absence of a Codex project gate, and runtime revocation after rebinding.
macOS tests cover the preference toolbar, pane restoration, Plugin status
dimensions, and removal of Codex from Project setup.

## Verification

- `cargo test --workspace` — passed.
- `cargo test -p daemon agent_adapter::codex_plugin::tests -- --nocapture` — passed.
- `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture` — passed.
- `cargo clippy -p daemon --all-targets -- -D warnings` — passed.
- `cargo fmt --all --check` — passed.
- `bun run test:macos` — passed.
- `bun run api:check` — passed.
- `bun run build` — passed.
- `sh dev/check-agent-runtime-boundary.sh` — passed.
- `sh dev/check-retired-terms.sh` — passed.
- `git diff --check` — passed.
- Installed App verification covered light and dark appearance, keyboard and
  VoiceOver navigation, long values and error copy, and all three preference
  panes.
- New Codex tasks in different bound repositories verified `/hooks`, global
  Plugin availability, absence of repository `.codex` files and Project Codex
  switches, and correct Memory/Kanban routing.

## Compatibility and migration

No schema migration is required. Historical Codex Adapter rows remain readable
for exact repository removal and legacy-file cleanup, but current installation,
UI, and runtime routing ignore them. Existing project-scoped Agents are
unchanged.

Older clients that attempt a project-level Codex installation receive an
explicit invalid-request response from the new daemon. Existing managed Codex
Plugins are upgraded to the version derived from the signed bundled runtime on
the next App startup or explicit Repair.

## Risk, security, and privacy

Reconciliation verifies both the signed bundled runtime and the OpenAI-signed
Codex CLI before invoking Plugin commands. Inspection is read-only, marketplace
conflicts fail closed, and setup mutations remain serialized by the existing
daemon lock. No Plugin configuration is edited manually.

Repository-to-Project binding is still resolved before every Codex tool call,
preventing a running task from silently following a repository rebind. Plugin
Enabled remains distinct from Hook Trusted and AgentRun Ready; users still
review changed Hooks through `/hooks`.

## Rollout and rollback

- Rollout: Merge through the normal pull request flow and ship in the next App
  build. After Plugin changes, restart Codex, start a new task, and review
  `/hooks`.
- Observability: Settings > Agent reports host, marketplace, Plugin, enabled,
  version, conflict, and readiness state. Runtime Diagnostics and daemon logs
  retain detailed failures.
- Rollback: Revert this PR and rebuild the App. No database rollback is needed;
  an already installed user-level Plugin may remain until removed through
  Codex.

## Reviewer focus

Confirm that the runtime bypass applies only to the exact Codex `host_plugin`
delivery gate while repository binding checks still run for every tool call.
Also verify that startup reconciliation ignores historical Codex rows without
changing cleanup semantics or the behavior of other project-scoped Agents.
