### PR TITLE
fix(macos): centralize Agent integration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Today, agent memory is trapped inside isolated model sessions or local markdown 
 1. Download the latest release from [Releases](https://github.com/lilhammerfun/clumsies/releases).
 2. Move `Clumsies.app` to `/Applications` or `~/Applications`.
 3. Open `Clumsies.app`. It automatically provisions the resident launchd daemon (`ai.clumsies.daemon`) and connects to your organization server.
-4. Bind a repository to its Project. Codex uses the global Plugin automatically; configure optional repository-writing hosts in **Project Settings → Agent**.
+4. Bind a repository to its Project. Codex uses the global Plugin automatically; configure optional repository-writing hosts in **Settings → Agent**.
 
 ### Development from Source
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,7 +62,7 @@ AI 编程智能体（Coding Agents）正在彻底重构软件开发的控制面�
 1. 在 [Releases 发布页面](https://github.com/lilhammerfun/clumsies/releases) 下载最新的安装包。
 2. 将 `Clumsies.app` 拖入 `/Applications` 或 `~/Applications` 目录。
 3. 打开 `Clumsies.app`，系统将自动配置常驻后台守护进程（`ai.clumsies.daemon`）并连接至组织服务器。
-4. 将仓库绑定到对应 Project。Codex 会自动使用全局 Plugin；需要写入仓库的其他 Agent 可在 **Project Settings → Agent** 中配置。
+4. 将仓库绑定到对应 Project。Codex 会自动使用全局 Plugin；需要写入仓库的其他 Agent 可在 **Settings → Agent** 中统一配置。
 
 ### 源码构建与本地开发
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -357,6 +357,7 @@ final class WorkspaceStore: ObservableObject {
     @Published private(set) var organization: OrganizationReference?
     @Published private(set) var capabilities: Set<String> = []
     @Published private(set) var projects: [ProjectState] = []
+    @Published private(set) var projectBindingsGeneration = UUID()
     @Published private(set) var projectMetadata: [String: ProjectRecord] = [:]
     @Published private(set) var projectMembers: [ProjectMemberRecord] = []
     @Published private(set) var orgRefCommitId: String?
@@ -1409,11 +1410,9 @@ final class WorkspaceStore: ObservableObject {
         description: String,
         idempotencyKey: String,
         repositoryPaths: [String],
-        bundleId: String?,
-        adapters: Set<ProjectAgentAdapterKind>
+        bundleId: String?
     ) async throws {
         let repositoryPaths = normalizedRepositoryPaths(repositoryPaths)
-        let adapters = adapters.filter { $0 != .codex }
         guard !repositoryPaths.isEmpty else { throw ProjectSetupError.noRepositories }
         let created: ProjectRecord = try await server.send(
             method: "POST",
@@ -1453,23 +1452,7 @@ final class WorkspaceStore: ObservableObject {
                     expectedRevision: nil
                 )
             )
-        }
-        if !adapters.isEmpty {
-            let agentRuntimePath = try bundledAgentRuntimePath()
-            for repositoryPath in repositoryPaths {
-                for adapter in adapters.sorted(by: { $0.rawValue < $1.rawValue }) {
-                    _ = try await daemon.installProjectAgentAdapter(
-                        .init(
-                            projectId: created.id,
-                            workspaceRoot: repositoryPath,
-                            adapter: adapter,
-                            runtimeBinaryPath: agentRuntimePath,
-                            hostBinaryPath: nil,
-                            expectedRevision: nil
-                        )
-                    )
-                }
-            }
+            projectBindingsGeneration = UUID()
         }
         selectedSection = .memory
         showsProjectSettings = false
@@ -1609,14 +1592,19 @@ final class WorkspaceStore: ObservableObject {
                     expectedRevision: nil
                 )
             ))
+            projectBindingsGeneration = UUID()
         }
         return bindings
     }
 
