### PR TITLE
macos: filter workspace content from toolbar search

### DIFF
--- a/apps/macos/Sources/App/AppDelegate.swift
+++ b/apps/macos/Sources/App/AppDelegate.swift
@@ -669,8 +669,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             store.focusIssueSearch()
         case .reviews:
             store.focusReviewSearch()
-        default:
-            store.showsGlobalSearch = true
+        case .memory, .bundles:
+            store.focusWorkspaceSearch()
+        case .sessions:
+            break
         }
     }
 

--- a/apps/macos/Sources/Components/ClassicSearchField.swift
+++ b/apps/macos/Sources/Components/ClassicSearchField.swift
@@ -16,15 +16,9 @@ struct ClassicSearchField: NSViewRepresentable {
     var accessibilityHelp: String?
     /// Increment to request first responder (e.g. the Cmd+K shortcut).
     var focusToken = 0
-    /// Called when the field gains or loses editing focus.
-    var onFocusChange: ((Bool) -> Void)?
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(
-            text: $text,
-            onFocusChange: onFocusChange,
-            focusToken: focusToken
-        )
+        Coordinator(text: $text, focusToken: focusToken)
     }
 
     func makeNSView(context: Context) -> NSSearchField {
@@ -44,7 +38,8 @@ struct ClassicSearchField: NSViewRepresentable {
     }
 
     func updateNSView(_ field: NSSearchField, context: Context) {
-        if field.stringValue != text, field.currentEditor() == nil {
+        if field.stringValue != text,
+           field.currentEditor() == nil || text.isEmpty {
             field.stringValue = text
         }
         if field.placeholderString != prompt {
@@ -63,16 +58,10 @@ struct ClassicSearchField: NSViewRepresentable {
 
     final class Coordinator: NSObject, NSSearchFieldDelegate {
         @Binding var text: String
-        private let onFocusChange: ((Bool) -> Void)?
         var lastFocusToken: Int
 
-        init(
-            text: Binding<String>,
-            onFocusChange: ((Bool) -> Void)?,
-            focusToken: Int
-        ) {
+        init(text: Binding<String>, focusToken: Int) {
             _text = text
-            self.onFocusChange = onFocusChange
             // Seed with the initial token so the first render never steals focus;
             // only explicit increments (e.g. Cmd+K) request first responder.
             lastFocusToken = focusToken
@@ -83,14 +72,6 @@ struct ClassicSearchField: NSViewRepresentable {
                   text != field.stringValue
             else { return }
             text = field.stringValue
-        }
-
-        func controlTextDidBeginEditing(_ obj: Notification) {
-            onFocusChange?(true)
-        }
-
-        func controlTextDidEndEditing(_ obj: Notification) {
-            onFocusChange?(false)
         }
     }
 }

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -388,7 +388,7 @@ final class WorkspaceStore: ObservableObject {
     @Published var selectedBundleId: String?
     @Published var selectedReviewId: String?
     @Published var searchQuery = ""
-    @Published var showsGlobalSearch = false
+    @Published var workspaceSearchFocusToken = UUID()
     @Published var issueSearchFocusToken = UUID()
     @Published var reviewSearchFocusToken = UUID()
     @Published var showsProjectCreation = false
@@ -1105,6 +1105,30 @@ final class WorkspaceStore: ObservableObject {
         return items.sorted { $0.document.path.localizedStandardCompare($1.document.path) == .orderedAscending }
     }
 
+    nonisolated static func filterMemoryItems(
+        _ items: [MemoryListItem],
+        query: String
+    ) -> [MemoryListItem] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).localizedLowercase
+        guard !needle.isEmpty else { return items }
+        return items.filter { item in
+            let document = item.document
+            return "\(document.title) \(document.path) \(document.body) \(item.kind.title)"
+                .localizedLowercase.contains(needle)
+        }
+    }
+
+    nonisolated static func filterBundles(
+        _ bundles: [PersonalBundle],
+        query: String
+    ) -> [PersonalBundle] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).localizedLowercase
+        guard !needle.isEmpty else { return bundles }
+        return bundles.filter {
+            "\($0.name) \($0.description)".localizedLowercase.contains(needle)
+        }
+    }
+
     /// The Project tree is the Project's effective Memory surface: selected
     /// Org authority plus its local Draft overlay. Existing project-scope
     /// authority remains visible as a compatibility layer until that legacy
@@ -1804,6 +1828,10 @@ final class WorkspaceStore: ObservableObject {
             guard projectSelectionGeneration == generation else { return }
             errorMessage = error.localizedDescription
         }
+    }
+
+    func focusWorkspaceSearch() {
+        workspaceSearchFocusToken = UUID()
     }
 
     func focusIssueSearch() {

--- a/apps/macos/Sources/Features/BundlesView.swift
+++ b/apps/macos/Sources/Features/BundlesView.swift
@@ -7,9 +7,11 @@ struct BundleNavigator: View {
         Group {
             if store.bundles.isEmpty {
                 BundleCollectionStatusView(store: store)
+            } else if !query.isEmpty, bundles.isEmpty {
+                ContentUnavailableView.search(text: query)
             } else {
                 List(selection: $store.selectedBundleId) {
-                    ForEach(store.bundles) { bundle in
+                    ForEach(bundles) { bundle in
                         VStack(alignment: .leading, spacing: 2) {
                             Text(bundle.name)
                                 .lineLimit(1)
@@ -32,6 +34,14 @@ struct BundleNavigator: View {
             }
         }
         .task { await store.prepareWorkspaceIndex(includeContent: false) }
+    }
+
+    private var query: String {
+        store.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var bundles: [PersonalBundle] {
+        WorkspaceStore.filterBundles(store.bundles, query: query)
     }
 }
 

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -5,13 +5,33 @@ struct MemoryNavigator: View {
     @ObservedObject var store: WorkspaceStore
 
     var body: some View {
-        FileTreeView(store: store, items: store.visibleMemoryItems)
+        content
             .safeAreaInset(edge: .bottom) {
                 DraftInventoryStatusBanner(store: store)
             }
             .onChange(of: store.selectedKind) { _, _ in
                 store.selectedItemId = nil
             }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if !query.isEmpty, items.isEmpty, store.isPreparingWorkspaceIndex {
+            ProgressView("Preparing Search…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if !store.visibleMemoryItems.isEmpty, !query.isEmpty, items.isEmpty {
+            ContentUnavailableView.search(text: query)
+        } else {
+            FileTreeView(store: store, items: items)
+        }
+    }
+
+    private var query: String {
+        store.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var items: [MemoryListItem] {
+        WorkspaceStore.filterMemoryItems(store.visibleMemoryItems, query: query)
     }
 }
 

--- a/apps/macos/Sources/Features/ReviewsView.swift
+++ b/apps/macos/Sources/Features/ReviewsView.swift
@@ -136,6 +136,7 @@ struct ReviewStatusFilterControl: View {
 struct ReviewListPage: View {
     @ObservedObject var store: WorkspaceStore
     let reviews: [ReviewRecord]
+    let searchQuery: String
     @Binding var statusFilter: ReviewStatusFilter
     let toolbarOwnership: ReviewToolbarOwnership
 
@@ -164,13 +165,17 @@ struct ReviewListPage: View {
                     description: Text("Reviews created from synchronized drafts appear here.")
                 )
             case .filteredEmpty:
-                ContentUnavailableView {
-                    Label("No \(statusFilter.title) Reviews", systemImage: statusFilter.symbolName)
-                } description: {
-                    Text("No Reviews match the current status filter.")
-                } actions: {
-                    Button("Show All Reviews") {
-                        statusFilter = .all
+                if !trimmedSearchQuery.isEmpty {
+                    ContentUnavailableView.search(text: trimmedSearchQuery)
+                } else {
+                    ContentUnavailableView {
+                        Label("No \(statusFilter.title) Reviews", systemImage: statusFilter.symbolName)
+                    } description: {
+                        Text("No Reviews match the current status filter.")
+                    } actions: {
+                        Button("Show All Reviews") {
+                            statusFilter = .all
+                        }
                     }
                 }
             case .content:
@@ -214,6 +219,10 @@ struct ReviewListPage: View {
 
     private func projectName(for review: ReviewRecord) -> String? {
         store.projects.first { $0.id == review.projectId }?.name
+    }
+
+    private var trimmedSearchQuery: String {
+        searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -138,6 +138,7 @@ struct WorkspaceView: View {
     @State private var showsIssueWorkflowHelp = false
     @State private var issueNavigationPath: [IssueBoardRoute] = []
     @State private var reviewNavigationPath: [ReviewRoute] = []
+    @State private var workspaceSearchFocusRequest = 0
     @State private var issueSearchFocusRequest = 0
     @State private var reviewSearchQuery = ""
     @State private var reviewSearchFocusRequest = 0
@@ -192,6 +193,9 @@ struct WorkspaceView: View {
                     store.dismissErrorMessage()
                 }
             }
+        }
+        .onChange(of: store.selectedSection) { _, _ in
+            store.searchQuery = ""
         }
     }
 
@@ -449,19 +453,8 @@ struct WorkspaceView: View {
                             prompt: workspaceSearchPrompt,
                             accessibilityIdentifier: "workspace-toolbar-search",
                             accessibilityHelp: "Search across the current workspace",
-                            onFocusChange: { focused in
-                                if focused {
-                                    store.showsGlobalSearch = true
-                                }
-                            }
+                            focusToken: workspaceSearchFocusRequest
                         )
-                        .popover(isPresented: $store.showsGlobalSearch, arrowEdge: .top) {
-                            WorkspaceSearchPopover(
-                                store: store,
-                                results: searchResults,
-                                onOpen: open
-                            )
-                        }
                     }
                 }
             }
@@ -471,8 +464,12 @@ struct WorkspaceView: View {
                 splitVisibility = target
             }
         }
+        .onChange(of: store.workspaceSearchFocusToken) { _, _ in
+            workspaceSearchFocusRequest += 1
+        }
         .onChange(of: store.searchQuery) { _, query in
-            guard !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            guard store.selectedSection == .memory,
+                  !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             Task { await store.prepareWorkspaceIndex(includeContent: true) }
         }
         .onChange(of: store.selectedSection) { _, section in
@@ -581,6 +578,7 @@ struct WorkspaceView: View {
                 ReviewListPage(
                     store: store,
                     reviews: filteredReviews,
+                    searchQuery: reviewSearchQuery,
                     statusFilter: $reviewStatusFilter,
                     toolbarOwnership: reviewToolbarOwnership
                 )
@@ -649,7 +647,9 @@ struct WorkspaceView: View {
         }
         .onChange(of: store.reviewSearchFocusToken) { _, _ in
             reviewNavigationPath.removeAll()
-            reviewSearchFocusRequest += 1
+            DispatchQueue.main.async {
+                reviewSearchFocusRequest += 1
+            }
         }
         .onChange(of: store.selectedReviewId) { _, reviewId in
             guard store.selectedSection == .reviews else { return }
@@ -1097,7 +1097,10 @@ struct WorkspaceView: View {
             }
         }
         .onChange(of: store.issueSearchFocusToken) { _, _ in
-            issueSearchFocusRequest += 1
+            issueNavigationPath.removeAll()
+            DispatchQueue.main.async {
+                issueSearchFocusRequest += 1
+            }
         }
         .onChange(of: issueSplitVisibility) { _, visibility in
             let expanded = visibility != .detailOnly
@@ -1305,59 +1308,6 @@ struct WorkspaceView: View {
         }
     }
 
-    private var searchResults: [SearchEntry] {
-        let needle = store.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).localizedLowercase
-        guard !needle.isEmpty else { return [] }
-        var entries: [SearchEntry] = []
-        switch store.selectedSection {
-        case .memory:
-            entries = memorySearchEntries(needle: needle)
-        case .bundles:
-            for bundle in store.bundles
-            where "\(bundle.name) \(bundle.description)".localizedLowercase.contains(needle) {
-                entries.append(.bundle(bundle))
-            }
-        case .reviews:
-            for review in store.reviews
-            where "\(review.title) \(review.description) \(review.author.email) \(review.status)"
-                .localizedLowercase.contains(needle) {
-                entries.append(.review(review))
-            }
-        case .issues:
-            break
-        case .sessions:
-            break
-        }
-        return Array(entries.prefix(30))
-    }
-
-    private func memorySearchEntries(needle: String) -> [SearchEntry] {
-        store.visibleMemoryItems
-            .compactMap { item in
-                let document = item.document
-                let haystack = "\(document.title) \(document.path) \(document.body) \(item.kind.title)"
-                    .localizedLowercase
-                guard haystack.contains(needle) else { return nil }
-                return .memory(item)
-            }
-    }
-
-    private func open(_ entry: SearchEntry) {
-        switch entry.destination {
-        case .memory(let item):
-            Task { await store.reveal(item) }
-        case .bundle(let bundle):
-            store.selectedSection = .bundles
-            store.selectedBundleId = bundle.id
-        case .review(let review):
-            store.selectedSection = .reviews
-            reviewStatusFilter = ReviewStatusFilter(rawValue: review.status) ?? .all
-            store.selectedReviewId = review.id
-        }
-        store.searchQuery = ""
-        store.showsGlobalSearch = false
-    }
-
     private var syncToolbarPresentation: SyncToolbarPresentation? {
         guard store.activeProjectId != nil else { return nil }
         return SyncToolbarPresentation.resolve(
@@ -1551,91 +1501,6 @@ private struct SyncIssuePopover: View {
     }
 }
 
-private struct WorkspaceSearchPopover: View {
-    @ObservedObject var store: WorkspaceStore
-    let results: [SearchEntry]
-    let onOpen: (SearchEntry) -> Void
-    @FocusState private var searchFocused: Bool
-
-    private var searchPrompt: String {
-        switch store.selectedSection {
-        case .memory: "Search Memory"
-        case .bundles: "Search Bundles"
-        case .reviews: "Search Reviews"
-        case .issues: "Search Issues"
-        case .sessions: "Search Activity"
-        }
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            TextField(searchPrompt, text: $store.searchQuery)
-                .textFieldStyle(.roundedBorder)
-                .focused($searchFocused)
-                .padding(12)
-
-            Divider()
-
-            ScrollView {
-                LazyVStack(alignment: .leading, spacing: 2) {
-                    if store.isPreparingWorkspaceIndex {
-                        Label("Preparing search", systemImage: "arrow.triangle.2.circlepath")
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                    }
-
-                    if store.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Text(searchPrompt)
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                    } else if results.isEmpty && !store.isPreparingWorkspaceIndex {
-                        Text("No Results")
-                            .foregroundStyle(.secondary)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 8)
-                    } else {
-                        ForEach(results) { entry in
-                            Button {
-                                onOpen(entry)
-                            } label: {
-                                Label {
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(entry.title)
-                                            .lineLimit(1)
-                                        Text(entry.detail)
-                                            .font(.caption)
-                                            .foregroundStyle(.secondary)
-                                            .lineLimit(1)
-                                    }
-                                } icon: {
-                                    Image(systemName: entry.symbol)
-                                        .frame(width: 18)
-                                }
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .contentShape(Rectangle())
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 7)
-                            }
-                            .buttonStyle(.plain)
-                            .focusEffectDisabled()
-                        }
-                    }
-                }
-                .padding(6)
-            }
-            .frame(minHeight: 88, maxHeight: 300)
-        }
-        .frame(width: 380)
-        .onAppear {
-            DispatchQueue.main.async {
-                searchFocused = true
-            }
-        }
-    }
-}
-
 private struct GlobalSidebar: View {
     @ObservedObject var store: WorkspaceStore
     let onOpenSettings: () -> Void
@@ -1733,49 +1598,6 @@ private struct SidebarDestinationLabel: View {
 
 private enum GlobalSidebarDestination: Hashable {
     case section(WorkspaceSection)
-}
-
-private struct SearchEntry: Identifiable {
-    enum Destination {
-        case memory(MemoryListItem)
-        case bundle(PersonalBundle)
-        case review(ReviewRecord)
-    }
-
-    let id: String
-    let title: String
-    let detail: String
-    let symbol: String
-    let destination: Destination
-
-    static func memory(_ item: MemoryListItem) -> Self {
-        .init(
-            id: "memory:\(item.id)",
-            title: item.document.title,
-            detail: "\(item.scope == .org ? "Organization" : "Project") · \(item.kind.title) · \(item.document.path)",
-            symbol: item.kind.symbol,
-            destination: .memory(item)
-        )
-    }
-    static func bundle(_ bundle: PersonalBundle) -> Self {
-        .init(
-            id: "bundle:\(bundle.id)",
-            title: bundle.name,
-            detail: "Bundle · \(bundle.resourceIds.count) resources",
-            symbol: "shippingbox",
-            destination: .bundle(bundle)
-        )
-    }
-
-    static func review(_ review: ReviewRecord) -> Self {
-        .init(
-            id: "review:\(review.id)",
-            title: review.title,
-            detail: "Review · \(review.status.capitalized)",
-            symbol: "checkmark.bubble",
-            destination: .review(review)
-        )
-    }
 }
 
 struct AvatarView: View {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -1185,7 +1185,7 @@ final class DaemonContractTests: XCTestCase {
             source.range(of: "func selectProject(_ projectId: String) async")
         )
         let selectEnd = try XCTUnwrap(
-            source[selectStart.lowerBound...].range(of: "\n    func focusIssueSearch")
+            source[selectStart.lowerBound...].range(of: "\n    func focusWorkspaceSearch")
         )
         XCTAssertTrue(
             source[selectStart.lowerBound..<selectEnd.lowerBound]

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -338,6 +338,68 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
+    func testWorkspaceSearchCommandRequestsToolbarFocus() {
+        let store = WorkspaceStore()
+        let initialFocusToken = store.workspaceSearchFocusToken
+
+        store.focusWorkspaceSearch()
+        let firstFocusToken = store.workspaceSearchFocusToken
+
+        XCTAssertNotEqual(firstFocusToken, initialFocusToken)
+
+        store.focusWorkspaceSearch()
+
+        XCTAssertNotEqual(store.workspaceSearchFocusToken, firstFocusToken)
+    }
+
+    func testWorkspaceSearchFiltersMemoryContent() {
+        let architecture = item(
+            path: "guides/architecture.md",
+            body: "Recall pipeline",
+            kind: .workflows
+        )
+        let notes = item(path: "notes.md")
+        let items = [architecture, notes]
+
+        XCTAssertEqual(WorkspaceStore.filterMemoryItems(items, query: "  "), items)
+        XCTAssertEqual(
+            WorkspaceStore.filterMemoryItems(items, query: "RECALL").map(\.id),
+            [architecture.id]
+        )
+        XCTAssertEqual(
+            WorkspaceStore.filterMemoryItems(items, query: "workflow").map(\.id),
+            [architecture.id]
+        )
+        XCTAssertTrue(WorkspaceStore.filterMemoryItems(items, query: "missing").isEmpty)
+    }
+
+    func testWorkspaceSearchFiltersBundles() {
+        let release = PersonalBundle(
+            id: "release",
+            name: "Release",
+            description: "Production checklist",
+            resourceIds: [],
+            revision: 1,
+            updatedAt: "2026-08-31T00:00:00Z"
+        )
+        let onboarding = PersonalBundle(
+            id: "onboarding",
+            name: "Onboarding",
+            description: "Starter context",
+            resourceIds: [],
+            revision: 1,
+            updatedAt: "2026-08-31T00:00:00Z"
+        )
+        let bundles = [release, onboarding]
+
+        XCTAssertEqual(WorkspaceStore.filterBundles(bundles, query: "  "), bundles)
+        XCTAssertEqual(
+            WorkspaceStore.filterBundles(bundles, query: "PRODUCTION").map(\.id),
+            [release.id]
+        )
+        XCTAssertTrue(WorkspaceStore.filterBundles(bundles, query: "missing").isEmpty)
+    }
+
     func testReviewDetailRouteCarriesOnlyTheStableReviewId() {
         let route = ReviewRoute(reviewId: "review-0123456789abcdef")
 
@@ -1861,18 +1923,26 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
-    private func item(path: String) -> MemoryListItem {
+    private func item(
+        path: String,
+        body: String = "",
+        kind: MemoryKind = .context
+    ) -> MemoryListItem {
         let resource = MemoryResource(
             id: path,
             scope: .org,
             projectId: nil,
             projectName: nil,
-            kind: .context,
+            kind: kind,
             contentHash: "hash",
             updatedAt: "2026-08-05T00:00:00Z",
             refCommitId: nil,
             contentLoaded: true,
-            document: .init(title: URL(fileURLWithPath: path).lastPathComponent, path: path, body: "")
+            document: .init(
+                title: URL(fileURLWithPath: path).lastPathComponent,
+                path: path,
+                body: body
+            )
         )
         return MemoryListItem(id: resource.id, resource: resource, draft: nil, inherited: false)
     }


### PR DESCRIPTION
## Context and summary

Follow-up to #176. The shared classic toolbar search field no longer
opens a secondary search popover. Typing now filters the current
Memory, Bundles, Reviews, or Issues content in place, with preparing
and no-results states rendered in the content area. Cmd+K focuses the
visible toolbar field.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before this change, focusing toolbar search in Memory or Bundles opened
a second search input and displayed "No Results" inside that popover.
After this change, the toolbar field is the only input: workspace lists
filter directly and empty search results replace the navigator content.
Issues and Reviews keep their inline filtering, and Cmd+K returns from
detail navigation before focusing the appropriate search field.

## Verification

- [x] `just test-macos` — build and macOS test suite passed.
- [x] `cargo test --workspace` — Rust workspace tests passed.
- [x] `cargo clippy -p daemon -- -D warnings` — passed.
- [x] `bun run api:check` and `bun run build` — passed.
- [x] `just test-dev-macos` and `just test-macos-package` — passed.
- [x] CI scripts, runtime boundaries, native recipes, and formatting passed.
- [x] Isolated Dev Instance rebuilt and launched successfully.
- [ ] Manual UI verification on macOS 14 and macOS 26 remains for review.

## Compatibility and migration

No API, persistence, configuration, or migration changes. Search
matching remains case-insensitive and covers the same user-visible
fields.

## Risk, security, and privacy

Risk is limited to macOS search and navigation state. Filtering stays
local to already loaded models and does not change storage, permissions,
or private-data handling. The main regression risk is focus routing
when returning from an Issue or Review detail.

## Rollout and rollback

- Rollout: Merge through the normal pull request flow; no feature flag
  or migration is required.
- Observability: CI and the macOS test suite cover search state; reviewers
  can manually check toolbar focus and content-area feedback.
- Rollback: Revert commit `222a2f4` to restore the previous search popover
  behavior.

## Reviewer focus

Verify Cmd+K focus after navigating into Issue and Review details, plus
Memory index-preparing and no-match transitions.
