### PR TITLE
dev: initialize fresh local instances before app launch

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -11,7 +11,9 @@ just dev-macos
 The command starts a complete Dev Instance owned by the current worktree: a
 uniquely named App and daemon, private data and Keychain identity, local Server,
 PostgreSQL, fake OIDC, and isolated `CODEX_HOME`. It does not replace the
-resident Debug App or global Codex Plugin.
+resident Debug App or global Codex Plugin. Fresh local Server data is initialized
+through the normal Setup API and fake OIDC before the App opens; product login is
+not bypassed.
 
 ```sh
 just dev-macos-status

--- a/dev/dev-instance-test.sh
+++ b/dev/dev-instance-test.sh
@@ -12,6 +12,7 @@ fake_docker_state=$test_root/docker.running
 fake_app_state=$test_root/app.running
 fake_daemon_state=$test_root/daemon.running
 fake_server_registry=$test_root/server.registry
+fake_setup_state=$test_root/setup.state
 compose_descriptor_marker=$test_root/compose-descriptor.checked
 test_home=$test_root/home
 dev_root=$test_root/dev-root
@@ -23,6 +24,7 @@ mkdir -p "$fake_bin" "$test_home/Applications/Clumsies.app" \
 printf 'stable-app\n' > "$test_home/Applications/Clumsies.app/sentinel"
 printf 'stable-daemon\n' > "$test_home/Library/Application Support/ai.clumsies/sentinel"
 printf 'stable-codex\n' > "$test_home/.codex/sentinel"
+printf 'setup_required\n' > "$fake_setup_state"
 
 cleanup() {
   if [ -n "${reset_pid:-}" ]; then
@@ -113,7 +115,7 @@ PY
     if [ "$#" -eq 2 ] && [ "$2" = --remove-orphans ]; then
       :
     elif [ "$#" -eq 3 ] && [ "$2" = -v ] && [ "$3" = --remove-orphans ]; then
-      :
+      printf 'setup_required\n' > "$FAKE_SETUP_STATE"
     else
       reject "$@"
     fi
@@ -131,20 +133,84 @@ cat > "$fake_bin/curl" <<'EOF'
 #!/bin/sh
 set -eu
 printf 'curl %s\n' "$*" >> "$FAKE_COMMAND_LOG"
-[ "$#" -eq 5 ] && [ "$1" = --fail ] && [ "$2" = --silent ] \
-  && [ "$3" = --max-time ] && [ "$4" = 3 ] || {
+reject() {
   printf 'curl %s\n' "$*" >> "$FAKE_REJECT_LOG"
   exit 97
 }
-case "$5" in
-  http://127.0.0.1:*/api/v1/admin/health|https://pr-*.example.test/api/v1/admin/health) ;;
-  *)
-    printf 'curl %s\n' "$*" >> "$FAKE_REJECT_LOG"
-    exit 97
-    ;;
-esac
+
+arg_after() {
+  wanted=$1
+  shift
+  while [ "$#" -gt 1 ]; do
+    if [ "$1" = "$wanted" ]; then
+      printf '%s\n' "$2"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+has_arg() {
+  wanted=$1
+  shift
+  for argument do
+    [ "$argument" = "$wanted" ] && return 0
+  done
+  return 1
+}
+
+for argument do url=$argument; done
+case "${url:-}" in http://*|https://*) ;; *) reject "$@" ;; esac
 [ "${FAKE_CURL_FAIL:-0}" = 0 ] || exit 22
-printf '{"status":"ok"}\n'
+
+case "$url" in
+  http://127.0.0.1:*/api/v1/admin/health|https://pr-*.example.test/api/v1/admin/health)
+    printf '{"status":"ok"}\n'
+    ;;
+  "$FAKE_OPEN_SERVER_URL/api/v1/setup")
+    printf '{"state":"%s"}\n' "$(cat "$FAKE_SETUP_STATE")"
+    ;;
+  "$FAKE_OPEN_SERVER_URL/api/v1/setup/sessions")
+    output=$(arg_after --output "$@") || reject "$@"
+    cookie_jar=$(arg_after --cookie-jar "$@") || reject "$@"
+    body=$(cat)
+    expected_setup_code=$(awk -F= '$1 == "CLUMSIES_SETUP_CODE" { print substr($0, index($0, "=") + 1) }' "$FAKE_COMPOSE_ENV")
+    printf '%s' "$body" | FAKE_EXPECTED_SETUP_CODE="$expected_setup_code" /usr/bin/python3 -c \
+      'import json,os,sys; assert json.load(sys.stdin) == {"setup_code": os.environ["FAKE_EXPECTED_SETUP_CODE"]}' \
+      || reject
+    : > "$cookie_jar"
+    printf '%s\n' '{"csrf_token":"fake-csrf-token","expires_at":"2099-01-01T00:00:00Z"}' > "$output"
+    ;;
+  "$FAKE_OPEN_SERVER_URL/api/v1/setup/configuration")
+    cookie_file=$(arg_after --cookie "$@") || reject "$@"
+    csrf_header=$(printf '%s\n' "$@" | sed -n 's#^@\(/.*\)#\1#p')
+    [ -f "$cookie_file" ] && [ -f "$csrf_header" ] || reject "$@"
+    grep -Fx 'x-csrf-token: fake-csrf-token' "$csrf_header" >/dev/null || reject
+    /usr/bin/python3 -c \
+      'import json,sys; assert json.load(sys.stdin) == {"org_name":"Clumsies Dev","default_project_name":"Default","allowed_email_domains":[]}' \
+      || reject
+    ;;
+  "$FAKE_OPEN_SERVER_URL/api/v1/setup/oidc-authorizations")
+    output=$(arg_after --output "$@") || reject "$@"
+    cookie_file=$(arg_after --cookie "$@") || reject "$@"
+    csrf_header=$(printf '%s\n' "$@" | sed -n 's#^@\(/.*\)#\1#p')
+    [ -f "$cookie_file" ] && [ -f "$csrf_header" ] || reject "$@"
+    grep -Fx 'x-csrf-token: fake-csrf-token' "$csrf_header" >/dev/null || reject
+    FAKE_EXPECTED_REDIRECT="$FAKE_OPEN_SERVER_URL/admin/setup/callback" \
+      /usr/bin/python3 -c \
+      'import json,os,sys; assert json.load(sys.stdin) == {"redirect_uri": os.environ["FAKE_EXPECTED_REDIRECT"]}' \
+      || reject
+    printf '%s\n' \
+      '{"authorization_url":"http://127.0.0.1:18091/clumsies/authorize?state=fake"}' \
+      > "$output"
+    ;;
+  http://127.0.0.1:18091/clumsies/authorize\?state=fake)
+    has_arg --location "$@" || reject "$@"
+    printf 'initialized\n' > "$FAKE_SETUP_STATE"
+    ;;
+  *) reject ;;
+esac
 EOF
 
 cat > "$fake_bin/bun" <<'EOF'
@@ -283,6 +349,11 @@ printf 'open %s\n' "$*" >> "$FAKE_COMMAND_LOG"
   printf 'open %s\n' "$*" >> "$FAKE_REJECT_LOG"
   exit 97
 }
+case "$FAKE_OPEN_SERVER_URL" in
+  http://127.0.0.1:*) [ "$(cat "$FAKE_SETUP_STATE")" = initialized ] || exit 97 ;;
+  https://*) ;;
+  *) exit 97 ;;
+esac
 : > "$FAKE_APP_STATE"
 : > "$FAKE_DAEMON_STATE"
 EOF
@@ -558,6 +629,7 @@ runner_environment() {
     FAKE_APP_STATE="$fake_app_state" \
     FAKE_DAEMON_STATE="$fake_daemon_state" \
     FAKE_SERVER_REGISTRY="$fake_server_registry" \
+    FAKE_SETUP_STATE="$fake_setup_state" \
     FAKE_COMPOSE_DESCRIPTOR_MARKER="$compose_descriptor_marker" \
     FAKE_RUNTIME_FILE="$runtime" \
     FAKE_INSTANCE_ROOT="$instance_root" \
@@ -654,6 +726,15 @@ wait "$launcher_pid" 2>/dev/null || true
 run up > "$test_root/recovered-up.out"
 [ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = running ]
 [ -f "$compose_descriptor_marker" ]
+setup_sequence=$(awk '
+  /\/api\/v1\/setup\/sessions$/ { print "session"; next }
+  /\/api\/v1\/setup\/configuration$/ { print "configuration"; next }
+  /\/api\/v1\/setup\/oidc-authorizations$/ { print "authorization"; next }
+  /\/clumsies\/authorize[?]state=fake$/ { print "oidc"; next }
+  /\/api\/v1\/setup$/ { print "state"; next }
+' "$fake_log")
+[ "$setup_sequence" = "$(printf '%s\n' state session configuration authorization oidc state)" ]
+setup_sessions_before_reset=$(grep -c '/api/v1/setup/sessions' "$fake_log")
 run reset
 
 FAKE_XCODEBUILD_FAIL=1
@@ -663,6 +744,8 @@ if run up > "$test_root/failed-up.out" 2> "$test_root/failed-up.err"; then
   exit 1
 fi
 unset FAKE_XCODEBUILD_FAIL
+setup_sessions_after_reset=$(grep -c '/api/v1/setup/sessions' "$fake_log")
+[ "$setup_sessions_after_reset" -eq $((setup_sessions_before_reset + 1)) ]
 [ -f "$runtime" ]
 [ "$(/usr/bin/python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["state"])' "$runtime")" = stopped ]
 [ ! -f "$fake_server_registry" ]
@@ -727,9 +810,12 @@ xcodebuild_after=$(grep -c '^xcodebuild ' "$fake_log" || true)
 [ ! -e "$instance_lock" ]
 
 xcodebuild_before=$(grep -c '^xcodebuild ' "$fake_log" || true)
+setup_sessions_before=$(grep -c '/api/v1/setup/sessions' "$fake_log" || true)
 run up > "$test_root/repeated-up.out"
 xcodebuild_after=$(grep -c '^xcodebuild ' "$fake_log" || true)
+setup_sessions_after=$(grep -c '/api/v1/setup/sessions' "$fake_log" || true)
 [ "$xcodebuild_after" -eq $((xcodebuild_before + 1)) ]
+[ "$setup_sessions_after" -eq "$setup_sessions_before" ]
 
 cp "$runtime" "$test_root/runtime.saved"
 /usr/bin/python3 - "$runtime" <<'PY'
@@ -917,9 +1003,12 @@ grep -F 'Preview Server is not healthy' "$test_root/unhealthy-preview.err" >/dev
 FAKE_OPEN_SERVER_URL=https://pr-73.example.test
 export FAKE_OPEN_SERVER_URL
 preview_curl_before=$(grep -c '^curl ' "$fake_log" || true)
+preview_setup_before=$(grep -c '/api/v1/setup' "$fake_log" || true)
 run up --preview "$preview_a" >/dev/null
 preview_curl_after=$(grep -c '^curl ' "$fake_log" || true)
+preview_setup_after=$(grep -c '/api/v1/setup' "$fake_log" || true)
 [ "$preview_curl_after" -ge $((preview_curl_before + 2)) ]
+[ "$preview_setup_after" -eq "$preview_setup_before" ]
 if run up --preview "$preview_b" > "$test_root/changed-preview.out" 2> "$test_root/changed-preview.err"; then
   echo "expected a changed Preview identity to require reset" >&2
   exit 1

--- a/dev/dev-instance.sh
+++ b/dev/dev-instance.sh
@@ -81,6 +81,7 @@ app_process_pattern=$(printf '%s' "$app_executable" | sed 's/[][\\.^$*+?(){}|]/\
 server_log=$logs_dir/server.log
 app_stdout=$logs_dir/app.out.log
 app_stderr=$logs_dir/app.err.log
+setup_temp_dir=
 
 compose() {
   docker compose \
@@ -523,6 +524,87 @@ server_is_healthy() {
     >/dev/null 2>&1
 }
 
+server_setup_state() {
+  curl --fail --silent --show-error --max-time 3 "$server_url/api/v1/setup" \
+    | "$python" -c '
+import json, sys
+state = json.load(sys.stdin).get("state")
+if state not in {"setup_required", "initialized"}:
+    raise SystemExit("invalid Server setup state")
+print(state)
+'
+}
+
+cleanup_setup_temp() {
+  case "${setup_temp_dir:-}" in
+    "$instance_root"/setup.*) rm -rf -- "$setup_temp_dir" ;;
+    '') ;;
+  esac
+  setup_temp_dir=
+}
+
+initialize_local_server() {
+  setup_state=$(server_setup_state) || die "could not read Server setup state"
+  case "$setup_state" in
+    initialized) return 0 ;;
+    setup_required) ;;
+    *) die "Server returned an invalid setup state" ;;
+  esac
+
+  setup_temp_dir=$(mktemp -d "$instance_root/setup.XXXXXX") \
+    || die "could not create temporary Server setup state"
+  setup_cookie_file=$setup_temp_dir/cookies
+  setup_csrf_header=$setup_temp_dir/csrf-header
+  setup_session_file=$setup_temp_dir/session.json
+  setup_authorization_file=$setup_temp_dir/authorization.json
+
+  printf '{"setup_code":"%s"}' "$setup_code" \
+    | curl --fail --silent --show-error --max-time 10 \
+      --request POST \
+      --header 'content-type: application/json' \
+      --cookie-jar "$setup_cookie_file" \
+      --data-binary @- \
+      --output "$setup_session_file" \
+      "$server_url/api/v1/setup/sessions"
+  setup_csrf_token=$(json_get "$setup_session_file" csrf_token) \
+    || die "Server setup session did not return a CSRF token"
+  [ -n "$setup_csrf_token" ] || die "Server setup session returned an empty CSRF token"
+  printf 'x-csrf-token: %s\n' "$setup_csrf_token" > "$setup_csrf_header"
+
+  printf '%s' \
+    '{"org_name":"Clumsies Dev","default_project_name":"Default","allowed_email_domains":[]}' \
+    | curl --fail --silent --show-error --max-time 10 \
+      --request PUT \
+      --header 'content-type: application/json' \
+      --header "@$setup_csrf_header" \
+      --cookie "$setup_cookie_file" \
+      --data-binary @- \
+      --output /dev/null \
+      "$server_url/api/v1/setup/configuration"
+
+  printf '{"redirect_uri":"%s/admin/setup/callback"}' "$server_url" \
+    | curl --fail --silent --show-error --max-time 10 \
+      --request POST \
+      --header 'content-type: application/json' \
+      --header "@$setup_csrf_header" \
+      --cookie "$setup_cookie_file" \
+      --data-binary @- \
+      --output "$setup_authorization_file" \
+      "$server_url/api/v1/setup/oidc-authorizations"
+  setup_authorization_url=$(json_get "$setup_authorization_file" authorization_url) \
+    || die "Server setup did not return an OIDC authorization URL"
+  case "$setup_authorization_url" in
+    "$oidc_issuer"/*) ;;
+    *) die "Server setup returned an unexpected OIDC authorization URL" ;;
+  esac
+  curl --fail --silent --show-error --location --max-time 30 \
+    --output /dev/null "$setup_authorization_url"
+
+  [ "$(server_setup_state)" = initialized ] \
+    || die "Server setup did not reach initialized state"
+  cleanup_setup_temp
+}
+
 daemon_is_running() {
   uid=$(id -u)
   launchctl print "gui/$uid/$daemon_label" >/dev/null 2>&1
@@ -682,6 +764,7 @@ on_exit() {
   if [ "$command_name" = up ] && [ "$status" -ne 0 ]; then
     cleanup_failed_up
   fi
+  cleanup_setup_temp
   cleanup_recovery_compose_env
   release_lock
   exit "$status"
@@ -894,6 +977,7 @@ run_up() {
       attempts=$((attempts + 1))
     done
     server_is_healthy || die "Server health did not become ready; see $server_log"
+    initialize_local_server
   else
     mv -f "$preview_candidate" "$preview_file"
     preview_candidate=


### PR DESCRIPTION
## Context and summary

Follow-up to https://github.com/lilhammerfun/clumsies/pull/216.

A fresh worktree-owned local Dev Instance started the Server with an empty
PostgreSQL volume, then opened the App without claiming the installation.
Product authentication correctly rejected that state with `setup_required`.

This change completes the existing one-time Setup API flow through the local
fake OIDC provider before opening the App. Already initialized volumes are a
no-op, and remote Preview environments remain outside this local bootstrap.

## Affected areas

- [ ] Rust daemon/runtime
- [x] Server/API
- [x] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [x] Storage, configuration, or schema
- [x] Documentation
- [x] CI, deployment, or release

## Behavior and evidence

- Fresh local instances exchange the private Setup Code for a setup session,
  save the default organization and project configuration, bind the first
  Owner through fake OIDC, and require `initialized` before App launch.
- Repeated startup skips the one-time setup. A real restart retained exactly
  one setup session, Owner, organization, and project.
- Preview startup never calls the local Setup API.
- Product login is not bypassed; only the required installation setup is
  completed automatically.

## Verification

- `just test-dev-macos`
- `shellcheck dev/dev-instance.sh dev/dev-instance-test.sh`
- `sh -n dev/dev-instance.sh`
- `sh -n dev/dev-instance-test.sh`
- `python3 dev/validate-pr-template.py --self-test`
- `git diff --check`
- Real fresh local `just dev-macos`: App, daemon, Server, PostgreSQL, and fake
  OIDC reported healthy; `/api/v1/setup` returned `initialized`; PostgreSQL
  contained one Owner, organization, and project.
- Repeated real `just dev-macos`: setup session, Owner, organization, and
  project counts remained one.
- Cleanup: `just dev-macos-reset` removed the isolated App, daemon state,
  credentials, containers, network, and PostgreSQL volume; OrbStack was
  returned to its prior stopped state.

Not run: a manual click-through of the subsequent product login. Product auth
code is unchanged, and the real setup OIDC callback was exercised.

## Compatibility and migration

No API, schema, or persistent configuration migration. Existing initialized
local volumes skip setup, fresh volumes initialize once, and Preview behavior
is unchanged. `just dev-macos-reset` remains the destructive cleanup boundary.

## Risk, security, and privacy

Setup cookies and CSRF material live only in an instance-private temporary
directory under the existing `umask 077`. The Setup Code is streamed on stdin
instead of exposed in process arguments. The returned authorization URL must
match the instance's fake OIDC issuer, and all bootstrap behavior is restricted
to local mode.

An uncatchable process termination may leave the temporary files inside the
private instance root until reset; the setup session expires after 15 minutes.

## Rollout and rollback

- Rollout: Merge normally; the next fresh local `just dev-macos` initializes before opening the Dev App.
- Observability: Use `just dev-macos-status`, `just dev-macos-logs`, and `/api/v1/setup` to inspect runtime and setup state.
- Rollback: Revert this commit; reset any disposable Dev Instance if a fresh pre-setup state is required.

## Reviewer focus

Please review the Setup session/configuration/OIDC ordering, temporary credential
handling, the local-versus-Preview boundary, and the fresh/reset/restart
contract coverage.
