### PR TITLE
daemon: bound Codex plugin signature checks

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -5160,6 +5160,14 @@ final class WorkspaceStore: ObservableObject {
         return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
     }
 
+    nonisolated static func codexPluginInspectionWarning(for error: any Error) -> String {
+        "Clumsies could not inspect the global Codex plugin. Open Settings > Agent to try again. \(error.localizedDescription)"
+    }
+
+    nonisolated static func codexPluginRepairWarning(for error: any Error) -> String {
+        "Clumsies could not repair the global Codex plugin. Open Settings > Agent to try again. \(error.localizedDescription)"
+    }
+
     private func refreshDraft(_ draftId: String) async throws {
         let detail = try await daemon.draft(draftId)
         let mapped = WorkspaceLoader.mapDraft(detail, resources: resources)
@@ -5951,10 +5959,14 @@ struct WorkspaceLoader: Sendable {
             do {
                 let status = try await daemon.inspectCodexPlugin(request)
                 if !status.ready {
-                    _ = try await daemon.reconcileCodexPlugin(request)
+                    do {
+                        _ = try await daemon.reconcileCodexPlugin(request)
+                    } catch {
+                        codexWarning = WorkspaceStore.codexPluginRepairWarning(for: error)
+                    }
                 }
             } catch {
-                codexWarning = "Clumsies could not repair the global Codex plugin. Open Settings > Agent to try again. \(error.localizedDescription)"
+                codexWarning = WorkspaceStore.codexPluginInspectionWarning(for: error)
             }
         }
         let installed = try await daemon.allProjectAgentAdapters()

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -793,6 +793,18 @@ final class DaemonContractTests: XCTestCase {
         )
     }
 
+    func testCodexPluginWarningsDistinguishInspectionFromRepair() {
+        let error = DaemonXPCError.requestTimedOut(timeout: 40)
+        let inspection = WorkspaceStore.codexPluginInspectionWarning(for: error)
+        let repair = WorkspaceStore.codexPluginRepairWarning(for: error)
+
+        XCTAssertTrue(inspection.contains("could not inspect"))
+        XCTAssertFalse(inspection.contains("could not repair"))
+        XCTAssertTrue(repair.contains("could not repair"))
+        XCTAssertTrue(inspection.contains("within 40.0s"))
+        XCTAssertTrue(repair.contains("within 40.0s"))
+    }
+
     func testLegacyInspectionDoesNotClearManagedPluginWarning() {
         XCTAssertEqual(
             WorkspaceStore.combinedAgentAdapterWarning("Codex repair failed", nil),

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -1956,7 +1956,6 @@ pub(crate) async fn inspect_codex_plugin(
     state: &DaemonState,
     request: DaemonCodexPluginRequest,
 ) -> Result<DaemonCodexPluginStatus, DaemonError> {
-    let _guard = state.inner.local_setup_lock.lock().await;
     let runtime_binary = canonical_agent_runtime_binary(&request.runtime_binary_path)?;
     #[cfg(target_os = "macos")]
     verify_code_signature(&runtime_binary)?;

--- a/crates/daemon/src/agent_adapter/codex_plugin.rs
+++ b/crates/daemon/src/agent_adapter/codex_plugin.rs
@@ -11,7 +11,7 @@ use crate::project_storage::{ensure_private_directory, write_private_file};
 use crate::{DEV_INSTANCE_ID_ENV, DaemonError};
 
 #[cfg(target_os = "macos")]
-use super::code_signature_info;
+use super::parse_code_signature_info;
 use super::{DaemonCodexPluginStatus, is_executable, shell_single_quote, state_error};
 
 const MARKETPLACE_NAME: &str = "clumsies-local";
@@ -88,7 +88,7 @@ pub(super) async fn ensure_installed(
         )
     })?;
     let codex = canonical_codex_cli(host_binary_path)?;
-    verify_codex_cli(&codex)?;
+    verify_codex_cli(&codex).await?;
     let plugin = materialize(daemon_root, runtime_binary, runtime_hash, dev_instance_id)?;
     ensure_marketplace(&codex, &plugin.marketplace_root).await?;
     ensure_plugin(&codex, &plugin.version).await
@@ -121,7 +121,7 @@ pub(super) async fn inspect(
         });
     };
     let codex = canonical_codex_cli(host_binary_path)?;
