### PR TITLE
macos: keep Memory tools visible and review all project changes

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -5101,6 +5101,17 @@ final class WorkspaceStore: ObservableObject {
         draft.scope == .org
     }
 
+    nonisolated static func reviewableProjectDrafts(
+        _ drafts: [LocalDraft],
+        projectId: String?
+    ) -> [LocalDraft] {
+        let openDrafts = preferredMemoryTreeDrafts(
+            memoryTreeDrafts(drafts, activeProjectId: projectId)
+        ).filter { $0.status == .open }
+        guard openDrafts.allSatisfy(canRequestReview) else { return [] }
+        return openDrafts
+    }
+
     private nonisolated static func isOrganizationDraft(_ draft: ServerDraft) -> Bool {
         draft.resource.scope == MemoryScope.org.rawValue
     }

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -2159,7 +2159,7 @@ struct DraftReconciliationView: View {
     }
 }
 
-private struct ReviewRequestSheet: View {
+struct ReviewRequestSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     let loadCandidate: () async throws -> DraftReconciliationCandidate

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -144,6 +144,8 @@ struct WorkspaceView: View {
     @State private var reviewSearchFocusRequest = 0
     @State private var reviewFilters = ReviewListFilters()
     @State private var pendingReviewToolbarAction: ReviewMenuAction?
+    @State private var pendingProjectReviewDrafts: [LocalDraft] = []
+    @State private var showsProjectReviewRequest = false
     @State private var selectedAdministrationSection: AdministrationSection? = .overview
 
     init(
@@ -166,6 +168,10 @@ struct WorkspaceView: View {
         store.selectedSection == .memory
             && !store.visibleTabs.isEmpty
             && !store.showsProjectSettings
+    }
+
+    private var showsMemoryContentToolbar: Bool {
+        store.selectedSection == .memory && !store.showsProjectSettings
     }
 
     private var documentReconciliationState: DocumentReconciliationToolbarState? {
@@ -221,7 +227,7 @@ struct WorkspaceView: View {
                         .frame(minWidth: 440, maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .toolbar {
-                    if showsDocumentTabs {
+                    if showsMemoryContentToolbar {
                         ToolbarItemGroup {
                             Button {
                                 if let state = documentReconciliationState {
@@ -252,13 +258,9 @@ struct WorkspaceView: View {
                             .help("Go Forward")
                             .accessibilityLabel("Go Forward")
                         }
-
-                        if #available(macOS 26.0, *) {
-                            ToolbarSpacer(.flexible)
-                        }
                     }
 
-                    if #available(macOS 26.0, *), !showsDocumentTabs {
+                    if #available(macOS 26.0, *) {
                         ToolbarSpacer(.flexible)
                     }
 
@@ -399,8 +401,11 @@ struct WorkspaceView: View {
                             .help("Document View")
                             .accessibilityLabel("Document View")
 
-                            if hasDocumentActions(item) {
-                                Menu {
+                        }
+
+                        if showsMemoryContentToolbar {
+                            Menu {
+                                if let item = store.currentItem, hasDocumentActions(item) {
                                     if canRequestDocumentReview(item),
                                        let draft = item.draft,
                                        let sessionKey = store.documentSessionKey(for: item) {
@@ -410,6 +415,7 @@ struct WorkspaceView: View {
                                                 draft: draft
                                             )
                                         }
+                                        .disabled(store.isSynchronizingDocument(item.id))
                                         Divider()
                                     }
                                     if canDiscardDocumentDraft(item),
@@ -421,6 +427,7 @@ struct WorkspaceView: View {
                                                 draft: draft
                                             )
                                         }
+                                        .disabled(store.isSynchronizingDocument(item.id))
                                     }
                                     if canProposeOrganizationDeletion(item),
                                        let sessionKey = store.documentSessionKey(for: item) {
@@ -432,15 +439,22 @@ struct WorkspaceView: View {
                                                 sessionKey: sessionKey
                                             )
                                         }
+                                        .disabled(store.isSynchronizingDocument(item.id))
                                     }
-                                } label: {
-                                    Image(systemName: "ellipsis")
+                                    Divider()
                                 }
-                                .disabled(store.isSynchronizingDocument(item.id))
-                                .menuIndicator(.hidden)
-                                .help("Document Actions")
-                                .accessibilityLabel("Document Actions")
+
+                                Button("Request Review for All Project Changes…") {
+                                    pendingProjectReviewDrafts = activeProjectReviewDrafts
+                                    showsProjectReviewRequest = true
+                                }
+                                .disabled(!canRequestProjectReview)
+                            } label: {
+                                Image(systemName: "ellipsis")
                             }
+                            .menuIndicator(.hidden)
+                            .help("Memory Actions")
+                            .accessibilityLabel("Memory Actions")
                         }
                     }
 
@@ -510,6 +524,18 @@ struct WorkspaceView: View {
         }
         .sheet(isPresented: $store.showsProjectCreation) {
             ProjectCreationSheet(store: store)
+        }
+        .sheet(isPresented: $showsProjectReviewRequest) {
+            ReviewRequestSheet(
+                initialTitle: "Update \(store.activeProject?.name ?? "project") memory",
+                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
+            ) { title, description, _, _ in
+                try await store.requestReview(
+                    for: pendingProjectReviewDrafts,
+                    title: title,
+                    description: description
+                )
+            }
         }
     }
 
@@ -1293,6 +1319,23 @@ struct WorkspaceView: View {
         canRequestDocumentReview(item)
             || canDiscardDocumentDraft(item)
             || canProposeOrganizationDeletion(item)
+    }
+
+    private var activeProjectReviewDrafts: [LocalDraft] {
+        WorkspaceStore.reviewableProjectDrafts(
+            store.drafts,
+            projectId: store.activeProjectId
+        )
+    }
+
+    private var canRequestProjectReview: Bool {
+        !activeProjectReviewDrafts.isEmpty
+            && activeProjectReviewDrafts.allSatisfy {
+                $0.syncStatus == .synced
+                    && $0.serverId != nil
+                    && $0.freshness == .current
+                    && !store.isSynchronizingDocument($0.targetId ?? $0.id)
+            }
     }
 
     private var documentMode: Binding<WorkbenchTabMode> {

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -397,6 +397,24 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
     }
 
+    func testMemoryToolbarNavigationAndMoreActionsDoNotRequireAnOpenDocument() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains(
+            "if showsMemoryContentToolbar {\n                        ToolbarItemGroup {"
+        ))
+        XCTAssertTrue(source.contains(
+            "if showsMemoryContentToolbar {\n                            Menu {"
+        ))
+        XCTAssertTrue(source.contains("Request Review for All Project Changes…"))
+    }
+
     func testWorkspaceSearchCommandRequestsToolbarFocus() {
         let store = WorkspaceStore()
         let initialFocusToken = store.workspaceSearchFocusToken
@@ -1733,6 +1751,47 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertFalse(WorkspaceStore.canRequestReview(localCreate))
         XCTAssertFalse(WorkspaceStore.canRequestReview(legacyProjectUpdate))
         XCTAssertTrue(WorkspaceStore.canRequestReview(orgCreate))
+    }
+
+    func testProjectReviewUsesEveryCurrentOpenOrganizationDraftOrNone() {
+        let older = localDraft(
+            id: "older",
+            targetId: "shared",
+            scope: .org,
+            updatedAt: "2026-08-18T00:00:00Z"
+        )
+        let newer = localDraft(
+            id: "newer",
+            targetId: "shared",
+            scope: .org,
+            updatedAt: "2026-08-20T00:00:00Z"
+        )
+        let created = localDraft(
+            id: "created",
+            targetId: nil,
+            scope: .org,
+            updatedAt: "2026-08-19T00:00:00Z"
+        )
+        let otherProject = localDraft(
+            id: "other",
+            targetId: nil,
+            projectId: "other-project",
+            scope: .org
+        )
+
+        XCTAssertEqual(
+            WorkspaceStore.reviewableProjectDrafts(
+                [older, newer, created, otherProject],
+                projectId: "project"
+            ).map(\.id),
+            ["newer", "created"]
+        )
+
+        let legacy = localDraft(id: "legacy", targetId: "legacy-memory")
+        XCTAssertTrue(WorkspaceStore.reviewableProjectDrafts(
+            [newer, created, legacy],
+            projectId: "project"
+        ).isEmpty)
     }
 
     func testMemoryTabsAreScopedToTheProjectViewContext() {


### PR DESCRIPTION
## Context and summary

Memory toolbar Back, Forward, and More actions disappeared until a document
was opened. Keep these page-level actions visible throughout the Memory
content surface and add a project-wide Review action that submits all open
Organization changes together through the existing ordered multi-Draft flow.

This implements Clumsies Native Kanban ISSUE-096.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before this change, navigation and More actions were unavailable without an
open document. The toolbar now keeps them visible on the Memory content
surface. More includes “Request Review for All Project Changes…”.

The project-wide action is disabled when there are no publishable changes or
when any current open Draft is legacy, unsynchronized, behind, or undergoing
reconciliation, preventing partial Reviews.

## Verification

- [x] Focused `WorkspaceNavigationTests`
- [x] `just test-macos`
- [x] `git diff --check`
- [ ] Interactive packaged-app verification remains for reviewer validation.

## Compatibility and migration

No API, storage, schema, or migration changes. The existing Review contract
is reused.

## Risk, security, and privacy

No new trust boundaries or private-data logging. The main risk is toolbar
layout behavior across empty and document states.

## Rollout and rollback

- Rollout: Merge through the normal macOS application release flow.
- Observability: Existing disabled states and Review request errors expose failures.
- Rollback: Revert this commit.

## Reviewer focus

Confirm that toolbar actions remain singular across empty and document states,
and that project-wide Review selection is all-or-none.
