### PR TITLE
macos: enable project review before draft sync

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -5159,11 +5159,11 @@ final class WorkspaceStore: ObservableObject {
         _ drafts: [LocalDraft],
         projectId: String?
     ) -> [LocalDraft] {
-        let openDrafts = preferredMemoryTreeDrafts(
+        preferredMemoryTreeDrafts(
             memoryTreeDrafts(drafts, activeProjectId: projectId)
-        ).filter { $0.status == .open }
-        guard openDrafts.allSatisfy(canRequestReview) else { return [] }
-        return openDrafts
+        ).filter {
+            $0.status == .open && canRequestReview($0)
+        }
     }
 
     private nonisolated static func isOrganizationDraft(_ draft: ServerDraft) -> Bool {

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -465,7 +465,7 @@ struct WorkspaceView: View {
                                     pendingProjectReviewDrafts = activeProjectReviewDrafts
                                     showsProjectReviewRequest = true
                                 }
-                                .disabled(!canRequestProjectReview)
+                                .disabled(activeProjectReviewDrafts.isEmpty)
                             } label: {
                                 Image(systemName: "ellipsis")
                             }
@@ -1303,16 +1303,6 @@ struct WorkspaceView: View {
             store.drafts,
             projectId: store.activeProjectId
         )
-    }
-
-    private var canRequestProjectReview: Bool {
-        !activeProjectReviewDrafts.isEmpty
-            && activeProjectReviewDrafts.allSatisfy {
-                $0.syncStatus == .synced
-                    && $0.serverId != nil
-                    && $0.freshness == .current
-                    && !store.isSynchronizingDocument($0.targetId ?? $0.id)
-            }
     }
 
     private var documentMode: Binding<WorkbenchTabMode> {

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -413,6 +413,7 @@ final class WorkspaceNavigationTests: XCTestCase {
             "if showsMemoryContentToolbar {\n                            Menu {"
         ))
         XCTAssertTrue(source.contains("Request Review for All Project Changes…"))
+        XCTAssertTrue(source.contains(".disabled(activeProjectReviewDrafts.isEmpty)"))
     }
 
     func testWorkspaceSearchCommandRequestsToolbarFocus() {
@@ -1753,7 +1754,7 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertTrue(WorkspaceStore.canRequestReview(orgCreate))
     }
 
-    func testProjectReviewUsesEveryCurrentOpenOrganizationDraftOrNone() {
+    func testProjectReviewUsesEveryOpenOrganizationDraft() {
         let older = localDraft(
             id: "older",
             targetId: "shared",
@@ -1788,10 +1789,13 @@ final class WorkspaceNavigationTests: XCTestCase {
         )
 
         let legacy = localDraft(id: "legacy", targetId: "legacy-memory")
-        XCTAssertTrue(WorkspaceStore.reviewableProjectDrafts(
-            [newer, created, legacy],
-            projectId: "project"
-        ).isEmpty)
+        XCTAssertEqual(
+            WorkspaceStore.reviewableProjectDrafts(
+                [newer, created, legacy],
+                projectId: "project"
+            ).map(\.id),
+            ["newer", "created"]
+        )
     }
 
     func testMemoryTabsAreScopedToTheProjectViewContext() {


### PR DESCRIPTION
## Context and summary

Follow-up to #232. “Request Review for All Project Changes…” remained
disabled whenever an eligible Organization Draft was uploading, missing its
Server ID, or behind the shared version.

These checks duplicated stricter preconditions than the existing batch Review
path, which already waits for Draft uploads and reports synchronization or
reconciliation failures. Enable the action whenever the Project has at least
one open publishable Organization Draft, and exclude legacy Project-scoped
Drafts individually instead of rejecting the entire batch.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before: the Project Review action remained disabled during normal Draft
synchronization and when any legacy Project-scoped Draft existed.

After: the action is enabled whenever open publishable Organization Drafts
exist. The existing batch Review path owns synchronization and presents any
failure to the user.

## Verification

- [x] Focused `WorkspaceNavigationTests`
- [x] `just test-macos`
- [ ] Manual UI verification remains for reviewer acceptance

## Compatibility and migration

None.

## Risk, security, and privacy

Low. No API, storage, permission, or data contract changes. Existing
synchronization and Review validation remain authoritative.

## Rollout and rollback

- Rollout: Normal macOS application release.
- Observability: Existing Draft synchronization status and Review error alerts.
- Rollback: Revert this commit.

## Reviewer focus

Verify the Project Review candidate filtering and the reuse of
`WorkspaceStore.requestReview(for:)` as the synchronization boundary.