-    func removeProjectRepository(
-        _ binding: DaemonProjectBinding,
-        adapters: [DaemonProjectAgentAdapter]
-    ) async throws {
+    func removeProjectRepository(_ binding: DaemonProjectBinding) async throws {
+        var didMutate = false
+        defer {
+            if didMutate {
+                projectBindingsGeneration = UUID()
+            }
+        }
+        let adapters = try await projectAgentAdapters(binding.projectId)
         for adapter in adapters where adapter.workspaceRoot == binding.workspaceRoot {
             _ = try await daemon.removeProjectAgentAdapter(
                 .init(
@@ -1625,6 +1613,7 @@ final class WorkspaceStore: ObservableObject {
                     expectedRevision: adapter.revision
                 )
             )
+            didMutate = true
         }
         _ = try await daemon.removeProjectBinding(
             .init(
@@ -1632,10 +1621,15 @@ final class WorkspaceStore: ObservableObject {
                 expectedRevision: binding.revision
             )
         )
+        didMutate = true
     }
 
     func projectAgentAdapters(_ projectId: String) async throws -> [DaemonProjectAgentAdapter] {
         try await daemon.projectAgentAdapters(projectId)
+    }
+
+    func allProjectAgentAdapters() async throws -> [DaemonProjectAgentAdapter] {
+        try await daemon.allProjectAgentAdapters()
     }
 
     func codexPluginStatus() async throws -> DaemonCodexPluginStatus {

--- a/apps/macos/Sources/Features/ProjectManagementView.swift
+++ b/apps/macos/Sources/Features/ProjectManagementView.swift
@@ -26,7 +26,6 @@ struct ProjectCreationSheet: View {
     @State private var description = ""
     @State private var repositories: [URL] = []
     @State private var selectedBundleId: String?
-    @State private var selectedAdapters: Set<ProjectAgentAdapterKind> = []
     @State private var isCreating = false
     @State private var errorMessage: String?
     @State private var idempotencyKey = UUID().uuidString.lowercased()
@@ -95,24 +94,6 @@ struct ProjectCreationSheet: View {
                     Text("A Bundle imports its Organization memory into the new Project.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                }
-
-                Section("Agent") {
-                    ForEach(ProjectAgentAdapterKind.projectScopedCases) { adapter in
-                        Toggle(
-                            adapter.title,
-                            isOn: Binding(
-                                get: { selectedAdapters.contains(adapter) },
-                                set: { selected in
-                                    if selected {
-                                        selectedAdapters.insert(adapter)
-                                    } else {
-                                        selectedAdapters.remove(adapter)
-                                    }
-                                }
-                            )
-                        )
-                    }
                 }
 
                 if let errorMessage {
@@ -190,8 +171,7 @@ struct ProjectCreationSheet: View {
                     description: description,
                     idempotencyKey: idempotencyKey,
                     repositoryPaths: repositories.map(\.path),
-                    bundleId: selectedBundleId,
-                    adapters: selectedAdapters
+                    bundleId: selectedBundleId
                 )
                 dismiss()
             } catch {
@@ -538,9 +518,6 @@ private struct InviteProjectMemberSheet: View {
 private struct ProjectLocalSetupSettings: View {
     @ObservedObject var store: WorkspaceStore
     @State private var bindings: [DaemonProjectBinding] = []
-    @State private var adapters: [DaemonProjectAgentAdapter] = []
-    @State private var pendingAdapterValues: [String: Bool] = [:]
-    @State private var workingKeys: Set<String> = []
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var bindingToRemove: DaemonProjectBinding?
@@ -600,30 +577,7 @@ private struct ProjectLocalSetupSettings: View {
             }
         }
 
-        Section("Agent") {
-            if bindings.isEmpty {
-                Text("Add a repository before configuring an Agent.")
-                    .foregroundStyle(.secondary)
-            } else {
-                ForEach(bindings) { binding in
-                    VStack(alignment: .leading, spacing: 8) {
-                        if bindings.count > 1 {
-                            Text(URL(fileURLWithPath: binding.workspaceRoot).lastPathComponent)
-                                .fontWeight(.medium)
-                        }
-                        ForEach(ProjectAgentAdapterKind.projectScopedCases) { adapter in
-                            Toggle(
-                                adapter.title,
-                                isOn: adapterBinding(adapter, repository: binding)
-                            )
-                            .disabled(workingKeys.contains(adapterKey(adapter, binding.workspaceRoot)))
-                        }
-                    }
-                    .padding(.vertical, 2)
-                }
-            }
-        }
-        .task(id: store.activeProjectId) {
+        .task(id: [store.activeProjectId ?? "", store.projectBindingsGeneration.uuidString]) {
             await load()
         }
         .confirmationDialog(
@@ -643,24 +597,20 @@ private struct ProjectLocalSetupSettings: View {
                 bindingToRemove = nil
             }
         } message: {
-            Text("Clumsies will remove its Agent configuration from this repository and stop resolving it to the Project.")
+            Text("Clumsies will remove the Agent integrations managed in Settings and stop resolving this repository to the Project.")
         }
     }
 
     private func load() async {
         guard let projectId = store.activeProjectId else {
             bindings = []
-            adapters = []
             return
         }
         isLoading = true
         errorMessage = nil
         defer { isLoading = false }
         do {
-            async let loadedBindings = store.projectBindings(projectId)
-            async let loadedAdapters = store.projectAgentAdapters(projectId)
-            (bindings, adapters) = try await (loadedBindings, loadedAdapters)
-            pendingAdapterValues = [:]
+            bindings = try await store.projectBindings(projectId)
         } catch is CancellationError {
             return
         } catch {
@@ -699,65 +649,11 @@ private struct ProjectLocalSetupSettings: View {
         isLoading = true
         errorMessage = nil
         do {
-            try await store.removeProjectRepository(binding, adapters: adapters)
+            try await store.removeProjectRepository(binding)
             await load()
         } catch {
             errorMessage = error.localizedDescription
             isLoading = false
         }
-    }
-
-    private func adapterBinding(
-        _ adapter: ProjectAgentAdapterKind,
-        repository: DaemonProjectBinding
-    ) -> Binding<Bool> {
-        let key = adapterKey(adapter, repository.workspaceRoot)
-        return Binding(
-            get: {
-                pendingAdapterValues[key]
-                    ?? (currentAdapter(adapter, repository.workspaceRoot) != nil)
-            },
-            set: { enabled in
-                pendingAdapterValues[key] = enabled
-                workingKeys.insert(key)
-                let current = currentAdapter(adapter, repository.workspaceRoot)
-                Task {
-                    do {
-                        try await store.setProjectAgentAdapter(
-                            adapter,
-                            enabled: enabled,
-                            projectId: repository.projectId,
-                            workspaceRoot: repository.workspaceRoot,
-                            current: current
-                        )
-                        // Installing the first Adapter can normalize a historical
-                        // symlink-based binding to its canonical filesystem path.
-                        // Refresh both collections so the toggle compares the two
-                        // daemon-owned records using the same workspace identity.
-                        async let refreshedBindings = store.projectBindings(repository.projectId)
-                        async let refreshedAdapters = store.projectAgentAdapters(repository.projectId)
-                        (bindings, adapters) = try await (refreshedBindings, refreshedAdapters)
-                        errorMessage = nil
-                    } catch {
-                        errorMessage = error.localizedDescription
-                    }
-                    pendingAdapterValues.removeValue(forKey: key)
-                    workingKeys.remove(key)
-                }
-            }
-        )
-    }
-
-    private func currentAdapter(
-        _ adapter: ProjectAgentAdapterKind,
-        _ workspaceRoot: String
-    ) -> DaemonProjectAgentAdapter? {
-        adapters.first {
-            $0.adapter == adapter && $0.workspaceRoot == workspaceRoot
-        }
-    }
-
-    private func adapterKey(_ adapter: ProjectAgentAdapterKind, _ workspaceRoot: String) -> String {
-        "\(workspaceRoot):\(adapter.rawValue)"
     }
 }

--- a/apps/macos/Sources/Features/SettingsView.swift
+++ b/apps/macos/Sources/Features/SettingsView.swift
@@ -142,11 +142,13 @@ private struct AgentsSettingsView: View {
                     .disabled(isWorking || status?.hostInstalled == false)
             }
 
-            Section("After Plugin Changes") {
+            Section("After Codex Plugin Changes") {
                 Text("Restart Codex and start a new task. In that task, open /hooks and review the current Clumsies Hook. Plugin Enabled does not mean Hook Trusted or AgentRun Ready.")
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
+
+            RepositoryAgentSettingsView(store: store)
         }
         .formStyle(.grouped)
         .padding(12)
@@ -167,6 +169,7 @@ private struct AgentsSettingsView: View {
         } catch is CancellationError {
             return
         } catch {
+            guard !Task.isCancelled else { return }
             errorMessage = error.localizedDescription
         }
     }
@@ -182,8 +185,182 @@ private struct AgentsSettingsView: View {
         } catch is CancellationError {
             return
         } catch {
+            guard !Task.isCancelled else { return }
             errorMessage = error.localizedDescription
         }
+    }
+}
+
+private struct AgentRepositoryProject: Identifiable {
+    let id: String
+    let name: String
+    let repositories: [DaemonProjectBinding]
+}
+
+private struct RepositoryAgentSettingsView: View {
+    @ObservedObject var store: WorkspaceStore
+    @State private var projects: [AgentRepositoryProject] = []
+    @State private var adapters: [DaemonProjectAgentAdapter] = []
+    @State private var pendingValues: [String: Bool] = [:]
+    @State private var workingKeys: Set<String> = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            Section("Repository Integrations") {
+                if isLoading, projects.isEmpty {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if store.projects.isEmpty {
+                    Text("Create a Project and bind a repository before configuring these Agents.")
+                        .foregroundStyle(.secondary)
+                } else if projects.isEmpty {
+                    Text("Add a repository in Project Settings before configuring these Agents.")
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("These integrations write Clumsies-managed configuration into specific repositories. Manage every Project here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .textSelection(.enabled)
+                        .foregroundStyle(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .task(id: [store.projectBindingsGeneration.uuidString]
+                + store.projects.map { "\($0.id):\($0.name)" }) {
+                await load()
+            }
+
+            ForEach(projects) { project in
+                Section(project.name) {
+                    ForEach(project.repositories) { repository in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(URL(fileURLWithPath: repository.workspaceRoot).lastPathComponent)
+                                .fontWeight(.medium)
+                            Text(repository.workspaceRoot)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .help(repository.workspaceRoot)
+
+                            ForEach(ProjectAgentAdapterKind.repositoryIntegrationCases) { adapter in
+                                Toggle(
+                                    adapter.title,
+                                    isOn: adapterBinding(adapter, repository: repository)
+                                )
+                                .disabled(!workingKeys.isEmpty)
+                                .accessibilityLabel(
+                                    "\(adapter.title) for \(URL(fileURLWithPath: repository.workspaceRoot).lastPathComponent) in \(project.name)"
+                                )
+                            }
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+        }
+    }
+
+    private func load() async {
+        isLoading = true
+        errorMessage = nil
+        defer {
+            if !Task.isCancelled {
+                isLoading = false
+            }
+        }
+        do {
+            try await reload()
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else { return }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func reload() async throws {
+        var nextProjects: [AgentRepositoryProject] = []
+        async let nextAdapters = store.allProjectAgentAdapters()
+        for project in store.projects {
+            try Task.checkCancellation()
+            let repositories = try await store.projectBindings(project.id)
+            if !repositories.isEmpty {
+                nextProjects.append(.init(
+                    id: project.id,
+                    name: project.name,
+                    repositories: repositories
+                ))
+            }
+        }
+        let loadedAdapters = try await nextAdapters
+        try Task.checkCancellation()
+        projects = nextProjects
+        adapters = loadedAdapters
+    }
+
+    private func adapterBinding(
+        _ adapter: ProjectAgentAdapterKind,
+        repository: DaemonProjectBinding
+    ) -> Binding<Bool> {
+        let key = adapterKey(adapter, repository)
+        return Binding(
+            get: {
+                pendingValues[key]
+                    ?? (currentAdapter(adapter, repository) != nil)
+            },
+            set: { enabled in
+                guard workingKeys.isEmpty else { return }
+                pendingValues[key] = enabled
+                workingKeys.insert(key)
+                let current = currentAdapter(adapter, repository)
+                Task {
+                    do {
+                        try await store.setProjectAgentAdapter(
+                            adapter,
+                            enabled: enabled,
+                            projectId: repository.projectId,
+                            workspaceRoot: repository.workspaceRoot,
+                            current: current
+                        )
+                        try await reload()
+                        errorMessage = nil
+                    } catch {
+                        let message = error.localizedDescription
+                        try? await reload()
+                        errorMessage = message
+                    }
+                    pendingValues.removeValue(forKey: key)
+                    workingKeys.remove(key)
+                }
+            }
+        )
+    }
+
+    private func currentAdapter(
+        _ adapter: ProjectAgentAdapterKind,
+        _ repository: DaemonProjectBinding
+    ) -> DaemonProjectAgentAdapter? {
+        adapters.first {
+            $0.adapter == adapter
+                && $0.serverUrl == repository.serverUrl
+                && $0.projectId == repository.projectId
+                && $0.workspaceRoot == repository.workspaceRoot
+        }
+    }
+
+    private func adapterKey(
+        _ adapter: ProjectAgentAdapterKind,
+        _ repository: DaemonProjectBinding
+    ) -> String {
+        "\(repository.serverUrl):\(repository.workspaceRoot):\(adapter.rawValue)"
     }
 }
 

--- a/apps/macos/Sources/Infrastructure/DaemonModels.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonModels.swift
@@ -98,7 +98,7 @@ enum ProjectAgentAdapterKind: String, Codable, CaseIterable, Hashable, Identifia
 
     var id: String { rawValue }
 
-    static var projectScopedCases: [Self] {
+    static var repositoryIntegrationCases: [Self] {
         allCases.filter { $0 != .codex }
     }
 

--- a/apps/macos/Tests/ProjectManagementTests.swift
+++ b/apps/macos/Tests/ProjectManagementTests.swift
@@ -2,11 +2,33 @@ import XCTest
 @testable import Clumsies
 
 final class ProjectManagementTests: XCTestCase {
-    func testProjectScopedAgentsExcludeGlobalCodexPlugin() {
+    func testRepositoryIntegrationsExcludeGlobalCodexPlugin() {
         XCTAssertEqual(
-            ProjectAgentAdapterKind.projectScopedCases,
+            ProjectAgentAdapterKind.repositoryIntegrationCases,
             [.claudeCode, .opencode, .dsh, .antigravity]
         )
+    }
+
+    func testAgentConfigurationLivesInGlobalSettings() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let settings = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/SettingsView.swift"),
+            encoding: .utf8
+        )
+        let projectManagement = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/ProjectManagementView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(settings.contains("Section(\"Repository Integrations\")"))
+        XCTAssertTrue(settings.contains("ProjectAgentAdapterKind.repositoryIntegrationCases"))
+        XCTAssertGreaterThanOrEqual(
+            settings.components(separatedBy: "try Task.checkCancellation()").count - 1,
+            2
+        )
+        XCTAssertFalse(projectManagement.contains("Section(\"Agent\")"))
     }
 
     func testProjectMetadataRequiresANonEmptyName() {

--- a/crates/daemon/src/agent_adapter.rs
+++ b/crates/daemon/src/agent_adapter.rs
@@ -2003,7 +2003,7 @@ pub(crate) async fn install(
 ) -> Result<DaemonProjectAgentAdapter, DaemonError> {
     if request.adapter == ProjectAgentAdapterKind::Codex {
         return Err(DaemonError::InvalidRequest(
-            "The Codex Plugin is managed globally; Project Agent settings cannot install it."
+            "The Codex Plugin is managed globally and cannot be installed as a repository integration."
                 .to_owned(),
         ));
     }

--- a/docs/adapter.md
+++ b/docs/adapter.md
@@ -41,7 +41,7 @@ release is detected and must be restarted.
 Codex is a global host integration managed from **Settings → Agent**. It is
 installed and enabled by default when the Codex App is available, and it never
 writes files into a repository. The other hosts are installed and removed from
-native Project Management; their direct-file integrations retain one revisioned
+**Settings → Agent**; their direct-file integrations retain one revisioned
 adapter record per Server authority, workspace root, and host.
 
 | Host | MCP registration | Lifecycle integration |
@@ -162,7 +162,8 @@ temporary quarantine UUID from entering LaunchAgent and host configuration.
   manifests are not accepted as native ownership proof.
 - Archived `repo`-scope generations are reported as unsupported. Remove their
   old Clumsies MCP/Hook entries; the App-owned global Codex Plugin replaces
-  repository-local Codex integration, while other hosts remain project-scoped.
+  repository-local Codex integration. Other hosts remain repository-scoped
+  integrations managed from **Settings → Agent**.
 - Reinstalling from the App is the explicit handoff: the native installer
   refuses foreign or drifted entries instead of silently adopting them.
 - Remove deletes only exact managed entries and files; drift becomes a conflict

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -120,7 +120,7 @@ Adapter is the host integration layer. It connects clumsies to coding agents
 such as Codex, Claude Code, opencode, and the DeepSeek Harness by installing
 the hooks, config, and runtime glue needed for the protocol to actually run.
 Codex uses one App-managed user-global Plugin; repository-writing hosts use
-project-scoped adapters.
+repository-scoped integrations managed from **Settings → Agent**.
 Hosts consume the MCP tools directly; the former thin host-native skill layer
 is retired.
 

--- a/docs/guides/cli-commands.md
+++ b/docs/guides/cli-commands.md
@@ -5,7 +5,7 @@ source is preserved under `archive/zig-cli/` for historical reference and is
 not built, tested, packaged, installed, or released.
 
 Current human workflows use the macOS Desktop. Supported Agent hosts are wired
-by native Project Management to the App-bundled Rust runtime:
+from **Settings → Agent** to the App-bundled Rust runtime:
 
 ```text
 clumsiesd mcp serve

--- a/docs/guides/dsh-integration.md
+++ b/docs/guides/dsh-integration.md
@@ -35,12 +35,12 @@ Register the Clumsies MCP server in the dsh profile patch layer
 by the hook (see below) — the daemon never lets an agent mint its own
 identity.
 
-## Agent adapter (project settings)
+## Agent adapter (global settings)
 
-dsh is a first-class Agent adapter. In the macOS app, Project Settings
-→ Agent (and the New Project sheet) lists **DeepSeek Harness (dsh)**
-next to Claude Code, opencode, and Antigravity. Enabling the toggle installs a
-workspace marker the dsh side reads:
+dsh is a first-class Agent adapter. In the macOS app, **Settings → Agent**
+lists **DeepSeek Harness (dsh)** next to Claude Code, opencode, and Antigravity
+for every bound repository. Enabling the toggle installs a workspace marker the
+dsh side reads:
 
 ```json
 {
@@ -56,7 +56,7 @@ like the other adapters' files. Disabling the toggle removes it.
 
 The marker is per-machine state (the App-bundled clumsiesd path and the
 daemon's server URL), so repositories using the dsh adapter should ignore it
-in git, like the other project-scoped Agent files:
+in git, like the other repository-scoped Agent files:
 
 ```gitignore
 .dsh/


### PR DESCRIPTION
## Context and summary

Agent integration controls belong to the app-wide Settings information architecture, but repository integrations were still exposed inside New Project and Project Settings. That split made the same class of configuration appear to have two owners.

This change removes Agent controls from project creation and project management, then groups every repository-scoped integration under Settings > Agent by project and repository. Codex remains a user-level plugin, while the existing daemon contracts continue to own repository binding state.

## Affected areas

- [x] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [x] Storage, configuration, or schema
- [x] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before: Codex was global, but other Agent integrations appeared during project creation and under each project's settings.

After: Settings > Agent contains Codex plus a Repository Integrations section grouped by project and repository. New Project and Project Settings no longer expose Agent controls. Existing bindings remain repository-scoped and use the same install/remove operations.

The settings loader now matches bindings with the complete repository identity, cancels superseded refreshes, makes one adapter enumeration call, and refreshes state after failed mutations without hiding the original error.

## Verification

- `just test-macos` — passed
- `just test-dev-macos` — passed
- `just test-macos-package` — Release app build and package validation passed; the disposable local package is intentionally not signed with the release Apple team
- `cargo fmt --all --check` — passed
- `cargo clippy -p daemon -- -D warnings` — passed
- `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture` — passed
- `cargo test --workspace` — all non-Docker suites passed; 8 server integration tests could not run because Docker Desktop and `/var/run/docker.sock` were unavailable locally
- `bun run api:check` — passed
- `bun run build` — passed
- Deployment, runtime-boundary, retired-term, development-script, promotion-contract, and Docker Compose configuration checks — passed

Manual UI verification was not required for this change.

## Compatibility and migration

No API, schema, or stored-binding migration. Existing repository bindings are preserved. The macOS app uses the existing daemon install/remove contracts, so mixed app/daemon versions do not require a protocol change. Rolling back restores the prior placement of the controls without changing binding data.

## Risk, security, and privacy

The main risk is stale asynchronous UI state while projects or bindings change. Superseded loads are cancellation-aware, mutation failures retain their original error, and project-removal refreshes are triggered after any partial mutation. No new permissions, network destinations, Memory payloads, or credential handling are introduced.

## Rollout and rollback

- Rollout: merge through the normal macOS app release flow.
- Observability: existing Settings error presentation and daemon logs cover load and mutation failures.
- Rollback: revert this commit; no data rollback or migration is required.

## Reviewer focus

Please focus on repository identity matching, cancellation during Settings refresh, and state refresh after adapter mutation or project removal.