-    verify_codex_cli(&codex)?;
+    verify_codex_cli(&codex).await?;
     let marketplace_root = daemon_root.join("agent-plugins/codex-marketplace");
     inspect_verified(&codex, &marketplace_root, expected_version).await
 }
@@ -376,16 +376,14 @@ async fn run_cli_json(codex: &Path, args: &[&str]) -> Result<Value, DaemonError>
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    let output = tokio::time::timeout(CLI_TIMEOUT, command.output())
-        .await
-        .map_err(|_| {
-            state_error(
-                "codex_plugin_timeout",
-                "Codex did not finish the plugin operation in time.",
-            )
-        })??;
+        .stderr(Stdio::piped());
+    let output = command_output(
+        command,
+        CLI_TIMEOUT,
+        "codex_plugin_timeout",
+        "Codex did not finish the plugin operation in time.",
+    )
+    .await?;
     if output.stdout.len() > MAX_CLI_OUTPUT_BYTES || output.stderr.len() > MAX_CLI_OUTPUT_BYTES {
         return Err(state_error(
             "codex_plugin_output_too_large",
@@ -404,6 +402,18 @@ async fn run_cli_json(codex: &Path, args: &[&str]) -> Result<Value, DaemonError>
             "Codex returned an invalid plugin response.",
         )
     })
