### PR TITLE
macos: fix Memory operations and project-scoped sync feedback

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -52,6 +52,33 @@ enum WorkspaceCollectionLoadState: Equatable, Sendable {
     }
 }
 
+enum SyncRetryOutcome: Equatable, Sendable {
+    case completed
+    case failed(String)
+    case cancelled
+}
+
+struct SyncRetryKey: Hashable, Sendable {
+    let channel: String
+    let projectId: String?
+}
+
+private struct SyncRetryTaskHandle {
+    let id: UUID
+    let task: Task<SyncRetryOutcome, Never>
+}
+
+private enum WorkspaceBackgroundErrorSource: Hashable {
+    case organizationResources
+    case staleResources(projectId: String)
+    case projectRefresh(projectId: String)
+}
+
+private struct WorkspaceBackgroundErrorPresentation {
+    let source: WorkspaceBackgroundErrorSource
+    let message: String
+}
+
 struct WorkspaceSnapshot: Sendable {
     let account: UserReference
     let organization: OrganizationReference
@@ -343,10 +370,17 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var reviewLoadState: WorkspaceCollectionLoadState = .loading
     @Published private(set) var runtime: RuntimeState?
     @Published private(set) var syncStatusAvailable = true
+    @Published private var retryingSyncKeys: Set<SyncRetryKey> = []
+    @Published private var syncRetryErrors: [SyncRetryKey: String] = [:]
     @Published private(set) var legacyAgentAdapterConflicts: [DaemonLegacyAgentAdapterConflict] = []
     @Published private(set) var legacyAgentAdapterInspectionWarning: String?
 
-    @Published var activeProjectId: String?
+    @Published var activeProjectId: String? = nil {
+        didSet {
+            guard oldValue != activeProjectId else { return }
+            clearIrrelevantScopedErrorPresentation()
+        }
+    }
     @Published var selectedSection: WorkspaceSection = .memory
     @Published var selectedKind: MemoryKind = .context
     @Published var selectedItemId: String?
@@ -397,6 +431,10 @@ final class WorkspaceStore: ObservableObject {
     private var legacyAgentAdapterInspectionTask: Task<Void, Never>?
     private var postReadySyncTask: Task<Void, Never>?
     private var postReadyRetrySyncTask: Task<Void, Never>?
+    private var syncRetryTasks: [SyncRetryKey: SyncRetryTaskHandle] = [:]
+    private var presentedSyncRetryErrorKey: SyncRetryKey?
+    private var dismissedBackgroundErrorSources: Set<WorkspaceBackgroundErrorSource> = []
+    private var presentedBackgroundError: WorkspaceBackgroundErrorPresentation?
     private var isSigningOut = false
     private var projectSelectionGeneration = UUID()
     private let projectSelectionSideEffectGate = ProjectSelectionSideEffectGate()
@@ -422,6 +460,121 @@ final class WorkspaceStore: ObservableObject {
 
     var activeProject: ProjectState? {
         projects.first { $0.id == activeProjectId }
+    }
+
+    var isRetryingSync: Bool {
+        retryingSyncKeys.contains { $0.projectId == activeProjectId }
+    }
+
+    var syncRetryErrorMessage: String? {
+        let messages = syncRetryErrors
+            .filter { $0.key.projectId == activeProjectId }
+            .sorted { $0.key.channel < $1.key.channel }
+            .map(\.value)
+        return messages.isEmpty ? nil : messages.joined(separator: "\n")
+    }
+
+    func isRetryingSync(channel: String, projectId: String?) -> Bool {
+        retryingSyncKeys.contains(
+            SyncRetryKey(channel: channel, projectId: projectId)
+        )
+    }
+
+    func dismissErrorMessage() {
+        if let presentation = presentedBackgroundError,
+           errorMessage == presentation.message {
+            dismissedBackgroundErrorSources.insert(presentation.source)
+        }
+        errorMessage = nil
+        presentedBackgroundError = nil
+        presentedSyncRetryErrorKey = nil
+    }
+
+    private func presentBackgroundError(
+        _ message: String,
+        source: WorkspaceBackgroundErrorSource
+    ) {
+        guard backgroundErrorIsRelevant(source),
+              !dismissedBackgroundErrorSources.contains(source),
+              errorMessage == nil || errorMessage == presentedBackgroundError?.message else {
+            return
+        }
+        presentedBackgroundError = .init(source: source, message: message)
+        errorMessage = message
+    }
+
+    private func resolveBackgroundError(_ source: WorkspaceBackgroundErrorSource) {
+        dismissedBackgroundErrorSources.remove(source)
+        guard let presentation = presentedBackgroundError,
+              presentation.source == source else {
+            return
+        }
+        if errorMessage == presentation.message {
+            errorMessage = nil
+        }
+        presentedBackgroundError = nil
+    }
+
+    private func backgroundErrorIsRelevant(_ source: WorkspaceBackgroundErrorSource) -> Bool {
+        switch source {
+        case .organizationResources:
+            return selectedSection == .memory && activeProjectId == nil
+        case .staleResources(let projectId), .projectRefresh(let projectId):
+            return activeProjectId == projectId
+        }
+    }
+
+    private func clearIrrelevantScopedErrorPresentation() {
+        if let key = presentedSyncRetryErrorKey, key.projectId != activeProjectId {
+            if errorMessage == syncRetryErrors[key] {
+                errorMessage = nil
+            }
+            presentedSyncRetryErrorKey = nil
+        }
+        if let presentation = presentedBackgroundError,
+           !backgroundErrorIsRelevant(presentation.source) {
+            if errorMessage == presentation.message {
+                errorMessage = nil
+            }
+            presentedBackgroundError = nil
+        }
+    }
+
+    private func cancelSyncRetries() {
+        if let key = presentedSyncRetryErrorKey,
+           errorMessage == syncRetryErrors[key] {
+            errorMessage = nil
+        }
+        syncRetryTasks.values.forEach { $0.task.cancel() }
+        syncRetryTasks.removeAll()
+        retryingSyncKeys.removeAll()
+        syncRetryErrors.removeAll()
+        presentedSyncRetryErrorKey = nil
+    }
+
+    private func clearSyncRetryErrors(channel: String, projectId: String?) {
+        let errorKeysToClear = channel == "all"
+            ? syncRetryErrors.keys.filter { $0.projectId == projectId }
+            : [SyncRetryKey(channel: channel, projectId: projectId)]
+        let presentedError = presentedSyncRetryErrorKey.flatMap { syncRetryErrors[$0] }
+        if let presentedSyncRetryErrorKey,
+           errorKeysToClear.contains(presentedSyncRetryErrorKey),
+           errorMessage == presentedError {
+            errorMessage = nil
+            self.presentedSyncRetryErrorKey = nil
+        }
+        for errorKey in errorKeysToClear {
+            syncRetryErrors[errorKey] = nil
+        }
+    }
+
+    private func resetBackgroundErrorPresentation() {
+        if let presentation = presentedBackgroundError,
+           errorMessage == presentation.message {
+            errorMessage = nil
+        }
+        dismissedBackgroundErrorSources.removeAll()
+        presentedBackgroundError = nil
     }
 
     var canManageOrgSelection: Bool {
@@ -1166,6 +1319,7 @@ final class WorkspaceStore: ObservableObject {
         // flushing. Let that serialized intent finish before a later reload.
         guard loadingProjectId == nil, !isSwitchingMemoryContext else { return }
         cancelPostReadyWork()
+        resetBackgroundErrorPresentation()
         let generation = UUID()
         workspaceReloadGeneration = generation
         let hadLoadedWorkspace = account != nil
@@ -2579,6 +2733,7 @@ final class WorkspaceStore: ObservableObject {
                 guard synchronizationItemId(for: draft) == nil else {
                     throw DocumentSyncError.mutationWhileSynchronizing
                 }
+                guard drafts.contains(where: { $0.id == draft.id }) else { return }
                 _ = try await daemon.store(
                     .init(
                         draftId: draft.id,
@@ -2601,24 +2756,85 @@ final class WorkspaceStore: ObservableObject {
         }
     }
 
-    func retrySync() async {
-        do {
-            _ = try await daemon.retrySync()
-            await refreshSyncStatus()
-        } catch {
-            syncStatusAvailable = false
-            errorMessage = error.localizedDescription
+    @discardableResult
+    func retrySync(
+        channel: String = "all",
+        projectId: String? = nil
+    ) async -> SyncRetryOutcome {
+        let projectId = projectId ?? activeProjectId
+        let key = SyncRetryKey(channel: channel, projectId: projectId)
+        if let inFlight = syncRetryTasks[key] {
+            return await inFlight.task.value
         }
+
+        clearSyncRetryErrors(channel: channel, projectId: projectId)
+        let predecessors = syncRetryTasks.compactMap { existingKey, handle in
+            existingKey.projectId == projectId ? handle.task : nil
+        }
+
+        let taskId = UUID()
+        let task = Task { @MainActor in
+            do {
+                for predecessor in predecessors {
+                    _ = await predecessor.value
+                    try Task.checkCancellation()
+                }
+                clearSyncRetryErrors(channel: channel, projectId: projectId)
+                try Task.checkCancellation()
+                _ = try await daemon.retrySync(channel: channel, projectId: projectId)
+                try Task.checkCancellation()
+                if channel == "all" {
+                    clearSyncRetryErrors(channel: channel, projectId: projectId)
+                }
+                if activeProjectId == projectId {
+                    await refreshSyncStatus()
+                    try Task.checkCancellation()
+                }
+                return SyncRetryOutcome.completed
+            } catch is CancellationError {
+                return .cancelled
+            } catch {
+                guard !Task.isCancelled else { return .cancelled }
+                let message = error.localizedDescription
+                syncRetryErrors[key] = message
+                if activeProjectId == projectId {
+                    syncStatusAvailable = false
+                    if errorMessage == nil {
+                        errorMessage = message
+                        presentedSyncRetryErrorKey = key
+                    }
+                }
+                return .failed(message)
+            }
+        }
+        syncRetryTasks[key] = .init(id: taskId, task: task)
+        retryingSyncKeys.insert(key)
+        let outcome = await task.value
+        if syncRetryTasks[key]?.id == taskId {
+            syncRetryTasks[key] = nil
+            retryingSyncKeys.remove(key)
+        }
+        return outcome
     }
 
     func refreshSyncStatus() async {
         guard phase == .ready else { return }
         let generation = workspaceReloadGeneration
+        let projectId = activeProjectId
         await refreshOrgResourcesIfNeeded()
-        guard workspaceReloadGeneration == generation, phase == .ready, let runtime else { return }
+        guard workspaceReloadGeneration == generation,
+              activeProjectId == projectId,
+              phase == .ready,
+              let runtime else {
+            return
+        }
         do {
-            let sync = try await daemon.syncStatus()
-            guard workspaceReloadGeneration == generation, phase == .ready else { return }
+            let sync = try await daemon.syncStatus(projectId: projectId)
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId,
+                  phase == .ready else {
+                return
+            }
             self.runtime = .init(
                 health: runtime.health,
                 sync: sync,
@@ -2628,14 +2844,22 @@ final class WorkspaceStore: ObservableObject {
             syncStatusAvailable = true
             if draftInventoryLoadTask == nil {
                 await refreshDraftInventory(
-                    includeFailed: sync.pendingOperationCount > 0,
+                    includeFailed: sync.pendingOperationCount > 0
+                        || sync.failedOperationCount > 0,
                     generation: generation
                 )
             }
-            guard workspaceReloadGeneration == generation, phase == .ready else { return }
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId,
+                  phase == .ready else {
+                return
+            }
             await refreshStaleResourcesIfNeeded(sync: sync)
         } catch {
-            guard workspaceReloadGeneration == generation else { return }
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId else {
+                return
+            }
             syncStatusAvailable = false
         }
     }
@@ -2753,8 +2977,16 @@ final class WorkspaceStore: ObservableObject {
             let head: (value: CommitStateResponse, response: DaemonServerResponse) =
                 try await server.getWithMetadata("/api/v1/org/commit-state")
             guard workspaceReloadGeneration == workspaceGeneration,
-                  !head.response.isStaleCache,
-                  head.value.ref.commitId != observedOrgRefCommitId else {
+                  phase == .ready,
+                  selectedSection == .memory,
+                  activeProjectId == nil,
+                  !isSwitchingMemoryContext,
+                  orgResourceRefreshGeneration == generation,
+                  !head.response.isStaleCache else {
+                return
+            }
+            guard head.value.ref.commitId != observedOrgRefCommitId else {
+                resolveBackgroundError(.organizationResources)
                 return
             }
             guard let snapshot = try await loadStableOrgAuthoritySnapshot(),
@@ -2819,9 +3051,23 @@ final class WorkspaceStore: ObservableObject {
             }
             pruneOrphanedMemoryTabs()
             refreshAllDocumentTabs()
+            resolveBackgroundError(.organizationResources)
+        } catch is CancellationError {
+            return
         } catch {
-            // Retain the installed Org generation. A later poll retries from
-            // a fresh commit-state response.
+            guard workspaceReloadGeneration == workspaceGeneration,
+                  phase == .ready,
+                  selectedSection == .memory,
+                  activeProjectId == nil,
+                  !isSwitchingMemoryContext,
+                  orgResourceRefreshGeneration == generation else {
+                return
+            }
+            presentBackgroundError(
+                "Couldn’t refresh Organization Memory. Existing content is still available. "
+                    + error.localizedDescription,
+                source: .organizationResources
+            )
         }
     }
 
@@ -3053,10 +3299,15 @@ final class WorkspaceStore: ObservableObject {
     }
 
     private func refreshStaleResourcesIfNeeded(sync: DaemonSyncStatus) async {
+        let workspaceGeneration = workspaceReloadGeneration
         guard let projectId = activeProjectId,
               let project = projects.first(where: { $0.id == projectId }),
-              let serverCursor = sync.commitSync.serverCursor,
-              serverCursor != project.refCommitId else {
+              let serverCursor = sync.commitSync.serverCursor else {
+            return
+        }
+        let errorSource = WorkspaceBackgroundErrorSource.staleResources(projectId: projectId)
+        guard serverCursor != project.refCommitId else {
+            resolveBackgroundError(errorSource)
             return
         }
         let observedRef = project.refCommitId
@@ -3086,6 +3337,7 @@ final class WorkspaceStore: ObservableObject {
                         orgSelectionRevision: project.orgSelectionRevision
                     )
                 }
+                resolveBackgroundError(errorSource)
                 return
             }
             let checkout = try await daemon.projectCheckout(projectId)
@@ -3142,6 +3394,7 @@ final class WorkspaceStore: ObservableObject {
                 snapshot.projectId == projectId
             }
             if !plan.isEmpty, Self.staleResourcePlansMatch(plan, installedPlan) {
+                resolveBackgroundError(errorSource)
                 return
             }
             let hydratedPlan = await hydrateStaleResourcePlan(plan)
@@ -3160,10 +3413,22 @@ final class WorkspaceStore: ObservableObject {
                     orgSelectionRevision: checkout.orgSelectionRevision
                 )
             }
+            resolveBackgroundError(errorSource)
+        } catch is CancellationError {
+            return
         } catch {
-            // Commit sync reports refresh failures separately. Retain a
-            // previously validated plan rather than replacing it with an
-            // unverified checkout.
+            guard workspaceReloadGeneration == workspaceGeneration,
+                  phase == .ready,
+                  activeProjectId == projectId,
+                  projects.first(where: { $0.id == projectId }) == project,
+                  staleResourceRefreshGenerations[projectId] == refreshGeneration else {
+                return
+            }
+            presentBackgroundError(
+                "Couldn’t update from the shared version. Existing content is unchanged. "
+                    + error.localizedDescription,
+                source: errorSource
+            )
         }
     }
 
@@ -3659,7 +3924,9 @@ final class WorkspaceStore: ObservableObject {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(15))
         var requestedRetry = false
-        while clock.now < deadline {
+        var requiresPostRetryCheck = false
+        while clock.now < deadline || requiresPostRetryCheck {
+            requiresPostRetryCheck = false
             try Task.checkCancellation()
             let detail = try await daemon.draft(draft.id)
             let failure = detail.operations.reversed().first {
@@ -3676,8 +3943,16 @@ final class WorkspaceStore: ObservableObject {
                 throw DocumentSyncError.draftUploadFailed(message)
             case .wait:
                 if !requestedRetry {
-                    _ = try await daemon.retrySync(channel: "drafts")
+                    let outcome = await retrySync(
+                        channel: "drafts",
+                        projectId: draft.projectId
+                    )
+                    if case .failed(let message) = outcome {
+                        throw DocumentSyncError.draftUploadFailed(message)
+                    }
                     requestedRetry = true
+                    requiresPostRetryCheck = true
+                    continue
                 }
             case .ready:
                 // A user edit may have been staged while the daemon was
@@ -3686,6 +3961,7 @@ final class WorkspaceStore: ObservableObject {
                 if pendingDocumentSaves[sessionKey] != nil {
                     try await flushDocumentSave(sessionKey)
                     requestedRetry = false
+                    requiresPostRetryCheck = true
                     continue
                 }
                 let mapped = WorkspaceLoader.mapDraft(detail, resources: resources)
@@ -3835,7 +4111,7 @@ final class WorkspaceStore: ObservableObject {
         )
         pruneOrphanedMemoryTabs()
         if projectId == activeProjectId {
-            _ = try? await daemon.retrySync(channel: "commits")
+            _ = await retrySync(channel: "commits", projectId: projectId)
         }
     }
 
@@ -4214,6 +4490,7 @@ final class WorkspaceStore: ObservableObject {
         draftId: String,
         candidate: DraftReconciliationCandidate,
         resolvedState: ReconciliationResourceState?,
+        projectId: String? = nil,
         documentItemId: String? = nil
     ) async throws {
         guard !isSwitchingMemoryContext else {
@@ -4243,6 +4520,9 @@ final class WorkspaceStore: ObservableObject {
                 standaloneReconciliationActivityIds.remove(standaloneActivityId)
             }
         }
+        guard let reconciliationProjectId = projectId ?? documentKey?.projectId else {
+            throw ProjectMemorySelectionError.projectUnavailable
+        }
         let _: DraftRebaseResult = try await server.send(
             method: "POST",
             path: "/api/v1/drafts/\(draftId)/rebases",
@@ -4253,7 +4533,7 @@ final class WorkspaceStore: ObservableObject {
                 resolvedState: resolvedState
             )
         )
-        _ = try? await daemon.retrySync(channel: "drafts")
+        _ = await retrySync(channel: "drafts", projectId: reconciliationProjectId)
         await reload(allowsDuringDocumentReconciliation: true)
     }
 
@@ -4445,6 +4725,8 @@ final class WorkspaceStore: ObservableObject {
     }
 
     func clearAuthorityScopedWorkspace() {
+        cancelSyncRetries()
+        resetBackgroundErrorPresentation()
         Self.invalidateWorkspaceTransitionState(
             generation: &projectSelectionGeneration,
             loadingProjectId: &loadingProjectId,
@@ -4788,7 +5070,7 @@ final class WorkspaceStore: ObservableObject {
                   !Task.isCancelled else {
                 return
             }
-            _ = try? await daemon.retrySync()
+            _ = await self.retrySync(projectId: self.activeProjectId)
         }
 
         postReadySyncTask = Task { @MainActor [weak self] in
@@ -4803,10 +5085,12 @@ final class WorkspaceStore: ObservableObject {
                   !Task.isCancelled else {
                 return
             }
-            async let syncRequest = try? daemon.syncStatus()
+            let projectId = self.activeProjectId
+            async let syncRequest = try? daemon.syncStatus(projectId: projectId)
             async let mcpRequest = try? daemon.mcpStatus()
             let (sync, mcp) = await (syncRequest, mcpRequest)
             guard self.workspaceReloadGeneration == generation,
+                  self.activeProjectId == projectId,
                   self.phase == .ready,
                   !Task.isCancelled,
                   let runtime = self.runtime else {
@@ -4973,14 +5257,25 @@ final class WorkspaceStore: ObservableObject {
     ) async {
         guard workspaceReloadGeneration == generation,
               phase == .ready,
-              !Task.isCancelled,
-              let inventory = try? await WorkspaceLoader.listAllDraftSummaries(
-                  listDrafts: { query in
-                      try await self.daemon.listDrafts(query)
-                  }
-              ) else {
+              !Task.isCancelled else {
             return
         }
+
+        let inventory: [DaemonDraftSummary]
+        do {
+            inventory = try await WorkspaceLoader.listAllDraftSummaries { query in
+                try await self.daemon.listDrafts(query)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard workspaceReloadGeneration == generation, phase == .ready else { return }
+            draftInventoryLoadState = .failed(
+                "Couldn’t refresh Drafts. \(error.localizedDescription)"
+            )
+            return
+        }
+
         guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
             return
         }
@@ -5016,27 +5311,49 @@ final class WorkspaceStore: ObservableObject {
         let targetIds = Set(summaries.compactMap(\.targetId))
         let baselines = resources.filter { targetIds.contains($0.id) && !$0.contentLoaded }
         let loader = WorkspaceLoader(daemon: daemon, bootstrap: bootstrap, server: server)
-        let loadedBaselines = try? await concurrentMap(baselines) {
-            try await loader.loadContent(for: $0)
-        }
-        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
-            return
-        }
-        if let loadedBaselines {
+
+        do {
+            let loadedBaselines = try await concurrentMap(baselines) {
+                try await loader.loadContent(for: $0)
+            }
+            guard workspaceReloadGeneration == generation,
+                  phase == .ready,
+                  !Task.isCancelled else {
+                return
+            }
             for loaded in loadedBaselines {
                 installLoadedResourceIfCurrent(loaded)
             }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard workspaceReloadGeneration == generation, phase == .ready else { return }
+            draftInventoryLoadState = .failed(
+                "Couldn’t refresh Draft source files. \(error.localizedDescription)"
+            )
+            return
         }
 
         let resourceSnapshot = resources
-        let mappedDrafts = try? await concurrentMap(summaries) { summary in
-            WorkspaceLoader.mapDraft(
-                try await self.daemon.draft(summary.draftId),
-                resources: resourceSnapshot
+        let mappedDrafts: [LocalDraft]
+        do {
+            mappedDrafts = try await concurrentMap(summaries) { summary in
+                WorkspaceLoader.mapDraft(
+                    try await self.daemon.draft(summary.draftId),
+                    resources: resourceSnapshot
+                )
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard workspaceReloadGeneration == generation, phase == .ready else { return }
+            draftInventoryLoadState = .failed(
+                "Couldn’t refresh Draft details. \(error.localizedDescription)"
             )
+            return
         }
-        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled,
-              let mappedDrafts else {
+
+        guard workspaceReloadGeneration == generation, phase == .ready, !Task.isCancelled else {
             return
         }
         for mapped in mappedDrafts {
@@ -5056,8 +5373,8 @@ final class WorkspaceStore: ObservableObject {
         projectName: String,
         generation: UUID
     ) async {
+        let workspaceGeneration = workspaceReloadGeneration
         do {
-            let workspaceGeneration = workspaceReloadGeneration
             guard let observedProject = projects.first(where: { $0.id == projectId }),
                   observedProject.name == projectName else { return }
             let loaded = try await WorkspaceLoader(
@@ -5078,8 +5395,21 @@ final class WorkspaceStore: ObservableObject {
                 projectId: projectId,
                 workspaceGeneration: workspaceGeneration
             )
+            resolveBackgroundError(.projectRefresh(projectId: projectId))
+        } catch is CancellationError {
+            return
         } catch {
-            // The installed Commit remains usable; commit sync reports refresh failures separately.
+            guard workspaceReloadGeneration == workspaceGeneration,
+                  projectSelectionGeneration == generation,
+                  phase == .ready,
+                  activeProjectId == projectId else {
+                return
+            }
+            presentBackgroundError(
+                "Couldn’t refresh \(projectName). Existing content is still available. "
+                    + error.localizedDescription,
+                source: .projectRefresh(projectId: projectId)
+            )
         }
     }
 

--- a/apps/macos/Sources/Features/DiagnosticsView.swift
+++ b/apps/macos/Sources/Features/DiagnosticsView.swift
@@ -118,6 +118,11 @@ private struct RuntimeDiagnosticsView: View {
                     LabeledContent("Log directory", value: runtime.health.logDir)
                 }
                 Section("Synchronization") {
+                    let retryProjectId = store.activeProjectId ?? runtime.health.projectId
+                    let isRetrying = store.isRetryingSync(
+                        channel: "all",
+                        projectId: retryProjectId
+                    )
                     LabeledContent("Drafts", value: runtime.sync?.draftSync.state.capitalized ?? "Loading")
                     LabeledContent("Commits", value: runtime.sync?.commitSync.state.capitalized ?? "Loading")
                     LabeledContent(
@@ -136,7 +141,14 @@ private struct RuntimeDiagnosticsView: View {
                         "Reconciliation conflicts",
                         value: runtime.sync.map { String($0.reconciliationConflictCount) } ?? "Loading"
                     )
-                    Button("Retry") { Task { await store.retrySync() } }
+                    Button(isRetrying ? "Retrying…" : "Retry Current Project") {
+                        Task {
+                            _ = await store.retrySync(
+                                projectId: retryProjectId
+                            )
+                        }
+                    }
+                    .disabled(isRetrying)
                 }
                 Section("Server") {
                     LabeledContent("Data source", value: runtime.serverDataSource.capitalized)

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -194,28 +194,125 @@ private struct ProjectPreparationView: View {
     }
 }
 
-private struct PendingOrganizationDeletion: Identifiable {
-    let id = UUID()
-    let items: [MemoryListItem]
+enum MemoryFileTreeAlert: Identifiable {
+    enum ID: Hashable {
+        case itemRename(String)
+        case directoryRename(String)
+        case organizationDeletion
+        case directoryDiscard
+        case directoryDeletion
+    }
+
+    case itemRename(item: MemoryListItem)
+    case directoryRename(id: String, items: [MemoryListItem])
+    case organizationDeletion(items: [MemoryListItem])
+    case directoryDiscard(name: String, drafts: [LocalDraft])
+    case directoryDeletion(name: String, plan: MemoryDirectoryDeletionPlan)
+
+    var id: ID {
+        switch self {
+        case .itemRename(let item):
+            .itemRename(item.id)
+        case .directoryRename(let id, _):
+            .directoryRename(id)
+        case .organizationDeletion:
+            .organizationDeletion
+        case .directoryDiscard:
+            .directoryDiscard
+        case .directoryDeletion:
+            .directoryDeletion
+        }
+    }
 
     var title: String {
-        items.count == 1
-            ? "Propose Organization Deletion?"
-            : "Propose \(items.count) Organization Deletions?"
+        switch self {
+        case .itemRename(let item):
+            item.resource == nil ? "Rename Draft" : "Propose Organization Rename"
+        case .directoryRename:
+            "Rename Folder"
+        case .organizationDeletion(let items):
+            items.count == 1
+                ? "Propose Organization Deletion?"
+                : "Propose \(items.count) Organization Deletions?"
+        case .directoryDiscard(let name, let drafts):
+            drafts.count == 1
+                ? "Discard Draft in \(name)?"
+                : "Discard \(drafts.count) Drafts in \(name)?"
+        case .directoryDeletion(let name, _):
+            "Delete \(name)?"
+        }
     }
 
     var confirmationTitle: String {
-        items.count == 1 ? "Propose Deletion" : "Propose Deletions"
+        switch self {
+        case .itemRename(let item):
+            item.resource == nil ? "Rename" : "Propose Rename"
+        case .directoryRename(_, let items):
+            items.contains { $0.resource != nil } ? "Propose Renames" : "Rename"
+        case .organizationDeletion(let items):
+            items.count == 1 ? "Propose Deletion" : "Propose Deletions"
+        case .directoryDiscard:
+            "Discard Drafts"
+        case .directoryDeletion:
+            "Delete Folder"
+        }
     }
 
     var message: String {
-        let subject = items.count == 1
-            ? "this organization memory"
-            : "these \(items.count) organization memories"
-        let proposal = items.count == 1 ? "a deletion draft proposal" : "deletion draft proposals"
-        let object = items.count == 1 ? "it" : "them"
-        return "This creates \(proposal). If reviewed and merged, \(subject) "
-            + "will be removed for every project that includes \(object)."
+        switch self {
+        case .itemRename(let item):
+            if item.resource == nil {
+                return "This changes the path in the current Project-carried Draft."
+            }
+            return "This creates a draft proposal. If it is reviewed and merged, "
+                + "the organization memory will be renamed for every project that includes it."
+        case .directoryRename(_, let items):
+            let sharedCount = items.filter { $0.resource != nil }.count
+            let draftCount = items.count - sharedCount
+            if sharedCount == 0 {
+                return "This preserves every relative file path in the current Project-carried "
+                    + "Drafts. Shared Organization Memory is unchanged."
+            }
+            if draftCount > 0 {
+                return "This preserves every relative file path, renames \(draftCount) unpublished "
+                    + "Drafts, and creates \(sharedCount) rename proposals. Shared Organization "
+                    + "Memory changes only after review and merge."
+            }
+            return "This preserves every relative file path and creates Project-carried rename "
+                + "Drafts. Organization Memory changes only after review and merge."
+        case .organizationDeletion(let items):
+            let subject = items.count == 1
+                ? "this organization memory"
+                : "these \(items.count) organization memories"
+            let proposal = items.count == 1
+                ? "a deletion draft proposal"
+                : "deletion draft proposals"
+            let object = items.count == 1 ? "it" : "them"
+            return "This creates \(proposal). If reviewed and merged, \(subject) "
+                + "will be removed for every project that includes \(object)."
+        case .directoryDiscard:
+            return "This removes the Project-carried Drafts in this folder. "
+                + "Shared Organization Memory is unchanged."
+        case .directoryDeletion(let name, let plan):
+            var effects: [String] = []
+            if !plan.itemsToDelete.isEmpty {
+                let noun = plan.itemsToDelete.count == 1 ? "memory" : "memories"
+                effects.append(
+                    "create deletion proposals for \(plan.itemsToDelete.count) shared "
+                        + noun
+                )
+            }
+            if !plan.draftsToDiscard.isEmpty {
+                let noun = plan.draftsToDiscard.count == 1 ? "draft" : "drafts"
+                effects.append(
+                    "discard \(plan.draftsToDiscard.count) unpublished "
+                        + noun
+                )
+            }
+            let joinedEffects = effects.joined(separator: " and ")
+            return "This will \(joinedEffects) in \(name). "
+                + "Shared memories are removed only after review and merge."
+        }
     }
 }
 
@@ -225,39 +322,6 @@ private struct PendingDirectoryReview: Identifiable {
     let initialTitle: String
 }
 
-private struct PendingDirectoryDiscard: Identifiable {
-    let id = UUID()
-    let name: String
-    let drafts: [LocalDraft]
-}
-
-private struct PendingDirectoryDeletion: Identifiable {
-    let id = UUID()
-    let name: String
-    let plan: MemoryDirectoryDeletionPlan
-
-    var message: String {
-        var effects: [String] = []
-        if !plan.itemsToDelete.isEmpty {
-            let noun = plan.itemsToDelete.count == 1 ? "memory" : "memories"
-            effects.append(
-                "create deletion proposals for \(plan.itemsToDelete.count) shared "
-                    + noun
-            )
-        }
-        if !plan.draftsToDiscard.isEmpty {
-            let noun = plan.draftsToDiscard.count == 1 ? "draft" : "drafts"
-            effects.append(
-                "discard \(plan.draftsToDiscard.count) unpublished "
-                    + noun
-            )
-        }
-        let joinedEffects = effects.joined(separator: " and ")
-        return "This will \(joinedEffects) in \(name). "
-            + "Shared memories are removed only after review and merge."
-    }
-}
-
 private struct FileTreeView: View {
     @ObservedObject var store: WorkspaceStore
     let items: [MemoryListItem]
@@ -265,14 +329,11 @@ private struct FileTreeView: View {
     @State private var selectedNodeIds: Set<String> = []
     @State private var selectionAnchorId: String?
     @State private var initializedExpansion = false
-    @State private var itemToRename: MemoryListItem?
     @State private var proposedName = ""
-    @State private var directoryToRenameId: String?
     @State private var proposedDirectoryName = ""
-    @State private var pendingOrganizationDeletion: PendingOrganizationDeletion?
-    @State private var pendingDirectoryDeletion: PendingDirectoryDeletion?
-    @State private var pendingDirectoryDiscard: PendingDirectoryDiscard?
+    @State private var pendingAlert: MemoryFileTreeAlert?
     @State private var pendingDirectoryReview: PendingDirectoryReview?
+    @State private var directoryOperationProgress: String?
 
     private var roots: [FileTreeNode] {
         FileTreeNode.build(items)
@@ -283,7 +344,7 @@ private struct FileTreeView: View {
     }
 
     var body: some View {
-        fileTreeWithDestructiveAlerts
+        fileTreeWithAlert
         .sheet(item: $pendingDirectoryReview) { request in
             ReviewRequestSheet(
                 initialTitle: request.initialTitle,
@@ -307,6 +368,21 @@ private struct FileTreeView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(Color(nsColor: .controlBackgroundColor))
+        .safeAreaInset(edge: .bottom) {
+            if let directoryOperationProgress {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(directoryOperationProgress)
+                        .font(.caption)
+                }
+                .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.bar)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(directoryOperationProgress)
+            }
+        }
         .contextMenu(forSelectionType: String.self) { nodeIds in
             fileTreeMenu(for: nodeIds)
         }
@@ -329,105 +405,45 @@ private struct FileTreeView: View {
             synchronizeSelectionWithActiveItem()
         }
         .onChange(of: store.activeProjectId) { _, _ in
-            itemToRename = nil
-            proposedName = ""
-            directoryToRenameId = nil
-            proposedDirectoryName = ""
-            pendingOrganizationDeletion = nil
-            pendingDirectoryDeletion = nil
-            pendingDirectoryDiscard = nil
+            dismissAlert()
             pendingDirectoryReview = nil
         }
     }
 
-    private var fileTreeWithRenameAlerts: some View {
+    private var fileTreeWithAlert: some View {
         fileTreeContent
         .alert(
-            itemRenameTitle,
+            pendingAlert?.title ?? "",
             isPresented: Binding(
-                get: { itemToRename != nil },
-                set: {
-                    if !$0 {
-                        itemToRename = nil
-                        proposedName = ""
-                    }
+                get: { pendingAlert != nil },
+                set: { if !$0 { dismissAlert() } }
+            ),
+            presenting: pendingAlert
+        ) { alert in
+            switch alert {
+            case .itemRename:
+                TextField("File name", text: $proposedName)
+                Button("Cancel", role: .cancel) { dismissAlert() }
+                Button(alert.confirmationTitle) { renameSelectedItem() }
+                    .disabled(
+                        directoryOperationProgress != nil || !isValidProposedName
+                    )
+            case .directoryRename:
+                TextField("Folder name", text: $proposedDirectoryName)
+                Button("Cancel", role: .cancel) { dismissAlert() }
+                Button(alert.confirmationTitle) { renameSelectedDirectory() }
+                    .disabled(
+                        directoryOperationProgress != nil || !isValidProposedDirectoryName
+                    )
+            case .organizationDeletion, .directoryDiscard, .directoryDeletion:
+                Button("Cancel", role: .cancel) { dismissAlert() }
+                Button(alert.confirmationTitle, role: .destructive) {
+                    confirm(alert)
                 }
-            )
-        ) {
-            TextField("File name", text: $proposedName)
-            Button("Cancel", role: .cancel) {
-                itemToRename = nil
+                .disabled(directoryOperationProgress != nil)
             }
-            Button(itemRenameConfirmationTitle) {
-                renameSelectedItem()
-            }
-            .disabled(!isValidProposedName)
-        } message: {
-            Text(itemRenameMessage)
-        }
-        .alert(
-            "Rename Folder",
-            isPresented: Binding(
-                get: { directoryToRenameId != nil },
-                set: {
-                    if !$0 {
-                        directoryToRenameId = nil
-                        proposedDirectoryName = ""
-                    }
-                }
-            )
-        ) {
-            TextField("Folder name", text: $proposedDirectoryName)
-            Button("Cancel", role: .cancel) {
-                directoryToRenameId = nil
-            }
-            Button(directoryRenameConfirmationTitle) {
-                renameSelectedDirectory()
-            }
-            .disabled(!isValidProposedDirectoryName)
-        } message: {
-            Text(directoryRenameMessage)
-        }
-    }
-
-    private var fileTreeWithDestructiveAlerts: some View {
-        fileTreeWithRenameAlerts
-        .alert(item: $pendingOrganizationDeletion) { deletion in
-            Alert(
-                title: Text(deletion.title),
-                message: Text(deletion.message),
-                primaryButton: .destructive(Text(deletion.confirmationTitle)) {
-                    deleteItems(deletion.items)
-                },
-                secondaryButton: .cancel()
-            )
-        }
-        .alert(item: $pendingDirectoryDiscard) { request in
-            Alert(
-                title: Text(
-                    request.drafts.count == 1
-                        ? "Discard Draft in \(request.name)?"
-                        : "Discard \(request.drafts.count) Drafts in \(request.name)?"
-                ),
-                message: Text(
-                    "This removes the Project-carried Drafts in this folder. "
-                        + "Shared Organization Memory is unchanged."
-                ),
-                primaryButton: .destructive(Text("Discard Drafts")) {
-                    discardDrafts(request.drafts)
-                },
-                secondaryButton: .cancel()
-            )
-        }
-        .alert(item: $pendingDirectoryDeletion) { request in
-            Alert(
-                title: Text("Delete \(request.name)?"),
-                message: Text(request.message),
-                primaryButton: .destructive(Text("Delete Folder")) {
-                    deleteDirectory(request.plan)
-                },
-                secondaryButton: .cancel()
-            )
+        } message: { alert in
+            Text(alert.message)
         }
     }
 
@@ -455,46 +471,14 @@ private struct FileTreeView: View {
         return !name.isEmpty && name != "." && name != ".." && !name.contains("/")
     }
 
-    private var itemRenameTitle: String {
-        itemToRename?.resource == nil ? "Rename Draft" : "Propose Organization Rename"
+    private var itemToRename: MemoryListItem? {
+        guard case .itemRename(let item) = pendingAlert else { return nil }
+        return item
     }
 
-    private var itemRenameConfirmationTitle: String {
-        itemToRename?.resource == nil ? "Rename" : "Propose Rename"
-    }
-
-    private var itemRenameMessage: String {
-        if itemToRename?.resource == nil {
-            return "This changes the path in the current Project-carried Draft."
-        }
-        return "This creates a draft proposal. If it is reviewed and merged, "
-            + "the organization memory will be renamed for every project that includes it."
-    }
-
-    private var directoryRenameItems: [MemoryListItem] {
-        guard let directoryToRenameId else { return [] }
-        return FileTreeNode.items(in: roots, selectedNodeIds: [directoryToRenameId])
-    }
-
-    private var directoryRenameConfirmationTitle: String {
-        directoryRenameItems.contains { $0.resource != nil } ? "Propose Renames" : "Rename"
-    }
-
-    private var directoryRenameMessage: String {
-        let items = directoryRenameItems
-        let sharedCount = items.filter { $0.resource != nil }.count
-        let draftCount = items.count - sharedCount
-        if sharedCount == 0 {
-            return "This preserves every relative file path in the current Project-carried "
-                + "Drafts. Shared Organization Memory is unchanged."
-        }
-        if draftCount > 0 {
-            return "This preserves every relative file path, renames \(draftCount) unpublished "
-                + "Drafts, and creates \(sharedCount) rename proposals. Shared Organization "
-                + "Memory changes only after review and merge."
-        }
-        return "This preserves every relative file path and creates Project-carried rename "
-            + "Drafts. Organization Memory changes only after review and merge."
+    private var directoryToRenameId: String? {
+        guard case .directoryRename(let id, _) = pendingAlert else { return nil }
+        return id
     }
 
     private var isValidProposedDirectoryName: Bool {
@@ -507,21 +491,28 @@ private struct FileTreeView: View {
         return name != directory.name
     }
 
+    private func dismissAlert() {
+        pendingAlert = nil
+        proposedName = ""
+        proposedDirectoryName = ""
+    }
+
     private func beginRenaming(_ item: MemoryListItem) {
+        guard directoryOperationProgress == nil else { return }
         guard !store.isSynchronizingDocument(item.id) else {
             store.errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
             return
         }
         proposedName = item.document.path.split(separator: "/").last.map(String.init)
             ?? item.document.path
-        itemToRename = item
+        pendingAlert = .itemRename(item: item)
     }
 
     private func renameSelectedItem() {
+        guard directoryOperationProgress == nil else { return }
         guard let item = itemToRename else { return }
         guard !store.isSynchronizingDocument(item.id) else {
-            itemToRename = nil
-            proposedName = ""
+            dismissAlert()
             store.errorMessage = DocumentSyncError.mutationWhileSynchronizing.localizedDescription
             return
         }
@@ -533,8 +524,7 @@ private struct FileTreeView: View {
             .dropLast()
             .joined(separator: "/")
         document.path = parent.isEmpty ? name : "\(parent)/\(name)"
-        itemToRename = nil
-        proposedName = ""
+        dismissAlert()
         Task {
             do {
                 try await store.rename(item, to: document.path)
@@ -545,6 +535,7 @@ private struct FileTreeView: View {
     }
 
     private func beginRenamingDirectory(_ directory: FileTreeNode) {
+        guard directoryOperationProgress == nil else { return }
         let targetItems = FileTreeNode.items(
             in: roots,
             selectedNodeIds: [directory.id]
@@ -557,11 +548,12 @@ private struct FileTreeView: View {
             store.errorMessage = MemoryDirectoryMutationError.readOnly.localizedDescription
             return
         }
-        directoryToRenameId = directory.id
         proposedDirectoryName = directory.name
+        pendingAlert = .directoryRename(id: directory.id, items: targetItems)
     }
 
     private func renameSelectedDirectory() {
+        guard directoryOperationProgress == nil else { return }
         guard let directoryToRenameId else { return }
         let name = proposedDirectoryName.trimmingCharacters(in: .whitespacesAndNewlines)
         let targetItems = FileTreeNode.items(
@@ -596,12 +588,15 @@ private struct FileTreeView: View {
                 occupiedTreePaths: occupiedTreePaths,
                 inOrgView: false
             )
-            self.directoryToRenameId = nil
-            proposedDirectoryName = ""
+            dismissAlert()
             Task {
                 var completed = 0
+                directoryOperationProgress = "Renaming \(plan.changes.count) memories…"
+                defer { directoryOperationProgress = nil }
                 do {
-                    for change in plan.changes {
+                    for (index, change) in plan.changes.enumerated() {
+                        directoryOperationProgress =
+                            "Renaming \(index + 1) of \(plan.changes.count) memories…"
                         try await store.rename(change.item, to: change.newPath)
                         completed += 1
                     }
@@ -731,16 +726,22 @@ private struct FileTreeView: View {
         if let selectedDirectory {
             if directoryRenameable {
                 Button("Rename Folder…") { beginRenamingDirectory(selectedDirectory) }
-                    .disabled(selectionContainsSynchronizingDocument)
+                    .disabled(
+                        directoryOperationProgress != nil
+                            || selectionContainsSynchronizingDocument
+                    )
             }
             if let directoryDeletionPlan, directoryDeletionAllowed {
                 Button("Delete Folder…", role: .destructive) {
-                    pendingDirectoryDeletion = .init(
+                    pendingAlert = .directoryDeletion(
                         name: selectedDirectory.name,
                         plan: directoryDeletionPlan
                     )
                 }
-                .disabled(selectionContainsSynchronizingDocument)
+                .disabled(
+                    directoryOperationProgress != nil
+                        || selectionContainsSynchronizingDocument
+                )
             }
         } else if let singleItem {
             Button("Open") { store.open(singleItem) }
@@ -751,13 +752,13 @@ private struct FileTreeView: View {
                 Button(
                     singleItem.resource == nil ? "Rename…" : "Propose Organization Rename…"
                 ) { beginRenaming(singleItem) }
-                    .disabled(singleSynchronizing)
+                    .disabled(directoryOperationProgress != nil || singleSynchronizing)
             }
             if singleTrashable {
                 Button("Propose Organization Deletion", role: .destructive) {
                     proposeOrganizationDeletion([singleItem])
                 }
-                .disabled(singleSynchronizing)
+                .disabled(directoryOperationProgress != nil || singleSynchronizing)
             }
         } else if !targetItems.isEmpty {
             Button("Open") { targetItems.forEach { store.open($0) } }
@@ -765,7 +766,10 @@ private struct FileTreeView: View {
                 Button(organizationDeletionTitle(count: trashableItems.count), role: .destructive) {
                     proposeOrganizationDeletion(trashableItems)
                 }
-                .disabled(trashSelectionContainsSynchronizingDocument)
+                .disabled(
+                    directoryOperationProgress != nil
+                        || trashSelectionContainsSynchronizingDocument
+                )
             }
         }
 
@@ -787,7 +791,8 @@ private struct FileTreeView: View {
                 }
             }
             .disabled(
-                !store.canManageOrgSelection
+                directoryOperationProgress != nil
+                    || !store.canManageOrgSelection
                     || store.projects.isEmpty
                     || selectionContainsSynchronizingDocument
             )
@@ -796,7 +801,11 @@ private struct FileTreeView: View {
             Button(removeFromProjectTitle(count: removableItems.count)) {
                 removeFromProject(removableItems)
             }
-            .disabled(!store.canManageOrgSelection || selectionContainsSynchronizingDocument)
+            .disabled(
+                directoryOperationProgress != nil
+                    || !store.canManageOrgSelection
+                    || selectionContainsSynchronizingDocument
+            )
         }
         if !isOrgView, !reviewDrafts.isEmpty {
             Button(reviewRequestTitle(count: reviewDrafts.count)) {
@@ -805,7 +814,11 @@ private struct FileTreeView: View {
                     initialTitle: directoryReviewTitle(for: nodeIds, draftCount: reviewDrafts.count)
                 )
             }
-            .disabled(!reviewSelectionIsReady || selectionContainsSynchronizingDocument)
+            .disabled(
+                directoryOperationProgress != nil
+                    || !reviewSelectionIsReady
+                    || selectionContainsSynchronizingDocument
+            )
         }
         if let selectedDirectory, !directoryDrafts.isEmpty {
             Button(
@@ -814,12 +827,15 @@ private struct FileTreeView: View {
                     : "Discard \(directoryDrafts.count) Drafts in Folder…",
                 role: .destructive
             ) {
-                pendingDirectoryDiscard = .init(
+                pendingAlert = .directoryDiscard(
                     name: selectedDirectory.name,
                     drafts: directoryDrafts
                 )
             }
-            .disabled(selectionContainsSynchronizingDocument)
+            .disabled(
+                directoryOperationProgress != nil
+                    || selectionContainsSynchronizingDocument
+            )
         }
         if let singleItem {
             let resourceIsStale = singleItem.resource.map {
@@ -832,44 +848,72 @@ private struct FileTreeView: View {
                       draft.freshness == .behind || resourceIsStale {
                 switch draft.syncStatus {
                 case .queued, .syncing, .retrying:
-                    Button("Waiting for Draft Sync…") {}
+                    Button("Uploading Draft Changes…") {}
                         .disabled(true)
                 case .failed:
-                    Button("Retry Draft Sync") {
-                        Task { await store.retrySync() }
+                    if store.isRetryingSync(
+                        channel: "drafts",
+                        projectId: draft.projectId
+                    ) {
+                        Button("Retrying Draft Sync…") {}
+                            .disabled(true)
+                    } else {
+                        Button("Retry Draft Sync") {
+                            Task {
+                                _ = await store.retrySync(
+                                    channel: "drafts",
+                                    projectId: draft.projectId
+                                )
+                            }
+                        }
+                        .disabled(directoryOperationProgress != nil)
                     }
                 case .synced:
                     if draft.serverId == nil {
                         Button("Draft Not Ready") {}
                             .disabled(true)
                     } else {
-                        Button(draft.hasUpstreamResourceChanges ? "Review Changes" : "Sync") {
+                        Button(
+                            draft.hasUpstreamResourceChanges
+                                ? "Review Shared Changes"
+                                : "Update from Shared Version"
+                        ) {
+                            guard directoryOperationProgress == nil else { return }
                             store.syncDocument(singleItem)
                         }
+                        .disabled(directoryOperationProgress != nil)
                     }
                 }
             } else if resourceIsStale {
-                Button("Sync") {
+                Button("Update from Shared Version") {
+                    guard directoryOperationProgress == nil else { return }
                     store.syncDocument(singleItem)
                 }
+                .disabled(directoryOperationProgress != nil)
             }
             if !isOrgView, let draft = singleItem.draft {
                 Button("Discard Draft") {
+                    guard directoryOperationProgress == nil else { return }
                     Task { await store.discard(draft) }
                 }
-                .disabled(singleSynchronizing)
+                .disabled(
+                    directoryOperationProgress != nil
+                        || singleSynchronizing
+                )
             }
         }
 
         if targetItems.isEmpty {
             if let scope = MemoryFileTreeMenu.creationScope(inOrgView: isOrgView) {
                 Button("Propose New Organization Memory") {
+                    guard directoryOperationProgress == nil else { return }
                     Task {
                         await store.createMemory(kind: store.selectedKind, scope: scope)
                     }
                 }
                 .disabled(
-                    !store.canCreateMemory(kind: store.selectedKind, scope: scope)
+                    directoryOperationProgress != nil
+                        || !store.canCreateMemory(kind: store.selectedKind, scope: scope)
                 )
             }
         }
@@ -907,26 +951,47 @@ private struct FileTreeView: View {
 
     private func proposeOrganizationDeletion(_ items: [MemoryListItem]) {
         guard !items.isEmpty else { return }
-        pendingOrganizationDeletion = .init(items: items)
+        pendingAlert = .organizationDeletion(items: items)
+    }
+
+    private func confirm(_ alert: MemoryFileTreeAlert) {
+        dismissAlert()
+        switch alert {
+        case .itemRename, .directoryRename:
+            return
+        case .organizationDeletion(let items):
+            deleteItems(items)
+        case .directoryDiscard(_, let drafts):
+            discardDrafts(drafts)
+        case .directoryDeletion(_, let plan):
+            deleteDirectory(plan)
+        }
     }
 
     private func deleteItems(_ items: [MemoryListItem]) {
+        guard directoryOperationProgress == nil else { return }
         Task {
-            for item in items {
+            directoryOperationProgress = "Proposing \(items.count) deletions…"
+            defer { directoryOperationProgress = nil }
+            for (index, item) in items.enumerated() {
+                directoryOperationProgress =
+                    "Proposing deletion \(index + 1) of \(items.count)…"
                 guard await store.delete(item) else { return }
             }
         }
     }
 
     private func discardDrafts(_ drafts: [LocalDraft]) {
+        guard directoryOperationProgress == nil else { return }
         Task {
+            directoryOperationProgress = "Discarding \(drafts.count) Drafts…"
+            defer { directoryOperationProgress = nil }
             for (index, draft) in drafts.enumerated() {
+                directoryOperationProgress =
+                    "Discarding Draft \(index + 1) of \(drafts.count)…"
                 guard await store.discard(draft) else {
-                    if index > 0 {
-                        let detail = store.errorMessage ?? "The remaining Drafts were not changed."
-                        store.errorMessage = "Discarded \(index) of \(drafts.count) Drafts. "
-                            + detail
-                    }
+                    let detail = store.errorMessage ?? "The remaining Drafts were not changed."
+                    store.errorMessage = "Discarded \(index) of \(drafts.count) Drafts. " + detail
                     return
                 }
             }
@@ -934,27 +999,30 @@ private struct FileTreeView: View {
     }
 
     private func deleteDirectory(_ plan: MemoryDirectoryDeletionPlan) {
+        guard directoryOperationProgress == nil else { return }
         Task {
             let total = plan.itemsToDelete.count + plan.draftsToDiscard.count
             var completed = 0
+            directoryOperationProgress = "Applying \(total) folder changes…"
+            defer { directoryOperationProgress = nil }
             for item in plan.itemsToDelete {
+                directoryOperationProgress =
+                    "Applying folder change \(completed + 1) of \(total)…"
                 guard await store.delete(item) else {
-                    if completed > 0 {
-                        let detail = store.errorMessage ?? "The remaining files were not changed."
-                        store.errorMessage = "Completed \(completed) of \(total) folder changes. "
-                            + detail
-                    }
+                    let detail = store.errorMessage ?? "The remaining files were not changed."
+                    store.errorMessage =
+                        "Completed \(completed) of \(total) folder changes. " + detail
                     return
                 }
                 completed += 1
             }
             for draft in plan.draftsToDiscard {
+                directoryOperationProgress =
+                    "Applying folder change \(completed + 1) of \(total)…"
                 guard await store.discard(draft) else {
-                    if completed > 0 {
-                        let detail = store.errorMessage ?? "The remaining files were not changed."
-                        store.errorMessage = "Completed \(completed) of \(total) folder changes. "
-                            + detail
-                    }
+                    let detail = store.errorMessage ?? "The remaining files were not changed."
+                    store.errorMessage =
+                        "Completed \(completed) of \(total) folder changes. " + detail
                     return
                 }
                 completed += 1
@@ -963,6 +1031,7 @@ private struct FileTreeView: View {
     }
 
     private func addToProject(_ items: [MemoryListItem], projectId: String) {
+        guard directoryOperationProgress == nil else { return }
         Task {
             do {
                 try await store.addOrgMemories(
@@ -976,6 +1045,7 @@ private struct FileTreeView: View {
     }
 
     private func removeFromProject(_ items: [MemoryListItem]) {
+        guard directoryOperationProgress == nil else { return }
         guard let projectId = store.activeProjectId else { return }
         Task {
             do {

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -674,7 +674,10 @@ struct ReviewDetailPage: View {
                     try await store.applyReconciliation(
                         draftId: candidate.draftId,
                         candidate: candidate,
-                        resolvedState: resolvedState
+                        resolvedState: resolvedState,
+                        projectId: fileChanges.first {
+                            $0.detail.draft.draftId == candidate.draftId
+                        }?.detail.draft.projectId
                     )
                 }
             } else if loading {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -65,7 +65,9 @@ enum SyncToolbarPresentation: Equatable {
     var label: String {
         switch self {
         case .syncing(let count):
-            count == 1 ? "Syncing 1 change" : count > 1 ? "Syncing \(count) changes" : "Syncing"
+            count == 1
+                ? "Uploading 1 Draft change"
+                : count > 1 ? "Uploading \(count) Draft changes" : "Uploading Draft changes"
         case .failed:
             "Sync failed"
         case .unavailable:
@@ -78,7 +80,7 @@ enum SyncToolbarPresentation: Equatable {
     var detail: String {
         switch self {
         case .syncing:
-            return "Clumsies is synchronizing changes in the background."
+            return "Clumsies is uploading Project-carried Draft changes in the background."
         case .failed(let count, let message):
             if let message, !message.isEmpty { return message }
             return count == 1
@@ -172,15 +174,24 @@ struct WorkspaceView: View {
     }
 
     var body: some View {
-        switch store.selectedSection {
-        case .issues:
-            issuesWorkspace
-        case .reviews:
-            reviewsWorkspace
-        case .sessions:
-            recallWorkspace
-        default:
-            regularWorkspace
+        Group {
+            switch store.selectedSection {
+            case .issues:
+                issuesWorkspace
+            case .reviews:
+                reviewsWorkspace
+            case .sessions:
+                recallWorkspace
+            default:
+                regularWorkspace
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if let message = store.errorMessage {
+                WorkspaceOperationErrorBanner(message: message) {
+                    store.dismissErrorMessage()
+                }
+            }
         }
     }
 
@@ -286,8 +297,7 @@ struct WorkspaceView: View {
                                 .popover(isPresented: $showsSyncIssuePopover, arrowEdge: .top) {
                                     SyncIssuePopover(
                                         presentation: syncToolbarPresentation,
-                                        store: store,
-                                        isPresented: $showsSyncIssuePopover
+                                        store: store
                                     )
                                 }
                             }
@@ -326,13 +336,30 @@ struct WorkspaceView: View {
                                         .help("Saving draft changes before sync")
                                         .accessibilityLabel("Saving draft changes before sync")
                                 case .failed:
-                                    Button {
-                                        Task { await store.retrySync() }
-                                    } label: {
-                                        Image(systemName: "arrow.clockwise")
+                                    if store.isRetryingSync(
+                                        channel: "drafts",
+                                        projectId: item.draft?.projectId ?? store.activeProjectId
+                                    ) {
+                                        ProgressView()
+                                            .controlSize(.small)
+                                            .frame(width: 24, height: 24)
+                                            .help("Retrying Draft Sync")
+                                            .accessibilityLabel("Retrying Draft Sync")
+                                    } else {
+                                        Button {
+                                            Task {
+                                                _ = await store.retrySync(
+                                                    channel: "drafts",
+                                                    projectId: item.draft?.projectId
+                                                        ?? store.activeProjectId
+                                                )
+                                            }
+                                        } label: {
+                                            Image(systemName: "arrow.clockwise")
+                                        }
+                                        .help("Retry Draft Sync")
+                                        .accessibilityLabel("Retry Draft Sync")
                                     }
-                                    .help("Retry Draft Sync")
-                                    .accessibilityLabel("Retry Draft Sync")
                                 case .unavailable:
                                     Button {} label: {
                                         Image(systemName: "exclamationmark.triangle")
@@ -480,18 +507,6 @@ struct WorkspaceView: View {
                     return
                 }
             }
-        }
-        .alert(
-            "Clumsies",
-            isPresented: Binding(
-                get: { store.errorMessage != nil },
-                set: { if !$0 { store.errorMessage = nil } }
-            )
-        ) {
-            Button("OK") { store.errorMessage = nil }
-        } message: {
-            Text(store.errorMessage ?? "")
-                .textSelection(.enabled)
         }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)
@@ -663,18 +678,6 @@ struct WorkspaceView: View {
                 }
             }
         }
-        .alert(
-            "Clumsies",
-            isPresented: Binding(
-                get: { store.errorMessage != nil },
-                set: { if !$0 { store.errorMessage = nil } }
-            )
-        ) {
-            Button("OK") { store.errorMessage = nil }
-        } message: {
-            Text(store.errorMessage ?? "")
-                .textSelection(.enabled)
-        }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)
         }
@@ -845,8 +848,7 @@ struct WorkspaceView: View {
                     .popover(isPresented: $showsSyncIssuePopover, arrowEdge: .top) {
                         SyncIssuePopover(
                             presentation: syncToolbarPresentation,
-                            store: store,
-                            isPresented: $showsSyncIssuePopover
+                            store: store
                         )
                     }
                 }
@@ -1064,8 +1066,7 @@ struct WorkspaceView: View {
                                 .popover(isPresented: $showsSyncIssuePopover, arrowEdge: .top) {
                                     SyncIssuePopover(
                                         presentation: syncToolbarPresentation,
-                                        store: store,
-                                        isPresented: $showsSyncIssuePopover
+                                        store: store
                                     )
                                 }
                             }
@@ -1136,18 +1137,6 @@ struct WorkspaceView: View {
         }
         .task(id: store.activeProjectId) {
             await store.refreshProjectMembers()
-        }
-        .alert(
-            "Clumsies",
-            isPresented: Binding(
-                get: { store.errorMessage != nil },
-                set: { if !$0 { store.errorMessage = nil } }
-            )
-        ) {
-            Button("OK") { store.errorMessage = nil }
-        } message: {
-            Text(store.errorMessage ?? "")
-                .textSelection(.enabled)
         }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)
@@ -1449,11 +1438,50 @@ private extension SyncToolbarPresentation {
     }
 }
 
+private struct WorkspaceOperationErrorBanner: View {
+    let message: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Operation Failed")
+                    .font(.headline)
+                Text(message)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Operation failed: \(message)")
+
+            Spacer(minLength: 16)
+
+            Button("Copy Details") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(message, forType: .string)
+            }
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.plain)
+            .help("Dismiss")
+            .accessibilityLabel("Dismiss operation failure")
+        }
+        .padding(10)
+        .background(.bar)
+        .overlay(alignment: .top) { Divider() }
+    }
+}
+
 private struct SyncIssuePopover: View {
     let presentation: SyncToolbarPresentation
     @ObservedObject var store: WorkspaceStore
-    @Binding var isPresented: Bool
-    @State private var isRetrying = false
+    @State private var isReloading = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -1468,6 +1496,14 @@ private struct SyncIssuePopover: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
 
+            if let message = store.syncRetryErrorMessage {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel("Sync retry failed: \(message)")
+            }
+
             Divider()
 
             HStack {
@@ -1475,39 +1511,35 @@ private struct SyncIssuePopover: View {
                 switch presentation {
                 case .failed, .unavailable:
                     Button {
-                        isRetrying = true
                         Task {
-                            await store.retrySync()
-                            isRetrying = false
-                            isPresented = false
+                            _ = await store.retrySync(projectId: store.activeProjectId)
                         }
                     } label: {
-                        if isRetrying {
+                        if store.isRetryingSync {
                             ProgressView()
                                 .controlSize(.small)
                         } else {
-                            Text("Try Again")
+                            Text("Retry Project Sync")
                         }
                     }
-                    .disabled(isRetrying)
+                    .disabled(store.isRetryingSync)
                     .keyboardShortcut(.defaultAction)
                 case .stale:
                     Button {
-                        isRetrying = true
+                        isReloading = true
                         Task {
                             await store.reload()
-                            isRetrying = false
-                            isPresented = false
+                            isReloading = false
                         }
                     } label: {
-                        if isRetrying {
+                        if isReloading {
                             ProgressView()
                                 .controlSize(.small)
                         } else {
-                            Text("Refresh")
+                            Text("Refresh Project")
                         }
                     }
-                    .disabled(isRetrying)
+                    .disabled(isReloading)
                     .keyboardShortcut(.defaultAction)
                 case .syncing:
                     EmptyView()
@@ -1515,7 +1547,7 @@ private struct SyncIssuePopover: View {
             }
         }
         .padding(16)
-        .frame(width: 320)
+        .frame(width: 360)
     }
 }
 

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -346,6 +346,15 @@ struct DaemonSyncRetryRequest: Codable, Sendable {
     let channel: String
 }
 
+struct DaemonProjectSyncStatusRequest: Codable, Sendable {
+    let projectId: String
+}
+
+struct DaemonProjectSyncRetryRequest: Codable, Sendable {
+    let projectId: String
+    let channel: String
+}
+
 struct DaemonRetryResponse: Codable, Sendable {
     let retryId: String
     let started: Bool

--- a/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
@@ -134,8 +134,14 @@ struct DaemonXPCClient: Sendable {
         )
     }
 
-    func syncStatus() async throws -> DaemonSyncStatus {
-        try await call(method: "sync_status", payload: EmptyPayload())
+    func syncStatus(projectId: String? = nil) async throws -> DaemonSyncStatus {
+        guard let projectId else {
+            return try await call(method: "sync_status", payload: EmptyPayload())
+        }
+        return try await call(
+            method: "project_sync_status",
+            payload: DaemonProjectSyncStatusRequest(projectId: projectId)
+        )
     }
 
     func projectStorage(_ projectId: String) async throws -> DaemonProjectStorage {
@@ -167,8 +173,25 @@ struct DaemonXPCClient: Sendable {
         try await call(method: "clear_project_cache", payload: request)
     }
 
-    func retrySync(channel: String = "all") async throws -> DaemonRetryResponse {
-        try await call(method: "retry_sync", payload: DaemonSyncRetryRequest(channel: channel))
+    func retrySync(
+        channel: String = "all",
+        projectId: String? = nil
+    ) async throws -> DaemonRetryResponse {
+        if let projectId {
+            return try await call(
+                method: "project_retry_sync",
+                payload: DaemonProjectSyncRetryRequest(
+                    projectId: projectId,
+                    channel: channel
+                ),
+                timeout: 300
+            )
+        }
+        return try await call(
+            method: "retry_sync",
+            payload: DaemonSyncRetryRequest(channel: channel),
+            timeout: 300
+        )
     }
 
     func mcpStatus() async throws -> DaemonMCPStatus {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -855,12 +855,258 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertLessThan(retryTask.lowerBound, statusTask.lowerBound)
         XCTAssertTrue(
             source[retryTask.lowerBound..<statusTask.lowerBound]
-                .contains("daemon.retrySync()")
+                .contains("self.retrySync(projectId: self.activeProjectId)")
         )
         XCTAssertFalse(
             source[statusTask.lowerBound..<statusEnd.lowerBound]
-                .contains("daemon.retrySync()")
+                .contains("self.retrySync(")
         )
+    }
+
+    func testRetrySyncSharesOnlyTheSameProjectAndChannelTask() throws {
+        let draftsA = SyncRetryKey(channel: "drafts", projectId: "project-a")
+        XCTAssertEqual(
+            draftsA,
+            SyncRetryKey(channel: "drafts", projectId: "project-a")
+        )
+        XCTAssertNotEqual(
+            draftsA,
+            SyncRetryKey(channel: "drafts", projectId: "project-b")
+        )
+        XCTAssertNotEqual(
+            draftsA,
+            SyncRetryKey(channel: "commits", projectId: "project-a")
+        )
+
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(source.range(of: "    func retrySync("))
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(of: "\n    func refreshSyncStatus()")
+        )
+        let retry = source[start.lowerBound..<end.lowerBound]
+
+        XCTAssertTrue(retry.contains("if let inFlight = syncRetryTasks[key]"))
+        XCTAssertTrue(retry.contains("return await inFlight.task.value"))
+        XCTAssertTrue(retry.contains("syncRetryTasks[key] = .init(id: taskId, task: task)"))
+        XCTAssertTrue(retry.contains("retryingSyncKeys.insert(key)"))
+        XCTAssertTrue(retry.contains("syncRetryTasks[key]?.id == taskId"))
+        XCTAssertTrue(retry.contains("existingKey.projectId == projectId ? handle.task : nil"))
+        XCTAssertTrue(retry.contains("for predecessor in predecessors"))
+        XCTAssertTrue(retry.contains("clearSyncRetryErrors(channel: channel, projectId: projectId)"))
+        let daemonRetry = try XCTUnwrap(
+            retry.range(of: "_ = try await daemon.retrySync(channel: channel, projectId: projectId)")
+        )
+        let completionClear = try XCTUnwrap(
+            retry[daemonRetry.upperBound...].range(of: "if channel == \"all\"")
+        )
+        let statusRefresh = try XCTUnwrap(
+            retry[completionClear.upperBound...].range(of: "await refreshSyncStatus()")
+        )
+        XCTAssertLessThan(completionClear.lowerBound, statusRefresh.lowerBound)
+        XCTAssertTrue(retry.contains("if errorMessage == nil"))
+        XCTAssertFalse(retry.contains("guard !isRetryingSync"))
+
+        XCTAssertTrue(source.contains(
+            "@Published private var retryingSyncKeys: Set<SyncRetryKey> = []"
+        ))
+        XCTAssertTrue(source.contains(
+            "@Published private var syncRetryErrors: [SyncRetryKey: String] = [:]"
+        ))
+        XCTAssertTrue(source.contains(
+            "retryingSyncKeys.contains { $0.projectId == activeProjectId }"
+        ))
+        XCTAssertTrue(source.contains(
+            "? syncRetryErrors.keys.filter { $0.projectId == projectId }"
+        ))
+        XCTAssertTrue(source.contains(
+            ".filter { $0.key.projectId == activeProjectId }"
+        ))
+    }
+
+    func testRetryControlsUseTheirProjectAndChannelState() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let workspace = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let memory = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/MemoryWorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let diagnostics = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/DiagnosticsView.swift"),
+            encoding: .utf8
+        )
+
+        for source in [workspace, memory] {
+            XCTAssertTrue(source.contains(
+                "store.isRetryingSync(\n"
+                    + "                                        channel: \"drafts\""
+            ) || source.contains(
+                "store.isRetryingSync(\n"
+                    + "                        channel: \"drafts\""
+            ))
+        }
+        XCTAssertTrue(diagnostics.contains(
+            "store.isRetryingSync(\n"
+                + "                        channel: \"all\",\n"
+                + "                        projectId: retryProjectId"
+        ))
+    }
+
+    func testAuthorityResetCancelsRetriesAndDismissedBackgroundErrorsStayDismissed() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let clearStart = try XCTUnwrap(source.range(of: "    func clearAuthorityScopedWorkspace()"))
+        let clearEnd = try XCTUnwrap(
+            source[clearStart.lowerBound...].range(of: "\n    private func apply(")
+        )
+        let clear = source[clearStart.lowerBound..<clearEnd.lowerBound]
+        XCTAssertTrue(clear.contains("cancelSyncRetries()"))
+        XCTAssertTrue(clear.contains("resetBackgroundErrorPresentation()"))
+
+        let cancelStart = try XCTUnwrap(source.range(of: "    private func cancelSyncRetries()"))
+        let cancelEnd = try XCTUnwrap(
+            source[cancelStart.lowerBound...].range(
+                of: "\n    private func resetBackgroundErrorPresentation()"
+            )
+        )
+        let cancel = source[cancelStart.lowerBound..<cancelEnd.lowerBound]
+        XCTAssertTrue(cancel.contains("syncRetryTasks.values.forEach { $0.task.cancel() }"))
+        XCTAssertTrue(cancel.contains("retryingSyncKeys.removeAll()"))
+        XCTAssertTrue(cancel.contains("syncRetryErrors.removeAll()"))
+
+        let dismissStart = try XCTUnwrap(source.range(of: "    func dismissErrorMessage()"))
+        let dismissEnd = try XCTUnwrap(
+            source[dismissStart.lowerBound...].range(of: "\n    private func presentBackgroundError(")
+        )
+        let dismiss = source[dismissStart.lowerBound..<dismissEnd.lowerBound]
+        XCTAssertTrue(dismiss.contains(
+            "dismissedBackgroundErrorSources.insert(presentation.source)"
+        ))
+
+        let resolveStart = try XCTUnwrap(
+            source.range(of: "    private func resolveBackgroundError(")
+        )
+        let resolveEnd = try XCTUnwrap(
+            source[resolveStart.lowerBound...].range(
+                of: "\n    private func backgroundErrorIsRelevant("
+            )
+        )
+        let resolve = source[resolveStart.lowerBound..<resolveEnd.lowerBound]
+        XCTAssertTrue(resolve.contains("dismissedBackgroundErrorSources.remove(source)"))
+
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "presentBackgroundError(").count - 1,
+            4
+        )
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "resolveBackgroundError(").count - 1,
+            8
+        )
+        XCTAssertGreaterThanOrEqual(
+            source.components(separatedBy: "catch is CancellationError").count - 1,
+            6
+        )
+        XCTAssertTrue(source.contains(
+            "workspaceReloadGeneration == workspaceGeneration,\n"
+                + "                  projectSelectionGeneration == generation"
+        ))
+
+        let workspace = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(workspace.contains("store.dismissErrorMessage()"))
+    }
+
+    func testDiscardRechecksTheDraftInsideTheMutationGate() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(source.range(of: "    func discard(_ draft: LocalDraft)"))
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(of: "\n    @discardableResult\n    func retrySync(")
+        )
+        let discard = source[start.lowerBound..<end.lowerBound]
+        let recheck = try XCTUnwrap(
+            discard.range(of: "guard drafts.contains(where: { $0.id == draft.id }) else { return }")
+        )
+        let store = try XCTUnwrap(discard.range(of: "_ = try await daemon.store("))
+
+        XCTAssertLessThan(recheck.lowerBound, store.lowerBound)
+    }
+
+    func testReconciliationRetryUsesTheDraftProject() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let storeSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(storeSource.range(of: "    func applyReconciliation("))
+        let end = try XCTUnwrap(
+            storeSource[start.lowerBound...].range(of: "\n    func reviewDetail(")
+        )
+        let apply = storeSource[start.lowerBound..<end.lowerBound]
+
+        XCTAssertTrue(apply.contains("projectId ?? documentKey?.projectId"))
+        XCTAssertTrue(apply.contains("projectId: reconciliationProjectId"))
+        XCTAssertFalse(apply.contains("projectId: activeProjectId"))
+
+        let reviewSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/ReviewsView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(reviewSource.contains(
+            "$0.detail.draft.draftId == candidate.draftId"
+        ))
+        XCTAssertTrue(reviewSource.contains("}?.detail.draft.projectId"))
+    }
+
+    func testDraftUploadBarrierRechecksAfterRetryPastDeadline() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(
+            source.range(of: "    private func synchronizedDraftForReconciliation(")
+        )
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(of: "\n    private func installSynchronizedDraft(")
+        )
+        let barrier = source[start.lowerBound..<end.lowerBound]
+
+        XCTAssertTrue(barrier.contains(
+            "while clock.now < deadline || requiresPostRetryCheck"
+        ))
+        XCTAssertTrue(barrier.contains(
+            "requestedRetry = true\n                    requiresPostRetryCheck = true\n                    continue"
+        ))
+        XCTAssertTrue(barrier.contains(
+            "try await flushDocumentSave(sessionKey)\n                    requestedRetry = false\n                    requiresPostRetryCheck = true\n                    continue"
+        ))
     }
 
     func testOrgResourceRefreshIsScopedToWorkspaceGeneration() throws {

--- a/apps/macos/Tests/MemoryFileTreeMenuTests.swift
+++ b/apps/macos/Tests/MemoryFileTreeMenuTests.swift
@@ -494,4 +494,114 @@ final class MemoryFileTreeMenuTests: XCTestCase {
             ["org-ref"]
         )
     }
+
+    // MARK: - Destructive operation confirmation
+
+    func testDestructiveAlertsDescribeTheirActualEffects() {
+        let shared = resourceItem(
+            "shared",
+            scope: .org,
+            inherited: true,
+            path: "notes/shared.md"
+        )
+        let draft = localDraft(
+            "draft",
+            scope: .org,
+            path: "notes/new.md"
+        )
+
+        let organization = MemoryFileTreeAlert.organizationDeletion(items: [shared])
+        XCTAssertEqual(organization.title, "Propose Organization Deletion?")
+        XCTAssertEqual(organization.confirmationTitle, "Propose Deletion")
+        XCTAssertTrue(organization.message.contains("every project"))
+
+        let discard = MemoryFileTreeAlert.directoryDiscard(
+            name: "notes",
+            drafts: [draft]
+        )
+        XCTAssertEqual(discard.title, "Discard Draft in notes?")
+        XCTAssertEqual(discard.confirmationTitle, "Discard Drafts")
+        XCTAssertTrue(discard.message.contains("Shared Organization Memory is unchanged"))
+
+        let deletion = MemoryFileTreeAlert.directoryDeletion(
+            name: "notes",
+            plan: .init(itemsToDelete: [shared], draftsToDiscard: [draft])
+        )
+        XCTAssertEqual(deletion.title, "Delete notes?")
+        XCTAssertEqual(deletion.confirmationTitle, "Delete Folder")
+        XCTAssertTrue(deletion.message.contains("create deletion proposals"))
+        XCTAssertTrue(deletion.message.contains("discard 1 unpublished draft"))
+    }
+
+    func testFileTreeOwnsExactlyOneAlertPresenter() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/MemoryWorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(source.range(of: "private struct FileTreeView: View {"))
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(of: "\nprivate struct FileTreeRow: View")
+        )
+        let fileTree = source[start.lowerBound..<end.lowerBound]
+
+        XCTAssertEqual(fileTree.components(separatedBy: ".alert(").count - 1, 1)
+        XCTAssertTrue(fileTree.contains("pendingAlert = .organizationDeletion"))
+        XCTAssertTrue(fileTree.contains("pendingAlert = .directoryDiscard"))
+        XCTAssertTrue(fileTree.contains("pendingAlert = .directoryDeletion"))
+    }
+
+    func testSingleDraftDiscardIsBlockedDuringDirectoryOperation() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/MemoryWorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let start = try XCTUnwrap(
+            source.range(of: "if !isOrgView, let draft = singleItem.draft {")
+        )
+        let end = try XCTUnwrap(
+            source[start.lowerBound...].range(of: "\n        if targetItems.isEmpty {")
+        )
+        let discardAction = source[start.lowerBound..<end.lowerBound]
+
+        XCTAssertTrue(
+            discardAction.contains("guard directoryOperationProgress == nil else { return }")
+        )
+        XCTAssertTrue(discardAction.contains("directoryOperationProgress != nil"))
+        XCTAssertTrue(discardAction.contains("|| singleSynchronizing"))
+    }
+
+    func testItemMutationsAreBlockedDuringDirectoryOperation() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/MemoryWorkspaceView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertGreaterThanOrEqual(
+            source.components(
+                separatedBy: ".disabled(directoryOperationProgress != nil || singleSynchronizing)"
+            ).count - 1,
+            2
+        )
+        XCTAssertTrue(source.contains(
+            "directoryOperationProgress != nil\n                        "
+                + "|| trashSelectionContainsSynchronizingDocument"
+        ))
+        XCTAssertTrue(source.contains(
+            "directoryOperationProgress != nil\n                    "
+                + "|| !reviewSelectionIsReady"
+        ))
+        XCTAssertTrue(source.contains(
+            "guard directoryOperationProgress == nil else { return }\n"
+                + "        guard let item = itemToRename"
+        ))
+    }
 }

--- a/crates/daemon/src/commit_sync.rs
+++ b/crates/daemon/src/commit_sync.rs
@@ -1,6 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
 
 use reqwest::header::ETAG;
 use serde::{Deserialize, Serialize};
@@ -17,6 +16,106 @@ const META_COMMIT_SYNC_LAST_ERROR: &str = "commit_sync_last_error";
 const MAIN_REF: &str = "refs/heads/main";
 const EMPTY_GENERATION: &str = "ref-none";
 const MAX_CONCURRENT_PROJECT_STATE_REQUESTS: usize = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum CommitSyncRunScope {
+    Idle,
+    Global,
+    Project(String),
+}
+
+impl CommitSyncRunScope {
+    fn new(project_id: Option<&str>) -> Self {
+        match project_id {
+            Some(project_id) => Self::Project(project_id.to_owned()),
+            None => Self::Global,
+        }
+    }
+
+    fn is_running_for(&self, project_id: Option<&str>) -> bool {
+        match (self, project_id) {
+            (Self::Idle, _) => false,
+            (_, None) | (Self::Global, Some(_)) => true,
+            (Self::Project(running_project_id), Some(project_id)) => {
+                running_project_id == project_id
+            }
+        }
+    }
+}
+
+struct CommitSyncOutcome {
+    attempted_project_ids: BTreeSet<String>,
+    project_errors: BTreeMap<String, String>,
+    error: Option<DaemonError>,
+}
+
+impl CommitSyncOutcome {
+    fn from_project_errors(
+        attempted_project_ids: BTreeSet<String>,
+        errors: BTreeMap<String, DaemonError>,
+    ) -> Self {
+        let project_errors = errors
+            .iter()
+            .map(|(project_id, error)| (project_id.clone(), error.to_string()))
+            .collect();
+        Self {
+            attempted_project_ids,
+            project_errors,
+            error: errors.into_values().next(),
+        }
+    }
+
+    fn from_shared_error(
+        attempted_project_ids: BTreeSet<String>,
+        errors: BTreeMap<String, DaemonError>,
+        shared_error: DaemonError,
+    ) -> Self {
+        Self::from_shared_error_inner(attempted_project_ids, errors, shared_error, false)
+    }
+
+    fn from_shared_error_after_project_errors(
+        attempted_project_ids: BTreeSet<String>,
+        errors: BTreeMap<String, DaemonError>,
+        shared_error: DaemonError,
+    ) -> Self {
+        Self::from_shared_error_inner(attempted_project_ids, errors, shared_error, true)
+    }
+
+    fn from_shared_error_inner(
+        attempted_project_ids: BTreeSet<String>,
+        errors: BTreeMap<String, DaemonError>,
+        shared_error: DaemonError,
+        project_error_first: bool,
+    ) -> Self {
+        let shared_message = shared_error.to_string();
+        let mut project_errors = errors
+            .iter()
+            .map(|(project_id, error)| (project_id.clone(), error.to_string()))
+            .collect::<BTreeMap<_, _>>();
+        for project_id in &attempted_project_ids {
+            project_errors
+                .entry(project_id.clone())
+                .or_insert_with(|| shared_message.clone());
+        }
+        let error = if project_error_first {
+            errors.into_values().next().unwrap_or(shared_error)
+        } else {
+            shared_error
+        };
+        Self {
+            attempted_project_ids,
+            project_errors,
+            error: Some(error),
+        }
+    }
+
+    fn into_result(self) -> Result<(), DaemonError> {
+        match self.error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct DaemonMemoryCacheRequest {
@@ -127,60 +226,121 @@ pub(super) async fn migrate(pool: &SqlitePool) -> Result<(), DaemonError> {
 }
 
 pub(super) async fn run(state: &DaemonState) -> Result<(), DaemonError> {
-    state
+    run_scoped(state, None).await
+}
+
+pub(super) async fn run_for_project(
+    state: &DaemonState,
+    project_id: &str,
+) -> Result<(), DaemonError> {
+    validate_cache_component("project_id", project_id)?;
+    run_scoped(state, Some(project_id)).await
+}
+
+async fn run_scoped(state: &DaemonState, project_id: Option<&str>) -> Result<(), DaemonError> {
+    *state
         .inner
-        .commit_sync_running
-        .store(true, Ordering::Release);
+        .commit_sync_run_scope
+        .write()
+        .expect("commit sync scope rwlock poisoned") = CommitSyncRunScope::new(project_id);
+    let last_attempt_key = commit_sync_meta_key(META_COMMIT_SYNC_LAST_ATTEMPT_AT, project_id);
+    let last_error_key = commit_sync_meta_key(META_COMMIT_SYNC_LAST_ERROR, project_id);
     let result = async {
-        upsert_meta_timestamp(&state.inner.pool, META_COMMIT_SYNC_LAST_ATTEMPT_AT).await?;
-        let sync_result = sync_refs(state).await;
-        match &sync_result {
-            Ok(()) => {
-                let mut tx = state.inner.pool.begin().await?;
-                upsert_meta_value(&mut tx, META_COMMIT_SYNC_LAST_ERROR, None).await?;
-                tx.commit().await?;
-                upsert_meta_timestamp(&state.inner.pool, META_COMMIT_SYNC_LAST_SUCCESS_AT).await?;
+        upsert_meta_timestamp(&state.inner.pool, &last_attempt_key).await?;
+        let outcome = match project_id {
+            Some(project_id) => sync_refs(state, BTreeSet::from([project_id.to_owned()])).await,
+            None => match sync_project_ids(state).await {
+                Ok(project_ids) => {
+                    record_project_attempts(&state.inner.pool, &project_ids).await?;
+                    sync_refs(state, project_ids).await
+                }
+                Err(error) => {
+                    CommitSyncOutcome::from_shared_error(BTreeSet::new(), BTreeMap::new(), error)
+                }
+            },
+        };
+        let mut tx = state.inner.pool.begin().await?;
+        match &outcome.error {
+            None => {
+                upsert_meta_value(&mut tx, &last_error_key, None).await?;
+                if project_id.is_none() {
+                    sqlx::query(
+                        "DELETE FROM daemon_meta
+                         WHERE key GLOB 'commit_sync_last_error:*'",
+                    )
+                    .execute(&mut *tx)
+                    .await?;
+                }
             }
-            Err(error) => {
-                let mut tx = state.inner.pool.begin().await?;
-                upsert_meta_value(
-                    &mut tx,
-                    META_COMMIT_SYNC_LAST_ERROR,
-                    Some(&error.to_string()),
-                )
-                .await?;
-                tx.commit().await?;
+            Some(error) => {
+                upsert_meta_value(&mut tx, &last_error_key, Some(&error.to_string())).await?;
+                if project_id.is_none() {
+                    for attempted_project_id in &outcome.attempted_project_ids {
+                        let key = commit_sync_meta_key(
+                            META_COMMIT_SYNC_LAST_ERROR,
+                            Some(attempted_project_id),
+                        );
+                        upsert_meta_value(
+                            &mut tx,
+                            &key,
+                            outcome
+                                .project_errors
+                                .get(attempted_project_id)
+                                .map(String::as_str),
+                        )
+                        .await?;
+                    }
+                }
             }
         }
-        sync_result
+        tx.commit().await?;
+        if project_id.is_none() && outcome.error.is_none() {
+            upsert_meta_timestamp(&state.inner.pool, META_COMMIT_SYNC_LAST_SUCCESS_AT).await?;
+        }
+        outcome.into_result()
     }
     .await;
-    state
+    *state
         .inner
-        .commit_sync_running
-        .store(false, Ordering::Release);
+        .commit_sync_run_scope
+        .write()
+        .expect("commit sync scope rwlock poisoned") = CommitSyncRunScope::Idle;
     result
 }
 
 pub(super) async fn status(state: &DaemonState) -> Result<SyncChannelStatus, DaemonError> {
+    status_scoped(state, None).await
+}
+
+pub(super) async fn status_for_project(
+    state: &DaemonState,
+    project_id: &str,
+) -> Result<SyncChannelStatus, DaemonError> {
+    validate_cache_component("project_id", project_id)?;
+    status_scoped(state, Some(project_id)).await
+}
+
+async fn status_scoped(
+    state: &DaemonState,
+    scoped_project_id: Option<&str>,
+) -> Result<SyncChannelStatus, DaemonError> {
     let config = state.project_config();
     let readiness = config.server_readiness();
-    let project_id = config.project_id.as_deref();
-    let server_cursor = match project_id {
-        Some(project_id) => {
-            load_ref_commit(&state.inner.pool, &project_ref_key(project_id)).await?
-        }
-        None => None,
+    let project_id = scoped_project_id.or(config.project_id.as_deref());
+    let (server_cursor, installed_at) = match project_id {
+        Some(project_id) => load_project_ref_status(&state.inner.pool, project_id).await?,
+        None => (None, None),
     };
-    let ref_installed = match project_id {
-        Some(project_id) => ref_exists(&state.inner.pool, &project_ref_key(project_id)).await?,
-        None => false,
+    let ref_installed = installed_at.is_some();
+    let last_attempt_key =
+        commit_sync_meta_key(META_COMMIT_SYNC_LAST_ATTEMPT_AT, scoped_project_id);
+    let last_error_key = commit_sync_meta_key(META_COMMIT_SYNC_LAST_ERROR, scoped_project_id);
+    let last_attempt_at = load_meta_value(&state.inner.pool, &last_attempt_key).await?;
+    let last_success_at = match scoped_project_id {
+        Some(_) => installed_at,
+        None => load_meta_value(&state.inner.pool, META_COMMIT_SYNC_LAST_SUCCESS_AT).await?,
     };
-    let last_attempt_at =
-        load_meta_value(&state.inner.pool, META_COMMIT_SYNC_LAST_ATTEMPT_AT).await?;
-    let last_success_at =
-        load_meta_value(&state.inner.pool, META_COMMIT_SYNC_LAST_SUCCESS_AT).await?;
-    let last_error = load_meta_value(&state.inner.pool, META_COMMIT_SYNC_LAST_ERROR).await?;
+    let last_error = load_meta_value(&state.inner.pool, &last_error_key).await?;
 
     let config_error = (!readiness.ready && state.inner.config.sync.enabled).then(|| ApiError {
         code: "daemon_project_config_incomplete".to_owned(),
@@ -191,7 +351,14 @@ pub(super) async fn status(state: &DaemonState) -> Result<SyncChannelStatus, Dae
         request_id: "local".to_owned(),
         details: json!({ "missing_fields": readiness.missing_fields }),
     });
-    let state_value = if state.inner.commit_sync_running.load(Ordering::Acquire) {
+    let running_scope = state
+        .inner
+        .commit_sync_run_scope
+        .read()
+        .expect("commit sync scope rwlock poisoned")
+        .clone();
+    let running = running_scope.is_running_for(scoped_project_id);
+    let state_value = if running {
         SyncState::Syncing
     } else if config_error.is_some() {
         SyncState::Degraded
@@ -217,6 +384,53 @@ pub(super) async fn status(state: &DaemonState) -> Result<SyncChannelStatus, Dae
             })
         }),
     })
+}
+
+async fn load_project_ref_status(
+    pool: &SqlitePool,
+    project_id: &str,
+) -> Result<(Option<String>, Option<String>), DaemonError> {
+    let row = sqlx::query(
+        "SELECT commit_id, installed_at
+         FROM cached_refs
+         WHERE ref_key = $1 AND scope = 'project'",
+    )
+    .bind(project_ref_key(project_id))
+    .fetch_optional(pool)
+    .await?;
+    match row {
+        Some(row) => Ok((
+            row.try_get("commit_id")?,
+            Some(row.try_get("installed_at")?),
+        )),
+        None => Ok((None, None)),
+    }
+}
+
+fn commit_sync_meta_key(base: &str, project_id: Option<&str>) -> String {
+    match project_id {
+        Some(project_id) => format!("{base}:{project_id}"),
+        None => base.to_owned(),
+    }
+}
+
+async fn record_project_attempts(
+    pool: &SqlitePool,
+    project_ids: &BTreeSet<String>,
+) -> Result<(), DaemonError> {
+    if project_ids.is_empty() {
+        return Ok(());
+    }
+    let mut tx = pool.begin().await?;
+    let timestamp: String = sqlx::query_scalar("SELECT strftime('%Y-%m-%dT%H:%M:%fZ', 'now')")
+        .fetch_one(&mut *tx)
+        .await?;
+    for project_id in project_ids {
+        let key = commit_sync_meta_key(META_COMMIT_SYNC_LAST_ATTEMPT_AT, Some(project_id));
+        upsert_meta_value(&mut tx, &key, Some(&timestamp)).await?;
+    }
+    tx.commit().await?;
+    Ok(())
 }
 
 pub(super) async fn current_base_commit_id(
@@ -410,8 +624,8 @@ pub(super) async fn project_checkout(
     Ok(checkout)
 }
 
-async fn sync_refs(state: &DaemonState) -> Result<(), DaemonError> {
-    let project_ids = sync_project_ids(state).await?;
+async fn sync_refs(state: &DaemonState, project_ids: BTreeSet<String>) -> CommitSyncOutcome {
+    let attempted_project_ids = project_ids.clone();
     let mut errors = BTreeMap::new();
     let mut ready_project_ids = Vec::new();
     for project_id in project_ids {
@@ -448,9 +662,18 @@ async fn sync_refs(state: &DaemonState) -> Result<(), DaemonError> {
 
     let mut projects = BTreeMap::new();
     while let Some(result) = project_tasks.join_next().await {
-        let (project_id, result) = result.map_err(|error| {
-            DaemonError::Server(format!("Project Commit-state request task failed: {error}"))
-        })?;
+        let (project_id, result) = match result {
+            Ok(result) => result,
+            Err(error) => {
+                return CommitSyncOutcome::from_shared_error(
+                    attempted_project_ids,
+                    errors,
+                    DaemonError::Server(format!(
+                        "Project Commit-state request task failed: {error}"
+                    )),
+                );
+            }
+        };
         match result {
             Ok(project) => {
                 projects.insert(project_id, project);
@@ -461,15 +684,17 @@ async fn sync_refs(state: &DaemonState) -> Result<(), DaemonError> {
         }
     }
     let Some((_, (first_project_state, _))) = projects.first_key_value() else {
-        return match errors.into_values().next() {
-            Some(error) => Err(error),
-            None => Ok(()),
-        };
+        return CommitSyncOutcome::from_project_errors(attempted_project_ids, errors);
     };
 
     let expected_org_id = first_project_state.reference.org_id.clone();
     let local_org_commit =
-        load_ref_commit(&state.inner.pool, &org_ref_key(&expected_org_id)).await?;
+        match load_ref_commit(&state.inner.pool, &org_ref_key(&expected_org_id)).await {
+            Ok(commit_id) => commit_id,
+            Err(error) => {
+                return CommitSyncOutcome::from_shared_error(attempted_project_ids, errors, error);
+            }
+        };
     let org_result = async {
         let (org_state, org_etag) = fetch_commit_state(
             state,
@@ -489,19 +714,31 @@ async fn sync_refs(state: &DaemonState) -> Result<(), DaemonError> {
     .await;
     let (org_state, org_etag) = match org_result {
         Ok(org) => org,
-        Err(error) => return Err(errors.into_values().next().unwrap_or(error)),
+        Err(error) => {
+            return CommitSyncOutcome::from_shared_error_after_project_errors(
+                attempted_project_ids,
+                errors,
+                error,
+            );
+        }
     };
 
     if org_state.reference.org_id != expected_org_id {
-        return Err(errors.into_values().next().unwrap_or_else(|| {
+        return CommitSyncOutcome::from_shared_error_after_project_errors(
+            attempted_project_ids,
+            errors,
             DaemonError::Server(
                 "Project and organization commit states belong to different organizations"
                     .to_owned(),
-            )
-        }));
+            ),
+        );
     }
     if let Err(error) = install_ref(state, &org_state, &org_etag, None).await {
-        return Err(errors.into_values().next().unwrap_or(error));
+        return CommitSyncOutcome::from_shared_error_after_project_errors(
+            attempted_project_ids,
+            errors,
+            error,
+        );
     }
 
     for (project_id, (project_state, project_etag)) in projects {
@@ -517,10 +754,7 @@ async fn sync_refs(state: &DaemonState) -> Result<(), DaemonError> {
             errors.insert(project_id, error);
         }
     }
-    match errors.into_values().next() {
-        Some(error) => Err(error),
-        None => Ok(()),
-    }
+    CommitSyncOutcome::from_project_errors(attempted_project_ids, errors)
 }
 
 async fn sync_project_ids(state: &DaemonState) -> Result<BTreeSet<String>, DaemonError> {
@@ -1319,14 +1553,6 @@ async fn load_ref_commit(pool: &SqlitePool, key: &str) -> Result<Option<String>,
     .flatten())
 }
 
-async fn ref_exists(pool: &SqlitePool, key: &str) -> Result<bool, DaemonError> {
-    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cached_refs WHERE ref_key = $1")
-        .bind(key)
-        .fetch_one(pool)
-        .await?;
-    Ok(count == 1)
-}
-
 async fn cached_commit_exists(pool: &SqlitePool, commit_id: &str) -> Result<bool, DaemonError> {
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cached_commits WHERE commit_id = $1")
         .bind(commit_id)
@@ -1847,6 +2073,38 @@ struct MaterializedManifestEntry<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn commit_sync_running_scope_is_read_as_one_snapshot() {
+        let running = std::sync::RwLock::new(CommitSyncRunScope::Project("prj_a".to_owned()));
+        let snapshot = running.read().unwrap().clone();
+        *running.write().unwrap() = CommitSyncRunScope::Idle;
+
+        assert!(snapshot.is_running_for(None));
+        assert!(snapshot.is_running_for(Some("prj_a")));
+        assert!(!snapshot.is_running_for(Some("prj_b")));
+        assert!(!running.read().unwrap().is_running_for(Some("prj_a")));
+        assert!(CommitSyncRunScope::Global.is_running_for(Some("prj_b")));
+    }
+
+    #[test]
+    fn shared_infrastructure_error_remains_the_primary_error() {
+        let outcome = CommitSyncOutcome::from_shared_error(
+            BTreeSet::from(["prj_a".to_owned(), "prj_b".to_owned()]),
+            BTreeMap::from([(
+                "prj_a".to_owned(),
+                DaemonError::Server("project A failed".to_owned()),
+            )]),
+            DaemonError::Server("shared infrastructure failed".to_owned()),
+        );
+
+        assert_eq!(
+            outcome.error.unwrap().to_string(),
+            "server sync error: shared infrastructure failed"
+        );
+        assert!(outcome.project_errors["prj_a"].contains("project A failed"));
+        assert!(outcome.project_errors["prj_b"].contains("shared infrastructure failed"));
+    }
 
     #[test]
     fn content_address_verification_matches_server_blob_ids() {

--- a/crates/daemon/src/draft.rs
+++ b/crates/daemon/src/draft.rs
@@ -431,49 +431,86 @@ pub(crate) fn local_draft_operation_from_row(
 }
 
 pub(crate) async fn load_sync_status(state: &DaemonState) -> Result<DaemonSyncStatus, DaemonError> {
+    load_sync_status_scoped(state, None).await
+}
+
+pub(crate) async fn load_project_sync_status(
+    state: &DaemonState,
+    project_id: &str,
+) -> Result<DaemonSyncStatus, DaemonError> {
+    load_sync_status_scoped(state, Some(project_id)).await
+}
+
+async fn load_sync_status_scoped(
+    state: &DaemonState,
+    project_id: Option<&str>,
+) -> Result<DaemonSyncStatus, DaemonError> {
     let pool = &state.inner.pool;
     let pending_operation_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
-         FROM local_draft_operations
-         WHERE sync_status IN ('queued', 'syncing', 'retrying')",
+         FROM local_draft_operations AS o
+         JOIN local_drafts AS d ON d.draft_id = o.draft_id
+         WHERE o.sync_status IN ('queued', 'syncing', 'retrying')
+           AND ($1 IS NULL OR d.project_id = $1)",
     )
+    .bind(project_id)
     .fetch_one(pool)
     .await?;
     let failed_operation_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
-         FROM local_draft_operations
-         WHERE sync_status = 'failed'",
+         FROM local_draft_operations AS o
+         JOIN local_drafts AS d ON d.draft_id = o.draft_id
+         WHERE o.sync_status = 'failed'
+           AND ($1 IS NULL OR d.project_id = $1)",
     )
+    .bind(project_id)
     .fetch_one(pool)
     .await?;
     let retrying_operation_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
-         FROM local_draft_operations
-         WHERE sync_status = 'retrying'",
+         FROM local_draft_operations AS o
+         JOIN local_drafts AS d ON d.draft_id = o.draft_id
+         WHERE o.sync_status = 'retrying'
+           AND ($1 IS NULL OR d.project_id = $1)",
     )
+    .bind(project_id)
     .fetch_one(pool)
     .await?;
-    let behind_draft_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts WHERE freshness = 'behind'")
-            .fetch_one(pool)
-            .await?;
-    let reconciliation_conflict_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM local_drafts WHERE reconciliation = 'conflicts'")
-            .fetch_one(pool)
-            .await?;
+    let behind_draft_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM local_drafts
+         WHERE freshness = 'behind' AND ($1 IS NULL OR project_id = $1)",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
+    let reconciliation_conflict_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM local_drafts
+         WHERE reconciliation = 'conflicts' AND ($1 IS NULL OR project_id = $1)",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await?;
     let server_cursor = load_meta_value(pool, META_DRAFT_EVENTS_CURSOR).await?;
-    let last_attempt_at = load_meta_value(pool, META_DRAFT_SYNC_LAST_ATTEMPT_AT).await?;
-    let last_success_at = load_meta_value(pool, META_DRAFT_SYNC_LAST_SUCCESS_AT).await?;
+    let last_attempt_key = draft_sync_meta_key(META_DRAFT_SYNC_LAST_ATTEMPT_AT, project_id);
+    let last_success_key = draft_sync_meta_key(META_DRAFT_SYNC_LAST_SUCCESS_AT, project_id);
+    let last_attempt_at = load_meta_value(pool, &last_attempt_key).await?;
+    let last_success_at = load_meta_value(pool, &last_success_key).await?;
     let last_error: Option<String> = sqlx::query_scalar(
-        "SELECT last_error
-         FROM local_draft_operations
-         WHERE sync_status IN ('retrying', 'failed') AND last_error IS NOT NULL
-         ORDER BY updated_at DESC
+        "SELECT o.last_error
+         FROM local_draft_operations AS o
+         JOIN local_drafts AS d ON d.draft_id = o.draft_id
+         WHERE o.sync_status IN ('retrying', 'failed') AND o.last_error IS NOT NULL
+           AND ($1 IS NULL OR d.project_id = $1)
+         ORDER BY o.updated_at DESC
          LIMIT 1",
     )
+    .bind(project_id)
     .fetch_optional(pool)
     .await?;
-    let readiness = state.project_config().readiness();
+    let readiness = match project_id {
+        Some(_) => state.project_config().server_readiness(),
+        None => state.project_config().readiness(),
+    };
     let config_error = (!readiness.ready
         && state.inner.config.sync.enabled
         && pending_operation_count > 0)
@@ -497,7 +534,10 @@ pub(crate) async fn load_sync_status(state: &DaemonState) -> Result<DaemonSyncSt
     } else {
         SyncState::Idle
     };
-    let commit_sync = commit_sync::status(state).await?;
+    let commit_sync = match project_id {
+        Some(project_id) => commit_sync::status_for_project(state, project_id).await?,
+        None => commit_sync::status(state).await?,
+    };
     let overall_last_success_at = match (&last_success_at, &commit_sync.last_success_at) {
         (Some(draft), Some(commit)) => Some(std::cmp::max(draft, commit).clone()),
         (Some(draft), None) => Some(draft.clone()),
@@ -533,10 +573,21 @@ pub(crate) async fn load_sync_status(state: &DaemonState) -> Result<DaemonSyncSt
     })
 }
 
-pub(crate) async fn drain_draft_queue(state: &DaemonState) -> Result<bool, DaemonError> {
+pub(crate) fn draft_sync_meta_key(base: &str, project_id: Option<&str>) -> String {
+    match project_id {
+        Some(project_id) => format!("{base}:{project_id}"),
+        None => base.to_owned(),
+    }
+}
+
+pub(crate) async fn drain_draft_queue(
+    state: &DaemonState,
+    project_id: Option<&str>,
+) -> Result<bool, DaemonError> {
     let mut queue_converged = true;
     loop {
-        let Some(operation) = load_next_queued_operation(&state.inner.pool).await? else {
+        let Some(operation) = load_next_queued_operation(&state.inner.pool, project_id).await?
+        else {
             break;
         };
         mark_operation_syncing(&state.inner.pool, &operation.local_operation_id).await?;
@@ -561,9 +612,12 @@ pub(crate) async fn drain_draft_queue(state: &DaemonState) -> Result<bool, Daemo
     }
     let unsynced_operation_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*)
-         FROM local_draft_operations
-         WHERE sync_status != 'synced'",
+         FROM local_draft_operations AS o
+         JOIN local_drafts AS d ON d.draft_id = o.draft_id
+         WHERE o.sync_status != 'synced'
+           AND ($1 IS NULL OR d.project_id = $1)",
     )
+    .bind(project_id)
     .fetch_one(&state.inner.pool)
     .await?;
     Ok(queue_converged && unsynced_operation_count == 0)
@@ -666,6 +720,7 @@ pub(crate) async fn sync_one_draft_operation(
 
 pub(crate) async fn load_next_queued_operation(
     pool: &SqlitePool,
+    project_id: Option<&str>,
 ) -> Result<Option<QueuedDraftOperation>, DaemonError> {
     let Some(row) = sqlx::query(
         "SELECT
@@ -675,6 +730,7 @@ pub(crate) async fn load_next_queued_operation(
          FROM local_draft_operations o
          JOIN local_drafts d ON d.draft_id = o.draft_id
          WHERE o.sync_status = 'queued'
+           AND ($1 IS NULL OR d.project_id = $1)
            AND NOT EXISTS (
                SELECT 1
                FROM local_draft_operations AS prior
@@ -685,6 +741,7 @@ pub(crate) async fn load_next_queued_operation(
          ORDER BY o.created_at, o.rowid
          LIMIT 1",
     )
+    .bind(project_id)
     .fetch_optional(pool)
     .await?
     else {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -46,8 +46,8 @@ pub use credentials::{
 };
 pub(crate) use draft::{
     LocalDraftResolutionInput, drain_draft_queue, list_local_drafts, load_local_draft_detail,
-    load_sync_status, pull_draft_events, queue_retrying_operations, recover_interrupted_operations,
-    resolve_local_draft,
+    load_project_sync_status, load_sync_status, pull_draft_events, queue_retrying_operations,
+    recover_interrupted_operations, resolve_local_draft,
 };
 pub use ipc::{DaemonIpcClient, DaemonIpcServer};
 pub(crate) use migration::{
@@ -104,10 +104,11 @@ pub use types::{
     DaemonProjectBindingListResponse, DaemonProjectBindingRemoveRequest,
     DaemonProjectBindingRemoveResponse, DaemonProjectBindingReplaceRequest,
     DaemonProjectBindingResolveRequest, DaemonProjectConfig, DaemonProjectConfigUpdateRequest,
-    DaemonProjectSelectionRequest, DaemonRetryResponse, DaemonServerRequest, DaemonServerResponse,
-    DaemonSyncRetryRequest, DaemonSyncStatus, DraftOperationSyncStatus, ErrorEnvelope,
-    LaunchAgentRuntimeStatus, LocalDbStatus, McpAdapterStatus,
-    ProjectAgentAdapterRuntimeRequirement, SyncChannelStatus, SyncRetryChannel, SyncState,
+    DaemonProjectSelectionRequest, DaemonProjectSyncRetryRequest, DaemonProjectSyncStatusRequest,
+    DaemonRetryResponse, DaemonServerRequest, DaemonServerResponse, DaemonSyncRetryRequest,
+    DaemonSyncStatus, DraftOperationSyncStatus, ErrorEnvelope, LaunchAgentRuntimeStatus,
+    LocalDbStatus, McpAdapterStatus, ProjectAgentAdapterRuntimeRequirement, SyncChannelStatus,
+    SyncRetryChannel, SyncState,
 };
 pub use types::{
     DaemonContentDraftUpdate, DaemonCreateDraftOperation, DaemonDeleteDraftOperation,

--- a/crates/daemon/src/state.rs
+++ b/crates/daemon/src/state.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::atomic::AtomicBool;
 use std::time::{Duration, Instant};
 
 use serde::de::DeserializeOwned;
@@ -163,7 +162,7 @@ pub(crate) struct DaemonInner {
     pub(crate) daemon_installation_id: String,
     pub(crate) sync_notify: Notify,
     pub(crate) sync_lock: Mutex<()>,
-    pub(crate) commit_sync_running: AtomicBool,
+    pub(crate) commit_sync_run_scope: RwLock<commit_sync::CommitSyncRunScope>,
     pub(crate) token_refresh: Mutex<()>,
     server_response_cache: std::sync::Mutex<ServerResponseCacheState>,
     server_response_cache_write: Mutex<()>,
@@ -292,7 +291,7 @@ impl DaemonState {
                 daemon_installation_id,
                 sync_notify: Notify::new(),
                 sync_lock: Mutex::new(()),
-                commit_sync_running: AtomicBool::new(false),
+                commit_sync_run_scope: RwLock::new(commit_sync::CommitSyncRunScope::Idle),
                 token_refresh: Mutex::new(()),
                 server_response_cache: std::sync::Mutex::new(ServerResponseCacheState::default()),
                 server_response_cache_write: Mutex::new(()),
@@ -1114,6 +1113,13 @@ impl DaemonState {
 
     pub async fn sync_status(&self) -> Result<DaemonSyncStatus, DaemonError> {
         load_sync_status(self).await
+    }
+
+    pub async fn project_sync_status(
+        &self,
+        request: DaemonProjectSyncStatusRequest,
+    ) -> Result<DaemonSyncStatus, DaemonError> {
+        load_project_sync_status(self, &request.project_id).await
     }
 
     pub async fn project_storage(
@@ -1991,36 +1997,52 @@ impl DaemonState {
         &self,
         request: DaemonSyncRetryRequest,
     ) -> Result<DaemonRetryResponse, DaemonError> {
+        self.retry_sync_scoped(request.channel, None).await
+    }
+
+    pub async fn project_retry_sync(
+        &self,
+        request: DaemonProjectSyncRetryRequest,
+    ) -> Result<DaemonRetryResponse, DaemonError> {
+        commit_sync::validate_cache_component("project_id", &request.project_id)?;
+        self.retry_sync_scoped(request.channel, Some(&request.project_id))
+            .await
+    }
+
+    async fn retry_sync_scoped(
+        &self,
+        channel: SyncRetryChannel,
+        project_id: Option<&str>,
+    ) -> Result<DaemonRetryResponse, DaemonError> {
         let retry_id = format!("retry_{}", Uuid::new_v4().simple());
-        let channel = request.channel.as_str();
 
         sqlx::query(
             "INSERT INTO sync_retries (retry_id, channel)
              VALUES ($1, $2)",
         )
         .bind(&retry_id)
-        .bind(channel)
+        .bind(channel.as_str())
         .execute(&self.inner.pool)
         .await?;
 
-        let retry_drafts = matches!(
-            request.channel,
-            SyncRetryChannel::Drafts | SyncRetryChannel::All
-        );
-        let retry_commits = matches!(
-            request.channel,
-            SyncRetryChannel::Commits | SyncRetryChannel::All
-        );
+        let retry_drafts = matches!(channel, SyncRetryChannel::Drafts | SyncRetryChannel::All);
+        let retry_commits = matches!(channel, SyncRetryChannel::Commits | SyncRetryChannel::All);
         if retry_drafts {
             sqlx::query(
                 "UPDATE local_draft_operations
                  SET sync_status = 'queued', updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-                 WHERE sync_status IN ('retrying', 'failed')",
+                 WHERE sync_status IN ('retrying', 'failed')
+                   AND (
+                       $1 IS NULL OR draft_id IN (
+                           SELECT draft_id FROM local_drafts WHERE project_id = $1
+                       )
+                   )",
             )
+            .bind(project_id)
             .execute(&self.inner.pool)
             .await?;
         }
-        self.run_sync_channels(retry_drafts, retry_commits, false)
+        self.run_sync_channels(retry_drafts, retry_commits, false, project_id)
             .await?;
 
         Ok(DaemonRetryResponse {
@@ -2324,8 +2346,8 @@ impl DaemonState {
         load_local_draft_detail(&self.inner.pool, draft_id).await
     }
 
-    async fn drain_draft_queue(&self) -> Result<bool, DaemonError> {
-        drain_draft_queue(self).await
+    async fn drain_draft_queue(&self, project_id: Option<&str>) -> Result<bool, DaemonError> {
+        drain_draft_queue(self, project_id).await
     }
 
     async fn pull_draft_events(&self) -> Result<(), DaemonError> {
@@ -2410,7 +2432,7 @@ impl DaemonState {
     }
 
     async fn run_sync_cycle(&self, retry_transient_failures: bool) -> Result<(), DaemonError> {
-        self.run_sync_channels(true, true, retry_transient_failures)
+        self.run_sync_channels(true, true, retry_transient_failures, None)
             .await
     }
 
@@ -2419,6 +2441,7 @@ impl DaemonState {
         sync_drafts: bool,
         sync_commits: bool,
         retry_transient_failures: bool,
+        project_id: Option<&str>,
     ) -> Result<(), DaemonError> {
         let _sync_guard = self.inner.sync_lock.lock().await;
         async {
@@ -2427,17 +2450,19 @@ impl DaemonState {
             }
             let mut first_error = None;
             if sync_drafts {
+                let last_attempt_key =
+                    crate::draft::draft_sync_meta_key(META_DRAFT_SYNC_LAST_ATTEMPT_AT, project_id);
+                let last_success_key =
+                    crate::draft::draft_sync_meta_key(META_DRAFT_SYNC_LAST_SUCCESS_AT, project_id);
                 let draft_result = async {
                     if retry_transient_failures {
                         queue_retrying_operations(&self.inner.pool).await?;
                     }
-                    upsert_meta_timestamp(&self.inner.pool, META_DRAFT_SYNC_LAST_ATTEMPT_AT)
-                        .await?;
-                    let queue_converged = self.drain_draft_queue().await?;
+                    upsert_meta_timestamp(&self.inner.pool, &last_attempt_key).await?;
+                    let queue_converged = self.drain_draft_queue(project_id).await?;
                     self.pull_draft_events().await?;
                     if queue_converged {
-                        upsert_meta_timestamp(&self.inner.pool, META_DRAFT_SYNC_LAST_SUCCESS_AT)
-                            .await?;
+                        upsert_meta_timestamp(&self.inner.pool, &last_success_key).await?;
                     }
                     Ok::<(), DaemonError>(())
                 }
@@ -2446,11 +2471,16 @@ impl DaemonState {
                     first_error = Some(error);
                 }
             }
-            if sync_commits
-                && let Err(error) = commit_sync::run(self).await
-                && first_error.is_none()
-            {
-                first_error = Some(error);
+            if sync_commits {
+                let commit_result = match project_id {
+                    Some(project_id) => commit_sync::run_for_project(self, project_id).await,
+                    None => commit_sync::run(self).await,
+                };
+                if let Err(error) = commit_result
+                    && first_error.is_none()
+                {
+                    first_error = Some(error);
+                }
             }
             match first_error {
                 Some(error) => Err(error),
@@ -2624,6 +2654,13 @@ impl DaemonIpcService {
 
     pub async fn sync_status(&self) -> Result<DaemonSyncStatus, DaemonError> {
         self.state.sync_status().await
+    }
+
+    pub async fn project_sync_status(
+        &self,
+        request: DaemonProjectSyncStatusRequest,
+    ) -> Result<DaemonSyncStatus, DaemonError> {
+        self.state.project_sync_status(request).await
     }
 
     pub async fn project_storage(
@@ -2871,6 +2908,13 @@ impl DaemonIpcService {
         self.state.retry_sync(request).await
     }
 
+    pub async fn project_retry_sync(
+        &self,
+        request: DaemonProjectSyncRetryRequest,
+    ) -> Result<DaemonRetryResponse, DaemonError> {
+        self.state.project_retry_sync(request).await
+    }
+
     pub fn mcp_status(&self) -> DaemonMcpStatus {
         self.state.mcp_status()
     }
@@ -2942,6 +2986,9 @@ impl DaemonIpcService {
                 dispatch_async!(self, request.payload, remove_project_agent_adapter)
             }
             "sync_status" => dispatch_result_async!(self, sync_status),
+            "project_sync_status" => {
+                dispatch_async!(self, request.payload, project_sync_status)
+            }
             "project_storage" => dispatch_async!(self, request.payload, project_storage),
             "replace_project_storage" => {
                 dispatch_async!(self, request.payload, replace_project_storage)
@@ -3019,6 +3066,9 @@ impl DaemonIpcService {
                 dispatch_async!(self, request.payload, export_evaluation_set)
             }
             "retry_sync" => dispatch_async!(self, request.payload, retry_sync),
+            "project_retry_sync" => {
+                dispatch_async!(self, request.payload, project_retry_sync)
+            }
             "mcp_status" => dispatch_value!(self, mcp_status),
             "list_drafts" => dispatch_async!(self, request.payload, list_drafts),
             "get_draft" => {

--- a/crates/daemon/src/types.rs
+++ b/crates/daemon/src/types.rs
@@ -337,6 +337,17 @@ pub struct DaemonSyncRetryRequest {
     pub channel: SyncRetryChannel,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonProjectSyncStatusRequest {
+    pub project_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct DaemonProjectSyncRetryRequest {
+    pub project_id: String,
+    pub channel: SyncRetryChannel,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SyncRetryChannel {

--- a/crates/daemon/tests/daemon_lifecycle.rs
+++ b/crates/daemon/tests/daemon_lifecycle.rs
@@ -23,11 +23,12 @@ use daemon::{
     DaemonProjectCacheClearRequest, DaemonProjectCheckout, DaemonProjectCheckoutRequest,
     DaemonProjectConfigUpdateRequest, DaemonProjectSelectionRequest, DaemonProjectStorage,
     DaemonProjectStorageMode, DaemonProjectStorageMoveState, DaemonProjectStorageReplaceRequest,
-    DaemonProjectStorageRequest, DaemonProjectStorageResetRequest, DaemonServerRequest,
-    DaemonState, DaemonSyncRetryRequest, DaemonUpdateDraftOperation, DraftOperationSyncStatus,
-    IDENTIFIER_NAMESPACE, LaunchAgentConfig, LaunchAgentController, LaunchAgentRuntimeStatus,
-    ProjectAgentAdapterDelivery, ProjectAgentAdapterKind, ProjectAgentAdapterRuntimeRequirement,
-    RecordAgentRunEventResponse, ServerCredentials, SyncRetryChannel, SyncState,
+    DaemonProjectStorageRequest, DaemonProjectStorageResetRequest, DaemonProjectSyncRetryRequest,
+    DaemonProjectSyncStatusRequest, DaemonServerRequest, DaemonState, DaemonSyncRetryRequest,
+    DaemonUpdateDraftOperation, DraftOperationSyncStatus, IDENTIFIER_NAMESPACE, LaunchAgentConfig,
+    LaunchAgentController, LaunchAgentRuntimeStatus, ProjectAgentAdapterDelivery,
+    ProjectAgentAdapterKind, ProjectAgentAdapterRuntimeRequirement, RecordAgentRunEventResponse,
+    ServerCredentials, SyncRetryChannel, SyncState,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -2049,6 +2050,158 @@ async fn draft_operation_is_written_to_local_queue_and_visible_in_sync_status() 
 }
 
 #[tokio::test]
+async fn project_sync_status_and_retry_are_isolated() {
+    let (_root, state, service) = common::test_daemon().await;
+    for (project_id, path) in [("prj_a", "docs/a.md"), ("prj_b", "docs/b.md")] {
+        service
+            .store_draft_operation(DaemonDraftOperationRequest {
+                draft_id: None,
+                base_commit_id: None,
+                project_id: project_id.to_owned(),
+                scope: DaemonDraftScope::Org,
+                resource: DaemonDraftResourceKind::Memory,
+                op: DaemonDraftOperation {
+                    create: Some(DaemonCreateDraftOperation {
+                        path: path.to_owned(),
+                        content: context_content(project_id),
+                        description: None,
+                    }),
+                    update: None,
+                    rename: None,
+                    delete: None,
+                    discard: None,
+                },
+                source: Some(DaemonDraftOperationSource::Desktop),
+            })
+            .await
+            .unwrap();
+    }
+
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    sqlx::query(
+        "UPDATE local_draft_operations
+         SET sync_status = 'failed', last_error = 'injected failure'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let global = service.sync_status().await.unwrap();
+    let project_a = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap();
+    let project_b = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(global.failed_operation_count, 2);
+    assert_eq!(project_a.failed_operation_count, 1);
+    assert_eq!(project_b.failed_operation_count, 1);
+
+    service
+        .project_retry_sync(DaemonProjectSyncRetryRequest {
+            project_id: "prj_a".to_owned(),
+            channel: SyncRetryChannel::Drafts,
+        })
+        .await
+        .unwrap();
+
+    let project_a = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap();
+    let project_b = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(project_a.pending_operation_count, 1);
+    assert_eq!(project_a.failed_operation_count, 0);
+    assert_eq!(project_b.pending_operation_count, 0);
+    assert_eq!(project_b.failed_operation_count, 1);
+}
+
+#[tokio::test]
+async fn project_draft_sync_uses_explicit_project_and_scoped_timestamps() {
+    let server = FakeServer::start().await;
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = server.url.clone();
+    let (state, _) = common::initialize_authenticated_daemon(config, "test-token", None).await;
+    let service = DaemonIpcService::new(state);
+
+    service
+        .store_draft_operation(DaemonDraftOperationRequest {
+            draft_id: None,
+            base_commit_id: None,
+            project_id: "prj_test".to_owned(),
+            scope: DaemonDraftScope::Org,
+            resource: DaemonDraftResourceKind::Memory,
+            op: DaemonDraftOperation {
+                create: Some(DaemonCreateDraftOperation {
+                    path: "docs/scoped-sync.md".to_owned(),
+                    content: context_content("Scoped sync"),
+                    description: None,
+                }),
+                update: None,
+                rename: None,
+                delete: None,
+                discard: None,
+            },
+            source: Some(DaemonDraftOperationSource::Desktop),
+        })
+        .await
+        .unwrap();
+
+    let before = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_test".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(before.draft_sync.state, SyncState::Queued);
+    assert!(before.draft_sync.last_error.is_none());
+
+    service
+        .project_retry_sync(DaemonProjectSyncRetryRequest {
+            project_id: "prj_test".to_owned(),
+            channel: SyncRetryChannel::Drafts,
+        })
+        .await
+        .unwrap();
+
+    let project = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_test".to_owned(),
+        })
+        .await
+        .unwrap();
+    let other_project = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_other".to_owned(),
+        })
+        .await
+        .unwrap();
+    let global = service.sync_status().await.unwrap();
+    assert!(project.draft_sync.last_attempt_at.is_some());
+    assert!(project.draft_sync.last_success_at.is_some());
+    assert_eq!(other_project.draft_sync.last_attempt_at, None);
+    assert_eq!(other_project.draft_sync.last_success_at, None);
+    assert_eq!(global.draft_sync.last_attempt_at, None);
+    assert_eq!(global.draft_sync.last_success_at, None);
+}
+
+#[tokio::test]
 async fn draft_operation_service_method_writes_local_queue_without_http() {
     let (_root, _state, service) = common::test_daemon().await;
 
@@ -3294,12 +3447,73 @@ async fn empty_org_commit_state() -> impl axum::response::IntoResponse {
     )
 }
 
+async fn failing_a_empty_b_project_commit_state(
+    axum::extract::Path(project_id): axum::extract::Path<String>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    if project_id == "prj_a" {
+        return (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            [(axum::http::header::ETAG, "\"failure\"")],
+            Json(json!({ "error": "injected project A failure" })),
+        )
+            .into_response();
+    }
+    empty_project_commit_state(axum::extract::Path(project_id))
+        .await
+        .into_response()
+}
+
 #[derive(Clone)]
 struct CommitSyncProbeState {
     org_requests: Arc<AtomicUsize>,
     project_requests: Arc<AtomicUsize>,
     project_in_flight: Arc<AtomicUsize>,
     max_project_in_flight: Arc<AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct ScopedCommitSyncProbeState {
+    project_requests: Arc<Mutex<Vec<String>>>,
+    started: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[derive(Deserialize)]
+struct ScopedCommitStateQuery {
+    local_commit_id: Option<String>,
+}
+
+async fn blocking_scoped_project_commit_state(
+    axum::extract::State(state): axum::extract::State<ScopedCommitSyncProbeState>,
+    axum::extract::Path(project_id): axum::extract::Path<String>,
+    axum::extract::Query(query): axum::extract::Query<ScopedCommitStateQuery>,
+) -> impl axum::response::IntoResponse {
+    state
+        .project_requests
+        .lock()
+        .unwrap()
+        .push(project_id.clone());
+    state.started.notify_one();
+    state.release.notified().await;
+    (
+        [(axum::http::header::ETAG, "\"ref-none\"")],
+        Json(json!({
+            "update_available": query.local_commit_id.is_some(),
+            "ref": {
+                "name": "refs/heads/main",
+                "scope": "project",
+                "org_id": "org_bindings",
+                "project_id": project_id,
+                "commit_id": null,
+                "updated_at": "2026-08-27T00:00:00Z"
+            },
+            "latest": null,
+            "download_url": null,
+            "incremental_supported": false
+        })),
+    )
 }
 
 async fn probed_empty_project_commit_state(
@@ -4100,6 +4314,17 @@ async fn commit_sync_installs_every_bound_project_independently_of_desktop_selec
         })
         .await
         .unwrap();
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    for project_id in ["prj_bound_first", "prj_bound_second"] {
+        sqlx::query("INSERT INTO daemon_meta (key, value) VALUES ($1, 'previous scoped failure')")
+            .bind(format!("commit_sync_last_error:{project_id}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+    pool.close().await;
     state
         .retry_sync(DaemonSyncRetryRequest {
             channel: SyncRetryChannel::Commits,
@@ -4115,12 +4340,254 @@ async fn commit_sync_installs_every_bound_project_independently_of_desktop_selec
             .await
             .unwrap();
         assert_eq!(cache.state, DaemonMemoryCacheState::Ready);
+        assert!(
+            state
+                .project_sync_status(DaemonProjectSyncStatusRequest {
+                    project_id: project_id.to_owned(),
+                })
+                .await
+                .unwrap()
+                .commit_sync
+                .last_error
+                .is_none()
+        );
     }
     assert_eq!(probe.org_requests.load(Ordering::Acquire), 1);
     assert_eq!(probe.project_requests.load(Ordering::Acquire), 3);
     let max_project_in_flight = probe.max_project_in_flight.load(Ordering::Acquire);
     assert!(max_project_in_flight > 1);
     assert!(max_project_in_flight <= 4);
+}
+
+#[tokio::test]
+async fn global_commit_sync_records_failure_and_success_per_project() {
+    let app = Router::new()
+        .route("/api/v1/projects/{project_id}", get(accessible_project))
+        .route(
+            "/api/v1/projects/{project_id}/commit-state",
+            get(failing_a_empty_b_project_commit_state),
+        )
+        .route("/api/v1/org/commit-state", get(empty_org_commit_state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let daemon_root = tempfile::tempdir().unwrap();
+    let workspace = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(daemon_root.path());
+    config.project.server_url = format!("http://{address}");
+    config.project.project_id = Some("prj_a".to_owned());
+    let (state, _) = common::initialize_authenticated_daemon(config, "test-token", None).await;
+    state
+        .replace_project_binding(DaemonProjectBindingReplaceRequest {
+            workspace_root: workspace.path().display().to_string(),
+            project_id: "prj_b".to_owned(),
+            expected_revision: None,
+        })
+        .await
+        .unwrap();
+
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO daemon_meta (key, value)
+         VALUES ('commit_sync_last_error:prj_b', 'stale project B failure')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let error = state
+        .retry_sync(DaemonSyncRetryRequest {
+            channel: SyncRetryChannel::Commits,
+        })
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("injected project A failure"),
+        "unexpected sync error: {error}"
+    );
+
+    let project_a = state
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap()
+        .commit_sync;
+    let project_b = state
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap()
+        .commit_sync;
+    assert_eq!(project_a.state, SyncState::Failed);
+    assert!(
+        project_a
+            .last_error
+            .as_ref()
+            .unwrap()
+            .message
+            .contains("injected project A failure")
+    );
+    assert!(project_a.last_attempt_at.is_some());
+    assert_eq!(project_b.state, SyncState::Idle);
+    assert!(project_b.last_error.is_none());
+    assert!(project_b.last_attempt_at.is_some());
+    assert!(project_b.last_success_at.is_some());
+    assert!(project_b.last_attempt_at <= project_b.last_success_at);
+    assert_eq!(
+        state.sync_status().await.unwrap().commit_sync.state,
+        SyncState::Failed
+    );
+}
+
+#[tokio::test]
+async fn project_commit_sync_status_and_retry_are_isolated() {
+    let probe = ScopedCommitSyncProbeState {
+        project_requests: Arc::new(Mutex::new(Vec::new())),
+        started: Arc::new(Notify::new()),
+        release: Arc::new(Notify::new()),
+    };
+    let app = Router::new()
+        .route(
+            "/api/v1/projects/{project_id}/commit-state",
+            get(blocking_scoped_project_commit_state),
+        )
+        .route("/api/v1/org/commit-state", get(empty_org_commit_state))
+        .with_state(probe.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let root = tempfile::tempdir().unwrap();
+    let mut config = DaemonConfig::for_root(root.path());
+    config.project.server_url = format!("http://{address}");
+    config.project.project_id = Some("prj_desktop_selection".to_owned());
+    let (state, _) = common::initialize_authenticated_daemon(config, "test-token", None).await;
+    let service = DaemonIpcService::new(state.clone());
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    for (project_id, commit_id) in [("prj_a", "commit-a"), ("prj_b", "commit-b")] {
+        sqlx::query(
+            "INSERT INTO cached_refs (
+                ref_key, name, scope, org_id, project_id, commit_id, etag,
+                server_updated_at, installed_at
+             ) VALUES ($1, 'refs/heads/main', 'project', 'org_bindings', $2, $3, $3,
+                       '2026-08-27T00:00:00Z', '2026-08-27T00:00:00Z')",
+        )
+        .bind(format!("project:{project_id}"))
+        .bind(project_id)
+        .bind(commit_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query(
+        "INSERT INTO daemon_meta (key, value)
+         VALUES ('commit_sync_last_error', 'failure from another Project')
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
+
+    let project_a = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap();
+    let project_b = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        project_a.commit_sync.server_cursor.as_deref(),
+        Some("commit-a")
+    );
+    assert_eq!(
+        project_b.commit_sync.server_cursor.as_deref(),
+        Some("commit-b")
+    );
+    assert!(project_a.commit_sync.last_error.is_none());
+    assert!(project_b.commit_sync.last_error.is_none());
+
+    let retry_service = service.clone();
+    let retry = tokio::spawn(async move {
+        retry_service
+            .project_retry_sync(DaemonProjectSyncRetryRequest {
+                project_id: "prj_a".to_owned(),
+                channel: SyncRetryChannel::Commits,
+            })
+            .await
+    });
+    probe.started.notified().await;
+
+    let project_a = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap();
+    let project_b = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(project_a.commit_sync.state, SyncState::Syncing);
+    assert_eq!(project_b.commit_sync.state, SyncState::Idle);
+
+    probe.release.notify_one();
+    retry.await.unwrap().unwrap();
+
+    let project_a = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_a".to_owned(),
+        })
+        .await
+        .unwrap();
+    let project_b = service
+        .project_sync_status(DaemonProjectSyncStatusRequest {
+            project_id: "prj_b".to_owned(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(project_a.commit_sync.server_cursor, None);
+    assert!(project_a.commit_sync.last_attempt_at.is_some());
+    assert!(project_a.commit_sync.last_success_at.is_some());
+    assert!(project_a.commit_sync.last_error.is_none());
+    assert_eq!(
+        project_b.commit_sync.server_cursor.as_deref(),
+        Some("commit-b")
+    );
+    assert_eq!(project_b.commit_sync.last_attempt_at, None);
+    assert!(project_b.commit_sync.last_error.is_none());
+    assert_eq!(
+        probe.project_requests.lock().unwrap().as_slice(),
+        &["prj_a".to_owned()]
+    );
+    assert!(
+        service
+            .sync_status()
+            .await
+            .unwrap()
+            .commit_sync
+            .last_error
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -5534,7 +6001,7 @@ async fn invalid_commit_payload_does_not_advance_the_installed_ref() {
     config.project.project_id = Some("prj_atomic".to_owned());
     let (state, _) =
         common::initialize_authenticated_daemon(config, "fake-access-token", None).await;
-    let service = DaemonIpcService::new(state);
+    let service = DaemonIpcService::new(state.clone());
 
     service
         .retry_sync(DaemonSyncRetryRequest {
@@ -5559,6 +6026,17 @@ async fn invalid_commit_payload_does_not_advance_the_installed_ref() {
         "Valid authority"
     );
 
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", state.local_db_path().display()))
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO daemon_meta (key, value)
+         VALUES ('commit_sync_last_error:prj_atomic', 'previous scoped failure')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    pool.close().await;
     server.publish_invalid_commit();
     let error = service
         .retry_sync(DaemonSyncRetryRequest {
@@ -5602,6 +6080,19 @@ async fn invalid_commit_payload_does_not_advance_the_installed_ref() {
         Some("commit-valid")
     );
     assert!(sync.commit_sync.last_error.is_some());
+    assert!(
+        service
+            .project_sync_status(DaemonProjectSyncStatusRequest {
+                project_id: "prj_atomic".to_owned(),
+            })
+            .await
+            .unwrap()
+            .commit_sync
+            .last_error
+            .unwrap()
+            .message
+            .contains("failed content-address verification")
+    );
 
     std::fs::remove_file(std::path::Path::new(&installed_root).join("manifest.json")).unwrap();
     let corrupted = service


### PR DESCRIPTION
## Context and summary

Memory folder actions attached competing SwiftUI alert presenters, so choosing Discard could close the context menu without presenting confirmation or changing the Draft. Synchronization feedback was also derived from global daemon state: retries, cursors, timestamps, and errors could be attributed to the wrong Project, while late background work could overwrite newer operation feedback.

This change routes Memory rename and destructive actions through one alert flow, serializes conflicting mutations, and keeps recoverable failures visible in the existing macOS banner. It adds additive project-scoped Draft and Commit status/retry requests so the app reports and retries the Project that owns the work.

## Affected areas

- [x] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [x] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before:
- Folder Discard could appear to do nothing because another alert presenter won.
- Batch Memory operations had no durable progress or partial-failure feedback.
- Project A sync activity or failure could disable or contaminate Project B controls.
- Dismissed polling errors could immediately reappear, and stale background requests could publish after a workspace transition.

After:
- One native alert presenter owns rename, folder discard, and deletion confirmation.
- Batch operations expose in-context progress, block conflicting mutations, and preserve actionable partial-failure details.
- Draft and Commit status, retry queues, timestamps, cursors, and errors are Project-scoped; same-Project channels execute in order while different Projects remain independent.
- Retry tasks are cancelled on authority reset, stale background results are generation-guarded, and dismissed background errors remain quiet until that source recovers.
- Reconciliation retries use the Draft's actual Project and always perform a post-retry Draft check, including after a pending save is flushed.
- The existing global error banner remains the single notification surface; no new toast framework or dependency was added.

## Verification

Passed:
- `sh apps/macos/Scripts/test.sh`
- `cargo test -p daemon --test daemon_lifecycle` (71 passed)
- `cargo test -p daemon --lib commit_sync::tests` (7 passed)
- `cargo clippy -p daemon --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `just test-dev-macos`
- `just build-macos`
- `git diff --check`

Not run locally:
- Docker-backed `cargo test -p daemon --test server_integration`; the local OrbStack Docker socket is unavailable. CI should run this suite in its configured container environment.
- A final manual UI pass; automated macOS tests and the Release app-plus-embedded-daemon build passed, and manual validation was waived for this submission.

## Compatibility and migration

The new daemon XPC requests are additive. Existing global `sync_status` and `retry_sync` behavior remains available, and existing daemon metadata remains readable. Project-scoped timestamps and errors are written lazily to new metadata keys; there is no database schema or server API migration.

The macOS app and bundled daemon should be upgraded together through the existing bootstrap/restart flow. A temporarily older daemon will not understand the new project-scoped requests until it is replaced and relaunched. Rollback leaves the additive metadata keys harmless and ignored by older code.

## Risk, security, and privacy

Destructive actions still require native confirmation, and Discard only removes Project-carried Draft state; shared Organization Memory is unchanged until review and merge. Project identifiers used in scoped metadata are validated before storage access.

The main reliability risks are retry cancellation, same-Project ordering, partial batch completion, and stale asynchronous results. These paths now have explicit task identity, Project/generation guards, serialized mutation gates, bounded XPC waiting, and regression coverage. No new external endpoint, permission, telemetry, dependency, or Memory payload logging is introduced.

## Rollout and rollback

- Rollout: Merge through the normal pull request flow and ship the macOS app with its bundled daemon in the next build.
- Observability: Watch the Project sync popover, persistent operation banner, Diagnostics status, and daemon sync logs for Project attribution, retry completion, and partial failures.
- Rollback: Revert this commit and rebuild the app and bundled daemon; the additive scoped metadata keys can remain without affecting the previous implementation.

## Reviewer focus

Please focus on the single FileTree alert owner and busy guards, `WorkspaceStore` retry task ordering/cancellation and banner precedence, daemon per-Project Draft/Commit outcome persistence, and the reconciliation upload barrier after long retries. The deliberate scope is to reuse the existing native banner rather than introduce a separate notification framework.
