### PR TITLE
macos: prevent workspace refresh amplification

### DIFF
--- a/apps/macos/Sources/Components/AvatarView.swift
+++ b/apps/macos/Sources/Components/AvatarView.swift
@@ -1,0 +1,101 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+private final class AvatarImageCache {
+    static let shared = AvatarImageCache()
+
+    private struct Load {
+        let id: UUID
+        let task: Task<NSImage?, Never>
+    }
+
+    private let images = NSCache<NSURL, NSImage>()
+    private var loads: [URL: Load] = [:]
+
+    private init() {
+        images.countLimit = 128
+    }
+
+    func image(for url: URL) async -> NSImage? {
+        if let image = images.object(forKey: url as NSURL) {
+            return image
+        }
+
+        let load: Load
+        if let existing = loads[url] {
+            load = existing
+        } else {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .returnCacheDataElseLoad
+            request.timeoutInterval = 15
+            let task = Task<NSImage?, Never> {
+                do {
+                    let (data, response) = try await URLSession.shared.data(for: request)
+                    guard let response = response as? HTTPURLResponse,
+                          (200..<300).contains(response.statusCode) else {
+                        return nil
+                    }
+                    return NSImage(data: data)
+                } catch {
+                    return nil
+                }
+            }
+            load = .init(id: UUID(), task: task)
+            loads[url] = load
+        }
+
+        let image = await load.task.value
+        if loads[url]?.id == load.id {
+            if let image {
+                images.setObject(image, forKey: url as NSURL)
+            }
+            loads[url] = nil
+        }
+        return image
+    }
+}
+
+struct AvatarView: View {
+    let account: UserReference?
+    @State private var image: NSImage?
+
+    private var avatarURL: URL? {
+        account?.avatarUrl.flatMap(URL.init(string:))
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 24, height: 24)
+                    .clipped()
+            } else {
+                fallback
+            }
+        }
+        .frame(width: 24, height: 24)
+        .clipShape(Circle())
+        .task(id: avatarURL) {
+            if image != nil {
+                image = nil
+            }
+            guard let avatarURL else { return }
+            let loaded = await AvatarImageCache.shared.image(for: avatarURL)
+            guard !Task.isCancelled else { return }
+            image = loaded
+        }
+    }
+
+    private var fallback: some View {
+        ZStack {
+            Color.accentColor.opacity(0.2)
+            Text(String((account?.displayName ?? account?.email ?? "C").prefix(1)).uppercased())
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+        }
+        .frame(width: 24, height: 24)
+    }
+}

--- a/apps/macos/Sources/Domain/MemoryModels.swift
+++ b/apps/macos/Sources/Domain/MemoryModels.swift
@@ -232,7 +232,7 @@ struct ProjectState: Identifiable, Hashable, Sendable {
     let isLoaded: Bool
 }
 