+}
+
+async fn command_output(
+    mut command: tokio::process::Command,
+    timeout: Duration,
+    timeout_code: &'static str,
+    timeout_message: &'static str,
+) -> Result<std::process::Output, DaemonError> {
+    command.kill_on_drop(true);
+    Ok(tokio::time::timeout(timeout, command.output())
+        .await
+        .map_err(|_| state_error(timeout_code, timeout_message))??)
 }
 
 fn canonical_paths_match(left: &Path, right: &Path) -> bool {
@@ -446,18 +456,23 @@ fn canonical_codex_cli(path: &str) -> Result<PathBuf, DaemonError> {
 }
 
 #[cfg(target_os = "macos")]
-fn verify_codex_cli(path: &Path) -> Result<(), DaemonError> {
-    let output = std::process::Command::new("/usr/bin/codesign")
-        .arg("--verify")
-        .arg("--strict")
-        .arg(path)
-        .output()?;
-    let info = code_signature_info(path)?;
-    if !output.status.success()
-        || info.identifier != CODEX_SIGNING_IDENTIFIER
-        || info.team_identifier.as_deref() != Some(OPENAI_TEAM_IDENTIFIER)
-        || info.ad_hoc
-        || !info.hardened_runtime
+async fn verify_codex_cli(path: &Path) -> Result<(), DaemonError> {
+    let verification = codesign_output(path, &["--verify", "--strict"]).await?;
+    let metadata = codesign_output(path, &["--display", "--verbose=4"]).await?;
+    let details = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&metadata.stdout),
+        String::from_utf8_lossy(&metadata.stderr)
+    );
+    let info = parse_code_signature_info(&details);
+    if !verification.status.success()
+        || !metadata.status.success()
+        || info.as_ref().is_none_or(|info| {
+            info.identifier != CODEX_SIGNING_IDENTIFIER
+                || info.team_identifier.as_deref() != Some(OPENAI_TEAM_IDENTIFIER)
+                || info.ad_hoc
+                || !info.hardened_runtime
+        })
     {
         return Err(state_error(
             "codex_plugin_invalid_host",
@@ -467,14 +482,59 @@ fn verify_codex_cli(path: &Path) -> Result<(), DaemonError> {
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+async fn codesign_output(path: &Path, args: &[&str]) -> Result<std::process::Output, DaemonError> {
+    let mut command = tokio::process::Command::new("/usr/bin/codesign");
+    command
+        .args(args)
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command_output(
+        command,
+        CLI_TIMEOUT,
+        "codex_plugin_signature_timeout",
+        "Codex App signature verification did not finish in time.",
+    )
+    .await
+}
+
 #[cfg(not(target_os = "macos"))]
-fn verify_codex_cli(_path: &Path) -> Result<(), DaemonError> {
+async fn verify_codex_cli(_path: &Path) -> Result<(), DaemonError> {
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn command_timeout_does_not_block_the_runtime() {
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.args(["-c", "exec sleep 60"]);
+        let started = std::time::Instant::now();
+        let waiting = tokio::spawn(command_output(
+            command,
+            Duration::from_millis(25),
+            "codex_plugin_signature_timeout",
+            "timed out",
+        ));
+        tokio::time::timeout(Duration::from_millis(100), tokio::task::yield_now())
+            .await
+            .unwrap();
+        let error = waiting.await.unwrap().unwrap_err();
+
+        assert!(matches!(
+            error,
+            DaemonError::State {
+                code: "codex_plugin_signature_timeout",
+                ..
+            }
+        ));
+        assert!(started.elapsed() < Duration::from_secs(1));
+    }
 
     #[test]
     fn materialized_plugin_pins_runtime_and_keeps_memory_skills_remote() {


### PR DESCRIPTION
## Context and summary

The macOS app checks the global Codex plugin during startup so an app update can reconcile the installed plugin with the bundled daemon runtime. That inspection synchronously ran codesign without a deadline. Under I/O pressure, signature verification could remain blocked for minutes while the app reported a generic 40-second daemon timeout.

This change runs both Codex signature commands asynchronously with a 15-second deadline and child cancellation, keeps the read-only inspection outside the local setup lock, and distinguishes inspection failures from repair failures in the macOS warning.

## Affected areas

- [x] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [x] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before:
- Codex host verification used blocking process output with no timeout.
- A stuck codesign process occupied a Tokio worker and held the local setup lock.
- Startup inspection failures were described as failed repairs even when repair never started.

After:
- codesign verify and metadata inspection use Tokio process execution, a 15-second deadline, and kill-on-drop cancellation.
- Read-only plugin inspection no longer takes the local setup lock.
- Timeout returns codex_plugin_signature_timeout before the app XPC deadline.
- Inspection and repair warnings identify the operation that failed.
- The promoted Debug app reconciled an installed and enabled Clumsies plugin without leaving a codesign process behind.

## Verification

Passed:
- cargo fmt --all --check
- cargo clippy -p daemon --all-targets -- -D warnings
- cargo test --workspace
- sh apps/macos/Scripts/test.sh
- git diff --check
- just promote-debug-macos
- Manual installed-state check: the launchd daemon remained responsive and the global Clumsies plugin was installed and enabled.

## Compatibility and migration

No API, schema, configuration, or stored-data migration. Existing plugin installations continue to use the same marketplace and plugin identity.

## Risk, security, and privacy

Signature trust requirements are unchanged: the Codex host must still have the expected identifier, OpenAI team identity, and hardened runtime. Timeouts fail closed. No private Memory, Hook, credential, or request payload is added to logs or persistence.

The read-only inspection can observe a transient state during a concurrent repair; the repair operation remains serialized by the existing setup lock and is idempotent.

## Rollout and rollback

- Rollout: merge and rebuild the macOS app and bundled daemon.
- Observability: codex_plugin_signature_timeout distinguishes signature stalls; macOS warnings distinguish inspection from repair.
- Rollback: revert this commit and rebuild the app.

## Reviewer focus

Please review Tokio child cancellation on timeout, the fail-closed signature metadata checks, and removal of the setup lock from the read-only inspection path.