### PR TITLE
reviews: fix multi-file diffs and large review layout

### DIFF
--- a/apps/macos/Sources/Components/UnifiedDiffView.swift
+++ b/apps/macos/Sources/Components/UnifiedDiffView.swift
@@ -48,15 +48,18 @@ struct UnifiedDiffBlockPresentation: Identifiable, Equatable, Sendable {
 struct UnifiedDiffPresentation: Equatable, Sendable {
     let blocks: [UnifiedDiffBlockPresentation]
     let showsRemoteLineNumbers: Bool
+    let maximumLineNumber: Int
 
     init(model: SplitDiffModel, anchoredLines: Set<Int> = []) {
         showsRemoteLineNumbers = false
         if model.blocks.isEmpty, !anchoredLines.isEmpty {
-            blocks = Self.anchoredContextBlocks(
+            let resolvedBlocks = Self.anchoredContextBlocks(
                 rows: model.rows,
                 anchoredLines: anchoredLines,
                 startingBlockId: 0
             )
+            blocks = resolvedBlocks
+            maximumLineNumber = Self.maximumLineNumber(in: resolvedBlocks)
             return
         }
 
@@ -83,12 +86,25 @@ struct UnifiedDiffPresentation: Equatable, Sendable {
             ))
         }
         blocks = presentations
+        maximumLineNumber = Self.maximumLineNumber(in: presentations)
     }
 
     var changedLineCount: Int {
         blocks.reduce(into: 0) { count, block in
             guard case .hunk = block.kind else { return }
             count += block.lines.count
+        }
+    }
+
+    private static func maximumLineNumber(
+        in blocks: [UnifiedDiffBlockPresentation]
+    ) -> Int {
+        blocks.reduce(into: 0) { result, block in
+            for line in block.lines {
+                result = max(result, line.oldLineNumber ?? 0)
+                result = max(result, line.newLineNumber ?? 0)
+                result = max(result, line.remoteLineNumber ?? 0)
+            }
         }
     }
 
@@ -568,6 +584,7 @@ extension UnifiedDiffPresentation {
         let changedIndices = lines.indices.filter { lines[$0].kind.isChanged }
         guard !changedIndices.isEmpty else {
             blocks = []
+            maximumLineNumber = 0
             return
         }
         let context = max(0, contextLineCount)
@@ -613,6 +630,7 @@ extension UnifiedDiffPresentation {
             ))
         }
         blocks = result
+        maximumLineNumber = Self.maximumLineNumber(in: result)
     }
 
     private static func threeWayHunkLabel(
@@ -649,11 +667,38 @@ extension UnifiedDiffPresentation {
     }
 }
 