-struct RuntimeState: Sendable {
+struct RuntimeState: Equatable, Sendable {
     let health: DaemonHealth
     let sync: DaemonSyncStatus?
     let mcp: DaemonMCPStatus?

--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -365,6 +365,11 @@ struct DraftInventoryPlan: Equatable, Sendable {
     let terminalIds: Set<String>
 }
 
+enum WorkspaceRefreshCadence {
+    static let syncStatus: Duration = .seconds(2)
+    static let synchronizedData: Duration = .seconds(30)
+}
+
 private struct ResourceLoadRequest: Sendable {
     let resource: MemoryResource
     let generation: UUID
@@ -460,8 +465,10 @@ final class WorkspaceStore: ObservableObject {
     private var bundleLoadTask: Task<Void, Never>?
     private var reviewLoadTask: Task<Void, Never>?
     private var legacyAgentAdapterInspectionTask: Task<Void, Never>?
-    private var postReadySyncTask: Task<Void, Never>?
+    private var postReadyMCPTask: Task<Void, Never>?
     private var postReadyRetrySyncTask: Task<Void, Never>?
+    private var isRefreshingSyncStatus = false
+    private var isRefreshingSynchronizedWorkspaceData = false
     private var syncRetryTasks: [SyncRetryKey: SyncRetryTaskHandle] = [:]
     private var presentedSyncRetryErrorKey: SyncRetryKey?
     private var dismissedBackgroundErrorSources: Set<WorkspaceBackgroundErrorSource> = []
@@ -3288,6 +3295,8 @@ final class WorkspaceStore: ObservableObject {
                 if activeProjectId == projectId {
                     await refreshSyncStatus()
                     try Task.checkCancellation()
+                    await refreshSynchronizedWorkspaceData()
+                    try Task.checkCancellation()
                 }
                 return SyncRetryOutcome.completed
             } catch is CancellationError {
@@ -3316,51 +3325,96 @@ final class WorkspaceStore: ObservableObject {
         return outcome
     }
 
+    func runRefreshLoop() async {
+        let clock = ContinuousClock()
+        var nextSynchronizedDataRefresh = clock.now
+        while !Task.isCancelled {
+            if phase == .ready {
+                await refreshSyncStatus()
+                guard !Task.isCancelled else { return }
+                if clock.now >= nextSynchronizedDataRefresh {
+                    await refreshSynchronizedWorkspaceData()
+                    nextSynchronizedDataRefresh = clock.now.advanced(
+                        by: WorkspaceRefreshCadence.synchronizedData
+                    )
+                }
+            }
+            do {
+                try await Task.sleep(for: WorkspaceRefreshCadence.syncStatus)
+            } catch {
+                return
+            }
+        }
+    }
+
     func refreshSyncStatus() async {
-        guard phase == .ready else { return }
+        guard phase == .ready, !isRefreshingSyncStatus else { return }
+        isRefreshingSyncStatus = true
+        defer { isRefreshingSyncStatus = false }
+        let generation = workspaceReloadGeneration
+        let projectId = activeProjectId
+        guard let runtime else { return }
+        do {
+            let sync = try await daemon.syncStatus(projectId: projectId)
+            try Task.checkCancellation()
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId,
+                  phase == .ready else {
+                return
+            }
+            let updatedRuntime = RuntimeState(
+                health: runtime.health,
+                sync: sync,
+                mcp: runtime.mcp,
+                serverDataSource: server.dataSource
+            )
+            if self.runtime != updatedRuntime {
+                self.runtime = updatedRuntime
+            }
+            if !syncStatusAvailable {
+                syncStatusAvailable = true
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard workspaceReloadGeneration == generation,
+                  activeProjectId == projectId else {
+                return
+            }
+            if syncStatusAvailable {
+                syncStatusAvailable = false
+            }
+        }
+    }
+
+    func refreshSynchronizedWorkspaceData() async {
+        guard phase == .ready, !isRefreshingSynchronizedWorkspaceData else { return }
+        isRefreshingSynchronizedWorkspaceData = true
+        defer { isRefreshingSynchronizedWorkspaceData = false }
         let generation = workspaceReloadGeneration
         let projectId = activeProjectId
         await refreshOrgResourcesIfNeeded()
         guard workspaceReloadGeneration == generation,
               activeProjectId == projectId,
               phase == .ready,
-              let runtime else {
+              !Task.isCancelled,
+              let sync = runtime?.sync else {
             return
         }
-        do {
-            let sync = try await daemon.syncStatus(projectId: projectId)
-            guard workspaceReloadGeneration == generation,
-                  activeProjectId == projectId,
-                  phase == .ready else {
-                return
-            }
-            self.runtime = .init(
-                health: runtime.health,
-                sync: sync,
-                mcp: runtime.mcp,
-                serverDataSource: server.dataSource
+        if draftInventoryLoadTask == nil {
+            await refreshDraftInventory(
+                includeFailed: sync.pendingOperationCount > 0
+                    || sync.failedOperationCount > 0,
+                generation: generation
             )
-            syncStatusAvailable = true
-            if draftInventoryLoadTask == nil {
-                await refreshDraftInventory(
-                    includeFailed: sync.pendingOperationCount > 0
-                        || sync.failedOperationCount > 0,
-                    generation: generation
-                )
-            }
-            guard workspaceReloadGeneration == generation,
-                  activeProjectId == projectId,
-                  phase == .ready else {
-                return
-            }
-            await refreshStaleResourcesIfNeeded(sync: sync)
-        } catch {
-            guard workspaceReloadGeneration == generation,
-                  activeProjectId == projectId else {
-                return
-            }
-            syncStatusAvailable = false
         }
+        guard workspaceReloadGeneration == generation,
+              activeProjectId == projectId,
+              phase == .ready,
+              !Task.isCancelled else {
+            return
+        }
+        await refreshStaleResourcesIfNeeded(sync: sync)
     }
 
     nonisolated static func stableOrgAuthorityCommitId(
@@ -5395,8 +5449,8 @@ final class WorkspaceStore: ObservableObject {
         reviewLoadTask = nil
         legacyAgentAdapterInspectionTask?.cancel()
         legacyAgentAdapterInspectionTask = nil
-        postReadySyncTask?.cancel()
-        postReadySyncTask = nil
+        postReadyMCPTask?.cancel()
+        postReadyMCPTask = nil
         postReadyRetrySyncTask?.cancel()
         postReadyRetrySyncTask = nil
     }
@@ -5587,10 +5641,10 @@ final class WorkspaceStore: ObservableObject {
             _ = await self.retrySync(projectId: self.activeProjectId)
         }
 
-        postReadySyncTask = Task { @MainActor [weak self] in
+        postReadyMCPTask = Task { @MainActor [weak self] in
             defer {
                 if let self, self.workspaceReloadGeneration == generation {
-                    self.postReadySyncTask = nil
+                    self.postReadyMCPTask = nil
                 }
             }
             guard let self,
@@ -5599,25 +5653,21 @@ final class WorkspaceStore: ObservableObject {
                   !Task.isCancelled else {
                 return
             }
-            let projectId = self.activeProjectId
-            async let syncRequest = try? daemon.syncStatus(projectId: projectId)
-            async let mcpRequest = try? daemon.mcpStatus()
-            let (sync, mcp) = await (syncRequest, mcpRequest)
+            let mcp = try? await daemon.mcpStatus()
             guard self.workspaceReloadGeneration == generation,
-                  self.activeProjectId == projectId,
                   self.phase == .ready,
                   !Task.isCancelled,
                   let runtime = self.runtime else {
                 return
             }
-            self.runtime = .init(
+            let updatedRuntime = RuntimeState(
                 health: runtime.health,
-                sync: sync != nil ? sync : runtime.sync,
-                mcp: mcp != nil ? mcp : runtime.mcp,
+                sync: runtime.sync,
+                mcp: mcp ?? runtime.mcp,
                 serverDataSource: runtime.serverDataSource
             )
-            if sync != nil {
-                self.syncStatusAvailable = true
+            if self.runtime != updatedRuntime {
+                self.runtime = updatedRuntime
             }
         }
     }

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -181,6 +181,15 @@ struct WorkspaceView: View {
         return state
     }
 
+    private func deferSidebarExpansionUpdate(_ expanded: Bool) {
+        guard store.sidebarExpanded != expanded else { return }
+        DispatchQueue.main.async {
+            if store.sidebarExpanded != expanded {
+                store.sidebarExpanded = expanded
+            }
+        }
+    }
+
     var body: some View {
         Group {
             switch store.selectedSection {
@@ -202,7 +211,15 @@ struct WorkspaceView: View {
             }
         }
         .onChange(of: store.selectedSection) { _, _ in
-            store.searchQuery = ""
+            DispatchQueue.main.async {
+                store.searchQuery = ""
+                if store.selectedSection != .memory {
+                    store.showsProjectSettings = false
+                }
+            }
+        }
+        .task {
+            await store.runRefreshLoop()
         }
     }
 
@@ -489,16 +506,11 @@ struct WorkspaceView: View {
                   !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             Task { await store.prepareWorkspaceIndex(includeContent: true) }
         }
-        .onChange(of: store.selectedSection) { _, section in
-            if section != .memory {
-                store.showsProjectSettings = false
-            }
-        }
         .onChange(of: splitVisibility) { _, visibility in
             if visibility == .all {
-                store.sidebarExpanded = true
+                deferSidebarExpansionUpdate(true)
             } else if visibility == .doubleColumn || visibility == .detailOnly {
-                store.sidebarExpanded = false
+                deferSidebarExpansionUpdate(false)
             }
         }
         .onChange(of: store.sidebarExpanded) { _, expanded in
@@ -510,16 +522,6 @@ struct WorkspaceView: View {
         .onChange(of: syncToolbarPresentation) { _, presentation in
             if presentation == nil || presentation?.isSyncing == true {
                 showsSyncIssuePopover = false
-            }
-        }
-        .task {
-            while !Task.isCancelled {
-                await store.refreshSyncStatus()
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
             }
         }
         .sheet(isPresented: $store.showsProjectCreation) {
@@ -640,7 +642,6 @@ struct WorkspaceView: View {
             }
         }
         .onAppear {
-            store.showsProjectSettings = false
             let target: NavigationSplitViewVisibility = store.sidebarExpanded ? .all : .detailOnly
             if reviewSplitVisibility != target {
                 reviewSplitVisibility = target
@@ -658,9 +659,7 @@ struct WorkspaceView: View {
         }
         .onChange(of: reviewSplitVisibility) { _, visibility in
             let expanded = visibility != .detailOnly
-            if store.sidebarExpanded != expanded {
-                store.sidebarExpanded = expanded
-            }
+            deferSidebarExpansionUpdate(expanded)
         }
         .onChange(of: store.sidebarExpanded) { _, expanded in
             let target: NavigationSplitViewVisibility = expanded ? .all : .detailOnly
@@ -670,11 +669,15 @@ struct WorkspaceView: View {
         }
         .onChange(of: reviewNavigationPath) { _, path in
             let reviewId = path.last?.reviewId
-            if store.selectedReviewId != reviewId {
-                store.selectedReviewId = reviewId
+            DispatchQueue.main.async {
+                if store.selectedReviewId != reviewId {
+                    store.selectedReviewId = reviewId
+                }
+                if reviewId == nil {
+                    store.reviewDecisionReadiness = nil
+                }
             }
             if reviewId == nil {
-                store.reviewDecisionReadiness = nil
                 pendingReviewToolbarAction = nil
             }
         }
@@ -699,16 +702,6 @@ struct WorkspaceView: View {
         .onChange(of: syncToolbarPresentation) { _, presentation in
             if presentation == nil || presentation?.isSyncing == true {
                 showsSyncIssuePopover = false
-            }
-        }
-        .task {
-            while !Task.isCancelled {
-                await store.refreshSyncStatus()
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
             }
         }
         .sheet(isPresented: $store.showsProjectCreation) {
@@ -948,7 +941,6 @@ struct WorkspaceView: View {
                 }
         }
         .onAppear {
-            store.showsProjectSettings = false
             let target: NavigationSplitViewVisibility = store.sidebarExpanded ? .all : .doubleColumn
             if recallSplitVisibility != target {
                 recallSplitVisibility = target
@@ -959,9 +951,7 @@ struct WorkspaceView: View {
         }
         .onChange(of: recallSplitVisibility) { _, visibility in
             let expanded = visibility != .detailOnly
-            if store.sidebarExpanded != expanded {
-                store.sidebarExpanded = expanded
-            }
+            deferSidebarExpansionUpdate(expanded)
         }
         .onChange(of: store.sidebarExpanded) { _, expanded in
             let target: NavigationSplitViewVisibility = expanded ? .all : .doubleColumn
@@ -1124,7 +1114,6 @@ struct WorkspaceView: View {
             }
         }
         .onAppear {
-            store.showsProjectSettings = false
             let target: NavigationSplitViewVisibility = store.sidebarExpanded ? .all : .detailOnly
             if issueSplitVisibility != target {
                 issueSplitVisibility = target
@@ -1138,9 +1127,7 @@ struct WorkspaceView: View {
         }
         .onChange(of: issueSplitVisibility) { _, visibility in
             let expanded = visibility != .detailOnly
-            if store.sidebarExpanded != expanded {
-                store.sidebarExpanded = expanded
-            }
+            deferSidebarExpansionUpdate(expanded)
         }
         .onChange(of: store.sidebarExpanded) { _, expanded in
             let target: NavigationSplitViewVisibility = expanded ? .all : .detailOnly
@@ -1160,16 +1147,6 @@ struct WorkspaceView: View {
         .onChange(of: syncToolbarPresentation) { _, presentation in
             if presentation == nil || presentation?.isSyncing == true {
                 showsSyncIssuePopover = false
-            }
-        }
-        .task {
-            while !Task.isCancelled {
-                await store.refreshSyncStatus()
-                do {
-                    try await Task.sleep(for: .seconds(1))
-                } catch {
-                    return
-                }
             }
         }
         .task(id: store.activeProjectId) {
@@ -1634,8 +1611,10 @@ private struct GlobalSidebar: View {
             set: { destination in
                 guard let destination else { return }
                 if case .section(let section) = destination {
-                    store.selectedSection = section
-                    store.selectedItemId = nil
+                    DispatchQueue.main.async {
+                        store.selectedSection = section
+                        store.selectedItemId = nil
+                    }
                 }
             }
         )
@@ -1659,38 +1638,4 @@ private struct SidebarDestinationLabel: View {
 
 private enum GlobalSidebarDestination: Hashable {
     case section(WorkspaceSection)
-}
-
-struct AvatarView: View {
-    let account: UserReference?
-
-    var body: some View {
-        Group {
-            if let value = account?.avatarUrl, let url = URL(string: value) {
-                AsyncImage(url: url) { image in
-                    image
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 24, height: 24)
-                        .clipped()
-                } placeholder: {
-                    fallback
-                }
-            } else {
-                fallback
-            }
-        }
-        .frame(width: 24, height: 24)
-        .clipShape(Circle())
-    }
-
-    private var fallback: some View {
-        ZStack {
-            Color.accentColor.opacity(0.2)
-            Text(String((account?.displayName ?? account?.email ?? "C").prefix(1)).uppercased())
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-        }
-        .frame(width: 24, height: 24)
-    }
 }

--- a/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
+++ b/apps/macos/Sources/Infrastructure/DaemonXPCClient.swift
@@ -339,39 +339,47 @@ struct DaemonXPCClient: Sendable {
         to serviceName: String,
         timeout: TimeInterval
     ) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-            let request = DaemonXPCRequestState(continuation: continuation)
-            let connection = xpc_connection_create_mach_service(serviceName, replyQueue, 0)
-            request.attach(connection)
-            xpc_connection_set_event_handler(connection) { event in
-                if xpc_get_type(event) == XPC_TYPE_ERROR {
-                    let desc = xpc_dictionary_get_string(event, XPC_ERROR_KEY_DESCRIPTION)
-                        .map(String.init(cString:))
-                    request.fail(.connectionFailed(detail: desc))
+        let request = DaemonXPCRequestState()
+        let response = try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                guard request.start(continuation) else { return }
+                let connection = xpc_connection_create_mach_service(serviceName, replyQueue, 0)
+                xpc_connection_set_event_handler(connection) { event in
+                    if xpc_get_type(event) == XPC_TYPE_ERROR {
+                        let desc = xpc_dictionary_get_string(event, XPC_ERROR_KEY_DESCRIPTION)
+                            .map(String.init(cString:))
+                        request.fail(.connectionFailed(detail: desc))
+                    }
                 }
-            }
-            xpc_connection_activate(connection)
+                guard request.attach(connection) else { return }
+                xpc_connection_activate(connection)
 
-            let message = xpc_dictionary_create(nil, nil, 0)
-            xpc_dictionary_set_string(message, "request_json", requestJSON)
-            xpc_connection_send_message_with_reply(connection, message, replyQueue) { reply in
-                guard xpc_get_type(reply) != XPC_TYPE_ERROR else {
-                    let desc = xpc_dictionary_get_string(reply, XPC_ERROR_KEY_DESCRIPTION)
-                        .map(String.init(cString:))
-                    request.fail(.connectionFailed(detail: desc))
-                    return
+                let message = xpc_dictionary_create(nil, nil, 0)
+                xpc_dictionary_set_string(message, "request_json", requestJSON)
+                xpc_connection_send_message_with_reply(connection, message, replyQueue) { reply in
+                    guard xpc_get_type(reply) != XPC_TYPE_ERROR else {
+                        let desc = xpc_dictionary_get_string(reply, XPC_ERROR_KEY_DESCRIPTION)
+                            .map(String.init(cString:))
+                        request.fail(.connectionFailed(detail: desc))
+                        return
+                    }
+                    guard xpc_get_type(reply) == XPC_TYPE_DICTIONARY,
+                          let responsePointer = xpc_dictionary_get_string(reply, "response_json") else {
+                        request.fail(.invalidReply)
+                        return
+                    }
+                    request.succeed(String(cString: responsePointer))
                 }
-                guard xpc_get_type(reply) == XPC_TYPE_DICTIONARY,
-                      let responsePointer = xpc_dictionary_get_string(reply, "response_json") else {
-                    request.fail(.invalidReply)
-                    return
+                replyQueue.asyncAfter(deadline: .now() + timeout) {
+                    request.fail(.requestTimedOut(timeout: timeout))
                 }
-                request.succeed(String(cString: responsePointer))
             }
-            replyQueue.asyncAfter(deadline: .now() + timeout) {
-                request.fail(.requestTimedOut(timeout: timeout))
-            }
+        } onCancel: {
+            request.cancel()
         }
+        try Task.checkCancellation()
+        return response
     }
 }
 
@@ -428,19 +436,36 @@ private extension Duration {
     }
 }
 
-private final class DaemonXPCRequestState: @unchecked Sendable {
+final class DaemonXPCRequestState: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<String, Error>?
     private var connection: xpc_connection_t?
+    private var isCancelled = false
 
-    init(continuation: CheckedContinuation<String, Error>) {
-        self.continuation = continuation
+    @discardableResult
+    func start(_ continuation: CheckedContinuation<String, Error>) -> Bool {
+        let didStart = lock.withLock {
+            guard !isCancelled, self.continuation == nil else { return false }
+            self.continuation = continuation
+            return true
+        }
+        if !didStart {
+            continuation.resume(throwing: CancellationError())
+        }
+        return didStart
     }
 
-    func attach(_ connection: xpc_connection_t) {
-        lock.withLock {
+    @discardableResult
+    func attach(_ connection: xpc_connection_t) -> Bool {
+        let didAttach = lock.withLock {
+            guard !isCancelled, continuation != nil else { return false }
             self.connection = connection
+            return true
         }
+        if !didAttach {
+            xpc_connection_cancel(connection)
+        }
+        return didAttach
     }
 
     func succeed(_ response: String) {
@@ -451,8 +476,15 @@ private final class DaemonXPCRequestState: @unchecked Sendable {
         finish(.failure(error))
     }
 
-    private func finish(_ result: Result<String, DaemonXPCError>) {
+    func cancel() {
+        finish(.failure(CancellationError()), markCancelled: true)
+    }
+
+    private func finish(_ result: Result<String, Error>, markCancelled: Bool = false) {
         let completion: (CheckedContinuation<String, Error>, xpc_connection_t?)? = lock.withLock {
+            if markCancelled {
+                isCancelled = true
+            }
             guard let continuation else { return nil }
             self.continuation = nil
             let connection = self.connection

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -844,6 +844,134 @@ final class DaemonContractTests: XCTestCase {
         XCTAssertFalse(warning.contains("release signing identity"))
     }
 
+    func testWorkspaceRefreshLoopHasOneOwnerAndBoundedCadence() throws {
+        XCTAssertEqual(WorkspaceRefreshCadence.syncStatus, .seconds(2))
+        XCTAssertEqual(WorkspaceRefreshCadence.synchronizedData, .seconds(30))
+
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let viewSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+        XCTAssertEqual(
+            viewSource.components(separatedBy: "await store.runRefreshLoop()").count - 1,
+            1
+        )
+        XCTAssertFalse(viewSource.contains("await store.refreshSyncStatus()"))
+
+        let storeSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Domain/WorkspaceStore.swift"),
+            encoding: .utf8
+        )
+        let statusStart = try XCTUnwrap(
+            storeSource.range(of: "    func refreshSyncStatus()")
+        )
+        let statusEnd = try XCTUnwrap(
+            storeSource[statusStart.lowerBound...].range(
+                of: "\n    func refreshSynchronizedWorkspaceData()"
+            )
+        )
+        let statusRefresh = storeSource[statusStart.lowerBound..<statusEnd.lowerBound]
+        XCTAssertEqual(
+            storeSource.components(separatedBy: "daemon.syncStatus(projectId: projectId)").count - 1,
+            1
+        )
+        XCTAssertTrue(statusRefresh.contains("!isRefreshingSyncStatus"))
+        XCTAssertTrue(statusRefresh.contains("daemon.syncStatus(projectId: projectId)"))
+        XCTAssertTrue(statusRefresh.contains("catch is CancellationError"))
+        XCTAssertFalse(statusRefresh.contains("refreshOrgResourcesIfNeeded()"))
+        XCTAssertFalse(statusRefresh.contains("refreshDraftInventory("))
+        XCTAssertFalse(statusRefresh.contains("refreshStaleResourcesIfNeeded("))
+
+        let dataStart = statusEnd.lowerBound
+        let dataEnd = try XCTUnwrap(
+            storeSource[dataStart...].range(
+                of: "\n    nonisolated static func stableOrgAuthorityCommitId("
+            )
+        )
+        let dataRefresh = storeSource[dataStart..<dataEnd.lowerBound]
+        XCTAssertTrue(dataRefresh.contains("!isRefreshingSynchronizedWorkspaceData"))
+        XCTAssertTrue(dataRefresh.contains("refreshOrgResourcesIfNeeded()"))
+        XCTAssertTrue(dataRefresh.contains("refreshDraftInventory("))
+        XCTAssertTrue(dataRefresh.contains("refreshStaleResourcesIfNeeded("))
+    }
+
+    func testWorkspaceNavigationDefersObservableWritesFromViewUpdates() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let selectionStart = try XCTUnwrap(
+            source.range(of: "    private var selection: Binding<GlobalSidebarDestination?>")
+        )
+        let selectionEnd = try XCTUnwrap(
+            source[selectionStart.lowerBound...].range(of: "\n    }\n\n}")
+        )
+        let selection = source[selectionStart.lowerBound..<selectionEnd.upperBound]
+
+        XCTAssertTrue(source.contains("private func deferSidebarExpansionUpdate"))
+        XCTAssertTrue(selection.contains("DispatchQueue.main.async"))
+        XCTAssertTrue(selection.contains("store.selectedSection = section"))
+        XCTAssertFalse(source.contains(
+            ".onAppear {\n            store.showsProjectSettings = false"
+        ))
+    }
+
+    func testXPCRequestStateCompletesCancellation() async {
+        let state = DaemonXPCRequestState()
+        let task = Task<String, Error> {
+            try await withCheckedThrowingContinuation { continuation in
+                state.start(continuation)
+            }
+        }
+
+        await Task.yield()
+        state.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testXPCTransportForwardsTaskCancellation() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Infrastructure/DaemonXPCClient.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("withTaskCancellationHandler"))
+        XCTAssertTrue(source.contains("request.cancel()"))
+        XCTAssertTrue(source.contains("try Task.checkCancellation()"))
+    }
+
+    func testAvatarLoadingIsCachedAndCoalesced() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Components/AvatarView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertFalse(source.contains("AsyncImage"))
+        XCTAssertTrue(source.contains("NSCache<NSURL, NSImage>"))
+        XCTAssertTrue(source.contains("if let existing = loads[url]"))
+        XCTAssertTrue(source.contains(".task(id: avatarURL)"))
+        XCTAssertTrue(source.contains("guard !Task.isCancelled else { return }"))
+    }
+
     func testRetrySyncHasAnIndependentPostReadyTask() throws {
         let macOSRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -856,7 +984,7 @@ final class DaemonContractTests: XCTestCase {
             source.range(of: "postReadyRetrySyncTask = Task")
         )
         let statusTask = try XCTUnwrap(
-            source.range(of: "postReadySyncTask = Task")
+            source.range(of: "postReadyMCPTask = Task")
         )
         let statusEnd = try XCTUnwrap(
             source[statusTask.lowerBound...].range(


### PR DESCRIPTION
## Context and summary

The macOS workspace created one one-second sync-status task inside each
Memory, Reviews, and Kanban branch. Section changes could leave overlapping
work, rebuild avatar requests, and publish navigation state during SwiftUI
view updates. This produced excessive XPC traffic, runtime warnings, and
client-side request cancellations.

This change gives each workspace one status polling owner, moves synchronized
organization, draft, and stale-resource refreshes to a guarded 30-second
cadence, propagates task cancellation through XPC, defers navigation-driven
observable writes, and caches and coalesces avatar requests.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before the change, the installed app recorded about 4,000 XPC activation and
cancellation events in five minutes, 26 SwiftUI view-update publication
warnings in ten minutes, and 25 grouped NSURLError -999 cancellations.

The candidate app completed 60 Memory, Reviews, and Kanban switching cycles
over 10 minutes 42 seconds with zero publication warnings and zero -999
cancellations. All 746 XPC activations had matching invalidations, with no
duplicate connection activations or pending connections. In an idle Memory
workspace, 73 seconds produced 36 paired XPC calls, a maximum concurrency of
one, and two low-frequency synchronized-data refresh batches.

Server unavailability still reports the failing Server URL. Daemon
unavailability reports that sync status could not be read from the background
service. Client task cancellation completes as CancellationError and does not
surface as either connectivity failure.

## Verification

- [x] `sh apps/macos/Scripts/test.sh`
- [x] `just test-macos`
- [x] `just test-macos-package`
- [x] `cargo clippy -p daemon -- -D warnings`
- [x] `cargo test -p daemon --test agent_runtime_xpc_e2e -- --nocapture`
- [x] `cargo fmt --all --check`
- [x] Repeated Memory, Reviews, and Kanban switching for 10 minutes 42 seconds.
- [x] Verified idle polling frequency and XPC connection pairing.
- [x] Injected isolated Server and daemon failures and verified distinct UI details.
- [x] `python3 dev/validate-pr-template.py --self-test`

## Compatibility and migration

No API, XPC contract, configuration, storage, or schema migration is required.
The existing sync and stale-cache behavior remains compatible. Cancellation
now terminates the in-flight one-shot XPC connection without presenting a
connectivity error.

## Risk, security, and privacy

The primary risk is cancellation ordering between Swift tasks and one-shot
XPC connections. A lock-protected request state prevents double completion,
handles cancellation before and after connection attachment, and has focused
contract tests. Avatar caching is bounded to 128 decoded images. No
permissions, credentials, private Memory payloads, or trust boundaries change.

## Rollout and rollback

- Rollout: Merge through the normal pull request flow and ship with the next macOS build.
- Observability: Monitor SwiftUI publication faults, NSURLError -999 groups, and XPC activation and invalidation pairing.
- Rollback: Revert the commit to restore the previous workspace polling and image-loading behavior.

## Reviewer focus

Review the single workspace refresh-loop ownership and its 2-second and
30-second cadence split, cancellation ordering in DaemonXPCRequestState,
deferred navigation publications, and the bounded avatar cache.
