### PR TITLE
dev: isolate worktree runtime instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install script tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes ripgrep
+
       - name: Check deployment scripts
         run: |
           bash -n deploy/server/*.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
           shellcheck dev/check-retired-terms.sh
           sh dev/check-retired-terms.sh
 
+      - name: Check worktree Dev scripts
+        run: |
+          for script in dev/dev-instance.sh dev/dev-instance-test.sh dev/dev-server.sh apps/macos/Scripts/promote-debug.sh apps/macos/Scripts/promote-debug-test.sh; do
+            sh -n "$script"
+          done
+          shellcheck dev/dev-instance.sh dev/dev-instance-test.sh dev/dev-server.sh apps/macos/Scripts/promote-debug.sh apps/macos/Scripts/promote-debug-test.sh
+          sh apps/macos/Scripts/promote-debug-test.sh
+          docker compose config -q
+
   docs:
     runs-on: ubuntu-latest
     steps:
@@ -80,32 +89,50 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install XcodeGen
+      - name: Install native development tools
         run: |
           brew update
-          brew install xcodegen
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.5
+          brew install just xcodegen
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
+      - name: Check native task boundary
+        run: |
+          just --list
+          if grep -i bun justfile; then
+            echo "native macOS recipes must not invoke Bun" >&2
+            exit 1
+          fi
+          just --dry-run build-macos
+          just --dry-run test-macos
+          just --dry-run test-macos-live
+          just --dry-run test-macos-package
+          just --dry-run promote-debug-macos
+          just --dry-run dev-macos
+          just --dry-run dev-macos-status
+          just --dry-run dev-macos-logs
+          just --dry-run dev-macos-down
+          just --dry-run dev-macos-reset
+          just --dry-run dev-macos-preview preview.json
+          just --dry-run test-dev-macos
+
+      - name: Check worktree Dev lifecycle
+        run: just test-dev-macos
+
       - name: Lint (clippy, daemon)
         run: cargo clippy -p daemon -- -D warnings
 
       - name: Run native macOS tests
-        run: bun run test:macos
+        run: just test-macos
 
       - name: Run Agent runtime process and XPC integration
         run: cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture
 
       - name: Build and verify the signed Agent runtime package
-        run: bun run test:macos:package
+        run: just test-macos-package
 
   # Aggregator so branch protection rules that require a single "build"
   # status check continue to resolve after the split. Also gives a

--- a/README.md
+++ b/README.md
@@ -66,14 +66,16 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 
 ### Development from Source
 
+The complete Dev Instance requires Just, XcodeGen, Xcode, Rust, Bun, and Docker
+Desktop.
+
 ```bash
 # Clone repository
 git clone https://github.com/lilhammerfun/clumsies.git
 cd clumsies
 
-# Install dependencies and launch native macOS App
-bun install
-bun run dev:macos
+# Launch a complete worktree-scoped Dev Instance
+just dev-macos
 ```
 
 For local server development:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,14 +66,15 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 
 ### 源码构建与本地开发
 
+完整 Dev Instance 需要 Just、XcodeGen、Xcode、Rust、Bun 和 Docker Desktop。
+
 ```bash
 # 克隆代码仓库
 git clone https://github.com/lilhammerfun/clumsies.git
 cd clumsies
 
-# 安装依赖并一键构建拉起原生 macOS App
-bun install
-bun run dev:macos
+# 启动完整、按 worktree 隔离的 Dev Instance
+just dev-macos
 ```
 
 启动本地后端与测试鉴权环境：

--- a/apps/macos/Clumsies.xcodeproj/project.pbxproj
+++ b/apps/macos/Clumsies.xcodeproj/project.pbxproj
@@ -512,6 +512,16 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CLUMSIES_APP_BUNDLE_IDENTIFIER = ai.clumsies.desktop;
+				CLUMSIES_APP_DISPLAY_NAME = Clumsies;
+				CLUMSIES_APP_PRODUCT_NAME = Clumsies;
+				CLUMSIES_CODEX_HOME = "";
+				CLUMSIES_DAEMON_CACHE_DIR = "";
+				CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR = "";
+				CLUMSIES_DAEMON_LOG_DIR = "";
+				CLUMSIES_DAEMON_ROOT = "";
+				CLUMSIES_DEV_INSTANCE_ID = "";
+				CLUMSIES_SERVER_URL = "https://app.clumsies.ai";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -552,7 +562,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.clumsies.desktop.tests;
 				SDKROOT = macosx;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clumsies.app/Contents/MacOS/Clumsies";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/$(CLUMSIES_APP_PRODUCT_NAME).app/Contents/MacOS/$(CLUMSIES_APP_PRODUCT_NAME)";
 			};
 			name = Release;
 		};
@@ -571,8 +581,9 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ai.clumsies.desktop;
-				PRODUCT_NAME = Clumsies;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CLUMSIES_APP_BUNDLE_IDENTIFIER)";
+				PRODUCT_MODULE_NAME = Clumsies;
+				PRODUCT_NAME = "$(CLUMSIES_APP_PRODUCT_NAME)";
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -590,7 +601,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ai.clumsies.desktop.tests;
 				SDKROOT = macosx;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Clumsies.app/Contents/MacOS/Clumsies";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/$(CLUMSIES_APP_PRODUCT_NAME).app/Contents/MacOS/$(CLUMSIES_APP_PRODUCT_NAME)";
 			};
 			name = Debug;
 		};
@@ -610,8 +621,9 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = ai.clumsies.desktop;
-				PRODUCT_NAME = Clumsies;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(CLUMSIES_APP_BUNDLE_IDENTIFIER)";
+				PRODUCT_MODULE_NAME = Clumsies;
+				PRODUCT_NAME = "$(CLUMSIES_APP_PRODUCT_NAME)";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -649,6 +661,16 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CLUMSIES_APP_BUNDLE_IDENTIFIER = ai.clumsies.desktop;
+				CLUMSIES_APP_DISPLAY_NAME = Clumsies;
+				CLUMSIES_APP_PRODUCT_NAME = Clumsies;
+				CLUMSIES_CODEX_HOME = "";
+				CLUMSIES_DAEMON_CACHE_DIR = "";
+				CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR = "";
+				CLUMSIES_DAEMON_LOG_DIR = "";
+				CLUMSIES_DAEMON_ROOT = "";
+				CLUMSIES_DEV_INSTANCE_ID = "";
+				CLUMSIES_SERVER_URL = "https://app.clumsies.ai";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/apps/macos/Config/Info.plist
+++ b/apps/macos/Config/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Clumsies</string>
+	<string>$(CLUMSIES_APP_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,13 +13,29 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>Clumsies</string>
+	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CLUMSIES_APP_DISPLAY_NAME</key>
+	<string>$(CLUMSIES_APP_DISPLAY_NAME)</string>
+	<key>CLUMSIES_CODEX_HOME</key>
+	<string>$(CLUMSIES_CODEX_HOME)</string>
+	<key>CLUMSIES_DAEMON_CACHE_DIR</key>
+	<string>$(CLUMSIES_DAEMON_CACHE_DIR)</string>
+	<key>CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR</key>
+	<string>$(CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR)</string>
+	<key>CLUMSIES_DAEMON_LOG_DIR</key>
+	<string>$(CLUMSIES_DAEMON_LOG_DIR)</string>
+	<key>CLUMSIES_DAEMON_ROOT</key>
+	<string>$(CLUMSIES_DAEMON_ROOT)</string>
+	<key>CLUMSIES_DEV_INSTANCE_ID</key>
+	<string>$(CLUMSIES_DEV_INSTANCE_ID)</string>
+	<key>CLUMSIES_SERVER_URL</key>
+	<string>$(CLUMSIES_SERVER_URL)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.productivity</string>
 	<key>LSMinimumSystemVersion</key>

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -5,10 +5,29 @@ This is the Clumsies desktop client. It uses AppKit and SwiftUI for the interfac
 ## Run
 
 ```sh
-bun run dev:macos
+just dev-macos
 ```
 
-The command builds the Debug app, atomically replaces `~/Applications/Clumsies.app`, reconciles the LaunchAgent against the newly embedded daemon, and launches that stable installation path. A running Clumsies instance exits only after the new build succeeds. Set `CLUMSIES_MACOS_INSTALL_DIR` to override the installation directory.
+The command starts a complete Dev Instance owned by the current worktree: a
+uniquely named App and daemon, private data and Keychain identity, local Server,
+PostgreSQL, fake OIDC, and isolated `CODEX_HOME`. It does not replace the
+resident Debug App or global Codex Plugin.
+
+```sh
+just dev-macos-status
+just dev-macos-logs
+just dev-macos-down   # preserve instance data
+just dev-macos-reset  # delete instance data and credentials
+just dev-macos-preview path/to/preview.json
+```
+
+To deliberately replace the resident Debug App and daemon, run the promotion
+entry point. The App then reconciles the global Codex Plugin; restart Codex and
+create a new task before testing the promoted build.
+
+```sh
+just promote-debug-macos
+```
 
 The build embeds `clumsiesd` in the app bundle. Set `CLUMSIES_SKIP_DAEMON_BUILD=1` only when iterating on UI code with an already installed daemon.
 Debug builds use Xcode's local ad-hoc signature so the test host can load Swift debug libraries under macOS system policy. The embedded daemon receives an explicit, stable designated requirement so rebuilding it does not invalidate its file-keychain access control entry.
@@ -16,16 +35,18 @@ Debug builds use Xcode's local ad-hoc signature so the test host can load Swift 
 ## Test
 
 ```sh
-bun run test:macos
-bun run test:macos:live
+just test-macos
+just test-macos-live
 ```
 
-The live suite loads the authenticated workspace through the installed daemon and the configured Server. The regular suite has no Server dependency.
+The live suite requires a running, authenticated `just dev-macos` instance and
+uses only that instance's daemon and Server. The regular suite has no Server
+dependency.
 
 ## Build
 
 ```sh
-bun run build:macos
+just build-macos
 ```
 
 The local build is unsigned, targets the current Mac's architecture, and is written to `/private/tmp/clumsies-macos-build`. Distribution signing and notarization are separate release operations.
@@ -41,12 +62,13 @@ Keep the Apple certificate, certificate passphrase, notarization account,
 app-specific password, team ID, temporary keychain password, and Sparkle private key
 in the protected `macos-signing` GitHub environment, using the secret names referenced
 by `release.yml`. Restrict that environment to the default branch and release tags and
-require a reviewer before its secrets are exposed. The Sparkle private key is required
-only for a tagged release; only its public key is committed in `project.yml`. The Debug
-App installed by `bun run dev:macos` uses the supported ad-hoc development path and can
-exercise managed Coding Agent integrations. A Debug ad-hoc runtime is accepted at the
-installation boundary; Release packages must carry an accepted team identity and the
-hardened-runtime flag.
+require a reviewer before its secrets are exposed. The Sparkle private key is
+required only for a tagged release; only its public key is committed in
+`project.yml`. The Debug App installed by `just promote-debug-macos` uses the
+supported ad-hoc development path and can exercise managed Coding Agent
+integrations. A Debug ad-hoc runtime is accepted at the installation boundary;
+Release packages must carry an accepted team identity and the hardened-runtime
+flag.
 
 ## Generate the Xcode project
 

--- a/apps/macos/Scripts/promote-debug-test.sh
+++ b/apps/macos/Scripts/promote-debug-test.sh
@@ -36,8 +36,10 @@ assert_absent() {
 assert_before() {
   first_line="$(line_of "$1")"
   second_line="$(line_of "$2")"
-  [ -n "$first_line" ] && [ -n "$second_line" ] && [ "$first_line" -lt "$second_line" ] \
-    || fail "expected '$1' before '$2'"
+  if [ -z "$first_line" ] || [ -z "$second_line" ] \
+    || [ "$first_line" -ge "$second_line" ]; then
+    fail "expected '$1' before '$2'"
+  fi
 }
 
 assert_installed_version() {

--- a/apps/macos/Scripts/promote-debug-test.sh
+++ b/apps/macos/Scripts/promote-debug-test.sh
@@ -1,0 +1,430 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+promote_script="$repo_root/apps/macos/Scripts/promote-debug.sh"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/clumsies-promote-debug-test.XXXXXX")"
+fake_bin="$test_root/bin"
+event_log="$test_root/events.log"
+
+cleanup_test() {
+  rm -rf "$test_root"
+}
+trap cleanup_test 0 1 2 15
+
+fail() {
+  printf '%s\n' "$1" >&2
+  if [ -f "$event_log" ]; then
+    printf '%s\n' "events:" >&2
+    sed 's/^/  /' "$event_log" >&2
+  fi
+  exit 1
+}
+
+line_of() {
+  awk -v event="$1" '$0 == event { print NR; exit }' "$event_log"
+}
+
+assert_present() {
+  [ -n "$(line_of "$1")" ] || fail "missing event: $1"
+}
+
+assert_absent() {
+  [ -z "$(line_of "$1")" ] || fail "unexpected event: $1"
+}
+
+assert_before() {
+  first_line="$(line_of "$1")"
+  second_line="$(line_of "$2")"
+  [ -n "$first_line" ] && [ -n "$second_line" ] && [ "$first_line" -lt "$second_line" ] \
+    || fail "expected '$1' before '$2'"
+}
+
+assert_installed_version() {
+  actual="$(sed -n '1p' "$install_dir/Clumsies.app/version" 2>/dev/null || true)"
+  [ "$actual" = "$1" ] || fail "expected installed App version '$1', got '$actual'"
+}
+
+assert_no_transaction_artifacts() {
+  for artifact in "$install_dir"/.Clumsies.*.app; do
+    [ ! -e "$artifact" ] || fail "transaction artifact was not cleaned up: $artifact"
+  done
+}
+
+mkdir -p "$fake_bin"
+
+cat >"$fake_bin/fake-command" <<'EOF'
+#!/bin/sh
+set -eu
+
+event() {
+  printf '%s\n' "$1" >>"$CLUMSIES_TEST_EVENT_LOG"
+}
+
+command_name="${0##*/}"
+case "$command_name" in
+  xcodegen)
+    event build-project
+    ;;
+  xcodebuild)
+    event build-app
+    if [ "$CLUMSIES_TEST_BUILD_FAIL" = 1 ]; then
+      exit 42
+    fi
+    app="$CLUMSIES_MACOS_DERIVED_DATA/Build/Products/Debug/Clumsies.app"
+    mkdir -p "$app/Contents/Resources"
+    printf '%s\n' new >"$app/version"
+    cp "$CLUMSIES_TEST_FAKE_COMMAND" "$app/Contents/Resources/clumsiesd"
+    chmod 755 "$app/Contents/Resources/clumsiesd"
+    ;;
+  codesign)
+    event verify-app
+    ;;
+  ditto)
+    event stage-app
+    cp -R "$1" "$2"
+    ;;
+  pgrep)
+    state="$(sed -n '1p' "$CLUMSIES_TEST_APP_STATE")"
+    case "$state" in
+      absent)
+        exit 1
+        ;;
+      running|stuck)
+        exit 0
+        ;;
+      quitting)
+        printf '%s\n' absent >"$CLUMSIES_TEST_APP_STATE"
+        exit 0
+        ;;
+      *)
+        printf 'unknown fake App state: %s\n' "$state" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  osascript)
+    event quit-app
+    state="$(sed -n '1p' "$CLUMSIES_TEST_APP_STATE")"
+    if [ "$state" = running ]; then
+      printf '%s\n' quitting >"$CLUMSIES_TEST_APP_STATE"
+    fi
+    ;;
+  sleep)
+    event wait-for-quit
+    ;;
+  mv)
+    source_name="${1##*/}"
+    target_name="${2##*/}"
+    case "$source_name:$target_name" in
+      Clumsies.app:.Clumsies.previous.*.app)
+        event backup-app
+        /bin/mv "$@"
+        if [ "$CLUMSIES_TEST_SIGNAL_AFTER_BACKUP" = 1 ]; then
+          event signal-after-backup
+          kill -TERM "$PPID"
+        fi
+        ;;
+      .Clumsies.previous.*.app:Clumsies.app)
+        event restore-app
+        /bin/mv "$@"
+        ;;
+      .Clumsies.*.app:Clumsies.app)
+        event install-app
+        if [ "$CLUMSIES_TEST_SWAP_FAIL" = 1 ]; then
+          exit 43
+        fi
+        /bin/mv "$@"
+        if [ "$CLUMSIES_TEST_SIGNAL_AFTER_INSTALL" = 1 ]; then
+          event signal-after-install
+          kill -TERM "$PPID"
+        fi
+        ;;
+      *)
+        /bin/mv "$@"
+        ;;
+    esac
+    ;;
+  clumsiesd)
+    app_root="${0%/Contents/Resources/clumsiesd}"
+    app_version="$(sed -n '1p' "$app_root/version")"
+    case "${1:-}" in
+      --reconcile-launch-agent)
+        event "reconcile-launch-agent-$app_version"
+        if [ "$CLUMSIES_TEST_RECONCILE_FAIL" = 1 ] && [ "$app_version" = new ]; then
+          exit 46
+        fi
+        plist="$HOME/Library/LaunchAgents/ai.clumsies.daemon.plist"
+        mkdir -p "${plist%/*}"
+        printf '%s\n' "$app_version" >"$plist"
+        ;;
+      *)
+        exit 44
+        ;;
+    esac
+    ;;
+  open)
+    event open-app
+    if [ "$CLUMSIES_TEST_OPEN_FAIL" = 1 ]; then
+      exit 47
+    fi
+    ;;
+  *)
+    printf 'unexpected fake command: %s\n' "$command_name" >&2
+    exit 45
+    ;;
+esac
+EOF
+chmod 755 "$fake_bin/fake-command"
+
+for command_name in xcodegen xcodebuild codesign ditto pgrep osascript sleep mv open; do
+  ln -s fake-command "$fake_bin/$command_name"
+done
+
+reset_case() {
+  case_name="$1"
+  initial_state="$2"
+  initial_install="${3:-present}"
+  case_root="$test_root/$case_name"
+  case_home="$case_root/home"
+  install_dir="$case_root/install"
+  derived_data="$case_root/derived"
+  event_log="$case_root/events.log"
+  app_state="$case_root/app-state"
+  stdout_log="$case_root/stdout.log"
+  stderr_log="$case_root/stderr.log"
+  build_fail=0
+  swap_fail=0
+  signal_after_backup=0
+  signal_after_install=0
+  reconcile_fail=0
+  open_fail=0
+
+  mkdir -p "$case_home" "$install_dir"
+  if [ "$initial_install" = present ]; then
+    mkdir -p "$install_dir/Clumsies.app/Contents/Resources"
+    printf '%s\n' old >"$install_dir/Clumsies.app/version"
+    cp "$fake_bin/fake-command" \
+      "$install_dir/Clumsies.app/Contents/Resources/clumsiesd"
+    chmod 755 "$install_dir/Clumsies.app/Contents/Resources/clumsiesd"
+  fi
+  printf '%s\n' "$initial_state" >"$app_state"
+  : >"$event_log"
+}
+
+run_promote() {
+  env \
+    HOME="$case_home" \
+    PATH="$fake_bin:/usr/bin:/bin" \
+    CLUMSIES_MACOS_INSTALL_DIR="$install_dir" \
+    CLUMSIES_MACOS_DERIVED_DATA="$derived_data" \
+    CLUMSIES_TEST_EVENT_LOG="$event_log" \
+    CLUMSIES_TEST_APP_STATE="$app_state" \
+    CLUMSIES_TEST_FAKE_COMMAND="$fake_bin/fake-command" \
+    CLUMSIES_TEST_BUILD_FAIL="$build_fail" \
+    CLUMSIES_TEST_SWAP_FAIL="$swap_fail" \
+    CLUMSIES_TEST_SIGNAL_AFTER_BACKUP="$signal_after_backup" \
+    CLUMSIES_TEST_SIGNAL_AFTER_INSTALL="$signal_after_install" \
+    CLUMSIES_TEST_RECONCILE_FAIL="$reconcile_fail" \
+    CLUMSIES_TEST_OPEN_FAIL="$open_fail" \
+    sh "$promote_script" >"$stdout_log" 2>"$stderr_log"
+}
+
+test_successful_promotion() {
+  reset_case success running
+  run_promote || fail "successful promotion failed"
+
+  assert_installed_version new
+  assert_before build-app stage-app
+  assert_before stage-app quit-app
+  assert_before quit-app backup-app
+  assert_before backup-app install-app
+  assert_before install-app reconcile-launch-agent-new
+  assert_before reconcile-launch-agent-new open-app
+  grep -q 'The App reconciles the global Plugin after launch' "$stdout_log" \
+    || fail "promotion did not explain the asynchronous Plugin reconciliation"
+  grep -q 'restart Codex and create a new task' "$stdout_log" \
+    || fail "promotion did not explain the Host refresh requirement"
+  assert_no_transaction_artifacts
+}
+
+test_quit_timeout_preserves_installed_app() {
+  reset_case timeout stuck
+  if run_promote; then
+    fail "promotion unexpectedly succeeded when the App never quit"
+  fi
+
+  grep -q 'did not quit within 10 seconds' "$stderr_log" \
+    || fail "quit timeout did not report the 10-second deadline"
+  assert_installed_version old
+  assert_present quit-app
+  assert_absent backup-app
+  assert_absent install-app
+  assert_absent reconcile-launch-agent-new
+  assert_absent reconcile-launch-agent-old
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_failed_swap_restores_installed_app() {
+  reset_case swap-failure absent
+  swap_fail=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded when the staging swap failed"
+  fi
+
+  assert_installed_version old
+  assert_before backup-app install-app
+  assert_before install-app restore-app
+  assert_before restore-app reconcile-launch-agent-old
+  assert_absent reconcile-launch-agent-new
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_failed_build_has_no_install_side_effects() {
+  reset_case build-failure running
+  build_fail=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded when the build failed"
+  fi
+
+  assert_installed_version old
+  assert_present build-app
+  assert_absent stage-app
+  assert_absent quit-app
+  assert_absent backup-app
+  assert_absent install-app
+  assert_absent reconcile-launch-agent-new
+  assert_absent reconcile-launch-agent-old
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_signal_after_backup_restores_installed_app() {
+  reset_case signal-restore absent
+  signal_after_backup=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded after an interrupted backup"
+  fi
+
+  assert_installed_version old
+  assert_before backup-app signal-after-backup
+  assert_before signal-after-backup restore-app
+  assert_before restore-app reconcile-launch-agent-old
+  assert_absent reconcile-launch-agent-new
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_failed_reconcile_restores_installed_app() {
+  reset_case reconcile-failure absent
+  reconcile_fail=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded when daemon reconciliation failed"
+  fi
+
+  assert_installed_version old
+  assert_before install-app reconcile-launch-agent-new
+  assert_before reconcile-launch-agent-new restore-app
+  assert_before restore-app reconcile-launch-agent-old
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_failed_open_restores_installed_app() {
+  reset_case open-failure absent
+  open_fail=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded when opening the App failed"
+  fi
+
+  assert_installed_version old
+  assert_before reconcile-launch-agent-new open-app
+  assert_before open-app restore-app
+  assert_before restore-app reconcile-launch-agent-old
+  assert_no_transaction_artifacts
+}
+
+test_signal_after_install_restores_installed_app() {
+  reset_case signal-after-install absent
+  signal_after_install=1
+  if run_promote; then
+    fail "promotion unexpectedly succeeded after an interrupted install"
+  fi
+
+  assert_installed_version old
+  assert_before install-app signal-after-install
+  assert_before signal-after-install restore-app
+  assert_before restore-app reconcile-launch-agent-old
+  assert_absent reconcile-launch-agent-new
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+test_successful_first_install_defers_reconcile_to_app() {
+  reset_case first-install-success absent missing
+  run_promote || fail "successful first promotion failed"
+
+  assert_installed_version new
+  assert_before install-app open-app
+  assert_absent reconcile-launch-agent-new
+  assert_absent reconcile-launch-agent-old
+  assert_no_transaction_artifacts
+}
+
+test_failed_first_install_removes_new_app_without_touching_launch_agent() {
+  reset_case first-install-failure absent missing
+  plist="$case_home/Library/LaunchAgents/ai.clumsies.daemon.plist"
+  mkdir -p "${plist%/*}"
+  printf '%s\n' existing >"$plist"
+  open_fail=1
+  if run_promote; then
+    fail "first promotion unexpectedly succeeded when opening the App failed"
+  fi
+
+  [ ! -e "$install_dir/Clumsies.app" ] \
+    || fail "failed first promotion left the new App installed"
+  [ "$(sed -n '1p' "$plist")" = existing ] \
+    || fail "failed first promotion changed the existing LaunchAgent plist"
+  assert_present open-app
+  assert_absent restore-app
+  assert_absent reconcile-launch-agent-new
+  assert_absent reconcile-launch-agent-old
+  assert_no_transaction_artifacts
+}
+
+test_interrupted_first_install_removes_new_app_without_touching_launch_agent() {
+  reset_case first-install-signal absent missing
+  plist="$case_home/Library/LaunchAgents/ai.clumsies.daemon.plist"
+  mkdir -p "${plist%/*}"
+  printf '%s\n' existing >"$plist"
+  signal_after_install=1
+  if run_promote; then
+    fail "first promotion unexpectedly succeeded after an interrupted install"
+  fi
+
+  [ ! -e "$install_dir/Clumsies.app" ] \
+    || fail "interrupted first promotion left the new App installed"
+  [ "$(sed -n '1p' "$plist")" = existing ] \
+    || fail "interrupted first promotion changed the existing LaunchAgent plist"
+  assert_absent reconcile-launch-agent-new
+  assert_absent open-app
+  assert_no_transaction_artifacts
+}
+
+[ -f "$promote_script" ] || fail "missing script under test: $promote_script"
+
+test_successful_promotion
+test_quit_timeout_preserves_installed_app
+test_failed_swap_restores_installed_app
+test_failed_build_has_no_install_side_effects
+test_signal_after_backup_restores_installed_app
+test_failed_reconcile_restores_installed_app
+test_failed_open_restores_installed_app
+test_signal_after_install_restores_installed_app
+test_successful_first_install_defers_reconcile_to_app
+test_failed_first_install_removes_new_app_without_touching_launch_agent
+test_interrupted_first_install_removes_new_app_without_touching_launch_agent
+
+printf '%s\n' 'macOS Debug promotion contract tests passed'

--- a/apps/macos/Scripts/promote-debug.sh
+++ b/apps/macos/Scripts/promote-debug.sh
@@ -8,12 +8,31 @@ built_app="$derived_data/Build/Products/Debug/Clumsies.app"
 installed_app="$install_dir/Clumsies.app"
 staging_app="$install_dir/.Clumsies.$$.app"
 previous_app="$install_dir/.Clumsies.previous.$$.app"
+transaction_active=0
+had_installed_app=0
 
 cleanup() {
-  rm -rf "$staging_app" "$previous_app"
+  trap - EXIT HUP INT TERM
+
+  if [ "$transaction_active" -eq 1 ]; then
+    if [ -e "$previous_app" ]; then
+      if rm -rf -- "$installed_app" && mv "$previous_app" "$installed_app"; then
+        if ! "$installed_app/Contents/Resources/clumsiesd" \
+          --reconcile-launch-agent >/dev/null 2>&1; then
+          echo "Warning: failed to reconcile the restored Clumsies daemon." >&2
+        fi
+      else
+        echo "Failed to restore the previous Clumsies app." >&2
+      fi
+    elif [ "$had_installed_app" -eq 0 ]; then
+      rm -rf -- "$installed_app"
+    fi
+  fi
+  rm -rf -- "$staging_app"
 }
 
-trap cleanup 0 1 2 15
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
 
 cd "$repo_root"
 xcodegen generate --spec apps/macos/project.yml
@@ -44,18 +63,20 @@ if pgrep -x Clumsies >/dev/null 2>&1; then
   done
 fi
 
+transaction_active=1
 if [ -e "$installed_app" ]; then
+  had_installed_app=1
   mv "$installed_app" "$previous_app"
 fi
 
-if ! mv "$staging_app" "$installed_app"; then
-  if [ -e "$previous_app" ]; then
-    mv "$previous_app" "$installed_app"
-  fi
-  exit 1
-fi
+mv "$staging_app" "$installed_app"
 
-rm -rf "$previous_app"
-trap - 0 1 2 15
-"$installed_app/Contents/Resources/clumsiesd" --reconcile-launch-agent >/dev/null
+if [ "$had_installed_app" -eq 1 ]; then
+  "$installed_app/Contents/Resources/clumsiesd" --reconcile-launch-agent >/dev/null
+fi
 open -n "$installed_app"
+transaction_active=0
+trap - EXIT HUP INT TERM
+rm -rf -- "$previous_app"
+printf '%s\n' \
+  'Clumsies Debug promoted. The App reconciles the global Plugin after launch; restart Codex and create a new task when it finishes.'

--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -242,7 +242,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     }
 
     private func presentMainLoading() {
-        presentMainContent(LaunchView(), surface: .loading, title: "Clumsies")
+        presentMainContent(
+            LaunchView(),
+            surface: .loading,
+            title: ClumsiesIdentifiers.appDisplayName
+        )
     }
 
     private func presentMainFailure(message: String, retry: @escaping () -> Void) {
@@ -253,7 +257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
                 onShowLogs: { [weak self] in self?.showLogsInFinder() }
             ),
             surface: .failure,
-            title: "Clumsies"
+            title: ClumsiesIdentifiers.appDisplayName
         )
     }
 
@@ -317,7 +321,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             backing: .buffered,
             defer: false
         )
-        window.title = "Clumsies"
+        window.title = ClumsiesIdentifiers.appDisplayName
         window.contentViewController = controller
         window.contentMinSize = size
         window.contentMaxSize = size
@@ -415,13 +419,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         guard let button = item.button else { return }
         let image = NSImage(named: "MenuBarIcon")
-            ?? NSImage(systemSymbolName: "wand.and.stars", accessibilityDescription: "Clumsies")
+            ?? NSImage(
+                systemSymbolName: "wand.and.stars",
+                accessibilityDescription: ClumsiesIdentifiers.appDisplayName
+            )
         image?.isTemplate = true
         image?.size = NSSize(width: 18, height: 18)
         button.image = image
         button.imagePosition = .imageOnly
         button.imageScaling = .scaleProportionallyDown
-        button.toolTip = "Clumsies"
+        button.toolTip = ClumsiesIdentifiers.appDisplayName
         button.target = self
         button.action = #selector(handleStatusItemClick(_:))
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
@@ -431,7 +438,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private func makeStatusMenu() -> NSMenu {
         let menu = NSMenu()
         let open = menu.addItem(
-            withTitle: "Open Clumsies",
+            withTitle: "Open \(ClumsiesIdentifiers.appDisplayName)",
             action: #selector(openFromStatusItem(_:)),
             keyEquivalent: ""
         )
@@ -450,7 +457,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         revealLogs.target = self
         menu.addItem(.separator())
         menu.addItem(
-            withTitle: "Quit Clumsies",
+            withTitle: "Quit \(ClumsiesIdentifiers.appDisplayName)",
             action: #selector(NSApplication.terminate(_:)),
             keyEquivalent: ""
         )
@@ -494,17 +501,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
         let applicationItem = NSMenuItem()
         mainMenu.addItem(applicationItem)
         let applicationMenu = NSMenu()
-        applicationMenu.addItem(withTitle: "About Clumsies", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        applicationMenu.addItem(
+            withTitle: "About \(ClumsiesIdentifiers.appDisplayName)",
+            action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+            keyEquivalent: ""
+        )
         applicationMenu.addItem(.separator())
         let settings = applicationMenu.addItem(withTitle: "Settings...", action: #selector(showSettings(_:)), keyEquivalent: ",")
         settings.target = self
         let updates = applicationMenu.addItem(withTitle: "Check for Updates...", action: #selector(checkForUpdates(_:)), keyEquivalent: "")
         updates.target = self
         applicationMenu.addItem(.separator())
-        applicationMenu.addItem(withTitle: "Hide Clumsies", action: #selector(NSApplication.hide(_:)), keyEquivalent: "h")
+        applicationMenu.addItem(
+            withTitle: "Hide \(ClumsiesIdentifiers.appDisplayName)",
+            action: #selector(NSApplication.hide(_:)),
+            keyEquivalent: "h"
+        )
         applicationMenu.addItem(withTitle: "Hide Others", action: #selector(NSApplication.hideOtherApplications(_:)), keyEquivalent: "h").keyEquivalentModifierMask = [.command, .option]
         applicationMenu.addItem(.separator())
-        applicationMenu.addItem(withTitle: "Quit Clumsies", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        applicationMenu.addItem(
+            withTitle: "Quit \(ClumsiesIdentifiers.appDisplayName)",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
         applicationItem.submenu = applicationMenu
 
         let fileItem = NSMenuItem()
@@ -690,7 +709,7 @@ private struct LaunchView: View {
                 BrandLogoView(size: 68, isBreathing: true)
 
                 VStack(spacing: 4) {
-                    Text("Clumsies")
+                    Text(ClumsiesIdentifiers.appDisplayName)
                         .font(.title2.weight(.semibold))
                         .foregroundStyle(.primary)
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -5660,7 +5660,8 @@ struct WorkspaceLoader: Sendable {
            payload.code == "project_agent_adapter_invalid_runtime" {
             return "The resident daemon rejected the bundled Agent runtime. Archived integration "
                 + "inspection was skipped. Reinstall and restart Clumsies so the App and daemon use "
-                + "the same build. For local development, use bun run dev:macos; distributed Release "
+                + "the same build. To replace the resident Debug installation, run "
+                + "just promote-debug-macos; distributed Release "
                 + "builds must use an accepted release signature."
         }
         return "Clumsies updated its managed integrations, but could not inspect the "

--- a/apps/macos/Sources/Infrastructure/AppBundleRuntimeLocation.swift
+++ b/apps/macos/Sources/Infrastructure/AppBundleRuntimeLocation.swift
@@ -13,8 +13,7 @@ enum AppBundleRuntimeLocationError: LocalizedError, Sendable {
 
 enum AppBundleRuntimeLocation {
     static var defaultLogDirectoryURL: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appending(components: "Library", "Logs", "ai.clumsies")
+        ClumsiesIdentifiers.daemonLogDirectoryURL
     }
 
     static func requireStable(_ bundleURL: URL) throws {

--- a/apps/macos/Sources/Infrastructure/AuthenticationClient.swift
+++ b/apps/macos/Sources/Infrastructure/AuthenticationClient.swift
@@ -28,7 +28,7 @@ enum AuthenticationError: LocalizedError, Sendable {
 }
 
 struct AuthenticationClient: Sendable {
-    static let serverURL = URL(string: "https://app.clumsies.ai")!
+    static let serverURL = ClumsiesIdentifiers.serverURL
 
     let daemon: DaemonXPCClient
 

--- a/apps/macos/Sources/Infrastructure/ClumsiesIdentifiers.swift
+++ b/apps/macos/Sources/Infrastructure/ClumsiesIdentifiers.swift
@@ -1,5 +1,159 @@
+import Foundation
+
 enum ClumsiesIdentifiers {
     static let namespace = "ai.clumsies"
-    static let daemon = "\(namespace).daemon"
+    static let stableAppBundleIdentifier = "ai.clumsies.desktop"
+    static let stableAppDisplayName = "Clumsies"
+    static let stableDaemon = "\(namespace).daemon"
+    static let stableServerURL = URL(string: "https://app.clumsies.ai")!
+
+    static let developmentInstanceID = bundleSetting("CLUMSIES_DEV_INSTANCE_ID")
+    static let appDisplayName = bundleSetting("CLUMSIES_APP_DISPLAY_NAME")
+        ?? stableAppDisplayName
+
+    static let serverURL: URL = {
+        let value = bundleSetting("CLUMSIES_SERVER_URL") ?? stableServerURL.absoluteString
+        guard let url = URL(string: value),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil else {
+            preconditionFailure("CLUMSIES_SERVER_URL must be an absolute HTTP(S) URL.")
+        }
+        return url
+    }()
+
+    static let developmentConfigurationDetected = detectsDevelopmentConfiguration(
+        bundleIdentifier: Bundle.main.bundleIdentifier,
+        appDisplayName: appDisplayName,
+        developmentInstanceID: developmentInstanceID,
+        serverURL: serverURL,
+        devOnlySettingValues: [
+            "CLUMSIES_DAEMON_ROOT",
+            "CLUMSIES_DAEMON_CACHE_DIR",
+            "CLUMSIES_DAEMON_LOG_DIR",
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+            "CLUMSIES_CODEX_HOME",
+        ].compactMap(bundleSetting)
+    )
+    static let daemon = daemonServiceName(
+        for: developmentInstanceID,
+        developmentConfigurationDetected: developmentConfigurationDetected
+    )
     static let xpcReplyQueue = "\(daemon).xpc-replies"
+
+    static var daemonLogDirectoryURL: URL {
+        if let path = bundleSetting("CLUMSIES_DAEMON_LOG_DIR") {
+            return URL(fileURLWithPath: path, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appending(components: "Library", "Logs", namespace)
+    }
+
+    static var daemonLaunchAgentPlistURL: URL {
+        let directory: URL
+        if let path = bundleSetting("CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR") {
+            directory = URL(fileURLWithPath: path, isDirectory: true)
+        } else {
+            directory = FileManager.default.homeDirectoryForCurrentUser
+                .appending(components: "Library", "LaunchAgents")
+        }
+        return directory.appending(path: "\(daemon).plist", directoryHint: .notDirectory)
+    }
+
+    static var missingDevelopmentSettings: [String] {
+        guard developmentConfigurationDetected else { return [] }
+        var missing = [
+            "CLUMSIES_DAEMON_ROOT",
+            "CLUMSIES_DAEMON_CACHE_DIR",
+            "CLUMSIES_DAEMON_LOG_DIR",
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+            "CLUMSIES_CODEX_HOME",
+        ].filter { bundleSetting($0) == nil }
+        if developmentInstanceID == nil {
+            missing.insert("CLUMSIES_DEV_INSTANCE_ID", at: 0)
+        }
+        if bundleSetting("CLUMSIES_SERVER_URL") == nil || isStableServerURL(serverURL) {
+            missing.append("CLUMSIES_SERVER_URL")
+        }
+        return missing
+    }
+
+    static func daemonEnvironment(
+        base: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = base
+        environment["CLUMSIES_SERVER_URL"] = serverURL.absoluteString
+        for key in [
+            "CLUMSIES_DEV_INSTANCE_ID",
+            "CLUMSIES_DAEMON_ROOT",
+            "CLUMSIES_DAEMON_CACHE_DIR",
+            "CLUMSIES_DAEMON_LOG_DIR",
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+        ] {
+            if let value = bundleSetting(key) {
+                environment[key] = value
+            }
+        }
+        if let codexHome = bundleSetting("CLUMSIES_CODEX_HOME") {
+            environment["CODEX_HOME"] = codexHome
+        }
+        return environment
+    }
+
+    static func daemonServiceName(
+        for developmentInstanceID: String?,
+        developmentConfigurationDetected: Bool = false
+    ) -> String {
+        guard let developmentInstanceID,
+              !developmentInstanceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return developmentConfigurationDetected
+                ? "\(stableDaemon).dev.invalid-configuration"
+                : stableDaemon
+        }
+        return "\(stableDaemon).dev.\(developmentInstanceID)"
+    }
+
+    static func isStableServerURL(_ url: URL) -> Bool {
+        guard let host = url.host, let stableHost = stableServerURL.host else { return false }
+        let dots = CharacterSet(charactersIn: ".")
+        return host.lowercased().trimmingCharacters(in: dots)
+            == stableHost.lowercased().trimmingCharacters(in: dots)
+    }
+
+    static func detectsDevelopmentConfiguration(
+        bundleIdentifier: String?,
+        appDisplayName: String?,
+        developmentInstanceID: String?,
+        serverURL: URL?,
+        devOnlySettingValues: [String]
+    ) -> Bool {
+        if let bundleIdentifier,
+           bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
+            != stableAppBundleIdentifier {
+            return true
+        }
+        if let appDisplayName,
+           appDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+            != stableAppDisplayName {
+            return true
+        }
+        if let developmentInstanceID,
+           !developmentInstanceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        if let serverURL, !isStableServerURL(serverURL) {
+            return true
+        }
+        return devOnlySettingValues.contains {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    private static func bundleSetting(_ key: String) -> String? {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
 }

--- a/apps/macos/Sources/Infrastructure/DaemonBootstrapController.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonBootstrapController.swift
@@ -10,6 +10,7 @@ struct DaemonBootstrapState: Equatable, Sendable {
 enum DaemonBootstrapError: LocalizedError, Sendable {
     case daemonBinaryMissing
     case daemonCommand(String)
+    case invalidDevelopmentConfiguration([String])
     case invalidStatus
 
     var errorDescription: String? {
@@ -18,6 +19,8 @@ enum DaemonBootstrapError: LocalizedError, Sendable {
             return "The Clumsies daemon is missing from the application bundle."
         case .daemonCommand(let message):
             return message
+        case .invalidDevelopmentConfiguration(let missing):
+            return "The Clumsies Dev App is missing required instance settings: \(missing.joined(separator: ", "))."
         case .invalidStatus:
             return "The Clumsies daemon returned an invalid LaunchAgent status."
         }
@@ -92,10 +95,15 @@ struct DaemonBootstrapController: Sendable {
     }
 
     private func runDaemon(_ arguments: [String]) throws -> ProcessResult {
+        let missingSettings = ClumsiesIdentifiers.missingDevelopmentSettings
+        guard missingSettings.isEmpty else {
+            throw DaemonBootstrapError.invalidDevelopmentConfiguration(missingSettings)
+        }
         let process = Process()
         let pipe = Pipe()
         process.executableURL = try daemonBinaryURL()
         process.arguments = arguments
+        process.environment = ClumsiesIdentifiers.daemonEnvironment()
         process.standardOutput = pipe
         process.standardError = pipe
         try process.run()
@@ -125,9 +133,7 @@ struct DaemonBootstrapController: Sendable {
     }
 
     private func launchAgentPlistExists() -> Bool {
-        let url = FileManager.default.homeDirectoryForCurrentUser
-            .appending(path: "Library/LaunchAgents", directoryHint: .isDirectory)
-            .appending(path: "\(Self.label).plist")
+        let url = ClumsiesIdentifiers.daemonLaunchAgentPlistURL
         return FileManager.default.fileExists(atPath: url.path)
     }
 }

--- a/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
@@ -9,19 +9,20 @@ enum DaemonXPCError: LocalizedError, Sendable {
     case daemon(APIErrorPayload)
 
     var errorDescription: String? {
+        let logHint = "Review logs in \(ClumsiesIdentifiers.daemonLogDirectoryURL.path)."
         switch self {
         case .invalidRequest:
             return "Could not encode the daemon request."
         case .connectionFailed(let detail):
             if let detail, !detail.isEmpty {
-                return "The local Clumsies daemon is unavailable (\(detail)). Review logs in ~/Library/Logs/ai.clumsies."
+                return "The local Clumsies daemon is unavailable (\(detail)). \(logHint)"
             }
-            return "The local Clumsies daemon is unavailable. Review logs in ~/Library/Logs/ai.clumsies."
+            return "The local Clumsies daemon is unavailable. \(logHint)"
         case .requestTimedOut(let timeout):
             if let timeout {
-                return "The local Clumsies daemon did not respond within \(String(format: "%.1f", timeout))s. Review logs in ~/Library/Logs/ai.clumsies."
+                return "The local Clumsies daemon did not respond within \(String(format: "%.1f", timeout))s. \(logHint)"
             }
-            return "The local Clumsies daemon did not respond in time. Review logs in ~/Library/Logs/ai.clumsies."
+            return "The local Clumsies daemon did not respond in time. \(logHint)"
         case .invalidReply:
             return "The local Clumsies daemon returned an invalid response."
         case .daemon(let error):

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -4,8 +4,129 @@ import XCTest
 final class DaemonContractTests: XCTestCase {
     func testNativeClientUsesClumsiesIdentifierNamespace() {
         XCTAssertEqual(ClumsiesIdentifiers.namespace, "ai.clumsies")
+        XCTAssertEqual(ClumsiesIdentifiers.appDisplayName, "Clumsies")
+        XCTAssertNil(ClumsiesIdentifiers.developmentInstanceID)
+        XCTAssertFalse(ClumsiesIdentifiers.developmentConfigurationDetected)
         XCTAssertEqual(DaemonBootstrapController.label, "ai.clumsies.daemon")
         XCTAssertEqual(DaemonXPCClient.serviceName, "ai.clumsies.daemon")
+        XCTAssertEqual(AuthenticationClient.serverURL, URL(string: "https://app.clumsies.ai"))
+    }
+
+    func testDevInstanceDerivesItsOwnDaemonService() {
+        XCTAssertEqual(
+            ClumsiesIdentifiers.daemonServiceName(for: "a1b2c3d4"),
+            "ai.clumsies.daemon.dev.a1b2c3d4"
+        )
+        XCTAssertEqual(ClumsiesIdentifiers.daemonServiceName(for: nil), "ai.clumsies.daemon")
+        XCTAssertEqual(ClumsiesIdentifiers.daemonServiceName(for: ""), "ai.clumsies.daemon")
+        XCTAssertTrue(
+            ClumsiesIdentifiers.isStableServerURL(URL(string: "https://app.clumsies.ai")!)
+        )
+        XCTAssertTrue(
+            ClumsiesIdentifiers.isStableServerURL(URL(string: "https://app.clumsies.ai.")!)
+        )
+        XCTAssertFalse(
+            ClumsiesIdentifiers.isStableServerURL(URL(string: "http://127.0.0.1:49152")!)
+        )
+    }
+
+    func testMalformedDevBundleCannotFallBackToStableDaemon() {
+        XCTAssertTrue(ClumsiesIdentifiers.detectsDevelopmentConfiguration(
+            bundleIdentifier: "ai.clumsies.desktop.dev.a1b2c3d4",
+            appDisplayName: "Clumsies",
+            developmentInstanceID: nil,
+            serverURL: URL(string: "https://app.clumsies.ai"),
+            devOnlySettingValues: []
+        ))
+        XCTAssertTrue(ClumsiesIdentifiers.detectsDevelopmentConfiguration(
+            bundleIdentifier: "ai.clumsies.desktop",
+            appDisplayName: "Clumsies",
+            developmentInstanceID: nil,
+            serverURL: URL(string: "https://app.clumsies.ai"),
+            devOnlySettingValues: ["/private/tmp/clumsies-dev/root"]
+        ))
+        XCTAssertFalse(ClumsiesIdentifiers.detectsDevelopmentConfiguration(
+            bundleIdentifier: "ai.clumsies.desktop",
+            appDisplayName: "Clumsies",
+            developmentInstanceID: nil,
+            serverURL: URL(string: "https://app.clumsies.ai"),
+            devOnlySettingValues: []
+        ))
+        XCTAssertEqual(
+            ClumsiesIdentifiers.daemonServiceName(
+                for: nil,
+                developmentConfigurationDetected: true
+            ),
+            "ai.clumsies.daemon.dev.invalid-configuration"
+        )
+    }
+
+    func testDaemonControlEnvironmentKeepsStableServerAndCallerEnvironment() {
+        let environment = ClumsiesIdentifiers.daemonEnvironment(base: ["PATH": "/usr/bin"])
+
+        XCTAssertEqual(environment["PATH"], "/usr/bin")
+        XCTAssertEqual(environment["CLUMSIES_SERVER_URL"], "https://app.clumsies.ai")
+        XCTAssertNil(environment["CLUMSIES_DEV_INSTANCE_ID"])
+        XCTAssertNil(environment["CODEX_HOME"])
+        XCTAssertNil(environment["CLUMSIES_CODEX_HOME"])
+    }
+
+    func testInfoPlistCarriesDevInstanceBuildSettings() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let data = try Data(contentsOf: macOSRoot.appending(path: "Config/Info.plist"))
+        let info = try XCTUnwrap(
+            PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any]
+        )
+
+        XCTAssertEqual(info["CFBundleDisplayName"] as? String, "$(CLUMSIES_APP_DISPLAY_NAME)")
+        XCTAssertEqual(info["CFBundleName"] as? String, "$(PRODUCT_NAME)")
+        for key in [
+            "CLUMSIES_APP_DISPLAY_NAME",
+            "CLUMSIES_DEV_INSTANCE_ID",
+            "CLUMSIES_DAEMON_ROOT",
+            "CLUMSIES_DAEMON_CACHE_DIR",
+            "CLUMSIES_DAEMON_LOG_DIR",
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+            "CLUMSIES_SERVER_URL",
+            "CLUMSIES_CODEX_HOME",
+        ] {
+            XCTAssertEqual(info[key] as? String, "$(\(key))")
+        }
+        XCTAssertNil(info["CLUMSIES_DAEMON_CODE_SIGN_IDENTIFIER"])
+    }
+
+    func testDevAppIdentityOverridesDoNotRenameTheTestBundle() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let projectYAML = try String(
+            contentsOf: macOSRoot.appending(path: "project.yml"),
+            encoding: .utf8
+        )
+        let appStart = try XCTUnwrap(projectYAML.range(of: "  Clumsies:\n"))
+        let testsStart = try XCTUnwrap(projectYAML.range(of: "  ClumsiesTests:\n"))
+        let schemesStart = try XCTUnwrap(projectYAML.range(of: "schemes:\n"))
+        let defaults = projectYAML[..<appStart.lowerBound]
+        let appTarget = projectYAML[appStart.lowerBound..<testsStart.lowerBound]
+        let testsTarget = projectYAML[testsStart.lowerBound..<schemesStart.lowerBound]
+
+        XCTAssertTrue(defaults.contains("CLUMSIES_APP_PRODUCT_NAME: Clumsies"))
+        XCTAssertTrue(defaults.contains("CLUMSIES_APP_BUNDLE_IDENTIFIER: ai.clumsies.desktop"))
+        XCTAssertTrue(appTarget.contains(
+            "PRODUCT_BUNDLE_IDENTIFIER: $(CLUMSIES_APP_BUNDLE_IDENTIFIER)"
+        ))
+        XCTAssertTrue(appTarget.contains("PRODUCT_NAME: $(CLUMSIES_APP_PRODUCT_NAME)"))
+        XCTAssertTrue(appTarget.contains("PRODUCT_MODULE_NAME: Clumsies"))
+        XCTAssertTrue(testsTarget.contains(
+            "PRODUCT_BUNDLE_IDENTIFIER: ai.clumsies.desktop.tests"
+        ))
+        XCTAssertTrue(testsTarget.contains(
+            "TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(CLUMSIES_APP_PRODUCT_NAME).app/Contents/MacOS/$(CLUMSIES_APP_PRODUCT_NAME)"
+        ))
+        XCTAssertTrue(testsTarget.contains("BUNDLE_LOADER: $(TEST_HOST)"))
+        XCTAssertFalse(testsTarget.contains("PRODUCT_NAME:"))
     }
 
     func testCodexPluginRequestIsGlobalAndUsesBundledRuntimePath() throws {
@@ -696,7 +817,7 @@ final class DaemonContractTests: XCTestCase {
         )
 
         XCTAssertTrue(warning.contains("Archived integration inspection was skipped"))
-        XCTAssertTrue(warning.contains("bun run dev:macos"))
+        XCTAssertTrue(warning.contains("just promote-debug-macos"))
         XCTAssertTrue(warning.contains("distributed Release"))
         XCTAssertFalse(warning.contains("archived Zig CLI integration store"))
     }

--- a/apps/macos/Tests/LiveWorkspaceIntegrationTests.swift
+++ b/apps/macos/Tests/LiveWorkspaceIntegrationTests.swift
@@ -2,6 +2,41 @@ import XCTest
 @testable import Clumsies
 
 final class LiveWorkspaceIntegrationTests: XCTestCase {
+    private enum DraftSyncBarrierDecision: Equatable {
+        case complete
+        case wait
+        case failed(Int)
+    }
+
+    private enum DraftSyncBarrierError: LocalizedError {
+        case failedOperations(Int)
+        case timedOut
+
+        var errorDescription: String? {
+            switch self {
+            case let .failedOperations(count):
+                "Draft sync reported \(count) failed operation(s)."
+            case .timedOut:
+                "Draft sync did not drain its pending operations within 30 seconds."
+            }
+        }
+    }
+
+    func testDraftSyncBarrierOnlyCompletesForAHealthyEmptyQueue() {
+        XCTAssertEqual(
+            Self.draftSyncBarrierDecision(pendingOperationCount: 0, failedOperationCount: 0),
+            .complete
+        )
+        XCTAssertEqual(
+            Self.draftSyncBarrierDecision(pendingOperationCount: 1, failedOperationCount: 0),
+            .wait
+        )
+        XCTAssertEqual(
+            Self.draftSyncBarrierDecision(pendingOperationCount: 0, failedOperationCount: 1),
+            .failed(1)
+        )
+    }
+
     func testLoadsAuthenticatedWorkspaceThroughDaemon() async throws {
         guard ProcessInfo.processInfo.environment["CLUMSIES_RUN_LIVE_TESTS"] == "1" else {
             throw XCTSkip("Set CLUMSIES_RUN_LIVE_TESTS=1 to exercise the local daemon and configured Server.")
@@ -74,6 +109,7 @@ final class LiveWorkspaceIntegrationTests: XCTestCase {
             }
             throw error
         }
+        try await waitForDraftSync(daemon: DaemonXPCClient())
     }
 
     @MainActor
@@ -90,7 +126,8 @@ final class LiveWorkspaceIntegrationTests: XCTestCase {
                 id: createdDraft.id,
                 resource: nil,
                 draft: createdDraft,
-                inherited: false
+                inherited: false,
+                projectContextId: createdDraft.projectId
             )
             try await store.save(item, document: document)
             let updatedDraft = try XCTUnwrap(store.drafts.first { $0.id == createdDraft.id })
@@ -104,5 +141,37 @@ final class LiveWorkspaceIntegrationTests: XCTestCase {
             }
             throw error
         }
+    }
+
+    private static func draftSyncBarrierDecision(
+        pendingOperationCount: Int,
+        failedOperationCount: Int
+    ) -> DraftSyncBarrierDecision {
+        if failedOperationCount > 0 {
+            return .failed(failedOperationCount)
+        }
+        return pendingOperationCount == 0 ? .complete : .wait
+    }
+
+    @MainActor
+    private func waitForDraftSync(daemon: DaemonXPCClient) async throws {
+        let maximumAttempts = 300
+        for attempt in 0..<maximumAttempts {
+            let status = try await daemon.syncStatus()
+            switch Self.draftSyncBarrierDecision(
+                pendingOperationCount: status.pendingOperationCount,
+                failedOperationCount: status.failedOperationCount
+            ) {
+            case .complete:
+                return
+            case .wait:
+                if attempt + 1 < maximumAttempts {
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+            case let .failed(count):
+                throw DraftSyncBarrierError.failedOperations(count)
+            }
+        }
+        throw DraftSyncBarrierError.timedOut
     }
 }

--- a/apps/macos/project.yml
+++ b/apps/macos/project.yml
@@ -15,6 +15,16 @@ settings:
     SWIFT_STRICT_CONCURRENCY: complete
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
+    CLUMSIES_APP_PRODUCT_NAME: Clumsies
+    CLUMSIES_APP_BUNDLE_IDENTIFIER: ai.clumsies.desktop
+    CLUMSIES_APP_DISPLAY_NAME: Clumsies
+    CLUMSIES_DEV_INSTANCE_ID: ""
+    CLUMSIES_DAEMON_ROOT: ""
+    CLUMSIES_DAEMON_CACHE_DIR: ""
+    CLUMSIES_DAEMON_LOG_DIR: ""
+    CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR: ""
+    CLUMSIES_SERVER_URL: https://app.clumsies.ai
+    CLUMSIES_CODEX_HOME: ""
 packages:
   MarkdownUI:
     url: https://github.com/gonzalezreal/swift-markdown-ui
@@ -36,10 +46,18 @@ targets:
     info:
       path: Config/Info.plist
       properties:
-        CFBundleDisplayName: Clumsies
-        CFBundleName: Clumsies
+        CFBundleDisplayName: $(CLUMSIES_APP_DISPLAY_NAME)
+        CFBundleName: $(PRODUCT_NAME)
         CFBundleShortVersionString: $(MARKETING_VERSION)
         CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        CLUMSIES_APP_DISPLAY_NAME: $(CLUMSIES_APP_DISPLAY_NAME)
+        CLUMSIES_DEV_INSTANCE_ID: $(CLUMSIES_DEV_INSTANCE_ID)
+        CLUMSIES_DAEMON_ROOT: $(CLUMSIES_DAEMON_ROOT)
+        CLUMSIES_DAEMON_CACHE_DIR: $(CLUMSIES_DAEMON_CACHE_DIR)
+        CLUMSIES_DAEMON_LOG_DIR: $(CLUMSIES_DAEMON_LOG_DIR)
+        CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR: $(CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR)
+        CLUMSIES_SERVER_URL: $(CLUMSIES_SERVER_URL)
+        CLUMSIES_CODEX_HOME: $(CLUMSIES_CODEX_HOME)
         LSApplicationCategoryType: public.app-category.productivity
         LSMinimumSystemVersion: "14.0"
         NSHighResolutionCapable: true
@@ -49,8 +67,9 @@ targets:
         SUPublicEDKey: oCAiBe/ez4wochO1I9ziO1uCEpmES+e7ypC74HJwIvw=
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: ai.clumsies.desktop
-        PRODUCT_NAME: Clumsies
+        PRODUCT_BUNDLE_IDENTIFIER: $(CLUMSIES_APP_BUNDLE_IDENTIFIER)
+        PRODUCT_NAME: $(CLUMSIES_APP_PRODUCT_NAME)
+        PRODUCT_MODULE_NAME: Clumsies
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
         CODE_SIGN_STYLE: Automatic
@@ -81,6 +100,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.clumsies.desktop.tests
         GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: $(BUILT_PRODUCTS_DIR)/$(CLUMSIES_APP_PRODUCT_NAME).app/Contents/MacOS/$(CLUMSIES_APP_PRODUCT_NAME)
+        BUNDLE_LOADER: $(TEST_HOST)
 schemes:
   Clumsies:
     build:

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -1966,6 +1966,7 @@ pub(crate) async fn inspect_codex_plugin(
         &runtime_binary,
         &runtime_hash,
         request.host_binary_path.as_deref(),
+        state.inner.config.dev_instance_id.as_deref(),
     )
     .await
 }
@@ -1984,6 +1985,7 @@ pub(crate) async fn reconcile_codex_plugin(
         &runtime_binary,
         &runtime_hash,
         request.host_binary_path.as_deref(),
+        state.inner.config.dev_instance_id.as_deref(),
     )
     .await?;
     codex_plugin::inspect(
@@ -1991,6 +1993,7 @@ pub(crate) async fn reconcile_codex_plugin(
         &runtime_binary,
         &runtime_hash,
         request.host_binary_path.as_deref(),
+        state.inner.config.dev_instance_id.as_deref(),
     )
     .await
 }

--- a/crates/daemon/src/agent_adapter/codex_plugin.rs
+++ b/crates/daemon/src/agent_adapter/codex_plugin.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-use crate::DaemonError;
 use crate::project_storage::{ensure_private_directory, write_private_file};
+use crate::{DEV_INSTANCE_ID_ENV, DaemonError};
 
 #[cfg(target_os = "macos")]
 use super::code_signature_info;
@@ -29,6 +29,7 @@ const MCP_TEMPLATE: &str = include_str!("../../../../packages/clumsies/.mcp.json
 const HOOKS: &str = include_str!("../../../../packages/clumsies/hooks/hooks.json");
 const HOOK_SCRIPT_TEMPLATE: &str =
     include_str!("../../../../packages/clumsies/scripts/issue-run-event.sh.tpl");
+const HOOK_DEV_ENV_PLACEHOLDER: &str = "__CLUMSIES_DEV_INSTANCE_ENV_REQUIRED__";
 const BOOTSTRAP_SKILL: &str =
     include_str!("../../../../packages/clumsies/skills/clumsies/SKILL.md");
 
@@ -79,6 +80,7 @@ pub(super) async fn ensure_installed(
     runtime_binary: &Path,
     runtime_hash: &str,
     host_binary_path: Option<&str>,
+    dev_instance_id: Option<&str>,
 ) -> Result<(), DaemonError> {
     let host_binary_path = host_binary_path.ok_or_else(|| {
         DaemonError::InvalidRequest(
@@ -87,7 +89,7 @@ pub(super) async fn ensure_installed(
     })?;
     let codex = canonical_codex_cli(host_binary_path)?;
     verify_codex_cli(&codex)?;
-    let plugin = materialize(daemon_root, runtime_binary, runtime_hash)?;
+    let plugin = materialize(daemon_root, runtime_binary, runtime_hash, dev_instance_id)?;
     ensure_marketplace(&codex, &plugin.marketplace_root).await?;
     ensure_plugin(&codex, &plugin.version).await
 }
@@ -97,12 +99,14 @@ pub(super) async fn inspect(
     runtime_binary: &Path,
     runtime_hash: &str,
     host_binary_path: Option<&str>,
+    dev_instance_id: Option<&str>,
 ) -> Result<DaemonCodexPluginStatus, DaemonError> {
     let expected_version = plugin_version(
         runtime_binary.to_str().ok_or_else(|| {
             DaemonError::InvalidRequest("Codex plugin runtime path is not UTF-8".to_owned())
         })?,
         runtime_hash,
+        dev_instance_id,
     );
     let Some(host_binary_path) = host_binary_path else {
         return Ok(DaemonCodexPluginStatus {
@@ -167,6 +171,7 @@ fn materialize(
     daemon_root: &Path,
     runtime_binary: &Path,
     runtime_hash: &str,
+    dev_instance_id: Option<&str>,
 ) -> Result<MaterializedPlugin, DaemonError> {
     if runtime_hash.len() != 64 || !runtime_hash.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(DaemonError::InvalidConfig(
@@ -188,7 +193,7 @@ fn materialize(
         ensure_private_directory(&directory)?;
     }
 
-    let version = plugin_version(runtime_path, runtime_hash);
+    let version = plugin_version(runtime_path, runtime_hash, dev_instance_id);
     let mut manifest: Value = serde_json::from_str(PLUGIN_MANIFEST)?;
     manifest["version"] = Value::String(version.clone());
     manifest["mcpServers"] = Value::String("./.mcp.json".to_owned());
@@ -196,13 +201,30 @@ fn materialize(
 
     let mut mcp: Value = serde_json::from_str(MCP_TEMPLATE)?;
     mcp["mcpServers"]["clumsies"]["command"] = Value::String(runtime_path.to_owned());
+    if let Some(instance_id) = dev_instance_id {
+        mcp["mcpServers"]["clumsies"]["env"] = json!({
+            DEV_INSTANCE_ID_ENV: instance_id
+        });
+    }
     write_json(&plugin_root.join(".mcp.json"), &mcp)?;
     write_private_file(&plugin_root.join("hooks/hooks.json"), HOOKS.as_bytes())?;
-    let hook_script = HOOK_SCRIPT_TEMPLATE.replace(
-        "__CLUMSIESD_SHELL_LITERAL_REQUIRED__",
-        &shell_single_quote(runtime_path),
-    );
-    if hook_script.contains("__CLUMSIESD_SHELL_LITERAL_REQUIRED__") {
+    let hook_dev_env = dev_instance_id
+        .map(|instance_id| {
+            format!(
+                "export {DEV_INSTANCE_ID_ENV}={}",
+                shell_single_quote(instance_id)
+            )
+        })
+        .unwrap_or_default();
+    let hook_script = HOOK_SCRIPT_TEMPLATE
+        .replace(
+            "__CLUMSIESD_SHELL_LITERAL_REQUIRED__",
+            &shell_single_quote(runtime_path),
+        )
+        .replace(HOOK_DEV_ENV_PLACEHOLDER, &hook_dev_env);
+    if hook_script.contains("__CLUMSIESD_SHELL_LITERAL_REQUIRED__")
+        || hook_script.contains(HOOK_DEV_ENV_PLACEHOLDER)
+    {
         return Err(DaemonError::InvalidConfig(
             "Codex plugin Hook template was not materialized".to_owned(),
         ));
@@ -239,7 +261,7 @@ fn materialize(
     })
 }
 
-fn plugin_version(runtime_path: &str, runtime_hash: &str) -> String {
+fn plugin_version(runtime_path: &str, runtime_hash: &str, dev_instance_id: Option<&str>) -> String {
     let mut digest = Sha256::new();
     for component in [
         b"clumsies-codex-plugin-v1".as_slice(),
@@ -253,6 +275,10 @@ fn plugin_version(runtime_path: &str, runtime_hash: &str) -> String {
     ] {
         digest.update((component.len() as u64).to_be_bytes());
         digest.update(component);
+    }
+    if let Some(instance_id) = dev_instance_id {
+        digest.update((instance_id.len() as u64).to_be_bytes());
+        digest.update(instance_id.as_bytes());
     }
     let identity = hex::encode(digest.finalize());
     format!("0.1.0+codex.{}", &identity[..16])
@@ -454,13 +480,14 @@ mod tests {
     fn materialized_plugin_pins_runtime_and_keeps_memory_skills_remote() {
         let root = tempfile::tempdir().unwrap();
         let runtime = Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd");
-        let plugin = materialize(root.path(), runtime, &"a".repeat(64)).unwrap();
+        let plugin = materialize(root.path(), runtime, &"a".repeat(64), None).unwrap();
         assert!(plugin.version.starts_with("0.1.0+codex."));
         let moved_root = tempfile::tempdir().unwrap();
         let moved = materialize(
             moved_root.path(),
             Path::new("/Users/test/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
             &"a".repeat(64),
+            None,
         )
         .unwrap();
         assert_ne!(plugin.version, moved.version);
@@ -483,11 +510,31 @@ mod tests {
                 "host-plugin"
             ])
         );
+        assert!(mcp["mcpServers"]["clumsies"].get("env").is_none());
         let skill = fs::read_to_string(plugin_root.join("skills/clumsies/SKILL.md")).unwrap();
         assert!(skill.contains("skill stored in Memory as ordinary Memory content"));
         assert!(!plugin_root.join("skills/coding").exists());
         let hooks = fs::read_to_string(plugin_root.join("hooks/hooks.json")).unwrap();
         assert!(hooks.contains("${PLUGIN_ROOT}/scripts/issue-run-event.sh"));
+        let hook = fs::read_to_string(plugin_root.join("scripts/issue-run-event.sh")).unwrap();
+        assert!(!hook.contains(DEV_INSTANCE_ID_ENV));
+    }
+
+    #[test]
+    fn dev_plugin_routes_mcp_and_hooks_to_its_daemon_instance() {
+        let root = tempfile::tempdir().unwrap();
+        let runtime = Path::new("/Applications/Clumsies Dev.app/Contents/Resources/clumsiesd");
+        let instance_id = "a1b2c3d4e5f6";
+        let plugin = materialize(root.path(), runtime, &"b".repeat(64), Some(instance_id)).unwrap();
+        let plugin_root = plugin.marketplace_root.join("plugins/clumsies");
+        let mcp: Value =
+            serde_json::from_slice(&fs::read(plugin_root.join(".mcp.json")).unwrap()).unwrap();
+        assert_eq!(
+            mcp["mcpServers"]["clumsies"]["env"],
+            json!({ DEV_INSTANCE_ID_ENV: instance_id })
+        );
+        let hook = fs::read_to_string(plugin_root.join("scripts/issue-run-event.sh")).unwrap();
+        assert!(hook.contains(&format!("export {DEV_INSTANCE_ID_ENV}='a1b2c3d4e5f6'")));
     }
 
     #[test]
@@ -511,6 +558,7 @@ mod tests {
             root.path(),
             Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
             &"a".repeat(64),
+            None,
             None,
         )
         .await
@@ -554,6 +602,7 @@ mod tests {
             daemon.path(),
             Path::new("/Applications/Clumsies.app/Contents/Resources/clumsiesd"),
             &"a".repeat(64),
+            None,
         )
         .unwrap();
         let host = tempfile::tempdir().unwrap();

--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -1,5 +1,6 @@
 use std::env;
-use std::path::{Path, PathBuf};
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::{Duration, Instant};
 
@@ -14,6 +15,10 @@ use crate::{
 pub const IDENTIFIER_NAMESPACE: &str = "ai.clumsies";
 pub const DAEMON_AGENT_LABEL: &str = "ai.clumsies.daemon";
 pub const DAEMON_MACH_SERVICE_NAME: &str = DAEMON_AGENT_LABEL;
+pub const DEV_INSTANCE_ID_ENV: &str = "CLUMSIES_DEV_INSTANCE_ID";
+const DEV_DAEMON_SERVICE_PREFIX: &str = "ai.clumsies.daemon.dev.";
+const DEV_KEYCHAIN_SERVICE_PREFIX: &str = "ai.clumsies.dev.";
+const MAX_DEV_INSTANCE_ID_BYTES: usize = 32;
 pub const CURRENT_LOCAL_SCHEMA_VERSION: i64 = 40;
 pub(crate) const META_DRAFT_EVENTS_CURSOR: &str = "draft_events_cursor";
 pub(crate) const META_MEMORY_CACHE_RESET_REQUIRED: &str = "memory_cache_reset_required";
@@ -22,10 +27,15 @@ pub(crate) const META_DRAFT_SYNC_LAST_SUCCESS_AT: &str = "draft_sync_last_succes
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DaemonConfig {
+    pub dev_instance_id: Option<String>,
+    pub launch_agent_label: String,
+    pub mach_service_name: String,
+    pub keychain_service: String,
     pub root_dir: PathBuf,
     pub cache_dir: PathBuf,
     pub log_dir: PathBuf,
     pub launch_agents_dir: PathBuf,
+    pub codex_home: Option<PathBuf>,
     pub project: ProjectConfig,
     pub sync: SyncConfig,
 }
@@ -45,9 +55,10 @@ pub struct SyncConfig {
 
 impl DaemonConfig {
     pub fn from_env() -> Result<Self, DaemonError> {
+        let dev_instance_id = Self::dev_instance_id_from_env()?;
         let mut paths = match env::var_os("CLUMSIES_DAEMON_ROOT") {
             Some(value) => DaemonRuntimePaths::for_root(PathBuf::from(value)),
-            None => DaemonRuntimePaths::from_home(home_dir()?),
+            None => DaemonRuntimePaths::from_home(home_dir()?, dev_instance_id.as_deref()),
         };
         if let Some(value) = env::var_os("CLUMSIES_DAEMON_CACHE_DIR") {
             paths.cache_dir = PathBuf::from(value);
@@ -58,6 +69,16 @@ impl DaemonConfig {
         if let Some(value) = env::var_os("CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR") {
             paths.launch_agents_dir = PathBuf::from(value);
         }
+        let codex_home = dev_codex_home(
+            dev_instance_id.as_deref(),
+            env::var_os("CODEX_HOME").map(PathBuf::from),
+            &paths.root_dir,
+        );
+        if let Some(instance_id) = dev_instance_id.as_deref() {
+            validate_dev_runtime_paths(instance_id, &paths, codex_home.as_deref())?;
+        }
+        let (launch_agent_label, mach_service_name, keychain_service) =
+            daemon_runtime_names(dev_instance_id.as_deref());
         let project = ProjectConfig::from_env();
         let sync = SyncConfig {
             enabled: parse_bool_env("CLUMSIES_SYNC_ENABLED")?.unwrap_or(true),
@@ -68,22 +89,56 @@ impl DaemonConfig {
             ),
         };
         Ok(Self {
+            dev_instance_id,
+            launch_agent_label,
+            mach_service_name,
+            keychain_service,
             root_dir: paths.root_dir,
             cache_dir: paths.cache_dir,
             log_dir: paths.log_dir,
             launch_agents_dir: paths.launch_agents_dir,
+            codex_home,
             project,
             sync,
         })
     }
 
+    pub fn dev_instance_id_from_env() -> Result<Option<String>, DaemonError> {
+        let instance_id = match env::var(DEV_INSTANCE_ID_ENV) {
+            Ok(value) => value,
+            Err(env::VarError::NotPresent) => return Ok(None),
+            Err(env::VarError::NotUnicode(_)) => {
+                return Err(DaemonError::InvalidConfig(format!(
+                    "{DEV_INSTANCE_ID_ENV} must be valid UTF-8"
+                )));
+            }
+        };
+        if !cfg!(debug_assertions) {
+            return Err(DaemonError::InvalidConfig(format!(
+                "{DEV_INSTANCE_ID_ENV} is unavailable in release builds"
+            )));
+        }
+        validate_dev_instance_id(&instance_id)?;
+        Ok(Some(instance_id))
+    }
+
+    pub fn dev_mach_service_name(instance_id: &str) -> Result<String, DaemonError> {
+        validate_dev_instance_id(instance_id)?;
+        Ok(format!("{DEV_DAEMON_SERVICE_PREFIX}{instance_id}"))
+    }
+
     pub fn for_root(root_dir: impl Into<PathBuf>) -> Self {
         let paths = DaemonRuntimePaths::for_root(root_dir.into());
         Self {
+            dev_instance_id: None,
+            launch_agent_label: DAEMON_AGENT_LABEL.to_owned(),
+            mach_service_name: DAEMON_MACH_SERVICE_NAME.to_owned(),
+            keychain_service: IDENTIFIER_NAMESPACE.to_owned(),
             root_dir: paths.root_dir,
             cache_dir: paths.cache_dir,
             log_dir: paths.log_dir,
             launch_agents_dir: paths.launch_agents_dir,
+            codex_home: None,
             project: ProjectConfig::default(),
             sync: SyncConfig {
                 enabled: false,
@@ -102,8 +157,106 @@ impl DaemonConfig {
 
     pub fn launch_agent_plist_path(&self) -> PathBuf {
         self.launch_agents_dir
-            .join(format!("{DAEMON_AGENT_LABEL}.plist"))
+            .join(format!("{}.plist", self.launch_agent_label))
     }
+}
+
+fn validate_dev_instance_id(instance_id: &str) -> Result<(), DaemonError> {
+    let bytes = instance_id.as_bytes();
+    let is_name_byte = |byte: &u8| byte.is_ascii_lowercase() || byte.is_ascii_digit();
+    let valid = !bytes.is_empty()
+        && bytes.len() <= MAX_DEV_INSTANCE_ID_BYTES
+        && bytes.first().is_some_and(is_name_byte)
+        && bytes.last().is_some_and(is_name_byte)
+        && bytes.iter().all(|byte| is_name_byte(byte) || *byte == b'-');
+    if valid {
+        Ok(())
+    } else {
+        Err(DaemonError::InvalidConfig(format!(
+            "{DEV_INSTANCE_ID_ENV} must be 1-{MAX_DEV_INSTANCE_ID_BYTES} lowercase ASCII letters, digits, or interior hyphens"
+        )))
+    }
+}
+
+fn daemon_runtime_names(dev_instance_id: Option<&str>) -> (String, String, String) {
+    match dev_instance_id {
+        Some(instance_id) => {
+            let daemon_service = format!("{DEV_DAEMON_SERVICE_PREFIX}{instance_id}");
+            (
+                daemon_service.clone(),
+                daemon_service,
+                format!("{DEV_KEYCHAIN_SERVICE_PREFIX}{instance_id}"),
+            )
+        }
+        None => (
+            DAEMON_AGENT_LABEL.to_owned(),
+            DAEMON_MACH_SERVICE_NAME.to_owned(),
+            IDENTIFIER_NAMESPACE.to_owned(),
+        ),
+    }
+}
+
+fn dev_codex_home(
+    dev_instance_id: Option<&str>,
+    inherited: Option<PathBuf>,
+    root_dir: &Path,
+) -> Option<PathBuf> {
+    dev_instance_id.map(|_| inherited.unwrap_or_else(|| root_dir.join("codex-home")))
+}
+
+fn validate_dev_runtime_paths(
+    instance_id: &str,
+    paths: &DaemonRuntimePaths,
+    codex_home: Option<&Path>,
+) -> Result<(), DaemonError> {
+    let required = [
+        ("CLUMSIES_DAEMON_ROOT", paths.root_dir.as_path()),
+        ("CLUMSIES_DAEMON_CACHE_DIR", paths.cache_dir.as_path()),
+        ("CLUMSIES_DAEMON_LOG_DIR", paths.log_dir.as_path()),
+        (
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+            paths.launch_agents_dir.as_path(),
+        ),
+        (
+            "CODEX_HOME",
+            codex_home.ok_or_else(|| {
+                DaemonError::InvalidConfig("Dev CODEX_HOME could not be derived".to_owned())
+            })?,
+        ),
+    ];
+    for (name, path) in required {
+        validate_dev_path(name, path, instance_id)?;
+        match std::fs::symlink_metadata(path) {
+            Ok(_) => {
+                let canonical = std::fs::canonicalize(path)?;
+                validate_dev_path(name, &canonical, instance_id)?;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+fn validate_dev_path(name: &str, path: &Path, instance_id: &str) -> Result<(), DaemonError> {
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| matches!(component, Component::CurDir | Component::ParentDir))
+    {
+        return Err(DaemonError::InvalidConfig(format!(
+            "{name} must be an absolute normalized Dev path"
+        )));
+    }
+    if !path
+        .components()
+        .any(|component| component.as_os_str() == OsStr::new(instance_id))
+    {
+        return Err(DaemonError::InvalidConfig(format!(
+            "{name} must contain the exact Dev instance id as a path component"
+        )));
+    }
+    Ok(())
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -124,18 +277,44 @@ impl DaemonRuntimePaths {
         }
     }
 
-    fn from_home(home: PathBuf) -> Self {
-        Self {
-            root_dir: home
-                .join("Library")
-                .join("Application Support")
-                .join(IDENTIFIER_NAMESPACE),
-            cache_dir: home
-                .join("Library")
-                .join("Caches")
-                .join(IDENTIFIER_NAMESPACE),
-            log_dir: home.join("Library").join("Logs").join(IDENTIFIER_NAMESPACE),
-            launch_agents_dir: home.join("Library").join("LaunchAgents"),
+    fn from_home(home: PathBuf, dev_instance_id: Option<&str>) -> Self {
+        match dev_instance_id {
+            Some(instance_id) => {
+                let root_dir = home
+                    .join("Library")
+                    .join("Application Support")
+                    .join(IDENTIFIER_NAMESPACE)
+                    .join("dev")
+                    .join(instance_id);
+                Self {
+                    cache_dir: home
+                        .join("Library")
+                        .join("Caches")
+                        .join(IDENTIFIER_NAMESPACE)
+                        .join("dev")
+                        .join(instance_id),
+                    log_dir: home
+                        .join("Library")
+                        .join("Logs")
+                        .join(IDENTIFIER_NAMESPACE)
+                        .join("dev")
+                        .join(instance_id),
+                    launch_agents_dir: root_dir.join("LaunchAgents"),
+                    root_dir,
+                }
+            }
+            None => Self {
+                root_dir: home
+                    .join("Library")
+                    .join("Application Support")
+                    .join(IDENTIFIER_NAMESPACE),
+                cache_dir: home
+                    .join("Library")
+                    .join("Caches")
+                    .join(IDENTIFIER_NAMESPACE),
+                log_dir: home.join("Library").join("Logs").join(IDENTIFIER_NAMESPACE),
+                launch_agents_dir: home.join("Library").join("LaunchAgents"),
+            },
         }
     }
 }
@@ -149,6 +328,10 @@ pub struct LaunchAgentConfig {
     pub root_dir: PathBuf,
     pub cache_dir: PathBuf,
     pub log_dir: PathBuf,
+    launch_agents_dir: PathBuf,
+    dev_instance_id: Option<String>,
+    server_url: String,
+    codex_home: Option<PathBuf>,
     binary_sha256: String,
 }
 
@@ -160,13 +343,17 @@ impl LaunchAgentConfig {
         let program_path = program_path.into();
         let binary_sha256 = hex::encode(Sha256::digest(std::fs::read(&program_path)?));
         Ok(Self {
-            label: DAEMON_AGENT_LABEL.to_owned(),
-            mach_service_name: DAEMON_MACH_SERVICE_NAME.to_owned(),
+            label: config.launch_agent_label.clone(),
+            mach_service_name: config.mach_service_name.clone(),
             program_path,
             plist_path: config.launch_agent_plist_path(),
             root_dir: config.root_dir.clone(),
             cache_dir: config.cache_dir.clone(),
             log_dir: config.log_dir.clone(),
+            launch_agents_dir: config.launch_agents_dir.clone(),
+            dev_instance_id: config.dev_instance_id.clone(),
+            server_url: config.project.server_url.clone(),
+            codex_home: config.codex_home.clone(),
             binary_sha256,
         })
     }
@@ -180,6 +367,25 @@ impl LaunchAgentConfig {
     }
 
     pub fn plist_contents(&self) -> String {
+        let mut dev_environment = String::new();
+        if let Some(instance_id) = self.dev_instance_id.as_deref() {
+            for (name, value) in [
+                (DEV_INSTANCE_ID_ENV, instance_id.to_owned()),
+                (
+                    "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+                    self.launch_agents_dir.display().to_string(),
+                ),
+                ("CLUMSIES_SERVER_URL", self.server_url.clone()),
+            ] {
+                dev_environment.push_str(&plist_environment_variable(name, &value));
+            }
+            if let Some(codex_home) = &self.codex_home {
+                dev_environment.push_str(&plist_environment_variable(
+                    "CODEX_HOME",
+                    &codex_home.display().to_string(),
+                ));
+            }
+        }
         format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -208,7 +414,7 @@ impl LaunchAgentConfig {
     <string>{cache_dir}</string>
     <key>CLUMSIES_DAEMON_LOG_DIR</key>
     <string>{log_dir}</string>
-    <key>CLUMSIES_DAEMON_BINARY_SHA256</key>
+{dev_environment}    <key>CLUMSIES_DAEMON_BINARY_SHA256</key>
     <string>{binary_sha256}</string>
     <key>RUST_LOG</key>
     <string>info</string>
@@ -226,6 +432,7 @@ impl LaunchAgentConfig {
             root_dir = escape_plist_value(self.root_dir.to_string_lossy().as_ref()),
             cache_dir = escape_plist_value(self.cache_dir.to_string_lossy().as_ref()),
             log_dir = escape_plist_value(self.log_dir.to_string_lossy().as_ref()),
+            dev_environment = dev_environment,
             binary_sha256 = escape_plist_value(&self.binary_sha256),
             stdout = escape_plist_value(self.standard_output_path().to_string_lossy().as_ref()),
             stderr = escape_plist_value(self.standard_error_path().to_string_lossy().as_ref()),
@@ -439,6 +646,196 @@ mod launch_agent_tests {
     use super::*;
 
     #[test]
+    fn dev_identity_is_bounded_and_derives_every_daemon_namespace() {
+        let instance_id = "a1b2c3d4e5f6";
+        let (label, mach_service, keychain_service) = daemon_runtime_names(Some(instance_id));
+
+        assert_eq!(label, "ai.clumsies.daemon.dev.a1b2c3d4e5f6");
+        assert_eq!(mach_service, label);
+        assert_eq!(keychain_service, "ai.clumsies.dev.a1b2c3d4e5f6");
+        assert_eq!(
+            DaemonConfig::dev_mach_service_name(instance_id).unwrap(),
+            mach_service
+        );
+        assert!(validate_dev_instance_id("worktree-1").is_ok());
+        for invalid in [
+            "",
+            "Worktree",
+            "-worktree",
+            "worktree-",
+            "worktree.name",
+            "worktree/name",
+            "012345678901234567890123456789012",
+        ] {
+            assert!(validate_dev_instance_id(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn dev_default_paths_are_isolated_while_stable_paths_are_unchanged() {
+        let home = PathBuf::from("/Users/tester");
+        let stable = DaemonRuntimePaths::from_home(home.clone(), None);
+        assert_eq!(
+            stable.root_dir,
+            home.join("Library/Application Support/ai.clumsies")
+        );
+        assert_eq!(stable.cache_dir, home.join("Library/Caches/ai.clumsies"));
+        assert_eq!(stable.log_dir, home.join("Library/Logs/ai.clumsies"));
+        assert_eq!(stable.launch_agents_dir, home.join("Library/LaunchAgents"));
+
+        let dev = DaemonRuntimePaths::from_home(home.clone(), Some("a1b2c3d4e5f6"));
+        assert_eq!(
+            dev.root_dir,
+            home.join("Library/Application Support/ai.clumsies/dev/a1b2c3d4e5f6")
+        );
+        assert_eq!(
+            dev.cache_dir,
+            home.join("Library/Caches/ai.clumsies/dev/a1b2c3d4e5f6")
+        );
+        assert_eq!(
+            dev.log_dir,
+            home.join("Library/Logs/ai.clumsies/dev/a1b2c3d4e5f6")
+        );
+        assert_eq!(dev.launch_agents_dir, dev.root_dir.join("LaunchAgents"));
+        assert_eq!(
+            dev_codex_home(
+                None,
+                Some(PathBuf::from("/tmp/inherited-codex-home")),
+                &stable.root_dir
+            ),
+            None
+        );
+        assert_eq!(
+            dev_codex_home(
+                Some("a1b2c3d4e5f6"),
+                Some(PathBuf::from("/tmp/dev-codex-home")),
+                &dev.root_dir
+            ),
+            Some(PathBuf::from("/tmp/dev-codex-home"))
+        );
+        assert_eq!(
+            dev_codex_home(Some("a1b2c3d4e5f6"), None, &dev.root_dir),
+            Some(dev.root_dir.join("codex-home"))
+        );
+        assert!(
+            validate_dev_runtime_paths(
+                "a1b2c3d4e5f6",
+                &dev,
+                Some(&dev.root_dir.join("codex-home"))
+            )
+            .is_ok()
+        );
+
+        let stable_paths = DaemonRuntimePaths::from_home(home, None);
+        let error = validate_dev_runtime_paths(
+            "a1b2c3d4e5f6",
+            &stable_paths,
+            Some(Path::new("/Users/tester/.codex")),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("CLUMSIES_DAEMON_ROOT"));
+
+        let mut escaping_paths = dev.clone();
+        escaping_paths.root_dir = PathBuf::from("/tmp/a1b2c3d4e5f6/../stable-ai.clumsies");
+        let error = validate_dev_runtime_paths(
+            "a1b2c3d4e5f6",
+            &escaping_paths,
+            Some(&dev.root_dir.join("codex-home")),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("absolute normalized Dev path"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dev_paths_cannot_resolve_through_a_symlink_to_stable_storage() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let instance_id = "a1b2c3d4e5f6";
+        let stable = temp.path().join("stable");
+        std::fs::create_dir(&stable).unwrap();
+        let linked_root = temp.path().join(instance_id);
+        symlink(&stable, &linked_root).unwrap();
+        let paths = DaemonRuntimePaths::for_root(linked_root.clone());
+
+        let error =
+            validate_dev_runtime_paths(instance_id, &paths, Some(&linked_root.join("codex-home")))
+                .unwrap_err();
+        assert!(error.to_string().contains("CLUMSIES_DAEMON_ROOT"));
+        assert!(
+            error
+                .to_string()
+                .contains("exact Dev instance id as a path component")
+        );
+    }
+
+    #[test]
+    fn dev_launch_agent_carries_the_complete_cold_start_environment() {
+        let root = tempfile::tempdir().unwrap();
+        let instance_id = "a1b2c3d4e5f6";
+        let paths = DaemonRuntimePaths::for_root(root.path().join("runtime"));
+        let (launch_agent_label, mach_service_name, keychain_service) =
+            daemon_runtime_names(Some(instance_id));
+        let config = DaemonConfig {
+            dev_instance_id: Some(instance_id.to_owned()),
+            launch_agent_label: launch_agent_label.clone(),
+            mach_service_name: mach_service_name.clone(),
+            keychain_service,
+            root_dir: paths.root_dir.clone(),
+            cache_dir: paths.cache_dir.clone(),
+            log_dir: paths.log_dir.clone(),
+            launch_agents_dir: paths.launch_agents_dir.clone(),
+            codex_home: Some(paths.root_dir.join("codex-home")),
+            project: ProjectConfig {
+                server_url: "http://127.0.0.1:43123/?a=1&b=2".to_owned(),
+                project_id: None,
+                memory_guidelines_path: None,
+            },
+            sync: SyncConfig {
+                enabled: true,
+                interval: Duration::from_secs(30),
+            },
+        };
+        let program_path = root
+            .path()
+            .join("Clumsies Dev.app/Contents/Resources/clumsiesd");
+        std::fs::create_dir_all(program_path.parent().unwrap()).unwrap();
+        std::fs::write(&program_path, "dev-daemon").unwrap();
+
+        let launch_agent = LaunchAgentConfig::from_daemon_config(&config, &program_path).unwrap();
+        let plist = launch_agent.plist_contents();
+
+        assert_eq!(launch_agent.label, launch_agent_label);
+        assert_eq!(launch_agent.mach_service_name, mach_service_name);
+        assert_eq!(config.keychain_service, "ai.clumsies.dev.a1b2c3d4e5f6");
+        assert_eq!(
+            launch_agent.plist_path,
+            paths
+                .launch_agents_dir
+                .join("ai.clumsies.daemon.dev.a1b2c3d4e5f6.plist")
+        );
+        for key in [
+            DEV_INSTANCE_ID_ENV,
+            "CLUMSIES_DAEMON_ROOT",
+            "CLUMSIES_DAEMON_CACHE_DIR",
+            "CLUMSIES_DAEMON_LOG_DIR",
+            "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR",
+            "CLUMSIES_SERVER_URL",
+            "CODEX_HOME",
+        ] {
+            assert!(plist.contains(&format!("<key>{key}</key>")), "{key}");
+        }
+        assert!(plist.contains("http://127.0.0.1:43123/?a=1&amp;b=2"));
+        assert!(plist.contains(&escape_plist_value(
+            paths.launch_agents_dir.to_string_lossy().as_ref()
+        )));
+        assert!(plist.contains(&escape_plist_value(
+            paths.root_dir.join("codex-home").to_string_lossy().as_ref()
+        )));
+    }
+
+    #[test]
     fn plist_currency_tracks_the_installed_launch_agent_definition() {
         let root = tempfile::tempdir().unwrap();
         let daemon_config = DaemonConfig::for_root(root.path());
@@ -549,6 +946,14 @@ fn escape_plist_value(value: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&apos;")
+}
+
+fn plist_environment_variable(name: &str, value: &str) -> String {
+    format!(
+        "    <key>{}</key>\n    <string>{}</string>\n",
+        escape_plist_value(name),
+        escape_plist_value(value)
+    )
 }
 
 #[cfg(unix)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -33,8 +33,9 @@ pub use commit_sync::{
     DaemonProjectCheckout, DaemonProjectCheckoutRequest, DaemonProjectCheckoutResource,
 };
 pub use config::{
-    CURRENT_LOCAL_SCHEMA_VERSION, DAEMON_AGENT_LABEL, DAEMON_MACH_SERVICE_NAME, DaemonConfig,
-    IDENTIFIER_NAMESPACE, LaunchAgentConfig, LaunchAgentController, ProjectConfig, SyncConfig,
+    CURRENT_LOCAL_SCHEMA_VERSION, DAEMON_AGENT_LABEL, DAEMON_MACH_SERVICE_NAME,
+    DEV_INSTANCE_ID_ENV, DaemonConfig, IDENTIFIER_NAMESPACE, LaunchAgentConfig,
+    LaunchAgentController, ProjectConfig, SyncConfig,
 };
 pub(crate) use config::{
     META_DRAFT_SYNC_LAST_ATTEMPT_AT, META_DRAFT_SYNC_LAST_SUCCESS_AT, RuntimeProjectConfig,

--- a/crates/daemon/src/main.rs
+++ b/crates/daemon/src/main.rs
@@ -8,11 +8,12 @@ use daemon::agent_runtime::hook::{
 use daemon::agent_runtime::mcp::McpServer;
 use daemon::agent_runtime::{AgentRuntimeBackend, mcp_contract::AgentRuntimeRequest};
 use daemon::{
-    AgentRunKind, CredentialStore, CredentialStoreError, DAEMON_MACH_SERVICE_NAME, DaemonConfig,
-    DaemonError, DaemonIpcClient, DaemonIpcResponse, DaemonIpcServer, DaemonIpcService,
-    DaemonProjectBindingResolveRequest, DaemonState, IssueBoardState, IssueDetailRequest,
-    LaunchAgentConfig, LaunchAgentController, ProjectAgentAdapterDelivery, ProjectAgentAdapterKind,
-    ProjectAgentAdapterRuntimeRequirement, RecordAgentRunEventResponse, ServerCredentials,
+    AgentRunKind, CredentialStore, CredentialStoreError, DAEMON_MACH_SERVICE_NAME,
+    DEV_INSTANCE_ID_ENV, DaemonConfig, DaemonError, DaemonIpcClient, DaemonIpcResponse,
+    DaemonIpcServer, DaemonIpcService, DaemonProjectBindingResolveRequest, DaemonState,
+    IssueBoardState, IssueDetailRequest, LaunchAgentConfig, LaunchAgentController,
+    ProjectAgentAdapterDelivery, ProjectAgentAdapterKind, ProjectAgentAdapterRuntimeRequirement,
+    RecordAgentRunEventResponse, ServerCredentials,
 };
 use serde_json::{Value, json};
 use tracing_subscriber::EnvFilter;
@@ -40,6 +41,12 @@ const AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV: &str =
 const AGENT_RUNTIME_STARTUP_IPC_TIMEOUT: Duration = Duration::from_secs(30);
 const AGENT_RUNTIME_MCP_IPC_TIMEOUT: Duration = Duration::from_secs(65);
 const AGENT_RUNTIME_HOOK_IPC_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DaemonRuntimeMode {
+    mach_service_name: String,
+    isolated_test: bool,
+}
 
 struct DeliveryCheckedBackend {
     client: DaemonIpcClient,
@@ -210,7 +217,8 @@ fn agent_runtime_requirement(
 fn run_mcp_proxy(
     required_adapter: Option<ProjectAgentAdapterRuntimeRequirement>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = agent_runtime_client(AGENT_RUNTIME_STARTUP_IPC_TIMEOUT)?;
+    let runtime_mode = daemon_runtime_mode_from_env()?;
+    let client = agent_runtime_client(AGENT_RUNTIME_STARTUP_IPC_TIMEOUT, &runtime_mode);
     verify_agent_runtime(&client)?;
     let workspace_path = std::env::current_dir()?.to_string_lossy().into_owned();
     let binding = client.resolve_project_binding(DaemonProjectBindingResolveRequest {
@@ -229,7 +237,7 @@ fn run_mcp_proxy(
     // The debug-only test seam changes the backend identity only after the
     // startup health and binding requests. This models a resident replacement
     // between MCP initialize and the next tools/call over real XPC.
-    let backend = match stale_tool_identity_for_test()? {
+    let backend = match stale_tool_identity_for_test(&runtime_mode)? {
         Some(identity) => DaemonIpcClient::for_agent_runtime(client.service_name(), identity)
             .with_timeout(AGENT_RUNTIME_MCP_IPC_TIMEOUT),
         None => client.with_timeout(AGENT_RUNTIME_MCP_IPC_TIMEOUT),
@@ -261,7 +269,8 @@ fn run_hook_proxy(
         Some(path) => path.to_owned(),
         None => std::env::current_dir()?.to_string_lossy().into_owned(),
     };
-    let client = agent_runtime_client(AGENT_RUNTIME_HOOK_IPC_TIMEOUT)?;
+    let runtime_mode = daemon_runtime_mode_from_env()?;
+    let client = agent_runtime_client(AGENT_RUNTIME_HOOK_IPC_TIMEOUT, &runtime_mode);
     verify_agent_runtime(&client)?;
     let binding = client.resolve_project_binding(DaemonProjectBindingResolveRequest {
         workspace_path,
@@ -288,28 +297,75 @@ fn verify_agent_runtime(client: &DaemonIpcClient) -> Result<(), Box<dyn std::err
     Ok(())
 }
 
-fn agent_runtime_client(request_timeout: Duration) -> Result<DaemonIpcClient, DaemonError> {
-    Ok(DaemonIpcClient::for_agent_runtime(
-        agent_runtime_mach_service_name()?,
+fn agent_runtime_client(
+    request_timeout: Duration,
+    runtime_mode: &DaemonRuntimeMode,
+) -> DaemonIpcClient {
+    DaemonIpcClient::for_agent_runtime(
+        runtime_mode.mach_service_name.clone(),
         daemon::agent_runtime::current_identity(),
     )
-    .with_timeout(request_timeout))
+    .with_timeout(request_timeout)
 }
 
 /// An isolated Mach service is required by the process/XPC integration test.
 /// The strict prefix and character allowlist prevent this seam from targeting
 /// the installed service or another user's launchd job.
-fn agent_runtime_mach_service_name() -> Result<String, DaemonError> {
-    let Some(service_name) = std::env::var(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV).ok() else {
-        return Ok(DAEMON_MACH_SERVICE_NAME.to_owned());
-    };
-    if !cfg!(debug_assertions) {
+fn daemon_runtime_mode_from_env() -> Result<DaemonRuntimeMode, DaemonError> {
+    let dev_instance_id = DaemonConfig::dev_instance_id_from_env()?;
+    daemon_runtime_mode(dev_instance_id.as_deref())
+}
+
+fn daemon_runtime_mode(dev_instance_id: Option<&str>) -> Result<DaemonRuntimeMode, DaemonError> {
+    let test_service_name = optional_utf8_env(
+        AGENT_RUNTIME_TEST_MACH_SERVICE_ENV,
+        std::env::var(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV),
+    )?;
+    resolve_daemon_runtime_mode(test_service_name.as_deref(), dev_instance_id)
+}
+
+fn resolve_daemon_runtime_mode(
+    test_service_name: Option<&str>,
+    dev_instance_id: Option<&str>,
+) -> Result<DaemonRuntimeMode, DaemonError> {
+    if test_service_name.is_some() && dev_instance_id.is_some() {
         return Err(DaemonError::InvalidConfig(format!(
-            "{AGENT_RUNTIME_TEST_MACH_SERVICE_ENV} is unavailable in release builds"
+            "{AGENT_RUNTIME_TEST_MACH_SERVICE_ENV} cannot be combined with {DEV_INSTANCE_ID_ENV}"
         )));
     }
-    validate_test_mach_service_name(&service_name)?;
-    Ok(service_name)
+    if let Some(service_name) = test_service_name {
+        if !cfg!(debug_assertions) {
+            return Err(DaemonError::InvalidConfig(format!(
+                "{AGENT_RUNTIME_TEST_MACH_SERVICE_ENV} is unavailable in release builds"
+            )));
+        }
+        validate_test_mach_service_name(service_name)?;
+        return Ok(DaemonRuntimeMode {
+            mach_service_name: service_name.to_owned(),
+            isolated_test: true,
+        });
+    }
+    let mach_service_name = match dev_instance_id {
+        Some(instance_id) => DaemonConfig::dev_mach_service_name(instance_id),
+        None => Ok(DAEMON_MACH_SERVICE_NAME.to_owned()),
+    }?;
+    Ok(DaemonRuntimeMode {
+        mach_service_name,
+        isolated_test: false,
+    })
+}
+
+fn optional_utf8_env(
+    name: &str,
+    value: Result<String, std::env::VarError>,
+) -> Result<Option<String>, DaemonError> {
+    match value {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(DaemonError::InvalidConfig(format!(
+            "{name} must be valid UTF-8"
+        ))),
+    }
 }
 
 fn validate_test_mach_service_name(service_name: &str) -> Result<(), DaemonError> {
@@ -326,12 +382,18 @@ fn validate_test_mach_service_name(service_name: &str) -> Result<(), DaemonError
     Ok(())
 }
 
-fn stale_tool_identity_for_test() -> Result<Option<daemon::AgentRuntimeIdentity>, DaemonError> {
-    let Some(build_id) = std::env::var(AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV).ok() else {
+fn stale_tool_identity_for_test(
+    runtime_mode: &DaemonRuntimeMode,
+) -> Result<Option<daemon::AgentRuntimeIdentity>, DaemonError> {
+    let Some(build_id) = optional_utf8_env(
+        AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV,
+        std::env::var(AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV),
+    )?
+    else {
         return Ok(None);
     };
     if !cfg!(debug_assertions)
-        || std::env::var(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV).is_err()
+        || !runtime_mode.isolated_test
         || build_id.is_empty()
         || build_id.len() > 128
         || !build_id.bytes().all(|byte| byte.is_ascii_graphic())
@@ -340,9 +402,6 @@ fn stale_tool_identity_for_test() -> Result<Option<daemon::AgentRuntimeIdentity>
             "{AGENT_RUNTIME_TEST_STALE_TOOL_BUILD_ENV} is allowed only for a bounded debug test service build id"
         )));
     }
-    // Re-validate the service here so the stale identity seam can never be
-    // used with the installed resident endpoint.
-    agent_runtime_mach_service_name()?;
     Ok(Some(daemon::AgentRuntimeIdentity {
         protocol_revision: daemon::agent_runtime::AGENT_RUNTIME_PROTOCOL_REVISION,
         build_id,
@@ -433,8 +492,8 @@ fn board_state_title(state: IssueBoardState) -> &'static str {
 
 async fn run_daemon(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let config = DaemonConfig::from_env()?;
-    let test_mach_service = std::env::var_os(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV).is_some();
-    let mach_service_name = agent_runtime_mach_service_name()?;
+    let runtime_mode = daemon_runtime_mode(config.dev_instance_id.as_deref())?;
+    let mach_service_name = runtime_mode.mach_service_name.clone();
 
     let log_file = Mutex::new(
         std::fs::OpenOptions::new()
@@ -555,7 +614,7 @@ async fn run_daemon(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>>
 
     install_crash_observability(&config);
 
-    let state = if test_mach_service {
+    let state = if runtime_mode.isolated_test {
         DaemonState::initialize_with_credential_store(config, Arc::new(IsolatedTestCredentialStore))
             .await?
     } else {
@@ -565,10 +624,13 @@ async fn run_daemon(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>>
     let _ipc_server = DaemonIpcServer::start(mach_service_name.clone(), service.clone())?;
     // The unique test service exercises the real process/XPC boundary while
     // deliberately avoiding network sync and model downloads in user space.
-    let _sync_worker = (!test_mach_service).then(|| state.start_sync_worker());
-    let _search_model_worker = (!test_mach_service).then(|| state.start_search_model_worker());
-    let _search_index_worker = (!test_mach_service).then(|| state.start_search_index_worker());
-    let _run_reaper = (!test_mach_service).then(|| state.start_run_reaper());
+    // Dev instances are not test services and retain every production worker.
+    let _sync_worker = (!runtime_mode.isolated_test).then(|| state.start_sync_worker());
+    let _search_model_worker =
+        (!runtime_mode.isolated_test).then(|| state.start_search_model_worker());
+    let _search_index_worker =
+        (!runtime_mode.isolated_test).then(|| state.start_search_index_worker());
+    let _run_reaper = (!runtime_mode.isolated_test).then(|| state.start_run_reaper());
     let health = service.health().await;
 
     tracing::info!(
@@ -671,5 +733,57 @@ mod tests {
         let error = validate_test_mach_service_name(DAEMON_MACH_SERVICE_NAME).unwrap_err();
         assert!(matches!(error, DaemonError::InvalidConfig(_)));
         assert!(validate_test_mach_service_name("ai.clumsies.test.issue049_1").is_ok());
+    }
+
+    #[test]
+    fn dev_proxy_uses_its_derived_service_without_entering_the_test_seam() {
+        let dev = resolve_daemon_runtime_mode(None, Some("a1b2c3d4e5f6")).unwrap();
+        assert_eq!(dev.mach_service_name, "ai.clumsies.daemon.dev.a1b2c3d4e5f6");
+        assert!(!dev.isolated_test);
+
+        let stable = resolve_daemon_runtime_mode(None, None).unwrap();
+        assert_eq!(stable.mach_service_name, DAEMON_MACH_SERVICE_NAME);
+        assert!(!stable.isolated_test);
+    }
+
+    #[test]
+    fn test_mach_service_and_dev_identity_are_mutually_exclusive() {
+        let error =
+            resolve_daemon_runtime_mode(Some("ai.clumsies.test.issue073"), Some("a1b2c3d4e5f6"))
+                .unwrap_err();
+        assert!(matches!(error, DaemonError::InvalidConfig(_)));
+        assert!(
+            error
+                .to_string()
+                .contains(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV)
+        );
+        assert!(error.to_string().contains(DEV_INSTANCE_ID_ENV));
+    }
+
+    #[test]
+    fn validated_test_mode_drives_both_endpoint_and_isolation() {
+        let mode = resolve_daemon_runtime_mode(Some("ai.clumsies.test.issue073"), None).unwrap();
+        assert_eq!(mode.mach_service_name, "ai.clumsies.test.issue073");
+        assert!(mode.isolated_test);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_test_service_cannot_fall_back_to_the_stable_endpoint() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let error = optional_utf8_env(
+            AGENT_RUNTIME_TEST_MACH_SERVICE_ENV,
+            Err(std::env::VarError::NotUnicode(
+                std::ffi::OsString::from_vec(vec![0xff]),
+            )),
+        )
+        .unwrap_err();
+        assert!(matches!(error, DaemonError::InvalidConfig(_)));
+        assert!(
+            error
+                .to_string()
+                .contains(AGENT_RUNTIME_TEST_MACH_SERVICE_ENV)
+        );
     }
 }

--- a/crates/daemon/src/recall.rs
+++ b/crates/daemon/src/recall.rs
@@ -848,6 +848,12 @@ fn codex_recall_session(session: codex::CodexSession, workspace_root: String) ->
     }
 }
 
+fn codex_sessions_home(configured_codex_home: Option<&Path>, home: &Path) -> PathBuf {
+    configured_codex_home
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| home.join(".codex"))
+}
+
 pub(super) async fn list_recalls(
     state: &DaemonState,
     request: ListRecallsRequest,
@@ -892,7 +898,8 @@ pub(super) async fn list_recalls(
         }
     }
 
-    match codex::load_sessions(&home.join(".codex"), limit, |cwd| {
+    let codex_home = codex_sessions_home(state.inner.config.codex_home.as_deref(), &home);
+    match codex::load_sessions(&codex_home, limit, |cwd| {
         binding_for_cwd(cwd, &roots).is_some()
     }) {
         Ok(codex_sessions) => {
@@ -935,6 +942,17 @@ mod tests {
         assert_eq!(
             encode_workspace_dir("/Users/weiwang/koal-agentos"),
             "--Users-weiwang-koal-agentos--"
+        );
+    }
+
+    #[test]
+    fn codex_sessions_use_dev_config_without_changing_the_stable_default() {
+        let home = Path::new("/Users/tester");
+        let dev_codex_home = Path::new("/tmp/clumsies-dev/a1b2c3d4e5f6/codex-home");
+        assert_eq!(codex_sessions_home(None, home), home.join(".codex"));
+        assert_eq!(
+            codex_sessions_home(Some(dev_codex_home), home),
+            PathBuf::from("/tmp/clumsies-dev/a1b2c3d4e5f6/codex-home")
         );
     }
 

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -233,8 +233,9 @@ impl Drop for ServerResponseCacheTransition<'_> {
 
 impl DaemonState {
     pub async fn initialize(config: DaemonConfig) -> Result<Self, DaemonError> {
-        Self::initialize_with_credential_store(config, Arc::new(SystemCredentialStore::default()))
-            .await
+        let credential_store =
+            SystemCredentialStore::new(config.keychain_service.clone(), KEYCHAIN_ACCOUNT);
+        Self::initialize_with_credential_store(config, Arc::new(credential_store)).await
     }
 
     pub async fn initialize_with_credential_store(

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -1895,6 +1895,10 @@ fn launch_agent_plist_uses_standard_identity_and_runtime_paths() {
     assert!(plist.contains("<key>MachServices</key>"));
     assert!(plist.contains("<key>CLUMSIES_DAEMON_ROOT</key>"));
     assert!(plist.contains(&format!("<string>{}</string>", root.path().display())));
+    assert!(!plist.contains("CLUMSIES_DEV_INSTANCE_ID"));
+    assert!(!plist.contains("CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR"));
+    assert!(!plist.contains("CLUMSIES_SERVER_URL"));
+    assert!(!plist.contains("CODEX_HOME"));
     assert!(!plist.contains("127.0.0.1"));
     assert!(!plist.contains("daemon-endpoint.json"));
 

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -1,4 +1,6 @@
 use std::future::{self, Future, IntoFuture};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::app::build_app;
@@ -10,6 +12,7 @@ use crate::project_authority_migration::{MigrationMode, migrate_project_authorit
 use crate::telemetry;
 
 const SHUTDOWN_DRAIN_TIMEOUT: Duration = Duration::from_secs(4);
+const SERVER_READY_FILE_ENV: &str = "CLUMSIES_SERVER_READY_FILE";
 
 #[derive(Debug, PartialEq, Eq)]
 enum DrainResult<T> {
@@ -24,14 +27,20 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         listen_addr,
         public_origin,
     } = ServerConfig::from_env()?;
+    let mut ready_file = ServerReadyFile::from_env()?;
 
     let pool = connect(&DatabaseConfig::from_url(database_url)).await?;
     run_migrations(&pool).await?;
+    let listener = tokio::net::TcpListener::bind(listen_addr).await?;
+    let listen_addr = listener.local_addr()?;
+    let public_origin = match public_origin {
+        Some(public_origin) => public_origin,
+        None => crate::config::PublicOrigin::for_loopback(listen_addr)?,
+    };
     let installation = InstallationService::from_env(pool.clone(), public_origin.secure_cookies())?;
     let auth = AuthService::from_env(pool.clone(), &public_origin).await?;
     let app = build_app(pool, auth, installation);
-    let listener = tokio::net::TcpListener::bind(listen_addr).await?;
-    let listen_addr = listener.local_addr()?;
+    ready_file.publish(listen_addr, &public_origin)?;
 
     tracing::info!(%listen_addr, "clumsies server started");
     let (graceful_shutdown, graceful_shutdown_received) = tokio::sync::oneshot::channel();
@@ -52,6 +61,153 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
     tracing::info!("clumsies server stopped");
     Ok(())
+}
+
+#[derive(Debug)]
+struct ServerReadyFile {
+    path: Option<PathBuf>,
+    owner_token: String,
+    published_identity: Option<ReadyFileIdentity>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadyFileIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+}
+
+impl ServerReadyFile {
+    fn from_env() -> Result<Self, std::io::Error> {
+        let path = std::env::var_os(SERVER_READY_FILE_ENV)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from);
+        Self::new(path)
+    }
+
+    fn new(path: Option<PathBuf>) -> Result<Self, std::io::Error> {
+        if let Some(path) = &path {
+            if !path.is_absolute() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("{SERVER_READY_FILE_ENV} must be an absolute path"),
+                ));
+            }
+            match std::fs::symlink_metadata(path) {
+                Ok(_) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        format!(
+                            "refusing to replace existing Server ready file {}",
+                            path.display()
+                        ),
+                    ));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(Self {
+            path,
+            owner_token: uuid::Uuid::new_v4().to_string(),
+            published_identity: None,
+        })
+    }
+
+    fn publish(
+        &mut self,
+        listen_addr: std::net::SocketAddr,
+        public_origin: &crate::config::PublicOrigin,
+    ) -> Result<(), std::io::Error> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let temporary = ready_temporary_path(path, &self.owner_token);
+        let mut temporary_created = false;
+        let result = (|| {
+            let mut options = std::fs::OpenOptions::new();
+            options.create_new(true).write(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.mode(0o600);
+            }
+            let mut file = options.open(&temporary)?;
+            temporary_created = true;
+            let mut contents = serde_json::to_vec(&serde_json::json!({
+                "listen_addr": listen_addr.to_string(),
+                "public_origin": public_origin.as_str(),
+                "owner_token": self.owner_token.as_str(),
+            }))
+            .map_err(std::io::Error::other)?;
+            contents.push(b'\n');
+            file.write_all(&contents)?;
+            file.sync_all()?;
+            let identity = ready_file_identity(&file.metadata()?);
+            drop(file);
+
+            // A hard link publishes atomically without ever replacing an
+            // existing target. Both paths are in the same directory.
+            std::fs::hard_link(&temporary, path)?;
+            self.published_identity = Some(identity);
+            std::fs::remove_file(&temporary)?;
+            Ok(())
+        })();
+        if result.is_err() && temporary_created {
+            let _ = std::fs::remove_file(&temporary);
+        }
+        result
+    }
+}
+
+impl Drop for ServerReadyFile {
+    fn drop(&mut self) {
+        if let (Some(path), Some(published_identity)) = (&self.path, self.published_identity)
+            && std::fs::symlink_metadata(path)
+                .is_ok_and(|metadata| ready_file_identity(&metadata) == published_identity)
+            && ready_file_owner(path).as_deref() == Some(self.owner_token.as_str())
+        {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+fn ready_file_identity(metadata: &std::fs::Metadata) -> ReadyFileIdentity {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        ReadyFileIdentity {
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        ReadyFileIdentity {}
+    }
+}
+
+fn ready_file_owner(path: &Path) -> Option<String> {
+    let file = std::fs::File::open(path).ok()?;
+    let value: serde_json::Value = serde_json::from_reader(file).ok()?;
+    value.get("owner_token")?.as_str().map(str::to_owned)
+}
+
+fn ready_temporary_path(path: &Path, owner_token: &str) -> PathBuf {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("server-ready.json");
+    path.with_file_name(format!(
+        ".{file_name}.{}.{owner_token}.tmp",
+        std::process::id()
+    ))
 }
 
 pub async fn run_project_authority_migration(
@@ -142,9 +298,167 @@ async fn terminate_signal() {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use tokio::time::Instant;
 
     use super::*;
+
+    #[test]
+    fn ready_file_is_private_atomic_json_and_removed_with_its_owner() {
+        let root = std::env::temp_dir().join(format!(
+            "clumsies-server-ready-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("server-ready.json");
+        let mut ready = ServerReadyFile::new(Some(path.clone())).unwrap();
+        let origin = crate::config::PublicOrigin::parse("http://127.0.0.1:49152").unwrap();
+
+        ready
+            .publish("127.0.0.1:49152".parse().unwrap(), &origin)
+            .unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(value["listen_addr"], "127.0.0.1:49152");
+        assert_eq!(value["public_origin"], "http://127.0.0.1:49152");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        assert!(fs::read_dir(&root).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".tmp")
+        }));
+
+        drop(ready);
+        assert!(!path.exists());
+        fs::remove_dir(&root).unwrap();
+    }
+
+    #[test]
+    fn ready_file_refuses_an_existing_target() {
+        let root = temporary_ready_test_root("existing");
+        let path = root.join("server-ready.json");
+        fs::write(&path, b"do not replace\n").unwrap();
+
+        let error = ServerReadyFile::new(Some(path.clone())).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&path).unwrap(), b"do not replace\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ready_file_publish_refuses_a_target_created_after_validation() {
+        let root = temporary_ready_test_root("publish-race");
+        let path = root.join("server-ready.json");
+        let mut ready = ServerReadyFile::new(Some(path.clone())).unwrap();
+        let origin = crate::config::PublicOrigin::parse("http://127.0.0.1:49152").unwrap();
+        fs::write(&path, b"do not replace after validation\n").unwrap();
+
+        let error = ready
+            .publish("127.0.0.1:49152".parse().unwrap(), &origin)
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            b"do not replace after validation\n"
+        );
+        drop(ready);
+        assert_eq!(
+            fs::read(&path).unwrap(),
+            b"do not replace after validation\n"
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ready_file_publish_does_not_delete_an_unowned_temporary_file() {
+        let root = temporary_ready_test_root("temporary-race");
+        let path = root.join("server-ready.json");
+        let mut ready = ServerReadyFile::new(Some(path.clone())).unwrap();
+        let temporary = ready_temporary_path(&path, &ready.owner_token);
+        let origin = crate::config::PublicOrigin::parse("http://127.0.0.1:49152").unwrap();
+        fs::write(&temporary, b"unowned temporary\n").unwrap();
+
+        let error = ready
+            .publish("127.0.0.1:49152".parse().unwrap(), &origin)
+            .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&temporary).unwrap(), b"unowned temporary\n");
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ready_file_drop_preserves_a_replacement_with_a_different_owner() {
+        let root = temporary_ready_test_root("replacement");
+        let path = root.join("server-ready.json");
+        let mut ready = ServerReadyFile::new(Some(path.clone())).unwrap();
+        let origin = crate::config::PublicOrigin::parse("http://127.0.0.1:49152").unwrap();
+        ready
+            .publish("127.0.0.1:49152".parse().unwrap(), &origin)
+            .unwrap();
+        fs::remove_file(&path).unwrap();
+        let replacement = serde_json::to_vec(&serde_json::json!({
+            "owner_token": "replacement-owner"
+        }))
+        .unwrap();
+        fs::write(&path, &replacement).unwrap();
+
+        drop(ready);
+
+        assert_eq!(fs::read(&path).unwrap(), replacement);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn ready_file_drop_preserves_a_different_file_with_the_same_owner_token() {
+        let root = temporary_ready_test_root("replacement-identity");
+        let path = root.join("server-ready.json");
+        let mut ready = ServerReadyFile::new(Some(path.clone())).unwrap();
+        let origin = crate::config::PublicOrigin::parse("http://127.0.0.1:49152").unwrap();
+        ready
+            .publish("127.0.0.1:49152".parse().unwrap(), &origin)
+            .unwrap();
+        let replacement = serde_json::to_vec(&serde_json::json!({
+            "owner_token": ready.owner_token.as_str()
+        }))
+        .unwrap();
+        fs::remove_file(&path).unwrap();
+        fs::write(&path, &replacement).unwrap();
+
+        drop(ready);
+
+        assert_eq!(fs::read(&path).unwrap(), replacement);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn temporary_ready_test_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "clumsies-server-ready-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
 
     #[tokio::test(start_paused = true)]
     async fn shutdown_allows_requests_to_drain_within_deadline() {

--- a/crates/server/src/bootstrap.rs
+++ b/crates/server/src/bootstrap.rs
@@ -67,7 +67,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
 struct ServerReadyFile {
     path: Option<PathBuf>,
     owner_token: String,
-    published_identity: Option<ReadyFileIdentity>,
+    published_file: Option<std::fs::File>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -111,7 +111,7 @@ impl ServerReadyFile {
         Ok(Self {
             path,
             owner_token: uuid::Uuid::new_v4().to_string(),
-            published_identity: None,
+            published_file: None,
         })
     }
 
@@ -147,13 +147,13 @@ impl ServerReadyFile {
             contents.push(b'\n');
             file.write_all(&contents)?;
             file.sync_all()?;
-            let identity = ready_file_identity(&file.metadata()?);
-            drop(file);
 
             // A hard link publishes atomically without ever replacing an
             // existing target. Both paths are in the same directory.
             std::fs::hard_link(&temporary, path)?;
-            self.published_identity = Some(identity);
+            // Keep the inode open so an unlinked replacement cannot reuse its
+            // identity before Drop decides whether to remove it.
+            self.published_file = Some(file);
             std::fs::remove_file(&temporary)?;
             Ok(())
         })();
@@ -166,9 +166,11 @@ impl ServerReadyFile {
 
 impl Drop for ServerReadyFile {
     fn drop(&mut self) {
-        if let (Some(path), Some(published_identity)) = (&self.path, self.published_identity)
-            && std::fs::symlink_metadata(path)
-                .is_ok_and(|metadata| ready_file_identity(&metadata) == published_identity)
+        if let (Some(path), Some(published_file)) = (&self.path, &self.published_file)
+            && let Ok(published_metadata) = published_file.metadata()
+            && std::fs::symlink_metadata(path).is_ok_and(|metadata| {
+                ready_file_identity(&metadata) == ready_file_identity(&published_metadata)
+            })
             && ready_file_owner(path).as_deref() == Some(self.owner_token.as_str())
         {
             let _ = std::fs::remove_file(path);

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -12,22 +12,36 @@ const DEFAULT_SERVER_ADDR: &str = "127.0.0.1:8080";
 pub(crate) struct ServerConfig {
     pub(crate) database_url: String,
     pub(crate) listen_addr: SocketAddr,
-    pub(crate) public_origin: PublicOrigin,
+    pub(crate) public_origin: Option<PublicOrigin>,
 }
 
 impl ServerConfig {
     pub(crate) fn from_env() -> Result<Self, ServerConfigError> {
         let database_url =
             env::var(DATABASE_URL_ENV).map_err(|_| ServerConfigError::Missing(DATABASE_URL_ENV))?;
-        let listen_addr = env::var(SERVER_ADDR_ENV)
+        let listen_addr: SocketAddr = env::var(SERVER_ADDR_ENV)
             .unwrap_or_else(|_| DEFAULT_SERVER_ADDR.to_owned())
             .parse()
             .map_err(ServerConfigError::InvalidListenAddress)?;
 
+        let public_origin = match env::var(PUBLIC_ORIGIN_ENV).map_err(|_| {
+            ServerConfigError::PublicOrigin(PublicOriginError::Missing(PUBLIC_ORIGIN_ENV))
+        })? {
+            value if value.trim().eq_ignore_ascii_case("auto") => {
+                if !listen_addr.ip().is_loopback() {
+                    return Err(ServerConfigError::PublicOrigin(
+                        PublicOriginError::AutoRequiresLoopback,
+                    ));
+                }
+                None
+            }
+            value => Some(PublicOrigin::parse(&value)?),
+        };
+
         Ok(Self {
             database_url,
             listen_addr,
-            public_origin: PublicOrigin::from_env()?,
+            public_origin,
         })
     }
 }
@@ -80,6 +94,17 @@ impl PublicOrigin {
         Ok(Self { url })
     }
 
+    pub(crate) fn for_loopback(listen_addr: SocketAddr) -> Result<Self, PublicOriginError> {
+        if !listen_addr.ip().is_loopback() {
+            return Err(PublicOriginError::AutoRequiresLoopback);
+        }
+        Self::parse(&format!("http://{listen_addr}"))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        self.url.as_str().trim_end_matches('/')
+    }
+
     pub fn oidc_callback_url(&self) -> String {
         self.url
             .join("/login/oauth2/code/oidc")
@@ -123,6 +148,8 @@ pub enum PublicOriginError {
     OriginOnly,
     #[error("{PUBLIC_ORIGIN_ENV} must use HTTPS unless it is a loopback development origin")]
     HttpsRequired,
+    #[error("{PUBLIC_ORIGIN_ENV}=auto requires a loopback {SERVER_ADDR_ENV}")]
+    AutoRequiresLoopback,
 }
 
 #[cfg(test)]
@@ -149,6 +176,20 @@ mod tests {
         let origin = PublicOrigin::parse("http://127.0.0.1:18080").unwrap();
 
         assert!(!origin.secure_cookies());
+    }
+
+    #[test]
+    fn auto_origin_resolves_from_the_bound_loopback_address() {
+        let origin = PublicOrigin::for_loopback("127.0.0.1:49152".parse().unwrap()).unwrap();
+
+        assert_eq!(origin.as_str(), "http://127.0.0.1:49152");
+    }
+
+    #[test]
+    fn auto_origin_rejects_a_non_loopback_listener() {
+        let error = PublicOrigin::for_loopback("0.0.0.0:49152".parse().unwrap()).unwrap_err();
+
+        assert!(matches!(error, PublicOriginError::AutoRequiresLoopback));
     }
 
     #[test]

--- a/dev/check-agent-runtime-boundary.sh
+++ b/dev/check-agent-runtime-boundary.sh
@@ -4,6 +4,11 @@ set -eu
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$repo_root"
 
+command -v rg >/dev/null 2>&1 || {
+  echo "ripgrep is required for the Agent runtime boundary check." >&2
+  exit 1
+}
+
 for retired_entry in build.zig build.zig.zon src install.sh dev/install-cli-macos.sh; do
   if [ -e "$retired_entry" ]; then
     echo "Archived Zig entry returned to the active repository: $retired_entry" >&2

--- a/dev/dev-instance-test.sh
+++ b/dev/dev-instance-test.sh
@@ -1,0 +1,951 @@
+#!/bin/sh
+set -eu
+
+unset CDPATH
+repo_root=$(cd -- "$(dirname -- "$0")/.." && pwd -P)
+runner=$repo_root/dev/dev-instance.sh
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/clumsies-dev-instance-test.XXXXXX")
+fake_bin=$test_root/bin
+fake_log=$test_root/commands.log
+fake_reject_log=$test_root/rejected-commands.log
+fake_docker_state=$test_root/docker.running
+fake_app_state=$test_root/app.running
+fake_daemon_state=$test_root/daemon.running
+fake_server_registry=$test_root/server.registry
+compose_descriptor_marker=$test_root/compose-descriptor.checked
+test_home=$test_root/home
+dev_root=$test_root/dev-root
+web_admin_dist=$repo_root/apps/web-admin/dist
+web_admin_dist_existed=0
+[ -d "$web_admin_dist" ] && web_admin_dist_existed=1
+mkdir -p "$fake_bin" "$test_home/Applications/Clumsies.app" \
+  "$test_home/Library/Application Support/ai.clumsies" "$test_home/.codex"
+printf 'stable-app\n' > "$test_home/Applications/Clumsies.app/sentinel"
+printf 'stable-daemon\n' > "$test_home/Library/Application Support/ai.clumsies/sentinel"
+printf 'stable-codex\n' > "$test_home/.codex/sentinel"
+
+cleanup() {
+  if [ -n "${reset_pid:-}" ]; then
+    : > "$reset_rm_continue"
+    wait "$reset_pid" 2>/dev/null || true
+  fi
+  if [ -n "${victim_pid:-}" ]; then
+    kill "$victim_pid" 2>/dev/null || true
+    wait "$victim_pid" 2>/dev/null || true
+  fi
+  if [ -f "$fake_server_registry" ]; then
+    cleanup_pid=$(sed -n 's/|.*//p' "$fake_server_registry")
+    case "$cleanup_pid" in
+      ''|*[!0-9]*) ;;
+      *) kill "$cleanup_pid" 2>/dev/null || true ;;
+    esac
+  fi
+  if [ -d "$dev_root" ]; then
+    run down >/dev/null 2>&1 || true
+  fi
+  if [ "$web_admin_dist_existed" = 0 ]; then
+    rmdir "$web_admin_dist" 2>/dev/null || true
+  fi
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT INT TERM
+
+cat > "$fake_bin/docker" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'docker %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+reject() {
+  printf 'docker %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+[ "$#" -ge 9 ] || reject "$@"
+[ "$1" = compose ] || reject "$@"
+shift
+[ "$1" = --env-file ] || reject "$@"
+case "$2" in
+  "$FAKE_COMPOSE_ENV"|"$FAKE_RECOVERY_COMPOSE_ENV") ;;
+  *) reject "$@" ;;
+esac
+shift 2
+[ "$1" = -f ] && [ "$2" = "$FAKE_COMPOSE_FILE" ] || reject "$@"
+shift 2
+[ "$1" = -p ] && [ "$2" = "$FAKE_COMPOSE_PROJECT" ] || reject "$@"
+shift 2
+case "${1:-}" in
+  up)
+    [ "$#" -eq 5 ] && [ "$2" = -d ] && [ "$3" = --wait ] \
+      && [ "$4" = postgres ] && [ "$5" = fake-oidc ] || reject "$@"
+    grep -Fx 'CLUMSIES_HOST_BIND_ADDRESS=127.0.0.1' "$FAKE_COMPOSE_ENV" >/dev/null \
+      || reject "$@"
+    /usr/bin/python3 - "$FAKE_RUNTIME_FILE" "$FAKE_INSTANCE_ROOT" \
+      "$FAKE_COMPOSE_PROJECT" "$FAKE_EXPECTED_SERVER_BIN" <<'PY'
+import json, sys
+
+path, root, project, binary = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+assert value["state"] == "starting"
+assert value["paths"]["instance_root"] == root
+assert value["paths"]["server_binary"] == binary
+assert value["compose_project"] == project
+assert value["processes"] == {"server_pid": None, "server_start_identity": None}
+PY
+    : > "$FAKE_COMPOSE_DESCRIPTOR_MARKER"
+    : > "$FAKE_DOCKER_STATE"
+    ;;
+  port)
+    [ -f "$FAKE_DOCKER_STATE" ] || reject "$@"
+    if [ "$#" -eq 3 ] && [ "$2" = postgres ] && [ "$3" = 5432 ]; then
+      printf '127.0.0.1:55432\n'
+    elif [ "$#" -eq 3 ] && [ "$2" = fake-oidc ] && [ "$3" = 8080 ]; then
+      printf '127.0.0.1:18091\n'
+    else
+      reject "$@"
+    fi
+    ;;
+  ps)
+    [ "$#" -eq 4 ] && [ "$2" = --status ] && [ "$3" = running ] \
+      && [ "$4" = --services ] || reject "$@"
+    [ -f "$FAKE_DOCKER_STATE" ] || exit 1
+    printf 'postgres\nfake-oidc\n'
+    ;;
+  down)
+    if [ "$#" -eq 2 ] && [ "$2" = --remove-orphans ]; then
+      :
+    elif [ "$#" -eq 3 ] && [ "$2" = -v ] && [ "$3" = --remove-orphans ]; then
+      :
+    else
+      reject "$@"
+    fi
+    rm -f "$FAKE_DOCKER_STATE"
+    ;;
+  logs)
+    [ "$#" -eq 5 ] && [ "$2" = --tail ] && [ "$3" = 200 ] \
+      && [ "$4" = postgres ] && [ "$5" = fake-oidc ] || reject "$@"
+    ;;
+  *) reject "$@" ;;
+esac
+EOF
+
+cat > "$fake_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'curl %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 5 ] && [ "$1" = --fail ] && [ "$2" = --silent ] \
+  && [ "$3" = --max-time ] && [ "$4" = 3 ] || {
+  printf 'curl %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+case "$5" in
+  http://127.0.0.1:*/api/v1/admin/health|https://pr-*.example.test/api/v1/admin/health) ;;
+  *)
+    printf 'curl %s\n' "$*" >> "$FAKE_REJECT_LOG"
+    exit 97
+    ;;
+esac
+[ "${FAKE_CURL_FAIL:-0}" = 0 ] || exit 22
+printf '{"status":"ok"}\n'
+EOF
+
+cat > "$fake_bin/bun" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'bun %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 2 ] && [ "$1" = install ] && [ "$2" = --frozen-lockfile ] \
+  && [ "$PWD" = "$FAKE_REPO_ROOT" ] && exit 0
+[ "$#" -eq 2 ] && [ "$1" = run ] && [ "$2" = build:web-admin ] \
+  && [ "$PWD" = "$FAKE_REPO_ROOT" ] || {
+  printf 'bun %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+mkdir -p "$PWD/apps/web-admin/dist"
+EOF
+
+cat > "$fake_bin/xcodegen" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'xcodegen %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 3 ] && [ "$1" = generate ] && [ "$2" = --spec ] \
+  && [ "$3" = "$FAKE_REPO_ROOT/apps/macos/project.yml" ] || {
+  printf 'xcodegen %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+EOF
+
+cat > "$fake_bin/xcodebuild" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'xcodebuild %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+derived=
+project=
+scheme=
+configuration=
+product=
+display_name=
+bundle=
+instance_id=
+daemon_root=
+daemon_cache=
+daemon_logs=
+launch_agents=
+server_url=
+codex_home=
+build_id=
+skip_daemon_build=
+only_testing=
+operation=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -project|-scheme|-configuration)
+      option=$1
+      shift
+      case "$option" in
+        -project) project=$1 ;;
+        -scheme) scheme=$1 ;;
+        -configuration) configuration=$1 ;;
+      esac
+      ;;
+    -derivedDataPath)
+      shift
+      derived=$1
+      ;;
+    -only-testing:*) only_testing=$1 ;;
+    build|test) operation=$1 ;;
+    CLUMSIES_APP_PRODUCT_NAME=*) product=${1#CLUMSIES_APP_PRODUCT_NAME=} ;;
+    CLUMSIES_APP_DISPLAY_NAME=*) display_name=${1#CLUMSIES_APP_DISPLAY_NAME=} ;;
+    CLUMSIES_APP_BUNDLE_IDENTIFIER=*) bundle=${1#CLUMSIES_APP_BUNDLE_IDENTIFIER=} ;;
+    CLUMSIES_DEV_INSTANCE_ID=*) instance_id=${1#CLUMSIES_DEV_INSTANCE_ID=} ;;
+    CLUMSIES_DAEMON_ROOT=*) daemon_root=${1#CLUMSIES_DAEMON_ROOT=} ;;
+    CLUMSIES_DAEMON_CACHE_DIR=*) daemon_cache=${1#CLUMSIES_DAEMON_CACHE_DIR=} ;;
+    CLUMSIES_DAEMON_LOG_DIR=*) daemon_logs=${1#CLUMSIES_DAEMON_LOG_DIR=} ;;
+    CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR=*) launch_agents=${1#CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR=} ;;
+    CLUMSIES_SERVER_URL=*) server_url=${1#CLUMSIES_SERVER_URL=} ;;
+    CLUMSIES_CODEX_HOME=*) codex_home=${1#CLUMSIES_CODEX_HOME=} ;;
+    CLUMSIES_AGENT_RUNTIME_BUILD_ID=*) build_id=${1#CLUMSIES_AGENT_RUNTIME_BUILD_ID=} ;;
+    CLUMSIES_SKIP_DAEMON_BUILD=*) skip_daemon_build=${1#CLUMSIES_SKIP_DAEMON_BUILD=} ;;
+  esac
+  shift
+done
+[ "$derived" = "$FAKE_DERIVED_DATA" ] \
+  && [ "$project" = "$FAKE_REPO_ROOT/apps/macos/Clumsies.xcodeproj" ] \
+  && [ "$configuration" = Debug ] \
+  && [ "$product" = "$FAKE_PRODUCT_NAME" ] \
+  && [ "$display_name" = "$FAKE_DISPLAY_NAME" ] \
+  && [ "$bundle" = "$FAKE_BUNDLE_ID" ] \
+  && [ "$instance_id" = "$FAKE_INSTANCE_ID" ] \
+  && [ "$daemon_root" = "$FAKE_DAEMON_ROOT" ] \
+  && [ "$daemon_cache" = "$FAKE_DAEMON_CACHE" ] \
+  && [ "$daemon_logs" = "$FAKE_DAEMON_LOGS" ] \
+  && [ "$launch_agents" = "$FAKE_LAUNCH_AGENTS" ] \
+  && [ "$codex_home" = "$FAKE_CODEX_HOME" ] \
+  && [ "$build_id" = "$FAKE_BUILD_ID" ] \
+  && [ "$server_url" = "$FAKE_OPEN_SERVER_URL" ] || {
+  printf 'xcodebuild identity mismatch\n' >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+case "$operation" in
+  build)
+    [ "$scheme" = Clumsies ] && [ -z "$skip_daemon_build" ] || exit 97
+    ;;
+  test)
+    [ "$scheme" = ClumsiesLiveTests ] \
+      && [ "$skip_daemon_build" = 1 ] \
+      && [ "$only_testing" = -only-testing:ClumsiesTests/LiveWorkspaceIntegrationTests ] \
+      && [ "${CLUMSIES_RUN_LIVE_TESTS:-}" = 1 ] \
+      && [ "${CLUMSIES_SKIP_DAEMON_BUILD:-}" = 1 ] \
+      && [ -f "$FAKE_INSTANCE_LOCK/pid" ] || exit 97
+    ;;
+  *) exit 97 ;;
+esac
+[ "${FAKE_XCODEBUILD_FAIL:-0}" = 0 ] || exit 73
+app=$derived/Build/Products/Debug/$product.app
+mkdir -p "$app/Contents/Resources" "$app/Contents/MacOS"
+printf '#!/bin/sh\nexit 0\n' > "$app/Contents/Resources/clumsiesd"
+printf '#!/bin/sh\nexit 0\n' > "$app/Contents/MacOS/$product"
+chmod +x "$app/Contents/Resources/clumsiesd" "$app/Contents/MacOS/$product"
+EOF
+
+cat > "$fake_bin/open" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'open %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 20 ] && [ "$1" = -n ] \
+  && [ "$2" = --stdout ] && [ "$3" = "$FAKE_APP_STDOUT" ] \
+  && [ "$4" = --stderr ] && [ "$5" = "$FAKE_APP_STDERR" ] \
+  && [ "$6" = --env ] && [ "$7" = "CLUMSIES_DEV_INSTANCE_ID=$FAKE_INSTANCE_ID" ] \
+  && [ "$8" = --env ] && [ "$9" = "CLUMSIES_DAEMON_ROOT=$FAKE_DAEMON_ROOT" ] \
+  && [ "${10}" = --env ] && [ "${11}" = "CLUMSIES_DAEMON_CACHE_DIR=$FAKE_DAEMON_CACHE" ] \
+  && [ "${12}" = --env ] && [ "${13}" = "CLUMSIES_DAEMON_LOG_DIR=$FAKE_DAEMON_LOGS" ] \
+  && [ "${14}" = --env ] && [ "${15}" = "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR=$FAKE_LAUNCH_AGENTS" ] \
+  && [ "${16}" = --env ] && [ "${17}" = "CLUMSIES_SERVER_URL=$FAKE_OPEN_SERVER_URL" ] \
+  && [ "${18}" = --env ] && [ "${19}" = "CLUMSIES_CODEX_HOME=$FAKE_CODEX_HOME" ] \
+  && [ "${20}" = "$FAKE_APP_PATH" ] || {
+  printf 'open %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+: > "$FAKE_APP_STATE"
+: > "$FAKE_DAEMON_STATE"
+EOF
+
+cat > "$fake_bin/launchctl" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'launchctl %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+reject() {
+  printf 'launchctl %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+
+server_pid() {
+  [ -f "$FAKE_SERVER_REGISTRY" ] || return 1
+  pid=$(sed -n 's/|.*//p' "$FAKE_SERVER_REGISTRY")
+  case "$pid" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$pid" -gt 1 ] && kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s\n' "$pid"
+}
+
+case "${1:-}" in
+  bootstrap)
+    [ "$#" -eq 3 ] \
+      && [ "$2" = "gui/$FAKE_UID" ] \
+      && [ "$3" = "$FAKE_SERVER_PLIST" ] \
+      && [ ! -f "$FAKE_SERVER_REGISTRY" ] || reject "$@"
+    server_address=$(/usr/bin/python3 - \
+      "$FAKE_SERVER_PLIST" "$FAKE_SERVER_LABEL" "$FAKE_SERVER_LAUNCHER" \
+      "$FAKE_COMPOSE_ENV" "$FAKE_EXPECTED_SERVER_BIN" \
+      "$FAKE_INSTANCE_ROOT/server-ready.json" "$FAKE_REPO_ROOT/apps/web-admin/dist" \
+      "$FAKE_INSTANCE_ROOT/logs/server.log" "$FAKE_SERVER_PORT" <<'PY'
+import os, plistlib, stat, sys
+
+(
+    path, label, launcher, compose_env, server_binary, ready_file,
+    web_admin_dir, server_log, server_port,
+) = sys.argv[1:]
+with open(path, "rb") as handle:
+    value = plistlib.load(handle)
+arguments = value.get("ProgramArguments")
+assert isinstance(arguments, list) and len(arguments) == 6
+assert arguments[:3] == [launcher, compose_env, server_binary]
+assert arguments[3] in {"127.0.0.1:0", f"127.0.0.1:{server_port}"}
+assert arguments[4:] == [ready_file, web_admin_dir]
+assert value == {
+    "Label": label,
+    "ProgramArguments": arguments,
+    "RunAtLoad": True,
+    "KeepAlive": True,
+    "StandardOutPath": server_log,
+    "StandardErrorPath": server_log,
+}
+assert stat.S_IMODE(os.stat(path).st_mode) == 0o600
+print(arguments[3])
+PY
+    ) || reject "$@"
+    "$FAKE_SERVER_LAUNCHER" "$FAKE_COMPOSE_ENV" "$FAKE_EXPECTED_SERVER_BIN" \
+      "$server_address" "$FAKE_INSTANCE_ROOT/server-ready.json" \
+      "$FAKE_REPO_ROOT/apps/web-admin/dist" \
+      >> "$FAKE_INSTANCE_ROOT/logs/server.log" 2>&1 &
+    ;;
+  print|bootout)
+    [ "$#" -eq 2 ] || reject "$@"
+    case "$2" in
+      "gui/$FAKE_UID/$FAKE_DAEMON_LABEL")
+        if [ "$1" = print ]; then
+          [ -f "$FAKE_DAEMON_STATE" ]
+        else
+          rm -f "$FAKE_DAEMON_STATE"
+        fi
+        ;;
+      "gui/$FAKE_UID/$FAKE_SERVER_LABEL")
+        pid=$(server_pid) || exit 1
+        if [ "$1" = print ]; then
+          printf '    pid = %s\n' "$pid"
+        else
+          kill "$pid"
+          attempts=0
+          while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 25 ]; do
+            /bin/sleep 0.02
+            attempts=$((attempts + 1))
+          done
+          if kill -0 "$pid" 2>/dev/null; then
+            kill -KILL "$pid"
+          fi
+          attempts=0
+          while kill -0 "$pid" 2>/dev/null && [ "$attempts" -lt 50 ]; do
+            /bin/sleep 0.02
+            attempts=$((attempts + 1))
+          done
+          ! kill -0 "$pid" 2>/dev/null || reject "$@"
+          rm -f "$FAKE_SERVER_REGISTRY"
+        fi
+        ;;
+      *) reject "$@" ;;
+    esac
+    ;;
+  *) reject "$@" ;;
+esac
+EOF
+
+cat > "$fake_bin/pgrep" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'pgrep %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 3 ] && [ "$1" = -f ] && [ "$2" = -x ] \
+  && [ "$3" = "$FAKE_APP_PATTERN" ] || {
+  printf 'pgrep %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+[ -f "$FAKE_APP_STATE" ]
+EOF
+
+cat > "$fake_bin/pkill" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'pkill %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 4 ] && [ "$1" = -TERM ] && [ "$2" = -f ] && [ "$3" = -x ] \
+  && [ "$4" = "$FAKE_APP_PATTERN" ] || {
+  printf 'pkill %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+rm -f "$FAKE_APP_STATE"
+EOF
+
+cat > "$fake_bin/osascript" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'osascript %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 2 ] && [ "$1" = -e ] \
+  && [ "$2" = "tell application id \"$FAKE_BUNDLE_ID\" to quit" ] || {
+  printf 'osascript %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+rm -f "$FAKE_APP_STATE"
+EOF
+
+cat > "$fake_bin/security" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'security %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 5 ] && [ "$1" = delete-generic-password ] \
+  && [ "$2" = -s ] && [ "$3" = "$FAKE_KEYCHAIN_SERVICE" ] \
+  && [ "$4" = -a ] && [ "$5" = server-session ] || {
+  printf 'security %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+EOF
+
+cat > "$fake_bin/rm" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "${FAKE_PAUSE_RESET_RM:-0}" = 1 ] \
+  && [ "$#" -eq 3 ] && [ "$1" = -rf ] && [ "$2" = -- ] \
+  && [ "$3" = "$FAKE_INSTANCE_ROOT" ]; then
+  : > "$FAKE_RESET_RM_STARTED"
+  attempts=0
+  while [ ! -f "$FAKE_RESET_RM_CONTINUE" ] && [ "$attempts" -lt 200 ]; do
+    /bin/sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  [ -f "$FAKE_RESET_RM_CONTINUE" ] || exit 98
+fi
+exec /bin/rm "$@"
+EOF
+
+cat > "$fake_bin/ps" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'ps %s\n' "$*" >> "$FAKE_COMMAND_LOG"
+[ "$#" -eq 4 ] && [ "$1" = -p ] && [ "$3" = -o ] || {
+  printf 'ps %s\n' "$*" >> "$FAKE_REJECT_LOG"
+  exit 97
+}
+case "$2" in
+  ''|*[!0-9]*)
+    printf 'ps %s\n' "$*" >> "$FAKE_REJECT_LOG"
+    exit 97
+    ;;
+esac
+[ -f "$FAKE_SERVER_REGISTRY" ] || exit 1
+IFS='|' read -r registered_pid registered_start < "$FAKE_SERVER_REGISTRY"
+[ "$2" = "$registered_pid" ] || exit 1
+kill -0 "$registered_pid" 2>/dev/null || exit 1
+case "$4" in
+  command=) printf '%s\n' "$FAKE_EXPECTED_SERVER_BIN" ;;
+  lstart=) printf '%s\n' "$registered_start" ;;
+  *)
+    printf 'ps %s\n' "$*" >> "$FAKE_REJECT_LOG"
+    exit 97
+    ;;
+esac
+EOF
+
+cat > "$test_root/fake-server" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'server web-admin %s\n' "${CLUMSIES_WEB_ADMIN_DIR:-}" >> "$FAKE_COMMAND_LOG"
+port=${FAKE_SERVER_PORT:-49152}
+delay_attempts=${FAKE_SERVER_READY_DELAY_ATTEMPTS:-0}
+start_identity=fake-start-$$
+temporary_registry=$FAKE_SERVER_REGISTRY.$$.tmp
+printf '%s|%s\n' "$$" "$start_identity" > "$temporary_registry"
+chmod 600 "$temporary_registry"
+mv "$temporary_registry" "$FAKE_SERVER_REGISTRY"
+cleanup_server() {
+  if [ -f "$FAKE_SERVER_REGISTRY" ] \
+    && [ "$(sed -n 's/|.*//p' "$FAKE_SERVER_REGISTRY")" = "$$" ]; then
+    rm -f "$FAKE_SERVER_REGISTRY"
+  fi
+  rm -f "$CLUMSIES_SERVER_READY_FILE"
+}
+trap cleanup_server 0
+trap 'exit 0' TERM INT
+while [ "$delay_attempts" -gt 0 ]; do
+  /bin/sleep 0.1
+  delay_attempts=$((delay_attempts - 1))
+done
+temporary=$CLUMSIES_SERVER_READY_FILE.$$.tmp
+printf '{"listen_addr":"127.0.0.1:%s","public_origin":"http://127.0.0.1:%s"}\n' \
+  "$port" "$port" > "$temporary"
+chmod 600 "$temporary"
+mv "$temporary" "$CLUMSIES_SERVER_READY_FILE"
+while :; do /bin/sleep 1; done
+EOF
+
+chmod +x "$fake_bin"/* "$test_root/fake-server"
+
+instance_id=$(printf '%s' "$repo_root" | shasum -a 256 | awk '{print substr($1, 1, 12)}')
+instance_root=$dev_root/instances/$instance_id
+instance_lock=$dev_root/instances/.locks/$instance_id
+runtime=$instance_root/runtime.json
+compose_project=clumsies-dev-$instance_id
+owned_server_binary=$instance_root/bin/clumsies-server
+owned_server_launcher=$instance_root/bin/dev-server
+bundle_id=ai.clumsies.desktop.dev.$instance_id
+daemon_label=ai.clumsies.daemon.dev.$instance_id
+server_label=ai.clumsies.server.dev.$instance_id
+keychain_service=ai.clumsies.dev.$instance_id
+product_name=ClumsiesDev-$instance_id
+display_name="Clumsies Dev $instance_id"
+derived_data=$instance_root/macos-derived
+app_path=$derived_data/Build/Products/Debug/$product_name.app
+app_executable=$app_path/Contents/MacOS/$product_name
+app_process_pattern=$(printf '%s' "$app_executable" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+daemon_root=$instance_root/daemon
+daemon_cache=$instance_root/cache
+daemon_logs=$instance_root/logs/daemon
+launch_agents=$instance_root/LaunchAgents
+server_launch_agent_plist=$launch_agents/$server_label.plist
+codex_home=$instance_root/codex-home
+compose_env=$instance_root/compose.env
+recovery_compose_env=$instance_lock/compose.env
+reset_rm_started=$test_root/reset-rm.started
+reset_rm_continue=$test_root/reset-rm.continue
+commit_id=$(git -C "$repo_root" rev-parse HEAD)
+commit_short=$(printf '%.12s' "$commit_id")
+expected_build_id=dev-$instance_id-$commit_short
+[ -z "$(git -C "$repo_root" status --porcelain --untracked-files=normal)" ] \
+  || expected_build_id=$expected_build_id-dirty
+
+runner_environment() {
+  env \
+    HOME="$test_home" \
+    CLUMSIES_DEV_ROOT="$dev_root" \
+    CLUMSIES_DEV_SERVER_BIN="$test_root/fake-server" \
+    FAKE_COMMAND_LOG="$fake_log" \
+    FAKE_REJECT_LOG="$fake_reject_log" \
+    FAKE_DOCKER_STATE="$fake_docker_state" \
+    FAKE_APP_STATE="$fake_app_state" \
+    FAKE_DAEMON_STATE="$fake_daemon_state" \
+    FAKE_SERVER_REGISTRY="$fake_server_registry" \
+    FAKE_COMPOSE_DESCRIPTOR_MARKER="$compose_descriptor_marker" \
+    FAKE_RUNTIME_FILE="$runtime" \
+    FAKE_INSTANCE_ROOT="$instance_root" \
+    FAKE_COMPOSE_PROJECT="$compose_project" \
+    FAKE_COMPOSE_ENV="$compose_env" \
+    FAKE_RECOVERY_COMPOSE_ENV="$recovery_compose_env" \
+    FAKE_COMPOSE_FILE="$repo_root/docker-compose.yml" \
+    FAKE_EXPECTED_SERVER_BIN="$owned_server_binary" \
+    FAKE_REPO_ROOT="$repo_root" \
+    FAKE_INSTANCE_ID="$instance_id" \
+    FAKE_BUNDLE_ID="$bundle_id" \
+    FAKE_DISPLAY_NAME="$display_name" \
+    FAKE_DAEMON_LABEL="$daemon_label" \
+    FAKE_SERVER_LABEL="$server_label" \
+    FAKE_SERVER_PLIST="$server_launch_agent_plist" \
+    FAKE_SERVER_LAUNCHER="$owned_server_launcher" \
+    FAKE_KEYCHAIN_SERVICE="$keychain_service" \
+    FAKE_PRODUCT_NAME="$product_name" \
+    FAKE_DERIVED_DATA="$derived_data" \
+    FAKE_INSTANCE_LOCK="$instance_lock" \
+    FAKE_APP_PATH="$app_path" \
+    FAKE_APP_PATTERN="$app_process_pattern" \
+    FAKE_APP_STDOUT="$instance_root/logs/app.out.log" \
+    FAKE_APP_STDERR="$instance_root/logs/app.err.log" \
+    FAKE_DAEMON_ROOT="$daemon_root" \
+    FAKE_DAEMON_CACHE="$daemon_cache" \
+    FAKE_DAEMON_LOGS="$daemon_logs" \
+    FAKE_LAUNCH_AGENTS="$launch_agents" \
+    FAKE_CODEX_HOME="$codex_home" \
+    FAKE_BUILD_ID="$expected_build_id" \
+    FAKE_RESET_RM_STARTED="$reset_rm_started" \
+    FAKE_RESET_RM_CONTINUE="$reset_rm_continue" \
+    FAKE_UID="$(id -u)" \
+    FAKE_OPEN_SERVER_URL="${FAKE_OPEN_SERVER_URL:-http://127.0.0.1:${FAKE_SERVER_PORT:-49152}}" \
+    FAKE_SERVER_PORT="${FAKE_SERVER_PORT:-49152}" \
+    FAKE_SERVER_READY_DELAY_ATTEMPTS="${FAKE_SERVER_READY_DELAY_ATTEMPTS:-0}" \
+    FAKE_XCODEBUILD_FAIL="${FAKE_XCODEBUILD_FAIL:-0}" \
+    FAKE_CURL_FAIL="${FAKE_CURL_FAIL:-0}" \
+    FAKE_PAUSE_RESET_RM="${FAKE_PAUSE_RESET_RM:-0}" \
+    PATH="$fake_bin:/usr/bin:/bin" \
+    "$@"
+}
+
+run() {
+  runner_environment "$runner" "$@"
+}
+
+if run test-live > "$test_root/no-runtime-live.out" 2> "$test_root/no-runtime-live.err"; then
+  echo "expected test-live without a runtime descriptor to fail" >&2
+  exit 1
+fi
+grep -F 'no runtime descriptor' "$test_root/no-runtime-live.err" >/dev/null
+if grep -q '^xcodebuild ' "$fake_log" 2>/dev/null; then
+  echo "test-live must not invoke xcodebuild without an owned runtime" >&2
+  exit 1
+fi
+
+FAKE_SERVER_PORT=49152 FAKE_SERVER_READY_DELAY_ATTEMPTS=300 \
+  runner_environment "$runner" up \
+  > "$test_root/interrupted-up.out" 2> "$test_root/interrupted-up.err" &
+launcher_pid=$!
+attempts=0
+while [ "$attempts" -lt 100 ]; do
+  if [ -f "$runtime" ] && /usr/bin/python3 -c \
+    'import json,sys; value=json.load(open(sys.argv[1])); raise SystemExit(0 if value["processes"]["server_pid"] and value["server_url"] == "http://127.0.0.1:0" else 1)' \
+    "$runtime"; then
+    break
+  fi
+  /bin/sleep 0.05
+  attempts=$((attempts + 1))
+done
+[ "$attempts" -lt 100 ]
+[ -f "$runtime" ]
+/usr/bin/python3 - "$runtime" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)
+assert value["state"] == "starting"
+assert value["server_url"] == "http://127.0.0.1:0"
+assert value["ports"]["server"] == 0
+assert value["processes"]["server_pid"] > 1
+assert value["processes"]["server_start_identity"].startswith("fake-start-")
+PY
+runner_pid=$(sed -n '1p' "$instance_lock/pid")
+case "$runner_pid" in
+  ''|*[!0-9]*)
+    echo "expected the runner lock to contain a PID" >&2
+    exit 1
+    ;;
+esac
+kill -KILL "$runner_pid"
+wait "$launcher_pid" 2>/dev/null || true
+run up > "$test_root/recovered-up.out"
+[ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = running ]
+[ -f "$compose_descriptor_marker" ]
+run reset
+
+FAKE_XCODEBUILD_FAIL=1
+export FAKE_XCODEBUILD_FAIL
+if run up > "$test_root/failed-up.out" 2> "$test_root/failed-up.err"; then
+  echo "expected the interrupted build to fail" >&2
+  exit 1
+fi
+unset FAKE_XCODEBUILD_FAIL
+[ -f "$runtime" ]
+[ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = stopped ]
+[ ! -f "$fake_server_registry" ]
+grep -F -- "--env-file $instance_root/compose.env" "$fake_log" >/dev/null
+grep -F -- "-p $compose_project" "$fake_log" >/dev/null
+grep -F -- "bun run build:web-admin" "$fake_log" >/dev/null
+if [ ! -x "$repo_root/node_modules/.bin/tsc" ]; then
+  grep -F -- "bun install --frozen-lockfile" "$fake_log" >/dev/null
+fi
+grep -F -- "server web-admin $repo_root/apps/web-admin/dist" "$fake_log" >/dev/null
+grep -F -- "CLUMSIES_APP_BUNDLE_IDENTIFIER=ai.clumsies.desktop.dev.$instance_id" "$fake_log" >/dev/null
+grep -F -- "CLUMSIES_APP_PRODUCT_NAME=ClumsiesDev-$instance_id" "$fake_log" >/dev/null
+if grep -E '(^| )PRODUCT_(BUNDLE_IDENTIFIER|NAME)=' "$fake_log" >/dev/null; then
+  echo "expected App identity overrides to use scoped build settings" >&2
+  exit 1
+fi
+grep -F -- "CLUMSIES_DB_PORT=55432" "$instance_root/compose.env" >/dev/null
+grep -F -- "CLUMSIES_OIDC_PORT=18091" "$instance_root/compose.env" >/dev/null
+grep -F -- "CLUMSIES_HOST_BIND_ADDRESS=127.0.0.1" "$instance_root/compose.env" >/dev/null
+grep -F -- "\${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:\${CLUMSIES_DB_PORT:-5432}:5432" "$repo_root/docker-compose.yml" >/dev/null
+grep -F -- "\${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:\${CLUMSIES_OIDC_PORT:-18081}:8080" "$repo_root/docker-compose.yml" >/dev/null
+grep -F -- "\${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:\${CLUMSIES_SERVER_PORT:-18080}:8080" "$repo_root/docker-compose.yml" >/dev/null
+
+run up > "$test_root/up.out"
+[ "$(stat -f '%Lp' "$runtime")" = 600 ]
+/usr/bin/python3 - "$runtime" "$repo_root" "$instance_root" "$instance_id" "$expected_build_id" <<'PY'
+import json, sys
+
+path, worktree, root, instance_id, build_id = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+assert value["mode"] == "local"
+assert value["state"] == "running"
+assert value["instance_id"] == instance_id
+assert value["worktree_path"] == worktree
+assert value["build_id"] == build_id
+assert value["server_url"] == "http://127.0.0.1:49152"
+assert value["ports"] == {"server": 49152, "postgres": 55432, "oidc": 18091}
+assert value["compose_project"] == f"clumsies-dev-{instance_id}"
+assert value["identities"]["launch_agent_label"] == f"ai.clumsies.daemon.dev.{instance_id}"
+assert value["identities"]["server_launch_agent_label"] == f"ai.clumsies.server.dev.{instance_id}"
+assert value["identities"]["keychain_service"] == f"ai.clumsies.dev.{instance_id}"
+assert value["paths"]["instance_root"] == root
+assert value["paths"]["codex_home"] == f"{root}/codex-home"
+assert value["paths"]["server_binary"] == f"{root}/bin/clumsies-server"
+assert value["paths"]["server_launcher"] == f"{root}/bin/dev-server"
+assert value["paths"]["server_launch_agent_plist"] == (
+    f"{root}/LaunchAgents/ai.clumsies.server.dev.{instance_id}.plist"
+)
+assert value["processes"]["server_pid"] > 1
+assert value["processes"]["server_start_identity"].startswith("fake-start-")
+PY
+
+run status > "$test_root/status.json"
+grep -F '"health": true' "$test_root/status.json" >/dev/null
+grep -F -- "pgrep -f -x" "$fake_log" >/dev/null
+
+xcodebuild_before=$(grep -c '^xcodebuild ' "$fake_log" || true)
+run test-live > "$test_root/live-test.out"
+xcodebuild_after=$(grep -c '^xcodebuild ' "$fake_log" || true)
+[ "$xcodebuild_after" -eq $((xcodebuild_before + 1)) ]
+[ ! -e "$instance_lock" ]
+
+xcodebuild_before=$(grep -c '^xcodebuild ' "$fake_log" || true)
+run up > "$test_root/repeated-up.out"
+xcodebuild_after=$(grep -c '^xcodebuild ' "$fake_log" || true)
+[ "$xcodebuild_after" -eq $((xcodebuild_before + 1)) ]
+
+cp "$runtime" "$test_root/runtime.saved"
+/usr/bin/python3 - "$runtime" <<'PY'
+import json, os, sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+value["paths"]["cache"] = os.path.expanduser("~/Library/Caches/ai.clumsies")
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(value, handle)
+PY
+if run reset > "$test_root/tampered.out" 2> "$test_root/tampered.err"; then
+  echo "expected tampered ownership to be rejected" >&2
+  exit 1
+fi
+grep -F 'path cache is not owned' "$test_root/tampered.err" >/dev/null
+cp "$test_root/runtime.saved" "$runtime"
+chmod 600 "$runtime"
+
+cp "$runtime" "$test_root/runtime-process.saved"
+/bin/sleep 30 &
+victim_pid=$!
+/usr/bin/python3 - "$runtime" "$victim_pid" <<'PY'
+import json, os, sys
+
+path, victim_pid = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+value["processes"]["server_pid"] = int(victim_pid)
+value["processes"]["server_start_identity"] = "forged-start-identity"
+temporary = f"{path}.{os.getpid()}.tmp"
+with open(temporary, "x", encoding="utf-8") as handle:
+    json.dump(value, handle)
+os.chmod(temporary, 0o600)
+os.replace(temporary, path)
+PY
+if run down > "$test_root/tampered-pid.out" 2> "$test_root/tampered-pid.err"; then
+  echo "expected an unregistered PID to be rejected" >&2
+  exit 1
+fi
+grep -F 'no longer belongs to this instance Server' "$test_root/tampered-pid.err" >/dev/null
+kill -0 "$victim_pid"
+cp "$test_root/runtime-process.saved" "$runtime"
+chmod 600 "$runtime"
+kill "$victim_pid"
+wait "$victim_pid" 2>/dev/null || true
+victim_pid=
+
+run down
+[ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = stopped ]
+[ -f "$server_launch_agent_plist" ]
+stopped_xcodebuild_before=$(grep -c '^xcodebuild ' "$fake_log" || true)
+if run test-live > "$test_root/stopped-live.out" 2> "$test_root/stopped-live.err"; then
+  echo "expected test-live to reject a stopped Dev Instance" >&2
+  exit 1
+fi
+grep -F 'Dev Instance is not running' "$test_root/stopped-live.err" >/dev/null
+stopped_xcodebuild_after=$(grep -c '^xcodebuild ' "$fake_log" || true)
+[ "$stopped_xcodebuild_before" -eq "$stopped_xcodebuild_after" ]
+grep -F -- "pkill -TERM -f -x" "$fake_log" >/dev/null
+grep -F -- "launchctl bootstrap gui/$(id -u) $server_launch_agent_plist" "$fake_log" >/dev/null
+grep -F -- "launchctl print gui/$(id -u)/$server_label" "$fake_log" >/dev/null
+grep -F -- "launchctl bootout gui/$(id -u)/$server_label" "$fake_log" >/dev/null
+
+rm "$compose_env"
+run logs >/dev/null
+[ ! -e "$compose_env" ]
+[ ! -e "$recovery_compose_env" ]
+run down
+[ ! -e "$compose_env" ]
+[ ! -e "$recovery_compose_env" ]
+if run up > "$test_root/missing-secrets.out" 2> "$test_root/missing-secrets.err"; then
+  echo "expected missing instance secrets to require reset" >&2
+  exit 1
+fi
+grep -F 'instance secrets are missing; run reset' "$test_root/missing-secrets.err" >/dev/null
+[ ! -e "$compose_env" ]
+
+FAKE_PAUSE_RESET_RM=1 runner_environment "$runner" reset \
+  > "$test_root/paused-reset.out" 2> "$test_root/paused-reset.err" &
+reset_pid=$!
+attempts=0
+while [ ! -f "$reset_rm_started" ] && [ "$attempts" -lt 100 ]; do
+  /bin/sleep 0.05
+  attempts=$((attempts + 1))
+done
+[ -f "$reset_rm_started" ]
+reset_lock_pid=$(sed -n '1p' "$instance_lock/pid")
+case "$reset_lock_pid" in
+  ''|*[!0-9]*) exit 1 ;;
+esac
+kill -0 "$reset_lock_pid"
+if run up > "$test_root/concurrent-up.out" 2> "$test_root/concurrent-up.err"; then
+  echo "expected reset to hold the lifecycle lock through instance deletion" >&2
+  exit 1
+fi
+grep -F 'another lifecycle command is active' "$test_root/concurrent-up.err" >/dev/null
+: > "$reset_rm_continue"
+wait "$reset_pid"
+reset_pid=
+[ ! -e "$instance_root" ]
+[ ! -e "$instance_lock" ]
+grep -F -- "down -v --remove-orphans" "$fake_log" >/dev/null
+grep -F -- "security delete-generic-password -s ai.clumsies.dev.$instance_id -a server-session" "$fake_log" >/dev/null
+
+mkdir "$instance_lock"
+if run up > "$test_root/missing-lock-pid.out" 2> "$test_root/missing-lock-pid.err"; then
+  echo "expected a pidless lifecycle lock to require manual review" >&2
+  exit 1
+fi
+grep -F 'lifecycle lock requires manual review' "$test_root/missing-lock-pid.err" >/dev/null
+[ -d "$instance_lock" ]
+rmdir "$instance_lock"
+mkdir "$instance_lock"
+printf 'not-a-pid\n' > "$instance_lock/pid"
+if run up > "$test_root/invalid-lock-pid.out" 2> "$test_root/invalid-lock-pid.err"; then
+  echo "expected an invalid lifecycle lock to require manual review" >&2
+  exit 1
+fi
+grep -F 'lifecycle lock requires manual review' "$test_root/invalid-lock-pid.err" >/dev/null
+grep -Fx 'not-a-pid' "$instance_lock/pid" >/dev/null
+rm "$instance_lock/pid"
+rmdir "$instance_lock"
+rm -rf -- "$instance_root"
+
+symlink_target=$test_root/stable-symlink-target
+mkdir -p "$symlink_target" "$dev_root/instances"
+printf 'stable-target\n' > "$symlink_target/sentinel"
+ln -s "$symlink_target" "$instance_root"
+docker_before_symlink=$(grep -c '^docker ' "$fake_log" || true)
+if run up > "$test_root/symlink-root.out" 2> "$test_root/symlink-root.err"; then
+  echo "expected a symlinked instance root to be rejected" >&2
+  exit 1
+fi
+grep -F 'instance root must not be a symlink' "$test_root/symlink-root.err" >/dev/null
+[ "$(grep -c '^docker ' "$fake_log" || true)" -eq "$docker_before_symlink" ]
+grep -F 'stable-target' "$symlink_target/sentinel" >/dev/null
+rm "$instance_root"
+rm -rf -- "$symlink_target"
+
+bad_preview=$test_root/bad-preview.json
+printf '%s\n' '{"schema_version":1,"environment_id":"pr-73","server_url":"http://preview.example.test","expires_at":"2099-01-01T00:00:00Z"}' > "$bad_preview"
+if run up --preview "$bad_preview" > "$test_root/bad-preview.out" 2> "$test_root/bad-preview.err"; then
+  echo "expected insecure Preview URL to be rejected" >&2
+  exit 1
+fi
+grep -F 'must be an HTTPS origin' "$test_root/bad-preview.err" >/dev/null
+
+stable_preview=$test_root/stable-preview.json
+printf '%s\n' '{"schema_version":1,"environment_id":"production","server_url":"https://app.clumsies.ai.","expires_at":"2099-01-01T00:00:00Z"}' > "$stable_preview"
+if run up --preview "$stable_preview" > "$test_root/stable-preview.out" 2> "$test_root/stable-preview.err"; then
+  echo "expected the stable production Server to be rejected as a Preview" >&2
+  exit 1
+fi
+grep -F 'must not target the stable production Server' "$test_root/stable-preview.err" >/dev/null
+
+expired_preview=$test_root/expired-preview.json
+printf '%s\n' '{"schema_version":1,"environment_id":"pr-73","server_url":"https://pr-73.example.test","expires_at":"2020-01-01T00:00:00Z"}' > "$expired_preview"
+if run up --preview "$expired_preview" > "$test_root/expired-preview.out" 2> "$test_root/expired-preview.err"; then
+  echo "expected an expired Preview descriptor to be rejected" >&2
+  exit 1
+fi
+grep -F 'Preview descriptor has expired' "$test_root/expired-preview.err" >/dev/null
+
+preview_a=$test_root/preview-a.json
+preview_b=$test_root/preview-b.json
+printf '%s\n' '{"schema_version":1,"mode":"preview","environment_id":"pr-73","server_url":"https://pr-73.example.test","oidc_issuer":"https://oidc.example.test","expires_at":"2099-01-01T00:00:00Z"}' > "$preview_a"
+printf '%s\n' '{"schema_version":1,"mode":"preview","environment_id":"pr-74","server_url":"https://pr-73.example.test","oidc_issuer":"https://oidc.example.test","expires_at":"2099-01-01T00:00:00Z"}' > "$preview_b"
+docker_before=$(grep -c '^docker ' "$fake_log" || true)
+bun_before=$(grep -c '^bun ' "$fake_log" || true)
+FAKE_CURL_FAIL=1
+export FAKE_CURL_FAIL
+if run up --preview "$preview_a" > "$test_root/unhealthy-preview.out" 2> "$test_root/unhealthy-preview.err"; then
+  echo "expected an unhealthy Preview Server to be rejected" >&2
+  exit 1
+fi
+unset FAKE_CURL_FAIL
+grep -F 'Preview Server is not healthy' "$test_root/unhealthy-preview.err" >/dev/null
+[ ! -f "$runtime" ]
+[ ! -f "$instance_root/preview.json" ]
+[ ! -f "$fake_app_state" ]
+[ ! -f "$fake_daemon_state" ]
+
+FAKE_OPEN_SERVER_URL=https://pr-73.example.test
+export FAKE_OPEN_SERVER_URL
+preview_curl_before=$(grep -c '^curl ' "$fake_log" || true)
+run up --preview "$preview_a" >/dev/null
+preview_curl_after=$(grep -c '^curl ' "$fake_log" || true)
+[ "$preview_curl_after" -ge $((preview_curl_before + 2)) ]
+if run up --preview "$preview_b" > "$test_root/changed-preview.out" 2> "$test_root/changed-preview.err"; then
+  echo "expected a changed Preview identity to require reset" >&2
+  exit 1
+fi
+grep -F 'run reset' "$test_root/changed-preview.err" >/dev/null
+[ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = running ]
+/usr/bin/python3 - "$instance_root/preview.json" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)
+assert value["environment_id"] == "pr-73"
+assert value["server_url"] == "https://pr-73.example.test"
+assert value["expires_at"] == "2099-01-01T00:00:00Z"
+PY
+run down
+run reset
+unset FAKE_OPEN_SERVER_URL
+docker_after=$(grep -c '^docker ' "$fake_log" || true)
+[ "$docker_before" -eq "$docker_after" ]
+bun_after=$(grep -c '^bun ' "$fake_log" || true)
+[ "$bun_before" -eq "$bun_after" ]
+
+grep -F 'stable-app' "$test_home/Applications/Clumsies.app/sentinel" >/dev/null
+grep -F 'stable-daemon' "$test_home/Library/Application Support/ai.clumsies/sentinel" >/dev/null
+grep -F 'stable-codex' "$test_home/.codex/sentinel" >/dev/null
+[ ! -s "$fake_reject_log" ]
+
+printf 'dev instance contract: ok\n'

--- a/dev/dev-instance.sh
+++ b/dev/dev-instance.sh
@@ -1,0 +1,1070 @@
+#!/bin/sh
+set -eu
+
+umask 077
+unset CDPATH
+
+die() {
+  printf 'clumsies dev: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'EOF'
+usage: dev/dev-instance.sh up [--preview DESCRIPTOR.json]
+       dev/dev-instance.sh status
+       dev/dev-instance.sh logs
+       dev/dev-instance.sh test-live
+       dev/dev-instance.sh down
+       dev/dev-instance.sh reset
+EOF
+  exit 64
+}
+
+command_name=${1:-}
+[ -n "$command_name" ] || usage
+shift
+
+case "$command_name" in
+  up|status|logs|test-live|down|reset) ;;
+  *) usage ;;
+esac
+
+python=${PYTHON:-/usr/bin/python3}
+[ -x "$python" ] || die "python3 is required"
+
+script_dir=$(cd -- "$(dirname -- "$0")" && pwd -P)
+repo_root=$(git -C "$script_dir/.." rev-parse --show-toplevel 2>/dev/null) \
+  || die "the runner must be inside a git worktree"
+repo_root=$(cd -- "$repo_root" && pwd -P)
+instance_id=$(printf '%s' "$repo_root" | shasum -a 256 | awk '{print substr($1, 1, 12)}')
+case "$instance_id" in
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) die "could not derive a valid instance id" ;;
+esac
+
+dev_root=${CLUMSIES_DEV_ROOT:-$HOME/Library/Application Support/ai.clumsies.dev}
+case "$dev_root" in
+  /*) ;;
+  *) die "CLUMSIES_DEV_ROOT must be absolute" ;;
+esac
+instances_root=$dev_root/instances
+instance_root=$instances_root/$instance_id
+runtime_file=$instance_root/runtime.json
+instance_compose_env=$instance_root/compose.env
+compose_env=$instance_compose_env
+ready_file=$instance_root/server-ready.json
+locks_root=$instances_root/.locks
+lock_dir=$locks_root/$instance_id
+logs_dir=$instance_root/logs
+daemon_root=$instance_root/daemon
+daemon_cache=$instance_root/cache
+daemon_logs=$logs_dir/daemon
+launch_agents=$instance_root/LaunchAgents
+codex_home=$instance_root/codex-home
+server_bin_dir=$instance_root/bin
+owned_server_binary=$server_bin_dir/clumsies-server
+server_launcher=$server_bin_dir/dev-server
+server_launcher_source=$repo_root/dev/dev-server.sh
+derived_data=$instance_root/macos-derived
+compose_project=clumsies-dev-$instance_id
+bundle_id=ai.clumsies.desktop.dev.$instance_id
+daemon_label=ai.clumsies.daemon.dev.$instance_id
+server_label=ai.clumsies.server.dev.$instance_id
+server_launch_agent_plist=$launch_agents/$server_label.plist
+keychain_service=ai.clumsies.dev.$instance_id
+product_name=ClumsiesDev-$instance_id
+display_name="Clumsies Dev $instance_id"
+app_path=$derived_data/Build/Products/Debug/$product_name.app
+app_executable=$app_path/Contents/MacOS/$product_name
+app_process_pattern=$(printf '%s' "$app_executable" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
+server_log=$logs_dir/server.log
+app_stdout=$logs_dir/app.out.log
+app_stderr=$logs_dir/app.err.log
+
+compose() {
+  docker compose \
+    --env-file "$compose_env" \
+    -f "$repo_root/docker-compose.yml" \
+    -p "$compose_project" \
+    "$@"
+}
+
+json_get() {
+  "$python" - "$1" "$2" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    value = json.load(handle)
+for component in sys.argv[2].split("."):
+    if not isinstance(value, dict) or component not in value:
+        sys.exit(2)
+    value = value[component]
+if value is None:
+    print("")
+elif isinstance(value, bool):
+    print("true" if value else "false")
+elif isinstance(value, (str, int)):
+    rendered = str(value)
+    if any(character in rendered for character in "\r\n\t"):
+        sys.exit(2)
+    print(rendered)
+else:
+    sys.exit(2)
+PY
+}
+
+validate_runtime() {
+  [ -f "$runtime_file" ] || die "no runtime descriptor for $instance_id"
+  "$python" - \
+    "$runtime_file" "$instance_id" "$repo_root" "$instance_root" \
+    "$bundle_id" "$daemon_label" "$server_label" "$keychain_service" "$compose_project" \
+    "$app_path" "$owned_server_binary" "$server_launcher" "$server_launch_agent_plist" \
+    "$daemon_root" "$daemon_cache" "$daemon_logs" "$launch_agents" "$codex_home" <<'PY'
+import json, sys
+
+(
+    path, instance_id, worktree, root, bundle, label, server_label, keychain, compose,
+    app, owned_server_binary, server_launcher, server_launch_agent_plist,
+    daemon_root, cache, logs, launch_agents, codex_home,
+) = sys.argv[1:]
+try:
+    with open(path, encoding="utf-8") as handle:
+        value = json.load(handle)
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"invalid runtime descriptor: {error}")
+
+if not isinstance(value, dict) or value.get("schema_version") != 1:
+    raise SystemExit("invalid runtime descriptor schema")
+expected = {
+    "instance_id": instance_id,
+    "worktree_path": worktree,
+}
+for key, wanted in expected.items():
+    if value.get(key) != wanted:
+        raise SystemExit(f"runtime descriptor {key} does not match this worktree")
+identities = value.get("identities")
+paths = value.get("paths")
+if not isinstance(identities, dict) or not isinstance(paths, dict):
+    raise SystemExit("runtime descriptor ownership is incomplete")
+for key, wanted in {
+    "bundle_id": bundle,
+    "launch_agent_label": label,
+    "mach_service": label,
+    "server_launch_agent_label": server_label,
+    "keychain_service": keychain,
+}.items():
+    if identities.get(key) != wanted:
+        raise SystemExit(f"runtime descriptor identity {key} is not owned by this instance")
+for key, wanted in {
+    "instance_root": root,
+    "app": app,
+    "server_launcher": server_launcher,
+    "server_launch_agent_plist": server_launch_agent_plist,
+    "daemon_root": daemon_root,
+    "cache": cache,
+    "logs": logs,
+    "launch_agents": launch_agents,
+    "codex_home": codex_home,
+}.items():
+    if paths.get(key) != wanted:
+        raise SystemExit(f"runtime descriptor path {key} is not owned by this instance")
+mode = value.get("mode")
+if mode not in {"local", "preview"}:
+    raise SystemExit("runtime descriptor mode is invalid")
+processes = value.get("processes")
+if not isinstance(processes, dict):
+    raise SystemExit("runtime descriptor process ownership is incomplete")
+server_pid = processes.get("server_pid")
+server_start_identity = processes.get("server_start_identity")
+if server_pid is not None and (isinstance(server_pid, bool) or not isinstance(server_pid, int) or server_pid <= 1):
+    raise SystemExit("runtime descriptor Server PID is invalid")
+if server_start_identity is not None and (
+    not isinstance(server_start_identity, str)
+    or not server_start_identity
+    or any(character in server_start_identity for character in "\r\n\t")
+):
+    raise SystemExit("runtime descriptor Server start identity is invalid")
+if (server_pid is None) != (server_start_identity is None):
+    raise SystemExit("runtime descriptor Server process identity is incomplete")
+if mode == "local":
+    if value.get("compose_project") != compose:
+        raise SystemExit("runtime descriptor Compose project is not owned by this instance")
+    if paths.get("server_binary") != owned_server_binary:
+        raise SystemExit("runtime descriptor path server_binary is not owned by this instance")
+else:
+    if value.get("compose_project") is not None or paths.get("server_binary") is not None:
+        raise SystemExit("Preview runtime descriptor contains local Server ownership")
+    if server_pid is not None:
+        raise SystemExit("Preview runtime descriptor contains a local Server process")
+    if not isinstance(value.get("preview_environment_id"), str) or not value["preview_environment_id"]:
+        raise SystemExit("Preview runtime descriptor environment identity is invalid")
+    if not isinstance(value.get("preview_expires_at"), str) or not value["preview_expires_at"]:
+        raise SystemExit("Preview runtime descriptor expiry is invalid")
+if value.get("state") not in {"starting", "running", "stopped"}:
+    raise SystemExit("runtime descriptor state is invalid")
+server_url = value.get("server_url")
+if not isinstance(server_url, str) or not server_url:
+    raise SystemExit("runtime descriptor Server URL is invalid")
+if any(character in server_url for character in "\r\n\t"):
+    raise SystemExit("runtime descriptor contains control characters")
+PY
+}
+
+normalize_preview() {
+  preview_source=$1
+  preview_target=$2
+  [ -f "$preview_source" ] || die "Preview descriptor does not exist: $preview_source"
+  "$python" - "$preview_source" "$preview_target" <<'PY'
+import datetime, json, os, re, sys, urllib.parse
+
+source, target = sys.argv[1:]
+try:
+    with open(source, encoding="utf-8") as handle:
+        value = json.load(handle)
+except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"invalid Preview descriptor: {error}")
+
+allowed = {"schema_version", "mode", "environment_id", "server_url", "oidc_issuer", "expires_at"}
+if not isinstance(value, dict) or set(value) - allowed:
+    raise SystemExit("Preview descriptor contains unsupported fields")
+if value.get("schema_version") != 1 or value.get("mode", "preview") != "preview":
+    raise SystemExit("Preview descriptor schema or mode is invalid")
+environment_id = value.get("environment_id")
+if not isinstance(environment_id, str) or not re.fullmatch(r"[A-Za-z0-9._-]{1,128}", environment_id):
+    raise SystemExit("Preview environment_id is invalid")
+
+def remote_origin(name, required):
+    raw = value.get(name)
+    if raw is None and not required:
+        return None
+    if not isinstance(raw, str):
+        raise SystemExit(f"Preview {name} is required")
+    parsed = urllib.parse.urlsplit(raw)
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise SystemExit(f"Preview {name} must be an HTTPS origin without credentials")
+    if parsed.hostname.rstrip(".").lower() == "app.clumsies.ai":
+        raise SystemExit(f"Preview {name} must not target the stable production Server")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise SystemExit(f"Preview {name} must contain only an origin")
+    return raw.rstrip("/")
+
+normalized = {
+    "schema_version": 1,
+    "mode": "preview",
+    "environment_id": environment_id,
+    "server_url": remote_origin("server_url", True),
+    "oidc_issuer": remote_origin("oidc_issuer", False),
+    "expires_at": value.get("expires_at"),
+}
+expires_at = normalized["expires_at"]
+if not isinstance(expires_at, str) or not re.fullmatch(
+    r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})",
+    expires_at,
+):
+    raise SystemExit("Preview expires_at must be an RFC3339 timestamp")
+try:
+    expires = datetime.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+except ValueError as error:
+    raise SystemExit(f"Preview expires_at must be an RFC3339 timestamp: {error}")
+if expires <= datetime.datetime.now(datetime.timezone.utc):
+    raise SystemExit("Preview descriptor has expired")
+temporary = f"{target}.{os.getpid()}.tmp"
+with open(temporary, "x", encoding="utf-8") as handle:
+    json.dump(normalized, handle, separators=(",", ":"), sort_keys=True)
+    handle.write("\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+os.chmod(temporary, 0o600)
+os.replace(temporary, target)
+PY
+}
+
+write_runtime() {
+  "$python" - \
+    "$runtime_file" "$runtime_mode" "$runtime_state" "$instance_id" "$repo_root" \
+    "$commit_id" "$build_id" "$server_url" "$oidc_issuer" "$preview_environment_id" "$preview_expires_at" \
+    "$compose_project_value" "$server_port" "$database_port" "$oidc_port" \
+    "$server_pid" "$server_start_identity" "$bundle_id" "$daemon_label" "$server_label" "$keychain_service" \
+    "$instance_root" "$app_path" "$server_binary" "$server_launcher" "$server_launch_agent_plist" \
+    "$daemon_root" "$daemon_cache" \
+    "$daemon_logs" "$launch_agents" "$codex_home" <<'PY'
+import datetime, json, os, sys
+
+(
+    path, mode, state, instance_id, worktree, commit, build_id, server_url, oidc_issuer,
+    environment_id, preview_expires_at, compose_project, server_port, database_port, oidc_port,
+    server_pid, server_start_identity, bundle_id, daemon_label, server_label, keychain_service, instance_root,
+    app_path, server_binary, server_launcher, server_launch_agent_plist,
+    daemon_root, daemon_cache, daemon_logs,
+    launch_agents, codex_home,
+) = sys.argv[1:]
+
+def number(value):
+    return int(value) if value else None
+
+value = {
+    "schema_version": 1,
+    "mode": mode,
+    "state": state,
+    "instance_id": instance_id,
+    "worktree_path": worktree,
+    "commit": commit,
+    "build_id": build_id,
+    "server_url": server_url,
+    "oidc_issuer": oidc_issuer or None,
+    "preview_environment_id": environment_id or None,
+    "preview_expires_at": preview_expires_at or None,
+    "compose_project": compose_project or None,
+    "ports": {
+        "server": number(server_port),
+        "postgres": number(database_port),
+        "oidc": number(oidc_port),
+    },
+    "processes": {
+        "server_pid": number(server_pid),
+        "server_start_identity": server_start_identity or None,
+    },
+    "identities": {
+        "bundle_id": bundle_id,
+        "launch_agent_label": daemon_label,
+        "mach_service": daemon_label,
+        "server_launch_agent_label": server_label,
+        "keychain_service": keychain_service,
+    },
+    "paths": {
+        "instance_root": instance_root,
+        "app": app_path,
+        "server_binary": server_binary or None,
+        "server_launcher": server_launcher,
+        "server_launch_agent_plist": server_launch_agent_plist,
+        "daemon_root": daemon_root,
+        "cache": daemon_cache,
+        "logs": daemon_logs,
+        "launch_agents": launch_agents,
+        "codex_home": codex_home,
+    },
+    "updated_at": datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z"),
+}
+temporary = f"{path}.{os.getpid()}.tmp"
+with open(temporary, "x", encoding="utf-8") as handle:
+    json.dump(value, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+os.chmod(temporary, 0o600)
+os.replace(temporary, path)
+PY
+}
+
+set_runtime_state() {
+  "$python" - "$runtime_file" "$1" <<'PY'
+import datetime, json, os, sys
+
+path, state = sys.argv[1:]
+with open(path, encoding="utf-8") as handle:
+    value = json.load(handle)
+value["state"] = state
+value["updated_at"] = datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+temporary = f"{path}.{os.getpid()}.tmp"
+with open(temporary, "x", encoding="utf-8") as handle:
+    json.dump(value, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+os.chmod(temporary, 0o600)
+os.replace(temporary, path)
+PY
+}
+
+acquire_lock() {
+  mkdir -p "$instances_root"
+  [ ! -L "$instances_root" ] || die "instances root must not be a symlink"
+  canonical_dev_root=$(cd -- "$dev_root" && pwd -P)
+  canonical_instances_root=$(cd -- "$instances_root" && pwd -P)
+  [ "$canonical_instances_root" = "$canonical_dev_root/instances" ] \
+    || die "instances root escapes CLUMSIES_DEV_ROOT"
+  [ ! -L "$locks_root" ] || die "lifecycle locks root must not be a symlink"
+  mkdir -p "$locks_root"
+  canonical_locks_root=$(cd -- "$locks_root" && pwd -P)
+  [ "$canonical_locks_root" = "$canonical_instances_root/.locks" ] \
+    || die "lifecycle locks root escapes instances root"
+  chmod 700 "$locks_root"
+  [ ! -L "$instance_root" ] || die "instance root must not be a symlink"
+  mkdir -p "$instance_root"
+  canonical_instance_root=$(cd -- "$instance_root" && pwd -P)
+  [ "$canonical_instance_root" = "$canonical_instances_root/$instance_id" ] \
+    || die "instance root is not owned by this worktree"
+  chmod 700 "$instance_root"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    [ ! -L "$lock_dir" ] || die "lifecycle lock must not be a symlink"
+    lock_pid=$(sed -n '1p' "$lock_dir/pid" 2>/dev/null || true)
+    case "$lock_pid" in
+      ''|*[!0-9]*) die "lifecycle lock requires manual review: $lock_dir" ;;
+    esac
+    if ! [ "$lock_pid" -gt 1 ] 2>/dev/null; then
+      die "lifecycle lock requires manual review: $lock_dir"
+    fi
+    if kill -0 "$lock_pid" 2>/dev/null; then
+      die "another lifecycle command is active for $instance_id"
+    fi
+    rm -f "$lock_dir/pid" "$lock_dir/compose.env" "$lock_dir/compose.env.$lock_pid.tmp"
+    rmdir "$lock_dir" 2>/dev/null || die "stale lifecycle lock requires manual review: $lock_dir"
+    mkdir "$lock_dir"
+  fi
+  printf '%s\n' "$$" > "$lock_dir/pid"
+  lock_held=1
+}
+
+release_lock() {
+  if [ "${lock_held:-0}" = 1 ]; then
+    rm -f "$lock_dir/pid"
+    rmdir "$lock_dir" 2>/dev/null || true
+    lock_held=0
+  fi
+}
+
+cleanup_recovery_compose_env() {
+  if [ -n "${recovery_compose_env:-}" ]; then
+    rm -f "$recovery_compose_env"
+    recovery_compose_env=
+    compose_env=$instance_compose_env
+  fi
+}
+
+write_compose_env() {
+  db_port_value=$1
+  oidc_port_value=$2
+  temporary=$compose_env.$$.tmp
+  {
+    printf 'CLUMSIES_HOST_BIND_ADDRESS=127.0.0.1\n'
+    printf 'CLUMSIES_DB_NAME=clumsies\n'
+    printf 'CLUMSIES_DB_USER=clumsies\n'
+    printf 'CLUMSIES_DB_PASSWORD=%s\n' "$database_password"
+    printf 'CLUMSIES_DB_PORT=%s\n' "$db_port_value"
+    printf 'CLUMSIES_OIDC_PORT=%s\n' "$oidc_port_value"
+    printf 'CLUMSIES_SETUP_CODE=%s\n' "$setup_code"
+  } > "$temporary"
+  chmod 600 "$temporary"
+  mv -f "$temporary" "$compose_env"
+}
+
+write_server_launch_agent() {
+  "$python" - \
+    "$server_launch_agent_plist" "$server_label" "$server_launcher" "$compose_env" \
+    "$server_binary" "$server_address" "$ready_file" "$web_admin_dir" "$server_log" <<'PY'
+import os, plistlib, sys
+
+(
+    path, label, launcher, compose_env, server_binary, server_address,
+    ready_file, web_admin_dir, server_log,
+) = sys.argv[1:]
+value = {
+    "Label": label,
+    "ProgramArguments": [
+        launcher,
+        compose_env,
+        server_binary,
+        server_address,
+        ready_file,
+        web_admin_dir,
+    ],
+    "RunAtLoad": True,
+    "KeepAlive": True,
+    "StandardOutPath": server_log,
+    "StandardErrorPath": server_log,
+}
+temporary = f"{path}.{os.getpid()}.tmp"
+with open(temporary, "xb") as handle:
+    plistlib.dump(value, handle)
+    handle.flush()
+    os.fsync(handle.fileno())
+os.chmod(temporary, 0o600)
+os.replace(temporary, path)
+PY
+}
+
+load_or_create_secrets() {
+  database_password=
+  setup_code=
+  if [ -f "$compose_env" ]; then
+    database_password=$(awk -F= '$1 == "CLUMSIES_DB_PASSWORD" { print substr($0, index($0, "=") + 1) }' "$compose_env")
+    setup_code=$(awk -F= '$1 == "CLUMSIES_SETUP_CODE" { print substr($0, index($0, "=") + 1) }' "$compose_env")
+  fi
+  case "$database_password" in
+    ''|*[!0-9a-f]*) database_password=$("$python" -c 'import secrets; print(secrets.token_hex(24))') ;;
+    *) ;;
+  esac
+  case "$setup_code" in
+    ''|*[!0-9a-f]*) setup_code=$("$python" -c 'import secrets; print(secrets.token_hex(24))') ;;
+    *) ;;
+  esac
+  [ "${#database_password}" -eq 48 ] || die "invalid instance database password"
+  [ "${#setup_code}" -eq 48 ] || die "invalid instance setup code"
+}
+
+published_port() {
+  address=$(compose port "$1" "$2") || return 1
+  case "$address" in
+    *:*) port=${address##*:} ;;
+    *) return 1 ;;
+  esac
+  case "$port" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$port" -ge 1 ] && [ "$port" -le 65535 ] || return 1
+  printf '%s\n' "$port"
+}
+
+server_is_healthy() {
+  health=$(curl --fail --silent --max-time 3 "$server_url/api/v1/admin/health" 2>/dev/null) || return 1
+  printf '%s' "$health" | "$python" -c \
+    'import json,sys; raise SystemExit(0 if json.load(sys.stdin).get("status") == "ok" else 1)' \
+    >/dev/null 2>&1
+}
+
+daemon_is_running() {
+  uid=$(id -u)
+  launchctl print "gui/$uid/$daemon_label" >/dev/null 2>&1
+}
+
+app_is_running() {
+  pgrep -f -x "$app_process_pattern" >/dev/null 2>&1
+}
+
+server_process_command() {
+  ps -p "$1" -o command= 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+server_process_start_identity() {
+  ps -p "$1" -o lstart= 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
+server_job_pid() {
+  uid=$(id -u)
+  launchctl print "gui/$uid/$server_label" 2>/dev/null \
+    | awk '$1 == "pid" && $2 == "=" { print $3; exit }'
+}
+
+server_process_is_owned() {
+  [ -n "${server_pid:-}" ] && [ -n "${server_start_identity:-}" ] || return 1
+  case "$server_pid" in
+    *[!0-9]*) return 1 ;;
+  esac
+  [ "$server_pid" -gt 1 ] || return 1
+  [ "$server_binary" = "$owned_server_binary" ] || return 1
+  kill -0 "$server_pid" 2>/dev/null || return 1
+  [ "$(server_process_command "$server_pid")" = "$owned_server_binary" ] || return 1
+  [ "$(server_process_start_identity "$server_pid")" = "$server_start_identity" ] || return 1
+}
+
+compose_is_running() {
+  [ -f "$compose_env" ] || return 1
+  services=$(compose ps --status running --services 2>/dev/null) || return 1
+  printf '%s\n' "$services" | grep -qx postgres \
+    && printf '%s\n' "$services" | grep -qx fake-oidc
+}
+
+print_status() {
+  validate_runtime
+  mode=$(json_get "$runtime_file" mode)
+  server_url=$(json_get "$runtime_file" server_url)
+  server_pid=$(json_get "$runtime_file" processes.server_pid)
+  server_start_identity=$(json_get "$runtime_file" processes.server_start_identity)
+  server_binary=$(json_get "$runtime_file" paths.server_binary)
+  server_running=false
+  compose_running=false
+  daemon_running=false
+  app_running=false
+  healthy=false
+  if [ "$mode" = preview ] \
+    || { [ "$(server_job_pid || true)" = "$server_pid" ] && server_process_is_owned; }; then
+    server_running=true
+  fi
+  if [ "$mode" = preview ] || compose_is_running; then compose_running=true; fi
+  if daemon_is_running; then daemon_running=true; fi
+  if app_is_running; then app_running=true; fi
+  if server_is_healthy; then healthy=true; fi
+  "$python" - "$runtime_file" \
+    "$server_running" "$compose_running" "$daemon_running" "$app_running" "$healthy" <<'PY'
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    descriptor = json.load(handle)
+names = ["server", "compose", "daemon", "app", "health"]
+observed = {name: value == "true" for name, value in zip(names, sys.argv[2:])}
+print(json.dumps({"descriptor": descriptor, "observed": observed}, indent=2, sort_keys=True))
+raise SystemExit(0 if all(observed.values()) else 1)
+PY
+}
+
+stop_server_job() {
+  if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+    server_process_is_owned || return 1
+  fi
+  uid=$(id -u)
+  if launchctl print "gui/$uid/$server_label" >/dev/null 2>&1; then
+    launchctl bootout "gui/$uid/$server_label" >/dev/null 2>&1 || return 1
+  fi
+  attempts=0
+  while [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null && [ "$attempts" -lt 50 ]; do
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+  if [ -n "$server_pid" ] && kill -0 "$server_pid" 2>/dev/null; then
+    server_process_is_owned || return 1
+    kill -KILL "$server_pid" 2>/dev/null || true
+  fi
+}
+
+ensure_recovery_compose_env() {
+  if [ -f "$instance_compose_env" ]; then
+    compose_env=$instance_compose_env
+    return 0
+  fi
+  recovery_compose_env=$lock_dir/compose.env
+  compose_env=$recovery_compose_env
+  database_password=$("$python" -c 'print("0" * 48)')
+  setup_code=$("$python" -c 'print("0" * 48)')
+  database_port=$(json_get "$runtime_file" ports.postgres)
+  oidc_port=$(json_get "$runtime_file" ports.oidc)
+  write_compose_env "${database_port:-0}" "${oidc_port:-0}"
+}
+
+stop_instance() {
+  validate_runtime
+  mode=$(json_get "$runtime_file" mode)
+  server_binary=$(json_get "$runtime_file" paths.server_binary)
+  server_pid=$(json_get "$runtime_file" processes.server_pid)
+  server_start_identity=$(json_get "$runtime_file" processes.server_start_identity)
+
+  stop_server_job || die "PID $server_pid no longer belongs to this instance Server"
+  osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 || true
+  pkill -TERM -f -x "$app_process_pattern" >/dev/null 2>&1 || true
+  uid=$(id -u)
+  launchctl bootout "gui/$uid/$daemon_label" >/dev/null 2>&1 || true
+  rm -f "$ready_file"
+  if [ "$mode" = local ]; then
+    ensure_recovery_compose_env
+    compose down "$@" --remove-orphans
+    cleanup_recovery_compose_env
+  fi
+  set_runtime_state stopped
+}
+
+cleanup_failed_up() {
+  rm -f "${preview_candidate:-}"
+  [ "${up_complete:-0}" = 1 ] && return 0
+  [ "${up_mutated:-0}" = 1 ] || return 0
+  osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1 || true
+  pkill -TERM -f -x "$app_process_pattern" >/dev/null 2>&1 || true
+  uid=$(id -u 2>/dev/null || true)
+  if [ -n "$uid" ]; then
+    launchctl bootout "gui/$uid/$daemon_label" >/dev/null 2>&1 || true
+  fi
+  if [ "${server_submitted:-0}" = 1 ]; then
+    uid=$(id -u 2>/dev/null || true)
+    [ -z "$uid" ] \
+      || launchctl bootout "gui/$uid/$server_label" >/dev/null 2>&1 \
+      || true
+  fi
+  if [ "${compose_started:-0}" = 1 ]; then
+    compose down --remove-orphans >/dev/null 2>&1 || true
+  fi
+  if [ -f "$runtime_file" ]; then
+    set_runtime_state stopped 2>/dev/null || true
+  fi
+}
+
+on_exit() {
+  status=$?
+  trap - 0
+  if [ "$command_name" = up ] && [ "$status" -ne 0 ]; then
+    cleanup_failed_up
+  fi
+  cleanup_recovery_compose_env
+  release_lock
+  exit "$status"
+}
+
+install_executable() {
+  source_executable=$1
+  target_executable=$2
+  temporary=$target_executable.$$.tmp
+  cp "$source_executable" "$temporary"
+  chmod 700 "$temporary"
+  mv -f "$temporary" "$target_executable"
+}
+
+run_up() {
+  preview_source=
+  case $# in
+    0) ;;
+    2)
+      [ "$1" = --preview ] || usage
+      preview_source=$2
+      ;;
+    *) usage ;;
+  esac
+
+  acquire_lock
+  trap on_exit 0
+  up_mutated=0
+  preview_file=$instance_root/preview.json
+  preview_candidate=
+  mkdir -p "$logs_dir" "$daemon_root" "$daemon_cache" "$daemon_logs" "$launch_agents" "$codex_home" "$server_bin_dir"
+  chmod 700 "$logs_dir" "$daemon_root" "$daemon_cache" "$daemon_logs" "$launch_agents" "$codex_home" "$server_bin_dir"
+
+  requested_mode=local
+  requested_server_url=
+  requested_oidc_issuer=
+  requested_preview_environment_id=
+  requested_preview_expires_at=
+  if [ -n "$preview_source" ]; then
+    requested_mode=preview
+    preview_candidate=$instance_root/preview.candidate.$$.json
+    normalize_preview "$preview_source" "$preview_candidate"
+    requested_server_url=$(json_get "$preview_candidate" server_url)
+    requested_oidc_issuer=$(json_get "$preview_candidate" oidc_issuer)
+    requested_preview_environment_id=$(json_get "$preview_candidate" environment_id)
+    requested_preview_expires_at=$(json_get "$preview_candidate" expires_at)
+    server_url=$requested_server_url
+    server_is_healthy || die "Preview Server is not healthy: $requested_server_url"
+  fi
+
+  old_server_url=
+  old_server_port=
+  old_database_port=
+  old_oidc_port=
+  if [ -f "$runtime_file" ]; then
+    validate_runtime
+    old_mode=$(json_get "$runtime_file" mode)
+    if [ "$old_mode" = local ] && [ ! -f "$instance_compose_env" ]; then
+      die "instance secrets are missing; run reset before starting it again"
+    fi
+    old_server_url=$(json_get "$runtime_file" server_url)
+    [ "$old_mode" = "$requested_mode" ] \
+      || die "instance mode changed; run reset before switching from $old_mode to $requested_mode"
+    if [ "$requested_mode" = preview ]; then
+      old_oidc_issuer=$(json_get "$runtime_file" oidc_issuer)
+      old_preview_environment_id=$(json_get "$runtime_file" preview_environment_id)
+      old_preview_expires_at=$(json_get "$runtime_file" preview_expires_at)
+      if [ "$old_server_url" != "$requested_server_url" ] \
+        || [ "$old_oidc_issuer" != "$requested_oidc_issuer" ] \
+        || [ "$old_preview_environment_id" != "$requested_preview_environment_id" ] \
+        || [ "$old_preview_expires_at" != "$requested_preview_expires_at" ]; then
+        die "Preview environment changed; run reset before selecting another Preview environment"
+      fi
+    fi
+    up_mutated=1
+    stop_instance
+    old_server_port=$(json_get "$runtime_file" ports.server)
+    old_database_port=$(json_get "$runtime_file" ports.postgres)
+    old_oidc_port=$(json_get "$runtime_file" ports.oidc)
+    if [ "$old_server_url" = http://127.0.0.1:0 ]; then
+      old_server_url=
+      old_server_port=
+    fi
+  fi
+
+  commit_id=$(git -C "$repo_root" rev-parse HEAD)
+  commit_short=$(printf '%.12s' "$commit_id")
+  build_id=dev-$instance_id-$commit_short
+  [ -z "$(git -C "$repo_root" status --porcelain --untracked-files=normal)" ] \
+    || build_id=$build_id-dirty
+  runtime_mode=$requested_mode
+  runtime_state=starting
+  server_url=$requested_server_url
+  server_port=
+  database_port=
+  oidc_port=
+  server_pid=
+  server_start_identity=
+  server_binary=
+  oidc_issuer=$requested_oidc_issuer
+  preview_environment_id=$requested_preview_environment_id
+  preview_expires_at=$requested_preview_expires_at
+  compose_project_value=
+  compose_started=0
+  server_submitted=0
+  up_complete=0
+  up_mutated=1
+
+  if [ "$runtime_mode" = local ]; then
+    compose_project_value=$compose_project
+    [ -x "$server_launcher_source" ] || die "Server launcher is not executable: $server_launcher_source"
+    if [ ! -x "$repo_root/node_modules/.bin/tsc" ]; then
+      (cd "$repo_root" && bun install --frozen-lockfile) >> "$logs_dir/build.log" 2>&1
+    fi
+    (cd "$repo_root" && bun run build:web-admin) >> "$logs_dir/build.log" 2>&1
+    web_admin_dir=$repo_root/apps/web-admin/dist
+    [ -d "$web_admin_dir" ] || die "Web Admin build did not produce $web_admin_dir"
+
+    if [ -n "${CLUMSIES_DEV_SERVER_BIN:-}" ]; then
+      server_source_binary=$CLUMSIES_DEV_SERVER_BIN
+      [ -f "$server_source_binary" ] && [ -x "$server_source_binary" ] \
+        || die "CLUMSIES_DEV_SERVER_BIN is not executable"
+    else
+      cargo build --locked -p server --bin clumsies-server
+      server_source_binary=$repo_root/target/debug/clumsies-server
+    fi
+    case "$server_source_binary" in
+      /*) ;;
+      *) die "the Server binary path must be absolute" ;;
+    esac
+    install_executable "$server_source_binary" "$owned_server_binary"
+    install_executable "$server_launcher_source" "$server_launcher"
+    server_binary=$owned_server_binary
+    server_port=${old_server_port:-0}
+    server_url=${old_server_url:-http://127.0.0.1:$server_port}
+    database_port=${old_database_port:-0}
+    oidc_port=${old_oidc_port:-0}
+    load_or_create_secrets
+    write_compose_env "$database_port" "$oidc_port"
+
+    # Publish deterministic ownership before the first Compose mutation. A
+    # later command can now reclaim even a launch interrupted inside `up`.
+    write_runtime
+    compose_started=1
+    compose up -d --wait postgres fake-oidc
+    database_port=$(published_port postgres 5432) \
+      || die "could not resolve the PostgreSQL host port"
+    oidc_port=$(published_port fake-oidc 8080) \
+      || die "could not resolve the fake OIDC host port"
+    write_compose_env "$database_port" "$oidc_port"
+    write_runtime
+
+    rm -f "$ready_file"
+    server_address=127.0.0.1:${old_server_port:-0}
+    oidc_issuer=http://127.0.0.1:$oidc_port/clumsies
+    uid=$(id -u)
+    launchctl print "gui/$uid/$server_label" >/dev/null 2>&1 \
+      && die "Server launch job already exists: $server_label"
+    write_server_launch_agent
+    launchctl bootstrap "gui/$uid" "$server_launch_agent_plist"
+    server_submitted=1
+    attempts=0
+    server_pid=
+    server_start_identity=
+    while [ -z "$server_start_identity" ] && [ "$attempts" -lt 250 ]; do
+      candidate_pid=$(server_job_pid || true)
+      if [ -n "$candidate_pid" ] && kill -0 "$candidate_pid" 2>/dev/null \
+        && [ "$(server_process_command "$candidate_pid")" = "$owned_server_binary" ]; then
+        candidate_start_identity=$(server_process_start_identity "$candidate_pid" || true)
+        if [ -n "$candidate_start_identity" ]; then
+          server_pid=$candidate_pid
+          server_start_identity=$candidate_start_identity
+          break
+        fi
+      fi
+      sleep 0.02
+      attempts=$((attempts + 1))
+    done
+    [ -n "$server_start_identity" ] \
+      || die "Server launch job did not assume its owned binary; see $server_log"
+    server_url=http://127.0.0.1:0
+    server_port=0
+    write_runtime
+
+    attempts=0
+    while [ ! -f "$ready_file" ] && [ "$attempts" -lt "${CLUMSIES_DEV_READY_ATTEMPTS:-600}" ]; do
+      kill -0 "$server_pid" 2>/dev/null || die "Server exited before becoming ready; see $server_log"
+      sleep 0.1
+      attempts=$((attempts + 1))
+    done
+    [ -f "$ready_file" ] || die "Server readiness timed out; see $server_log"
+    server_url=$(json_get "$ready_file" public_origin)
+    listen_addr=$(json_get "$ready_file" listen_addr)
+    case "$server_url" in
+      http://127.0.0.1:*) ;;
+      *) die "Server returned a non-loopback development origin" ;;
+    esac
+    server_port=${listen_addr##*:}
+    case "$server_port" in
+      ''|*[!0-9]*) die "Server returned an invalid bound port" ;;
+    esac
+    if [ -n "$old_server_url" ] && [ "$server_url" != "$old_server_url" ]; then
+      die "local Server URL changed; run reset before allocating another port"
+    fi
+    attempts=0
+    while ! server_is_healthy && [ "$attempts" -lt 100 ]; do
+      kill -0 "$server_pid" 2>/dev/null || die "Server exited during its health check; see $server_log"
+      sleep 0.1
+      attempts=$((attempts + 1))
+    done
+    server_is_healthy || die "Server health did not become ready; see $server_log"
+  else
+    mv -f "$preview_candidate" "$preview_file"
+    preview_candidate=
+  fi
+
+  # Publish ownership before the comparatively long Xcode build. A later up
+  # can then reclaim an interrupted Server/Compose launch without guessing.
+  write_runtime
+
+  host_arch=$(uname -m)
+  case "$host_arch" in
+    arm64|x86_64) ;;
+    *) die "unsupported macOS architecture: $host_arch" ;;
+  esac
+  xcodegen generate --spec "$repo_root/apps/macos/project.yml" >> "$logs_dir/build.log" 2>&1
+  xcodebuild \
+    -project "$repo_root/apps/macos/Clumsies.xcodeproj" \
+    -scheme Clumsies \
+    -configuration Debug \
+    -destination "platform=macOS,arch=$host_arch" \
+    -derivedDataPath "$derived_data" \
+    ARCHS="$host_arch" \
+    ONLY_ACTIVE_ARCH=YES \
+    CLUMSIES_APP_BUNDLE_IDENTIFIER="$bundle_id" \
+    CLUMSIES_APP_PRODUCT_NAME="$product_name" \
+    CLUMSIES_APP_DISPLAY_NAME="$display_name" \
+    CLUMSIES_DEV_INSTANCE_ID="$instance_id" \
+    CLUMSIES_DAEMON_ROOT="$daemon_root" \
+    CLUMSIES_DAEMON_CACHE_DIR="$daemon_cache" \
+    CLUMSIES_DAEMON_LOG_DIR="$daemon_logs" \
+    CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR="$launch_agents" \
+    CLUMSIES_SERVER_URL="$server_url" \
+    CLUMSIES_CODEX_HOME="$codex_home" \
+    CLUMSIES_AGENT_RUNTIME_BUILD_ID="$build_id" \
+    build >> "$logs_dir/build.log" 2>&1
+  [ -d "$app_path" ] || die "Xcode did not produce $app_path"
+  [ -x "$app_path/Contents/Resources/clumsiesd" ] || die "the Dev App does not contain an executable daemon"
+
+  open -n \
+    --stdout "$app_stdout" \
+    --stderr "$app_stderr" \
+    --env "CLUMSIES_DEV_INSTANCE_ID=$instance_id" \
+    --env "CLUMSIES_DAEMON_ROOT=$daemon_root" \
+    --env "CLUMSIES_DAEMON_CACHE_DIR=$daemon_cache" \
+    --env "CLUMSIES_DAEMON_LOG_DIR=$daemon_logs" \
+    --env "CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR=$launch_agents" \
+    --env "CLUMSIES_SERVER_URL=$server_url" \
+    --env "CLUMSIES_CODEX_HOME=$codex_home" \
+    "$app_path"
+
+  attempts=0
+  while ! daemon_is_running && [ "$attempts" -lt 200 ]; do
+    sleep 0.1
+    attempts=$((attempts + 1))
+  done
+  daemon_is_running || die "Dev daemon did not become ready; see $app_stderr and $daemon_logs"
+  server_is_healthy || die "Server became unhealthy while the Dev App was building"
+  runtime_state=running
+  write_runtime
+  up_complete=1
+  printf '%s\n' "$runtime_file"
+}
+
+run_status() {
+  [ $# -eq 0 ] || usage
+  print_status
+}
+
+run_logs() {
+  [ $# -eq 0 ] || usage
+  acquire_lock
+  trap on_exit 0
+  validate_runtime
+  mode=$(json_get "$runtime_file" mode)
+  if [ "$mode" = local ]; then
+    ensure_recovery_compose_env
+    compose logs --tail 200 postgres fake-oidc || true
+  fi
+  for log in "$server_log" "$app_stdout" "$app_stderr" "$daemon_logs/daemon.log"; do
+    if [ -f "$log" ]; then
+      printf '\n==> %s <==\n' "$log"
+      tail -n 200 "$log"
+    fi
+  done
+}
+
+run_test_live() {
+  [ $# -eq 0 ] || usage
+  acquire_lock
+  trap on_exit 0
+  validate_runtime
+  [ "$(json_get "$runtime_file" state)" = running ] \
+    || die "Dev Instance is not running; run up before test-live"
+  mode=$(json_get "$runtime_file" mode)
+  server_url=$(json_get "$runtime_file" server_url)
+  build_id=$(json_get "$runtime_file" build_id 2>/dev/null) \
+    || die "runtime descriptor has no build identity; run up before test-live"
+  case "$build_id" in
+    "dev-$instance_id-"*) ;;
+    *) die "runtime descriptor build identity is not owned by this instance" ;;
+  esac
+  [ -d "$app_path" ] && [ -x "$app_path/Contents/Resources/clumsiesd" ] \
+    || die "Dev App is missing; run up before test-live"
+  daemon_is_running || die "Dev daemon is not running; run up before test-live"
+  server_is_healthy || die "Dev Server is not healthy; run up before test-live"
+  if [ "$mode" = local ]; then
+    server_binary=$(json_get "$runtime_file" paths.server_binary)
+    server_pid=$(json_get "$runtime_file" processes.server_pid)
+    server_start_identity=$(json_get "$runtime_file" processes.server_start_identity)
+    if [ "$(server_job_pid || true)" != "$server_pid" ] || ! server_process_is_owned; then
+      die "Dev Server process is not owned by this instance"
+    fi
+    compose_is_running || die "Dev Compose services are not running"
+  fi
+
+  host_arch=$(uname -m)
+  case "$host_arch" in
+    arm64|x86_64) ;;
+    *) die "unsupported macOS architecture: $host_arch" ;;
+  esac
+  xcodegen generate --spec "$repo_root/apps/macos/project.yml"
+  env CLUMSIES_RUN_LIVE_TESTS=1 CLUMSIES_SKIP_DAEMON_BUILD=1 \
+    xcodebuild -quiet \
+      -project "$repo_root/apps/macos/Clumsies.xcodeproj" \
+      -scheme ClumsiesLiveTests \
+      -configuration Debug \
+      -destination "platform=macOS,arch=$host_arch" \
+      -derivedDataPath "$derived_data" \
+      ARCHS="$host_arch" \
+      ONLY_ACTIVE_ARCH=YES \
+      CLUMSIES_SKIP_DAEMON_BUILD=1 \
+      CLUMSIES_APP_BUNDLE_IDENTIFIER="$bundle_id" \
+      CLUMSIES_APP_PRODUCT_NAME="$product_name" \
+      CLUMSIES_APP_DISPLAY_NAME="$display_name" \
+      CLUMSIES_DEV_INSTANCE_ID="$instance_id" \
+      CLUMSIES_DAEMON_ROOT="$daemon_root" \
+      CLUMSIES_DAEMON_CACHE_DIR="$daemon_cache" \
+      CLUMSIES_DAEMON_LOG_DIR="$daemon_logs" \
+      CLUMSIES_DAEMON_LAUNCH_AGENTS_DIR="$launch_agents" \
+      CLUMSIES_SERVER_URL="$server_url" \
+      CLUMSIES_CODEX_HOME="$codex_home" \
+      CLUMSIES_AGENT_RUNTIME_BUILD_ID="$build_id" \
+      -only-testing:ClumsiesTests/LiveWorkspaceIntegrationTests \
+      test
+}
+
+run_down() {
+  [ $# -eq 0 ] || usage
+  acquire_lock
+  trap on_exit 0
+  stop_instance
+}
+
+run_reset() {
+  [ $# -eq 0 ] || usage
+  acquire_lock
+  trap on_exit 0
+  validate_runtime
+  stop_instance -v
+  security delete-generic-password -s "$keychain_service" -a server-session >/dev/null 2>&1 || true
+  case "$instance_root" in
+    "$instances_root/$instance_id") ;;
+    *) die "refusing to remove an unowned instance root" ;;
+  esac
+  rm -rf -- "$instance_root"
+}
+
+case "$command_name" in
+  up) run_up "$@" ;;
+  status) run_status "$@" ;;
+  logs) run_logs "$@" ;;
+  test-live) run_test_live "$@" ;;
+  down) run_down "$@" ;;
+  reset) run_reset "$@" ;;
+esac

--- a/dev/dev-instance.sh
+++ b/dev/dev-instance.sh
@@ -802,8 +802,9 @@ run_up() {
 
     if [ -n "${CLUMSIES_DEV_SERVER_BIN:-}" ]; then
       server_source_binary=$CLUMSIES_DEV_SERVER_BIN
-      [ -f "$server_source_binary" ] && [ -x "$server_source_binary" ] \
-        || die "CLUMSIES_DEV_SERVER_BIN is not executable"
+      if [ ! -f "$server_source_binary" ] || [ ! -x "$server_source_binary" ]; then
+        die "CLUMSIES_DEV_SERVER_BIN is not executable"
+      fi
     else
       cargo build --locked -p server --bin clumsies-server
       server_source_binary=$repo_root/target/debug/clumsies-server
@@ -994,8 +995,9 @@ run_test_live() {
     "dev-$instance_id-"*) ;;
     *) die "runtime descriptor build identity is not owned by this instance" ;;
   esac
-  [ -d "$app_path" ] && [ -x "$app_path/Contents/Resources/clumsiesd" ] \
-    || die "Dev App is missing; run up before test-live"
+  if [ ! -d "$app_path" ] || [ ! -x "$app_path/Contents/Resources/clumsiesd" ]; then
+    die "Dev App is missing; run up before test-live"
+  fi
   daemon_is_running || die "Dev daemon is not running; run up before test-live"
   server_is_healthy || die "Dev Server is not healthy; run up before test-live"
   if [ "$mode" = local ]; then

--- a/dev/dev-server.sh
+++ b/dev/dev-server.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+[ "$#" -eq 5 ] || exit 64
+compose_env=$1
+server_binary=$2
+server_address=$3
+ready_file=$4
+web_admin_dir=$5
+
+[ -f "$compose_env" ] && [ ! -L "$compose_env" ] \
+  && [ -x "$server_binary" ] && [ -d "$web_admin_dir" ] || exit 66
+case "$ready_file" in /*) ;; *) exit 64 ;; esac
+case "$server_address" in 127.0.0.1:*) ;; *) exit 64 ;; esac
+
+env_value() {
+  awk -F= -v key="$1" '$1 == key { print substr($0, index($0, "=") + 1) }' "$compose_env"
+}
+
+database_port=$(env_value CLUMSIES_DB_PORT)
+oidc_port=$(env_value CLUMSIES_OIDC_PORT)
+database_password=$(env_value CLUMSIES_DB_PASSWORD)
+setup_code=$(env_value CLUMSIES_SETUP_CODE)
+server_port=${server_address##*:}
+case "$database_port:$oidc_port:$server_port" in
+  *[!0-9:]*) exit 65 ;;
+esac
+[ -n "$database_port" ] && [ "$database_port" -ge 1 ] && [ "$database_port" -le 65535 ] \
+  && [ -n "$oidc_port" ] && [ "$oidc_port" -ge 1 ] && [ "$oidc_port" -le 65535 ] \
+  && [ -n "$server_port" ] && [ "$server_port" -le 65535 ] || exit 65
+case "$database_password:$setup_code" in
+  *[!0-9a-f:]*) exit 65 ;;
+esac
+[ "${#database_password}" -eq 48 ] && [ "${#setup_code}" -eq 48 ] || exit 65
+
+exec env \
+  DATABASE_URL="postgres://clumsies:$database_password@127.0.0.1:$database_port/clumsies" \
+  CLUMSIES_SERVER_ADDR="$server_address" \
+  CLUMSIES_PUBLIC_ORIGIN=auto \
+  CLUMSIES_SERVER_READY_FILE="$ready_file" \
+  CLUMSIES_WEB_ADMIN_DIR="$web_admin_dir" \
+  CLUMSIES_SETUP_CODE="$setup_code" \
+  CLUMSIES_OIDC_CLIENT_ID=clumsies-local \
+  CLUMSIES_OIDC_CLIENT_SECRET=clumsies-local-secret \
+  CLUMSIES_OIDC_ISSUER="http://127.0.0.1:$oidc_port/clumsies" \
+  CLUMSIES_CLIENT_REDIRECT_URIS=http://127.0.0.1/callback \
+  CLUMSIES_CORS_ORIGINS=http://127.0.0.1:1421,http://localhost:1421 \
+  "$server_binary"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: ${CLUMSIES_DB_USER:-clumsies}
       POSTGRES_PASSWORD: ${CLUMSIES_DB_PASSWORD:-clumsies}
     ports:
-      - "${CLUMSIES_DB_PORT:-5432}:5432"
+      - "${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:${CLUMSIES_DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U \"$${POSTGRES_USER}\" -d \"$${POSTGRES_DB}\""]
       interval: 2s
@@ -25,7 +25,7 @@ services:
       LOG_LEVEL: WARN
       SERVER_PORT: 8080
     ports:
-      - "${CLUMSIES_OIDC_PORT:-18081}:8080"
+      - "${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:${CLUMSIES_OIDC_PORT:-18081}:8080"
     volumes:
       - ./dev/oidc/config.json:/app/config.json:ro
     healthcheck:
@@ -48,15 +48,15 @@ services:
     environment:
       DATABASE_URL: postgres://${CLUMSIES_DB_USER:-clumsies}:${CLUMSIES_DB_PASSWORD:-clumsies}@postgres:5432/${CLUMSIES_DB_NAME:-clumsies}
       CLUMSIES_SERVER_ADDR: 0.0.0.0:8080
-      CLUMSIES_PUBLIC_ORIGIN: http://127.0.0.1:18080
+      CLUMSIES_PUBLIC_ORIGIN: ${CLUMSIES_PUBLIC_ORIGIN:-http://127.0.0.1:18080}
       CLUMSIES_SETUP_CODE: ${CLUMSIES_SETUP_CODE:-clumsies-local-setup-code-00000001}
       CLUMSIES_OIDC_CLIENT_ID: clumsies-local
       CLUMSIES_OIDC_CLIENT_SECRET: clumsies-local-secret
-      CLUMSIES_OIDC_ISSUER: http://host.docker.internal:18081/clumsies
+      CLUMSIES_OIDC_ISSUER: ${CLUMSIES_OIDC_ISSUER:-http://host.docker.internal:18081/clumsies}
       CLUMSIES_CLIENT_REDIRECT_URIS: http://127.0.0.1/callback,http://127.0.0.1/admin/setup/callback,http://127.0.0.1:1421/admin/
       CLUMSIES_CORS_ORIGINS: ${CLUMSIES_CORS_ORIGINS:-http://127.0.0.1:1421,http://localhost:1421}
     ports:
-      - "18080:8080"
+      - "${CLUMSIES_HOST_BIND_ADDRESS:-0.0.0.0}:${CLUMSIES_SERVER_PORT:-18080}:8080"
     healthcheck:
       test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:8080/api/v1/admin/health"]
       interval: 5s

--- a/docs/guides/development-workflow.md
+++ b/docs/guides/development-workflow.md
@@ -33,6 +33,7 @@ repository, one remote, and one set of git hooks.
    so the branch stays reviewable.
 7. **Clean up**:
    ```sh
+   just dev-macos-reset
    git worktree remove target/codex-worktrees/<wt-name>
    git branch -d <branch>
    ```
@@ -61,12 +62,16 @@ and runs in every worktree.
 
 ## Isolation and shared state
 
-- Each worktree has its own `target/` and frontend build output; builds do not
-  interfere.
-- Git hooks, remotes, and `~/.clumsies` state are shared by design.
-- The running daemon and macOS app are **not** part of the worktree: they run
-  from `~/Applications/Clumsies.app` and `~/Library/...`. Code changes take
-  effect only after the daemon/app is rebuilt and redeployed.
+- Each worktree can start a complete Dev Instance with `just dev-macos`. Its
+  canonical path determines the App identity,
+  daemon service, runtime directories, Keychain service, Compose project,
+  dynamic ports, and isolated `CODEX_HOME`.
+- `down` stops only that instance and preserves its data. `reset` removes its
+  data and test credentials and must run before deleting the worktree.
+- The resident Debug App, daemon, stable data, Keychain identity, and global
+  Codex Plugin remain shared and unchanged. Only
+  `just promote-debug-macos` may replace that installation.
+- Git hooks and remotes remain shared by design.
 - Safety snapshot branches (e.g. `codex/safety-*`) are kept until their
   content is confirmed present in `main`; deleting the worktree does not delete
   the branch.
@@ -76,7 +81,8 @@ and runs in every worktree.
 | Layer | Command |
 |---|---|
 | daemon (lib + integration) | `cargo test -p daemon --lib` and `cargo test -p daemon --test daemon_lifecycle` |
-| macOS app | `cd apps/macos && xcodebuild -project Clumsies.xcodeproj -scheme Clumsies -configuration Debug build` |
+| macOS app | `just test-macos` |
+| worktree Dev lifecycle | `just test-dev-macos` |
 | public docs | `bun run build` |
 
 Run at least the suites covering the changed layer before `kanban.request_closure`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,52 @@
+# Show available development tasks.
+default:
+    @just --list
+
+# Build the native macOS App without installing it.
+build-macos:
+    sh apps/macos/Scripts/build.sh
+
+# Run the native macOS unit and contract tests.
+test-macos:
+    sh apps/macos/Scripts/promote-debug-test.sh
+    sh apps/macos/Scripts/test.sh
+
+# Run live tests through the running authenticated worktree Dev Instance.
+test-macos-live:
+    sh dev/dev-instance.sh test-live
+
+# Verify the packaged native macOS App and embedded daemon.
+test-macos-package:
+    sh apps/macos/Scripts/test-runtime-package.sh
+
+# Promote the long-lived Debug App and daemon; its App reconciles the global Plugin.
+promote-debug-macos:
+    sh apps/macos/Scripts/promote-debug.sh
+
+# Start the complete worktree-scoped Dev Instance.
+dev-macos:
+    sh dev/dev-instance.sh up
+
+# Show the current worktree Dev Instance status.
+dev-macos-status:
+    sh dev/dev-instance.sh status
+
+# Show logs for the current worktree Dev Instance.
+dev-macos-logs:
+    sh dev/dev-instance.sh logs
+
+# Stop the current worktree Dev Instance and preserve its data.
+dev-macos-down:
+    sh dev/dev-instance.sh down
+
+# Delete the current worktree Dev Instance data and credentials.
+dev-macos-reset:
+    sh dev/dev-instance.sh reset
+
+# Start the current worktree Dev Instance against a Preview descriptor.
+dev-macos-preview descriptor:
+    sh dev/dev-instance.sh up --preview "{{descriptor}}"
+
+# Run the worktree Dev Instance lifecycle contract.
+test-dev-macos:
+    sh dev/dev-instance-test.sh

--- a/package.json
+++ b/package.json
@@ -10,17 +10,12 @@
   "scripts": {
     "dev": "vitepress dev docs",
     "dev:site": "python3 -m http.server 4000 --directory site",
-    "dev:macos": "sh apps/macos/Scripts/run.sh",
     "dev:web-admin": "bun run --cwd apps/web-admin dev",
     "dev:infra": "docker compose up -d --wait postgres fake-oidc",
     "dev:infra:down": "docker compose down",
     "dev:server": "sh dev/server.sh",
     "build": "vitepress build docs",
     "build:web-admin": "bun run --cwd apps/web-admin build",
-    "build:macos": "sh apps/macos/Scripts/build.sh",
-    "test:macos:package": "sh apps/macos/Scripts/test-runtime-package.sh",
-    "test:macos": "sh apps/macos/Scripts/test.sh",
-    "test:macos:live": "xcodegen generate --spec apps/macos/project.yml && CLUMSIES_SKIP_DAEMON_BUILD=1 xcodebuild -quiet -project apps/macos/Clumsies.xcodeproj -scheme ClumsiesLiveTests -configuration Debug -derivedDataPath /private/tmp/clumsies-macos-live-tests test",
     "preview": "vitepress preview docs",
     "api:generate": "bun run --cwd packages/api-contract generate",
     "api:check": "bun run --cwd packages/api-contract check && bun run --cwd packages/api-client typecheck && bun run --cwd packages/api-client test"

--- a/packages/clumsies/scripts/issue-run-event.sh.tpl
+++ b/packages/clumsies/scripts/issue-run-event.sh.tpl
@@ -3,6 +3,7 @@
 # Best effort only: lifecycle observation must never block Codex.
 
 set -euo pipefail
+__CLUMSIES_DEV_INSTANCE_ENV_REQUIRED__
 
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 CLUMSIES=__CLUMSIESD_SHELL_LITERAL_REQUIRED__


### PR DESCRIPTION
## Context and summary

Implements the worktree-scoped Dev Instance from native `ISSUE-073` and
restores the Just command boundary from `ISSUE-069` after that earlier WIP was
cleaned without being committed.

Git worktrees isolate source, but the previous macOS development command still
replaced the resident Debug App and reused its bundle, LaunchAgent, Mach
service, data, Keychain, ports, Server, and global Codex Plugin. This change
derives one bounded instance identity from the canonical worktree path and uses
it for a complete App → daemon → Server/PostgreSQL/OIDC stack. The stable
installation is changed only by the explicit promotion recipe.

## Affected areas

- [x] Rust daemon/runtime
- [x] Server/API
- [x] macOS app
- [ ] Web Admin
- [x] MCP, CLI, or agent protocol
- [x] Storage, configuration, or schema
- [x] Documentation
- [x] CI, deployment, or release

## Behavior and evidence

- `just dev-macos` now starts a complete worktree-owned instance with unique
  App/daemon identities, private runtime directories and Keychain service, an
  isolated `CODEX_HOME`, a dedicated Compose project, and runtime-assigned
  loopback ports.
- A private atomic runtime descriptor records source/build identity, ownership,
  endpoints, process identity, state, and Preview metadata. Dirty WIP builds are
  identified explicitly.
- `status`, `logs`, `down`, `reset`, Preview startup, lifecycle tests, and live
  tests are exposed as thin Just recipes. The live suite refuses the stable
  daemon and runs only against a healthy authenticated Dev Instance.
- Dev Codex Plugin materialization routes MCP and hooks to the instance daemon
  inside its isolated `CODEX_HOME`; normal global Plugin reconciliation remains
  unchanged.
- `just promote-debug-macos` is the only long-lived Debug promotion path. Its
  App swap, daemon reconciliation, open, signal handling, and rollback behavior
  are covered by a black-box contract. First installation defers daemon/Plugin
  reconciliation to the launched App so a failed open cannot leave a dangling
  LaunchAgent.
- A real local Dev App was previously started and authenticated through the
  isolated XPC/HTTP/PostgreSQL chain. It loaded Memory, created/saved/discarded
  temporary Context, Rule, and Workflow drafts, exercised bundle lifecycle,
  drained the sync queue, and left the recorded resident App/daemon/data/Plugin
  baseline unchanged.

## Verification

- `cargo fmt --all --check`
- `cargo check -p daemon`
- `cargo test --workspace`
- `cargo clippy -p daemon -- -D warnings`
- `cargo clippy -p server --all-targets -- -D warnings`
- `bun install --frozen-lockfile`
- `bun run api:check`
- `bun run build`
- `bun run build:web-admin`
- `just test-macos`
- `just test-macos-package`
- `just test-dev-macos`
- `sh apps/macos/Scripts/promote-debug-test.sh`
- `bash deploy/server/server-release-test.sh`
- `sh dev/check-agent-runtime-boundary.sh`
- `sh dev/check-retired-terms.sh`
- `docker compose config -q`
- `shellcheck` for all changed development and promotion scripts
- `actionlint`
- `python3 dev/validate-pr-template.py --self-test`
- `git diff --check origin/main...HEAD`

Not rerun in the final clean commit: two physical worktrees running the full
stack concurrently, a remote Preview supplied by `ISSUE-074`, a real Codex
CLI/app-server Plugin session in the isolated `CODEX_HOME`, and promotion of the
resident Debug installation. The latter would intentionally mutate the
long-lived local App/daemon/Plugin; the request explicitly waived another
manual verification pass.

## Compatibility and migration

There is no public API or database schema migration. Stable bundle, daemon,
storage, Keychain, Server, and Plugin defaults remain unchanged. Development
runtime overrides are accepted only as a complete validated Debug identity.

Native macOS commands move from Bun package shims to Just. Use
`just build-macos`, `just test-macos`, `just test-macos-live`,
`just test-macos-package`, `just dev-macos`, and
`just promote-debug-macos`. Existing Dev descriptors without the new build
identity can still be stopped/reset; run `just dev-macos` again before live
testing to refresh them.

## Risk, security, and privacy

Instance roots and descriptors are private, canonicalized, and rejected when
symlinked outside their owner. Destructive lifecycle actions validate every
owned path and exact process PID/start identity. External lifecycle locks cover
the complete reset deletion window; invalid locks require manual review instead
of unsafe reclamation.

Local services bind to loopback. Missing Compose secrets are never regenerated
over an existing instance; temporary recovery values exist only under the held
lock for logs/down/reset and are deleted afterward. Preview descriptors reject
unsafe origins. Dev Plugin state stays under the isolated `CODEX_HOME`.

Promotion is intentionally privileged and explicit. It stages the App,
preserves the prior install through daemon reconciliation and launch, restores
the old App/daemon on failure, and tells the user to restart Codex/create a new
task after asynchronous global Plugin reconciliation.

## Rollout and rollback

- Rollout: Merge normally; developers opt in with `just dev-macos`. No stable App, daemon, or Plugin is promoted automatically.
- Observability: `just dev-macos-status`, `just dev-macos-logs`, the runtime descriptor, Server ready file, and required CI jobs expose instance health and ownership.
- Rollback: Revert this commit. Run `just dev-macos-reset` before deleting an affected worktree; the resident installation remains independent.

## Reviewer focus

Please focus on the canonical ownership checks, launchd identities/environment,
PID/start-time validation, atomic Server ready-file contract, Compose recovery,
Dev Plugin routing, and promotion rollback transaction.

Known limitations: orphan discovery/pruning after a worktree has already been
deleted is not yet implemented; reset must run first. The physical two-worktree,
remote Preview, and real isolated Codex Plugin scenarios listed above remain
follow-up verification work. `ISSUE-074` owns remote Preview creation and
cleanup. This PR therefore does not request Kanban closure for `ISSUE-073`.