-private enum UnifiedDiffMetrics {
-    static let oldLineGutterWidth: CGFloat = 42
-    static let newLineGutterWidth: CGFloat = 42
+enum UnifiedDiffMetrics {
+    static let minimumLineGutterWidth: CGFloat = 30
     static let markerWidth: CGFloat = 18
     static let commentButtonWidth: CGFloat = 26
+    static let minimumInlineCommentWidth: CGFloat = 320
+    static let inlineCommentWidthRatio: CGFloat = 0.75
+
+    static func lineGutterWidth(maximumLineNumber: Int) -> CGFloat {
+        let digits = String(max(1, maximumLineNumber)).count
+        return max(minimumLineGutterWidth, CGFloat(digits * 8 + 8))
+    }
+
+    static func contentLeadingInset(
+        lineGutterWidth: CGFloat,
+        showsRemoteLineNumbers: Bool
+    ) -> CGFloat {
+        lineGutterWidth * (showsRemoteLineNumbers ? 3 : 2)
+            + markerWidth
+            + commentButtonWidth
+    }
+
+    static func inlineCommentWidth(
+        viewportWidth: CGFloat,
+        leadingInset: CGFloat
+    ) -> CGFloat {
+        let availableWidth = max(viewportWidth - leadingInset - 12, 1)
+        let preferredWidth = max(
+            minimumInlineCommentWidth,
+            availableWidth * inlineCommentWidthRatio
+        )
+        return min(availableWidth, DocumentContentMetrics.maximumWidth, preferredWidth)
+    }
 }
 
 private struct UnifiedDiffViewportWidthKey: PreferenceKey {
@@ -733,7 +778,7 @@ struct UnifiedDiffView: View {
                     .frame(maxWidth: .infinity, minHeight: 96)
             } else {
                 ScrollView(.horizontal, showsIndicators: true) {
-                    LazyVStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: 0) {
                         ForEach(presentation.blocks) { block in
                             blockView(block)
                         }
@@ -757,6 +802,26 @@ struct UnifiedDiffView: View {
 
     private var minimumContentWidth: CGFloat {
         max(viewportWidth, 1)
+    }
+
+    private var lineGutterWidth: CGFloat {
+        UnifiedDiffMetrics.lineGutterWidth(
+            maximumLineNumber: presentation.maximumLineNumber
+        )
+    }
+
+    private var contentLeadingInset: CGFloat {
+        UnifiedDiffMetrics.contentLeadingInset(
+            lineGutterWidth: lineGutterWidth,
+            showsRemoteLineNumbers: presentation.showsRemoteLineNumbers
+        )
+    }
+
+    private var inlineCommentWidth: CGFloat {
+        UnifiedDiffMetrics.inlineCommentWidth(
+            viewportWidth: minimumContentWidth,
+            leadingInset: contentLeadingInset
+        )
     }
 
     @ViewBuilder
@@ -848,10 +913,10 @@ struct UnifiedDiffView: View {
 
     private func diffRow(_ line: UnifiedDiffLine) -> some View {
         HStack(alignment: .top, spacing: 0) {
-            lineNumber(line.oldLineNumber, width: UnifiedDiffMetrics.oldLineGutterWidth)
-            lineNumber(line.newLineNumber, width: UnifiedDiffMetrics.newLineGutterWidth)
+            lineNumber(line.oldLineNumber, width: lineGutterWidth)
+            lineNumber(line.newLineNumber, width: lineGutterWidth)
             if presentation.showsRemoteLineNumbers {
-                lineNumber(line.remoteLineNumber, width: UnifiedDiffMetrics.newLineGutterWidth)
+                lineNumber(line.remoteLineNumber, width: lineGutterWidth)
             }
 
             Text(marker(for: line.kind))
@@ -884,8 +949,8 @@ struct UnifiedDiffView: View {
     private func lineNumber(_ value: Int?, width: CGFloat) -> some View {
         Text(value.map(String.init) ?? "")
             .foregroundStyle(.tertiary)
+            .padding(.trailing, 8)
             .frame(width: width, alignment: .trailing)
-            .padding(.trailing, 7)
             .frame(maxHeight: .infinity, alignment: .topTrailing)
             .background(Color(nsColor: .controlBackgroundColor).opacity(0.48))
     }
@@ -919,14 +984,11 @@ struct UnifiedDiffView: View {
                 }
             }
         }
-        .padding(.leading, 112)
+        .frame(width: inlineCommentWidth, alignment: .leading)
+        .padding(.leading, contentLeadingInset)
         .padding(.trailing, 12)
         .padding(.vertical, 8)
-        .frame(
-            minWidth: minimumContentWidth,
-            maxWidth: .infinity,
-            alignment: .leading
-        )
+        .frame(width: minimumContentWidth, alignment: .leading)
         .background(Color.accentColor.opacity(0.035))
     }
 
@@ -937,14 +999,11 @@ struct UnifiedDiffView: View {
             onCancel: onCancelComment,
             onSubmit: { onSubmitComment(line) }
         )
-        .padding(.leading, 112)
+        .frame(width: inlineCommentWidth, alignment: .leading)
+        .padding(.leading, contentLeadingInset)
         .padding(.trailing, 12)
         .padding(.vertical, 8)
-        .frame(
-            minWidth: minimumContentWidth,
-            maxWidth: .infinity,
-            alignment: .leading
-        )
+        .frame(width: minimumContentWidth, alignment: .leading)
         .background(Color.accentColor.opacity(0.035))
     }
 

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -6310,6 +6310,8 @@ struct WorkspaceLoader: Sendable {
         base: CommitPayload?,
         current: CommitPayload?
     ) throws -> ReviewChangeSources {
+        let baseEntry = commitResourceEntry(base, resource: draft.resource)
+        let currentEntry = commitResourceEntry(current, resource: draft.resource)
         let terminalOperation = operations.last
         let draftContent: String?
         let resolutionContent: String?
@@ -6323,7 +6325,10 @@ struct WorkspaceLoader: Sendable {
             draftContent = content?.renderedText
             resolutionContent = content?.primaryText
         }
-        let initialPath = operations.first?.resource.path ?? draft.resource.path
+        let initialPath = operations.first?.resource.path
+            ?? draft.resource.path
+            ?? baseEntry?.path
+            ?? currentEntry?.path
         let finalPath = operations.reduce(initialPath) { path, operation in
             if let newPath = operation.newPath { return newPath }
             if operation.action == "create", let createdPath = operation.resource.path { return createdPath }
@@ -6340,8 +6345,8 @@ struct WorkspaceLoader: Sendable {
             operationLabels = []
         }
         return try .init(
-            baseContent: commitResourceText(base, resource: draft.resource),
-            currentContent: commitResourceText(current, resource: draft.resource),
+            baseContent: commitResourceText(base, entry: baseEntry),
+            currentContent: commitResourceText(current, entry: currentEntry),
             draftContent: draftContent,
             resolutionContent: resolutionContent,
             proposedPath: finalPath,
@@ -6349,17 +6354,23 @@ struct WorkspaceLoader: Sendable {
         )
     }
 
-    private static func commitResourceText(
+    private static func commitResourceEntry(
         _ payload: CommitPayload?,
         resource: ServerDraftResourceReference
-    ) throws -> String? {
-        guard let payload else { return nil }
-        let entry = payload.tree.entries.first { candidate in
+    ) -> CommitTreeEntry? {
+        payload?.tree.entries.first { candidate in
             guard candidate.type == .memory else { return false }
             if let resourceId = resource.id { return candidate.id == resourceId }
             return candidate.path == resource.path
         }
-        guard let entry,
+    }
+
+    private static func commitResourceText(
+        _ payload: CommitPayload?,
+        entry: CommitTreeEntry?
+    ) throws -> String? {
+        guard let payload,
+              let entry,
               let blob = payload.blobs.first(where: { $0.blobId == entry.blobId }) else { return nil }
         return blob.content
     }

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -2243,6 +2243,41 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertEqual(mapped.currentCommitId, "commit-current")
     }
 
+    func testReviewChangeSourcesResolveIdOnlyResourcePathFromCommitTree() throws {
+        let resource = ServerDraftResourceReference(
+            scope: "org",
+            id: "memory-1",
+            path: nil
+        )
+        let detail = reviewDetail(
+            resource: resource,
+            operations: [
+                ServerDraftOperation(
+                    action: "update",
+                    resource: resource,
+                    content: .init(description: nil, content: "Draft body"),
+                    newPath: nil,
+                    operationId: "operation-1",
+                    createdAt: timestamp
+                )
+            ]
+        )
+
+        let sources = try WorkspaceLoader.mapReviewChangeSources(
+            detail: detail,
+            base: commit(
+                id: "commit-base",
+                resource: resource,
+                body: "Base body",
+                treePath: "context/guides/review.md"
+            ),
+            current: nil
+        )
+
+        XCTAssertEqual(sources.proposedPath, "context/guides/review.md")
+        XCTAssertEqual(sources.baseContent, "Base body")
+    }
+
     func testReviewChangeSourcesPreserveRenameAlongsideContentUpdate() throws {
         let resource = ServerDraftResourceReference(
             scope: "project",
@@ -2999,14 +3034,16 @@ final class DaemonContractTests: XCTestCase {
     private func commit(
         id: String,
         resource: ServerDraftResourceReference,
-        body: String
+        body: String,
+        treePath: String? = nil
     ) -> CommitPayload {
-        .init(
+        let isOrgResource = resource.scope == "org"
+        return .init(
             commit: .init(
                 commitId: id,
-                scope: "project",
+                scope: isOrgResource ? "org" : "project",
                 orgId: "org-1",
-                projectId: "project-1",
+                projectId: isOrgResource ? nil : "project-1",
                 treeId: "tree-\(id)",
                 parentCommitId: nil,
                 version: 1,
@@ -3019,10 +3056,10 @@ final class DaemonContractTests: XCTestCase {
                         id: resource.id ?? "context-1",
                         type: .memory,
                         scope: resource.scope,
-                        projectId: "project-1",
-                        path: resource.path,
+                        projectId: isOrgResource ? nil : "project-1",
+                        path: treePath ?? resource.path,
                         blobId: "blob-\(id)",
-                        source: "project",
+                        source: isOrgResource ? "org" : "project",
                         description: nil
                     )
                 ]

--- a/apps/macos/Tests/FileTreeSelectionTests.swift
+++ b/apps/macos/Tests/FileTreeSelectionTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import XCTest
 @testable import Clumsies
 
@@ -20,6 +21,121 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertNotNil(PathTreeNode.node(withId: "review-file", in: roots)?.item)
     }
 
+    func testUnifiedDiffGutterFitsLineNumbersAndAlignsNestedContent() {
+        let short = UnifiedDiffMetrics.lineGutterWidth(maximumLineNumber: 99)
+        let long = UnifiedDiffMetrics.lineGutterWidth(maximumLineNumber: 99_999)
+
+        XCTAssertEqual(short, 30)
+        XCTAssertEqual(long, 48)
+        XCTAssertEqual(
+            UnifiedDiffMetrics.contentLeadingInset(
+                lineGutterWidth: short,
+                showsRemoteLineNumbers: false
+            ),
+            104
+        )
+        XCTAssertEqual(
+            UnifiedDiffMetrics.contentLeadingInset(
+                lineGutterWidth: short,
+                showsRemoteLineNumbers: true
+            ),
+            134
+        )
+
+        let lines = (1...1_500).map { lineNumber in
+            UnifiedDiffLine(
+                id: "line-\(lineNumber)",
+                kind: lineNumber == 750 ? .insertion : .context,
+                text: "line \(lineNumber)",
+                oldLineNumber: lineNumber,
+                newLineNumber: lineNumber
+            )
+        }
+        XCTAssertEqual(UnifiedDiffPresentation(lines: lines).maximumLineNumber, 1_500)
+    }
+
+    func testInlineDiffCommentsUseViewportWidthInsteadOfLongCodeWidth() {
+        XCTAssertEqual(
+            UnifiedDiffMetrics.inlineCommentWidth(
+                viewportWidth: 900,
+                leadingInset: 104
+            ),
+            588
+        )
+        XCTAssertEqual(
+            UnifiedDiffMetrics.inlineCommentWidth(
+                viewportWidth: 2_000,
+                leadingInset: 104
+            ),
+            760
+        )
+        XCTAssertEqual(
+            UnifiedDiffMetrics.inlineCommentWidth(
+                viewportWidth: 440,
+                leadingInset: 104
+            ),
+            320
+        )
+        XCTAssertEqual(
+            UnifiedDiffMetrics.inlineCommentWidth(
+                viewportWidth: 200,
+                leadingInset: 104
+            ),
+            84
+        )
+    }
+
+    @MainActor
+    func testLongUnifiedDiffLineCreatesHorizontalScrollRangeAfterHunkHeader() throws {
+        let presentation = UnifiedDiffPresentation(lines: [
+            .init(
+                id: "long-insertion",
+                kind: .insertion,
+                text: String(repeating: "x", count: 300),
+                oldLineNumber: nil,
+                newLineNumber: 1
+            )
+        ])
+        let root = HSplitView {
+            Color.clear
+                .frame(minWidth: 180, idealWidth: 220, maxWidth: 280, maxHeight: .infinity)
+            ScrollView(.vertical) {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text("Header")
+                    UnifiedDiffView(presentation: presentation)
+                }
+                .frame(maxWidth: 1180, alignment: .leading)
+                .frame(maxWidth: .infinity, alignment: .top)
+                .padding(.horizontal, 24)
+            }
+            .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(width: 900, height: 500)
+
+        let host = NSHostingView(rootView: root)
+        host.frame = NSRect(x: 0, y: 0, width: 900, height: 500)
+        let window = NSWindow(
+            contentRect: host.frame,
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+
+        for _ in 0..<3 {
+            host.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        let inner = try XCTUnwrap(
+            descendantScrollViews(in: host).first {
+                $0.hasHorizontalScroller && !$0.hasVerticalScroller
+            }
+        )
+        let documentWidth = try XCTUnwrap(inner.documentView).frame.width
+        XCTAssertGreaterThan(documentWidth, inner.contentView.bounds.width + 1)
+    }
+
     func testPlainDirectoryClickSelectsAndTogglesDirectory() {
         let result = FileTreeSelectionInteraction.directoryClick(
             nodeId: "directory:design",
@@ -32,6 +148,12 @@ final class FileTreeSelectionTests: XCTestCase {
         XCTAssertEqual(result.selection, ["directory:design"])
         XCTAssertEqual(result.anchorId, "directory:design")
         XCTAssertTrue(result.togglesDirectory)
+    }
+
+    @MainActor
+    private func descendantScrollViews(in view: NSView) -> [NSScrollView] {
+        let current = (view as? NSScrollView).map { [$0] } ?? []
+        return current + view.subviews.flatMap(descendantScrollViews)
     }
 
     func testShiftClickDirectorySelectsRangeWithoutTogglingDirectory() {


### PR DESCRIPTION
## Context and summary

A multi-file Request Review could render as a single untitled file when
draft references carried only resource IDs. Large diffs also clipped long
lines, used oversized gutters, repeatedly rescanned line metadata during
large unchanged-section expansion, and allowed inline comment editors to
grow with the code document instead of the visible viewport.

This change recovers paths from commit trees, preserves a horizontally
scrollable diff document, caches line-number sizing, and constrains inline
comments to the visible review width.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Multi-file Reviews now retain their complete file tree even when resource
references omit paths. Long lines remain horizontally scrollable, gutters
scale to the displayed line numbers, and inline comment threads use 75% of
the usable viewport with a 320–760 point bound. Large expanded sections no
longer recalculate the maximum line number for every rendered row.

The isolated Dev app was exercised with a three-file Review containing a
long line and more than one thousand unchanged lines.

## Verification

- [x] `just test-macos`
- [x] `just test-dev-macos`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture`
- [x] `just test-macos-package`
- [x] `git diff --check`
- [x] Exercise multi-file navigation, long-line scrolling, unchanged-line
      expansion, and inline comments in the isolated Dev app

## Compatibility and migration

No API, persistence, or configuration contract changes. Existing ID-only
draft references gain a read-time path fallback from their commit tree.

## Risk, security, and privacy

No trust boundary, permission, credential, or private Memory handling
changes. Expanded sections still construct their rows eagerly; cached
line-number metadata removes the repeated full-presentation scan without
introducing a second rendering path.

## Rollout and rollback

- Rollout: ship with the next macOS app build.
- Observability: verify multi-file Review trees and long diff interaction.
- Rollback: revert the commit; no data migration is required.

## Reviewer focus

Review ID-only resource path resolution and the SwiftUI viewport width
calculation for inline comments.
