### PR TITLE
activity: parse current Codex memory calls

### DIFF
--- a/crates/daemon/src/recall/codex.rs
+++ b/crates/daemon/src/recall/codex.rs
@@ -297,9 +297,27 @@ where
                         });
                         current_task = Some(tasks.len() - 1);
                     }
-                    Some("mcp_tool_call_end") => {
-                        let Some(invocation) = payload.get("invocation") else {
-                            continue;
+                    Some(event @ ("mcp_tool_call_end" | "item_completed")) => {
+                        let (invocation, call_id, result, error) = match event {
+                            "mcp_tool_call_end" => {
+                                let Some(invocation) = payload.get("invocation") else {
+                                    continue;
+                                };
+                                (
+                                    invocation,
+                                    payload.get("call_id"),
+                                    payload.get("result"),
+                                    None,
+                                )
+                            }
+                            _ => {
+                                let Some(item) = payload.get("item").filter(|item| {
+                                    item.get("type").and_then(Value::as_str) == Some("McpToolCall")
+                                }) else {
+                                    continue;
+                                };
+                                (item, item.get("id"), item.get("result"), item.get("error"))
+                            }
                         };
                         let server = invocation
                             .get("server")
@@ -320,8 +338,7 @@ where
                         };
 
                         activation_number += 1;
-                        let call_id = payload
-                            .get("call_id")
+                        let call_id = call_id
                             .and_then(Value::as_str)
                             .filter(|id| !id.is_empty())
                             .map(str::to_owned)
@@ -342,7 +359,7 @@ where
                             continue;
                         }
 
-                        let result = payload.get("result").unwrap_or(&Value::Null);
+                        let result = result.unwrap_or(&Value::Null);
                         let activation = CodexActivation {
                             tool_name: tool.to_owned(),
                             call_id,
@@ -351,7 +368,8 @@ where
                             timestamp: record_timestamp(&record),
                             run_id: extract_run_id(result),
                             fragments: extract_fragments(result),
-                            result_error: extract_result_error(result),
+                            result_error: extract_result_error(result)
+                                .or_else(|| error.map(|error| truncate(&display_json(error), 240))),
                         };
                         if let Some(task) = tasks.get_mut(task_index) {
                             task.activations.push(activation);
@@ -577,7 +595,8 @@ fn extract_activation_arguments(tool: &str, value: &Value) -> Option<(String, Op
 fn extract_run_id(result: &Value) -> Option<String> {
     result
         .get("Ok")
-        .and_then(|ok| ok.get("structuredContent"))
+        .unwrap_or(result)
+        .get("structuredContent")
         .and_then(|content| content.get("run_id").or_else(|| content.get("runId")))
         .and_then(Value::as_str)
         .filter(|run_id| !run_id.is_empty())
@@ -587,7 +606,8 @@ fn extract_run_id(result: &Value) -> Option<String> {
 fn extract_fragments(result: &Value) -> Vec<CodexFragment> {
     let Some(fragments) = result
         .get("Ok")
-        .and_then(|ok| ok.get("structuredContent"))
+        .unwrap_or(result)
+        .get("structuredContent")
         .and_then(|content| content.get("fragments"))
         .and_then(Value::as_array)
     else {
@@ -660,7 +680,7 @@ fn extract_result_error(result: &Value) -> Option<String> {
     if let Some(error) = result.get("Err") {
         return Some(truncate(&display_json(error), 240));
     }
-    let ok = result.get("Ok")?;
+    let ok = result.get("Ok").unwrap_or(result);
     if !ok.get("isError").and_then(Value::as_bool).unwrap_or(false) {
         return None;
     }
@@ -713,8 +733,10 @@ mod tests {
         let rollout = [
             r#"{"timestamp":"2026-08-19T08:00:00.000Z","type":"session_meta","payload":{"id":"session-1","timestamp":"2026-08-19T07:59:00.000Z","cwd":"/repo","originator":"codex_desktop"}}"#,
             "not json",
-            r#"{"timestamp":"2026-08-19T08:01:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"Show the recalled memory"}}"#,
-            r#"{"timestamp":"2026-08-19T08:01:01.000Z","type":"event_msg","payload":{"type":"mcp_tool_call_end","call_id":"call-1","invocation":{"server":"clumsies","tool":"memory","arguments":{"op":{"activate":{"query":"recall parser","state":"opaque"}}}},"result":{"Ok":{"structuredContent":{"run_id":"run-1","fragments":[{"action":"add","resource_id":"rule-1","path":"rules/parser.md","content":"Keep only recall data."}]},"isError":false}}}}"#,
+            r#"{"timestamp":"2026-08-19T08:01:00.000Z","type":"response_item","payload":{"type":"message","id":"prompt-1","role":"user","content":[{"type":"input_text","text":"Show the recalled memory"}],"internal_chat_message_metadata_passthrough":{"content_item_kinds":["user.text"]}}}"#,
+            r#"{"timestamp":"2026-08-19T08:01:01.000Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"McpToolCall","id":"call-1","server":"clumsies","tool":"memory","arguments":{"op":{"activate":{"query":"recall parser","state":"opaque"}}},"status":"completed","result":{"structuredContent":{"run_id":"run-1","fragments":[{"action":"add","resource_id":"rule-1","path":"rules/parser.md","content":"Keep only recall data."}]},"isError":false}}}}"#,
+            r#"{"timestamp":"2026-08-19T08:01:02.000Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"McpToolCall","id":"load-1","server":"clumsies","tool":"memory","arguments":{"op":{"load":{"ids":["rule-1"]}}},"status":"completed","result":{"structuredContent":{},"isError":false}}}}"#,
+            r#"{"timestamp":"2026-08-19T08:01:03.000Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"McpToolCall","id":"call-2","server":"clumsies","tool":"memory","arguments":{"op":{"activate":{"query":"retry parser"}}},"status":"failed","error":{"message":"connection closed"}}}}"#,
         ]
         .join("\n");
 
@@ -730,7 +752,7 @@ mod tests {
         assert_eq!(session.created_at, Some(1234));
         assert_eq!(session.tasks.len(), 1);
         assert_eq!(session.tasks[0].text, "Show the recalled memory");
-        assert_eq!(session.tasks[0].activations.len(), 1);
+        assert_eq!(session.tasks[0].activations.len(), 2);
 
         let activation = &session.tasks[0].activations[0];
         assert_eq!(activation.call_id, "call-1");
@@ -742,6 +764,10 @@ mod tests {
         assert_eq!(activation.fragments[0].resource_id, "rule-1");
         assert_eq!(activation.fragments[0].path, "rules/parser.md");
         assert_eq!(activation.fragments[0].content, "Keep only recall data.");
+        assert_eq!(
+            session.tasks[0].activations[1].result_error.as_deref(),
+            Some("connection closed")
+        );
     }
 
     #[test]

--- a/docs/recall.md
+++ b/docs/recall.md
@@ -75,30 +75,33 @@ Codex rollouts are discovered under `~/.codex/sessions` and
 `~/.codex/archived_sessions`. `session_meta.payload.cwd` binds a rollout to a
 workspace; active and archived copies are de-duplicated by session id.
 
-The projection consumes human `user_message` events and completed MCP calls. A
-current activation is recorded atomically as:
+The projection consumes structured human `response_item` records, legacy
+`user_message` events, and completed MCP calls. A current activation is
+recorded atomically as:
 
 ```text
-event_msg.payload.type = "mcp_tool_call_end"
-payload.call_id
-payload.invocation = {
+event_msg.payload.type = "item_completed"
+payload.item = {
+  type: "McpToolCall",
+  id: "...",
   server: "clumsies",
   tool: "memory",
-  arguments: { op: { activate: { query: "...", state?: "..." } } }
+  arguments: { op: { activate: { query: "...", state?: "..." } } },
+  result?: { structuredContent: { run_id?, fragments, ... }, isError? },
+  error?: { message: "..." }
 }
-payload.result = { Ok: { structuredContent: { run_id?, fragments, ... }, isError? } }
-               | { Err: "..." }
 ```
 
-The earlier dedicated tool names `memory/activate` and `activate`, including
-JSON-encoded arguments, are accepted as compatibility input. Other MCP servers
-and other `memory` operations are ignored.
+Legacy `mcp_tool_call_end` events and the earlier dedicated tool names
+`memory/activate` and `activate`, including JSON-encoded arguments, are
+accepted as compatibility input. Other MCP servers and other `memory`
+operations are ignored.
 
 ## Projection and retrieval-run identity
 
 Each genuine human message starts a task. Subsequent clumsies activations belong
 to that task until the next human message. DSH call/result records are paired by
-`callId`; Codex `mcp_tool_call_end` already contains both sides.
+`callId`; a Codex `McpToolCall` completion already contains both sides.
 
 For new logs, `structuredContent.run_id` is the authoritative link to
 `retrieval_runs`; selected candidates from that exact run supply stable chunk

--- a/docs/zh/recall.md
+++ b/docs/zh/recall.md
@@ -84,25 +84,23 @@ Codex rollout 从以下目录递归发现：
 当前结构化 activation 记录为：
 
 ```text
-event_msg.payload.type = "mcp_tool_call_end"
-payload.call_id
-payload.invocation = {
+event_msg.payload.type = "item_completed"
+payload.item = {
+  type: "McpToolCall",
+  id: "...",
   server: "clumsies",
   tool: "memory",
-  arguments: { op: { activate: { query: "...", state?: "..." } } }
-}
-payload.result = {
-  Ok: { structuredContent: { run_id?, fragments, ... }, isError? }
-} | {
-  Err: "..."
+  arguments: { op: { activate: { query: "...", state?: "..." } } },
+  result?: { structuredContent: { run_id?, fragments, ... }, isError? },
+  error?: { message: "..." }
 }
 ```
 
-用户请求优先读取结构化 `response_item` 中标记为 `user.text` 的内容，并兼容旧 `event_msg.payload.type = "user_message"`。旧工具名 `memory/activate`、`activate` 及 JSON 字符串参数继续作为只读兼容输入；其他 MCP Server 和 `memory` 的其他 operation 被忽略。
+用户请求优先读取结构化 `response_item` 中标记为 `user.text` 的内容，并兼容旧 `event_msg.payload.type = "user_message"`。旧 `mcp_tool_call_end` 事件、工具名 `memory/activate`、`activate` 及 JSON 字符串参数继续作为只读兼容输入；其他 MCP Server 和 `memory` 的其他 operation 被忽略。
 
 ## 请求、activation 与 Retrieval Run 的关联
 
-每条真实人类消息开始一个请求；之后的 Clumsies activation 归入该请求，直到下一条人类消息。DSH 用 `callId` 配对调用和结果；Codex 的 `mcp_tool_call_end` 已同时包含两端。
+每条真实人类消息开始一个请求；之后的 Clumsies activation 归入该请求，直到下一条人类消息。DSH 用 `callId` 配对调用和结果；Codex 的 `McpToolCall` 完成事件已同时包含两端。
 
 新日志中，`structuredContent.run_id` 是关联本地 `retrieval_runs` 的权威身份。daemon 还会校验该 run 属于工作区绑定的 Project；查询文本只用于展示，不是身份键。
 


### PR DESCRIPTION
## Context and summary

Current Codex rollouts record completed MCP calls as `item_completed`
`McpToolCall` entries. Activity already parsed the session and user request
but ignored those Memory activations, so every Memory search and recalled
chunk count remained zero. Parse the current call, result, and error shapes
while retaining legacy rollout support and excluding `memory.load` and
`memory.store`.

## Affected areas

- [x] Rust daemon/runtime
- [ ] Server/API
- [ ] macOS app
- [ ] Web Admin
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [x] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before this change, Activity showed the correct Codex session and request but
reported zero Memory searches and zero recalled chunks. The parser now
projects successful and failed Memory activations from current rollout
events, including run IDs and returned fragments. Legacy events remain
readable, while `memory.load` and `memory.store` remain excluded. The
regression fixture covers one successful activation, one ignored load, and
one failed activation.

## Verification

- [x] `bash -n deploy/server/*.sh`
- [x] `shellcheck deploy/server/*.sh`
- [x] `bash -n deploy/site.sh`
- [x] `shellcheck deploy/site.sh`
- [x] `bash deploy/server/server-release-test.sh`
- [x] `shellcheck dev/check-agent-runtime-boundary.sh`
- [x] `sh dev/check-agent-runtime-boundary.sh`
- [x] `shellcheck dev/check-retired-terms.sh`
- [x] `sh dev/check-retired-terms.sh`
- [x] Dev and promotion script syntax and ShellCheck commands from CI
- [x] `sh apps/macos/Scripts/promote-debug-test.sh`
- [x] `docker compose config -q`
- [x] `bun install --frozen-lockfile`
- [x] `bun run build`
- [x] `bun run api:check`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace`
- [x] Native task-boundary list, no-Bun, and required dry-run checks from CI
- [x] `just test-dev-macos`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `just test-macos`
- [x] `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture`
- [x] `just test-macos-package`
- [x] `python3 dev/validate-pr-template.py --self-test`

## Compatibility and migration

Existing `mcp_tool_call_end` rollouts remain readable, and the Activity API
schema is unchanged. No configuration, storage, or data migration is
required. Mixed app and daemon versions remain wire-compatible. Downgrading
restores the previous projection behavior for current-format logs without
altering or losing those logs.

## Risk, security, and privacy

The change only reads local Codex rollout fields already in Activity scope.
It does not widen filesystem access, persist additional transcript data, or
modify Memory. The main risk is future rollout shape drift; a current-format
regression fixture now covers success, failure, and non-activation filtering.

## Rollout and rollback

- Rollout: Merge through the normal pull request flow and ship with the next macOS app build.
- Observability: Activity search and recalled-chunk counts reflect local Codex rollout records; parser tests and CI surface regressions.
- Rollback: Revert this commit to restore the previous parser.

## Reviewer focus

Confirm that current and legacy Codex events share the same activation
filters, especially failed calls and exclusion of `memory.load` and
`memory.store`.
