### PR TITLE
review: reconcile every draft atomically

### DIFF
--- a/apps/macos/Sources/Domain/WorkspaceStore.swift
+++ b/apps/macos/Sources/Domain/WorkspaceStore.swift
@@ -160,7 +160,6 @@ enum ReviewRequestError: LocalizedError, Sendable {
     case draftNotSynchronized
     case legacyProjectDraftCannotBePublished
     case reconciliationRequired
-    case reconcileDirectoryDrafts
     case mixedProjects
     case reviewChanged
 
@@ -172,8 +171,6 @@ enum ReviewRequestError: LocalizedError, Sendable {
             "Legacy Project-scoped drafts are read-only and cannot be published."
         case .reconciliationRequired:
             "Merge the latest shared version before requesting a review."
-        case .reconcileDirectoryDrafts:
-            "Sync every changed file in this directory before requesting one review."
         case .mixedProjects:
             "All drafts in a review must belong to the same Project."
         case .reviewChanged:
@@ -4829,12 +4826,12 @@ final class WorkspaceStore: ObservableObject {
             body: CreateReviewRequest(
                 drafts: [ReviewDraftRequest(
                     draftId: serverId,
-                    expectedDraftVersion: candidate?.draftVersion ?? draft.serverVersion
+                    expectedDraftVersion: candidate?.draftVersion ?? draft.serverVersion,
+                    candidateId: candidate?.candidateId,
+                    resolvedState: resolvedState
                 )],
                 title: title,
-                description: description,
-                candidateId: candidate?.candidateId,
-                resolvedState: resolvedState
+                description: description
             )
         )
         let record = WorkspaceLoader.mapReview(detail)
@@ -4846,7 +4843,8 @@ final class WorkspaceStore: ObservableObject {
     func requestReview(
         for drafts: [LocalDraft],
         title: String,
-        description: String
+        description: String,
+        reconciliations: [ReviewDraftReconciliation] = []
     ) async throws {
         let selectedDrafts = drafts.sorted {
             $0.document.path.localizedStandardCompare($1.document.path) == .orderedAscending
@@ -4872,27 +4870,44 @@ final class WorkspaceStore: ObservableObject {
             )
         }
         guard let primary = drafts.first else { return }
-        guard drafts.allSatisfy({ $0.freshness == .current }) else {
-            throw ReviewRequestError.reconcileDirectoryDrafts
-        }
         guard drafts.allSatisfy({ $0.serverId != nil }) else {
             throw ReviewRequestError.draftNotSynchronized
+        }
+        let reconciliationByDraftId = Dictionary(
+            reconciliations.map { ($0.candidate.draftId, $0) },
+            uniquingKeysWith: { _, latest in latest }
+        )
+        guard drafts.allSatisfy({ draft in
+            draft.freshness == .current
+                || draft.serverId.flatMap { reconciliationByDraftId[$0] } != nil
+        }) else {
+            throw ReviewRequestError.reconciliationRequired
+        }
+        let selectedDraftIds = Set(drafts.compactMap(\.serverId))
+        guard reconciliationByDraftId.keys.allSatisfy(selectedDraftIds.contains) else {
+            throw ReviewRequestError.reconciliationRequired
         }
         let detail: ReviewDetail = try await server.send(
             method: "POST",
             path: "/api/v1/reviews",
-            headers: ["If-Match": Self.refETag(primary.currentCommitId)],
+            headers: [
+                "If-Match": Self.refETag(
+                    reconciliations.first?.candidate.currentCommitId ?? primary.currentCommitId
+                )
+            ],
             body: CreateReviewRequest(
-                drafts: drafts.map {
-                    ReviewDraftRequest(
-                        draftId: $0.serverId!,
-                        expectedDraftVersion: $0.serverVersion
+                drafts: drafts.map { draft in
+                    let reconciliation = reconciliationByDraftId[draft.serverId!]
+                    return ReviewDraftRequest(
+                        draftId: draft.serverId!,
+                        expectedDraftVersion: reconciliation?.candidate.draftVersion
+                            ?? draft.serverVersion,
+                        candidateId: reconciliation?.candidate.candidateId,
+                        resolvedState: reconciliation?.resolvedState
                     )
                 },
                 title: title,
-                description: description,
-                candidateId: nil,
-                resolvedState: nil
+                description: description
             )
         )
         let record = WorkspaceLoader.mapReview(detail)
@@ -4928,18 +4943,20 @@ final class WorkspaceStore: ObservableObject {
                 expectedReviewVersion: review.version,
                 drafts: (detail.drafts ?? [
                     ReviewDraftDetail(draft: detail.draft, operations: detail.operations)
-                ]).map {
-                    ReviewDraftRequest(
-                        draftId: $0.draft.draftId,
-                        expectedDraftVersion: $0.draft.draftId == detail.draft.draftId
-                            ? candidate?.draftVersion ?? $0.draft.version
-                            : $0.draft.version
+                ]).map { draftDetail in
+                    let reconciliation = candidate.flatMap { candidate in
+                        candidate.draftId == draftDetail.draft.draftId ? candidate : nil
+                    }
+                    return ReviewDraftRequest(
+                        draftId: draftDetail.draft.draftId,
+                        expectedDraftVersion: reconciliation?.draftVersion
+                            ?? draftDetail.draft.version,
+                        candidateId: reconciliation?.candidateId,
+                        resolvedState: reconciliation == nil ? nil : resolvedState
                     )
                 },
                 title: review.title,
-                description: review.description,
-                candidateId: candidate?.candidateId,
-                resolvedState: resolvedState
+                description: review.description
             )
         )
         replaceReview(with: WorkspaceLoader.mapReview(updated))
@@ -4998,6 +5015,28 @@ final class WorkspaceStore: ObservableObject {
             throw CancellationError()
         }
         return candidate
+    }
+
+    func reconciliationCandidates(
+        for drafts: [LocalDraft]
+    ) async throws -> [DraftReconciliationCandidate] {
+        guard !isSwitchingMemoryContext else {
+            throw DocumentSyncError.mutationWhileSynchronizing
+        }
+        let selectedDrafts = drafts.sorted {
+            $0.document.path.localizedStandardCompare($1.document.path) == .orderedAscending
+        }
+        var candidates = [DraftReconciliationCandidate]()
+        for draft in selectedDrafts {
+            let synchronized = try await synchronizedDraftForReconciliation(
+                itemId: draft.targetId ?? draft.id,
+                draft: draft
+            )
+            if synchronized.freshness == .behind {
+                candidates.append(try await requestReconciliationCandidate(for: synchronized))
+            }
+        }
+        return candidates
     }
 
     private func requestReconciliationCandidate(

--- a/apps/macos/Sources/Features/MemoryWorkspaceView.swift
+++ b/apps/macos/Sources/Features/MemoryWorkspaceView.swift
@@ -368,12 +368,15 @@ private struct FileTreeView: View {
         .sheet(item: $pendingDirectoryReview) { request in
             ReviewRequestSheet(
                 initialTitle: request.initialTitle,
-                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
-            ) { title, description, _, _ in
+                loadCandidates: {
+                    try await store.reconciliationCandidates(for: request.drafts)
+                }
+            ) { title, description, reconciliations in
                 try await store.requestReview(
                     for: request.drafts,
                     title: title,
-                    description: description
+                    description: description,
+                    reconciliations: reconciliations
                 )
             }
         }
@@ -1482,14 +1485,15 @@ private struct DocumentSessionView: View {
         .sheet(item: $reviewDraft) { draft in
             ReviewRequestSheet(
                 initialTitle: document.title,
-                loadCandidate: { try await loadReviewCandidate(draft) }
-            ) { title, description, candidate, resolvedState in
+                loadCandidates: { [try await loadReviewCandidate(draft)] }
+            ) { title, description, reconciliations in
+                let reconciliation = reconciliations.first
                 try await submitReview(
                     draft,
                     title: title,
                     description: description,
-                    candidate: candidate,
-                    resolvedState: resolvedState
+                    candidate: reconciliation?.candidate,
+                    resolvedState: reconciliation?.resolvedState
                 )
             }
         }
@@ -2162,51 +2166,57 @@ struct DraftReconciliationView: View {
 struct ReviewRequestSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    let loadCandidate: () async throws -> DraftReconciliationCandidate
-    let onSubmit: (
-        String,
-        String,
-        DraftReconciliationCandidate?,
-        ReconciliationResourceState?
-    ) async throws -> Void
+    let loadCandidates: () async throws -> [DraftReconciliationCandidate]
+    let onSubmit: (String, String, [ReviewDraftReconciliation]) async throws -> Void
 
     @State private var title: String
     @State private var description = ""
     @State private var isSubmitting = false
     @State private var errorMessage: String?
-    @State private var reconciliationCandidate: DraftReconciliationCandidate?
+    @State private var reconciliationCandidates = [DraftReconciliationCandidate]()
+    @State private var resolvedStatesByCandidateId = [String: ReconciliationResourceState]()
+    @State private var conflictIndex = 0
 
     init(
         initialTitle: String,
-        loadCandidate: @escaping () async throws -> DraftReconciliationCandidate,
-        onSubmit: @escaping (
-            String,
-            String,
-            DraftReconciliationCandidate?,
-            ReconciliationResourceState?
-        ) async throws -> Void
+        loadCandidates: @escaping () async throws -> [DraftReconciliationCandidate],
+        onSubmit: @escaping (String, String, [ReviewDraftReconciliation]) async throws -> Void
     ) {
         _title = State(initialValue: initialTitle)
-        self.loadCandidate = loadCandidate
+        self.loadCandidates = loadCandidates
         self.onSubmit = onSubmit
     }
 
     var body: some View {
         Group {
-            if let candidate = reconciliationCandidate {
+            if reconciliationCandidates.count == 1,
+               let candidate = reconciliationCandidates.first {
                 DraftReconciliationView(
                     candidate: candidate,
-                    onCancel: { reconciliationCandidate = nil },
+                    onCancel: resetReconciliation,
                     onApplied: { dismiss() }
                 ) { resolvedState in
                     try await onSubmit(
                         normalizedTitle,
-                        description.trimmingCharacters(in: .whitespacesAndNewlines),
-                        candidate,
-                        resolvedState
+                        normalizedDescription,
+                        [.init(candidate: candidate, resolvedState: resolvedState)]
                     )
                 }
                 .frame(minWidth: 780, idealWidth: 980, minHeight: 560, idealHeight: 680)
+            } else if let candidate = activeConflictCandidate {
+                DraftReconciliationView(
+                    candidate: candidate,
+                    onCancel: resetReconciliation,
+                    onApplied: { conflictIndex += 1 }
+                ) { resolvedState in
+                    if let resolvedState {
+                        resolvedStatesByCandidateId[candidate.candidateId] = resolvedState
+                    }
+                }
+                .id(candidate.candidateId)
+                .frame(minWidth: 780, idealWidth: 980, minHeight: 560, idealHeight: 680)
+            } else if !reconciliationCandidates.isEmpty {
+                batchConfirmation
             } else {
                 requestForm
             }
@@ -2261,27 +2271,126 @@ struct ReviewRequestSheet: View {
         .frame(width: 480, height: 270)
     }
 
+    private var batchConfirmation: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Update Drafts and Request Review")
+                    .font(.title2.weight(.semibold))
+                Text("The latest shared changes will be applied to these drafts in one transaction.")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+
+            Divider()
+
+            List(reconciliationCandidates) { candidate in
+                HStack(spacing: 10) {
+                    Image(systemName: candidate.status == .conflicts
+                        ? "checkmark.circle.fill"
+                        : "arrow.trianglehead.merge")
+                        .foregroundStyle(candidate.status == .conflicts ? .green : .secondary)
+                    Text(candidatePath(candidate))
+                        .font(.body.monospaced())
+                    Spacer()
+                    Text(candidate.status == .conflicts ? "Resolved" : "Clean")
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Button("Back") { resetReconciliation() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button {
+                    submitBatch()
+                } label: {
+                    if isSubmitting {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Text("Update and Request Review")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(isSubmitting || reconciliationCandidates.contains { !$0.valid })
+            }
+            .padding(12)
+        }
+        .frame(width: 620, height: 460)
+    }
+
     private var normalizedTitle: String {
         title.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var normalizedDescription: String {
+        description.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var activeConflictCandidate: DraftReconciliationCandidate? {
+        let conflicts = reconciliationCandidates.filter { $0.status == .conflicts }
+        guard conflictIndex < conflicts.count else { return nil }
+        return conflicts[conflictIndex]
+    }
+
+    private func candidatePath(_ candidate: DraftReconciliationCandidate) -> String {
+        candidate.proposedState?.resource.path
+            ?? candidate.draftState.resource.path
+            ?? candidate.currentState.resource.path
+            ?? candidate.draftId
+    }
+
+    private func resetReconciliation() {
+        reconciliationCandidates = []
+        resolvedStatesByCandidateId = [:]
+        conflictIndex = 0
+    }
+
     private func submit() {
-        let submittedTitle = normalizedTitle
-        let submittedDescription = description.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !submittedTitle.isEmpty else { return }
+        guard !normalizedTitle.isEmpty else { return }
         isSubmitting = true
         Task {
             do {
-                try await onSubmit(submittedTitle, submittedDescription, nil, nil)
+                try await onSubmit(normalizedTitle, normalizedDescription, [])
                 dismiss()
             } catch ReviewRequestError.reconciliationRequired {
                 do {
-                    reconciliationCandidate = try await loadCandidate()
+                    let candidates = try await loadCandidates()
+                    if candidates.isEmpty {
+                        try await onSubmit(normalizedTitle, normalizedDescription, [])
+                        dismiss()
+                    } else {
+                        reconciliationCandidates = candidates
+                        resolvedStatesByCandidateId = [:]
+                        conflictIndex = 0
+                    }
                     isSubmitting = false
                 } catch {
                     errorMessage = error.localizedDescription
                     isSubmitting = false
                 }
+            } catch {
+                errorMessage = error.localizedDescription
+                isSubmitting = false
+            }
+        }
+    }
+
+    private func submitBatch() {
+        isSubmitting = true
+        let reconciliations = reconciliationCandidates.map { candidate in
+            ReviewDraftReconciliation(
+                candidate: candidate,
+                resolvedState: resolvedStatesByCandidateId[candidate.candidateId]
+            )
+        }
+        Task {
+            do {
+                try await onSubmit(normalizedTitle, normalizedDescription, reconciliations)
+                dismiss()
             } catch {
                 errorMessage = error.localizedDescription
                 isSubmitting = false

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -530,12 +530,15 @@ struct WorkspaceView: View {
         .sheet(isPresented: $showsProjectReviewRequest) {
             ReviewRequestSheet(
                 initialTitle: "Update \(store.activeProject?.name ?? "project") memory",
-                loadCandidate: { throw ReviewRequestError.reconcileDirectoryDrafts }
-            ) { title, description, _, _ in
+                loadCandidates: {
+                    try await store.reconciliationCandidates(for: pendingProjectReviewDrafts)
+                }
+            ) { title, description, reconciliations in
                 try await store.requestReview(
                     for: pendingProjectReviewDrafts,
                     title: title,
-                    description: description
+                    description: description,
+                    reconciliations: reconciliations
                 )
             }
         }

--- a/apps/macos/Sources/Infrastructure/ServerModels.swift
+++ b/apps/macos/Sources/Infrastructure/ServerModels.swift
@@ -560,8 +560,6 @@ struct CreateReviewRequest: Codable, Sendable {
     let drafts: [ReviewDraftRequest]
     let title: String
     let description: String
-    let candidateId: String?
-    let resolvedState: ReconciliationResourceState?
 }
 
 struct CreateReviewSubmissionRequest: Codable, Sendable {
@@ -569,13 +567,18 @@ struct CreateReviewSubmissionRequest: Codable, Sendable {
     let drafts: [ReviewDraftRequest]
     let title: String
     let description: String
-    let candidateId: String?
-    let resolvedState: ReconciliationResourceState?
 }
 
 struct ReviewDraftRequest: Codable, Sendable {
     let draftId: String
     let expectedDraftVersion: Int
+    let candidateId: String?
+    let resolvedState: ReconciliationResourceState?
+}
+
+struct ReviewDraftReconciliation: Sendable {
+    let candidate: DraftReconciliationCandidate
+    let resolvedState: ReconciliationResourceState?
 }
 
 struct CreateReviewCommentRequest: Codable, Sendable {

--- a/apps/macos/Tests/DaemonContractTests.swift
+++ b/apps/macos/Tests/DaemonContractTests.swift
@@ -2015,20 +2015,31 @@ final class DaemonContractTests: XCTestCase {
     func testReviewRequestUsesRequiredDraftArray() throws {
         let request = CreateReviewRequest(
             drafts: [
-                .init(draftId: "draft-1", expectedDraftVersion: 1),
-                .init(draftId: "draft-2", expectedDraftVersion: 2),
+                .init(
+                    draftId: "draft-1",
+                    expectedDraftVersion: 1,
+                    candidateId: nil,
+                    resolvedState: nil
+                ),
+                .init(
+                    draftId: "draft-2",
+                    expectedDraftVersion: 2,
+                    candidateId: "candidate-2",
+                    resolvedState: nil
+                ),
             ],
             title: "Directory update",
-            description: "",
-            candidateId: nil,
-            resolvedState: nil
+            description: ""
         )
         let object = try XCTUnwrap(
             JSONSerialization.jsonObject(with: JSONCoding.encoder().encode(request))
                 as? [String: Any]
         )
-        XCTAssertEqual((object["drafts"] as? [[String: Any]])?.count, 2)
+        let drafts = try XCTUnwrap(object["drafts"] as? [[String: Any]])
+        XCTAssertEqual(drafts.count, 2)
         XCTAssertNil(object["draft_id"])
+        XCTAssertNil(object["candidate_id"])
+        XCTAssertEqual(drafts[1]["candidate_id"] as? String, "candidate-2")
     }
 
     func testReconciliationCandidateAndRebaseWireContract() throws {
@@ -2113,20 +2124,21 @@ final class DaemonContractTests: XCTestCase {
             expectedReviewVersion: 4,
             drafts: [.init(
                 draftId: candidate.draftId,
-                expectedDraftVersion: candidate.draftVersion
+                expectedDraftVersion: candidate.draftVersion,
+                candidateId: candidate.candidateId,
+                resolvedState: nil
             )],
             title: "Guide",
-            description: "",
-            candidateId: candidate.candidateId,
-            resolvedState: nil
+            description: ""
         )
         let submissionData = try JSONCoding.encoder().encode(submission)
         let submissionObject = try XCTUnwrap(
             JSONSerialization.jsonObject(with: submissionData) as? [String: Any]
         )
-        XCTAssertEqual(submissionObject["candidate_id"] as? String, "candidate-1")
+        XCTAssertNil(submissionObject["candidate_id"])
         XCTAssertEqual(submissionObject["expected_review_version"] as? Int, 4)
         let submissionDrafts = try XCTUnwrap(submissionObject["drafts"] as? [[String: Any]])
+        XCTAssertEqual(submissionDrafts.first?["candidate_id"] as? String, "candidate-1")
         XCTAssertEqual(submissionDrafts.first?["expected_draft_version"] as? Int, 7)
     }
 

--- a/apps/macos/Tests/WorkspaceNavigationTests.swift
+++ b/apps/macos/Tests/WorkspaceNavigationTests.swift
@@ -416,6 +416,27 @@ final class WorkspaceNavigationTests: XCTestCase {
         XCTAssertTrue(source.contains(".disabled(activeProjectReviewDrafts.isEmpty)"))
     }
 
+    func testProjectReviewCollectsEveryCandidateBeforeOneSubmission() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let workspaceSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+        let reviewSource = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/MemoryWorkspaceView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(workspaceSource.contains(
+            "store.reconciliationCandidates(for: pendingProjectReviewDrafts)"
+        ))
+        XCTAssertTrue(reviewSource.contains("Text(\"Update and Request Review\")"))
+        XCTAssertTrue(reviewSource.contains("resolvedStatesByCandidateId[candidate.candidateId]"))
+        XCTAssertTrue(reviewSource.contains(".id(candidate.candidateId)"))
+    }
+
     func testWorkspaceSearchCommandRequestsToolbarFocus() {
         let store = WorkspaceStore()
         let initialFocusToken = store.workspaceSearchFocusToken

--- a/crates/daemon/tests/server_integration.rs
+++ b/crates/daemon/tests/server_integration.rs
@@ -120,11 +120,11 @@ async fn approve_and_merge(
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft_id.to_owned(),
                     expected_draft_version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -566,11 +566,11 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft.draft.draft_id.clone(),
                     expected_draft_version: draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -649,11 +649,11 @@ async fn local_draft_refreshes_auth_and_syncs_to_the_real_server() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: rejected.draft.draft_id.clone(),
                     expected_draft_version: edited.draft.server_version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: Some("Revised daemon context".to_owned()),
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -1386,11 +1386,11 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: server_behind.draft.draft_id.clone(),
                     expected_draft_version: server_behind.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -1494,11 +1494,11 @@ async fn offline_behind_draft_stays_editable_until_explicit_reconciliation() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: rebased.draft.draft.draft_id.clone(),
                     expected_draft_version: rebased.draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -2640,11 +2640,11 @@ async fn merged_commit_materializes_on_two_daemons_and_survives_restart() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft.draft.draft_id,
                     expected_draft_version: draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await

--- a/crates/server/openapi/clumsies.public.v1.yaml
+++ b/crates/server/openapi/clumsies.public.v1.yaml
@@ -919,7 +919,7 @@ paths:
               $ref: "#/components/schemas/CreateReviewSubmissionRequest"
       responses:
         "200":
-          description: Reopened review and resubmitted draft, atomically rebased when a confirmed candidate was supplied.
+          description: Reopened review and resubmitted draft, atomically rebased when confirmed per-Draft candidates were supplied.
           content:
             application/json:
               schema:
@@ -1921,13 +1921,6 @@ components:
           type: string
         description:
           type: string
-        candidate_id:
-          type: string
-        resolved_state:
-          description: Required complete user-resolved result for a conflicts candidate; must be omitted for a clean candidate.
-          oneOf:
-            - $ref: "#/components/schemas/ReconciliationResourceState"
-            - type: "null"
     CreateReviewSubmissionRequest:
       type: object
       required: [expected_review_version, drafts]
@@ -1943,14 +1936,6 @@ components:
           type: string
         description:
           type: string
-        candidate_id:
-          type: string
-          description: Confirmed reconciliation candidate to apply atomically before resubmission when the Draft is behind.
-        resolved_state:
-          description: Required complete user-resolved result for a conflicts candidate; must be omitted for a clean candidate.
-          oneOf:
-            - $ref: "#/components/schemas/ReconciliationResourceState"
-            - type: "null"
     ReviewDraftRequest:
       type: object
       required: [draft_id, expected_draft_version]
@@ -1959,6 +1944,14 @@ components:
           type: string
         expected_draft_version:
           type: integer
+        candidate_id:
+          type: string
+          description: Confirmed reconciliation candidate to apply atomically for this Draft when it is behind.
+        resolved_state:
+          description: Required complete user-resolved result for this Draft's conflicts candidate; must be omitted for a clean candidate.
+          oneOf:
+            - $ref: "#/components/schemas/ReconciliationResourceState"
+            - type: "null"
     ReviewDraftDetail:
       type: object
       required: [draft, operations]

--- a/crates/server/src/changes/api.rs
+++ b/crates/server/src/changes/api.rs
@@ -284,6 +284,8 @@ pub struct DraftOperationBatchResponse {
 pub struct ReviewDraftRequest {
     pub draft_id: String,
     pub expected_draft_version: i64,
+    pub candidate_id: Option<String>,
+    pub resolved_state: Option<ReconciliationResourceState>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -291,8 +293,6 @@ pub struct CreateReviewRequest {
     pub drafts: Vec<ReviewDraftRequest>,
     pub title: Option<String>,
     pub description: Option<String>,
-    pub candidate_id: Option<String>,
-    pub resolved_state: Option<ReconciliationResourceState>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -301,8 +301,6 @@ pub struct CreateReviewSubmissionRequest {
     pub drafts: Vec<ReviewDraftRequest>,
     pub title: Option<String>,
     pub description: Option<String>,
-    pub candidate_id: Option<String>,
-    pub resolved_state: Option<ReconciliationResourceState>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/server/src/changes/postgres.rs
+++ b/crates/server/src/changes/postgres.rs
@@ -3055,35 +3055,103 @@ pub(super) async fn create_review_decision(
     Ok(detail)
 }
 
+async fn missing_review_reconciliation_candidate(
+    tx: &mut Transaction<'_, Postgres>,
+    current_ref: &Option<String>,
+    requests: &[ReviewDraftRequest],
+) -> Result<Option<ServerError>, ServerError> {
+    for request in requests {
+        if request.candidate_id.is_some() {
+            continue;
+        }
+        let row = sqlx::query("SELECT base_commit_id FROM drafts WHERE draft_id = $1 FOR UPDATE")
+            .bind(&request.draft_id)
+            .fetch_optional(&mut **tx)
+            .await?
+            .ok_or_else(|| ServerError::not_found("draft", &request.draft_id))?;
+        if row.try_get::<Option<String>, _>("base_commit_id")? == *current_ref {
+            continue;
+        }
+        let candidate = create_reconciliation_candidate_in_tx(
+            tx,
+            &request.draft_id,
+            request.expected_draft_version,
+        )
+        .await?;
+        return Ok(Some(ServerError::ReconciliationRequired {
+            draft_id: request.draft_id.clone(),
+            candidate_id: candidate.candidate_id,
+            current_commit_id: candidate.current_commit_id,
+        }));
+    }
+    Ok(None)
+}
+
+async fn reconcile_review_draft(
+    tx: &mut Transaction<'_, Postgres>,
+    author_user_id: &str,
+    expected_ref: Option<&str>,
+    current_ref: &Option<String>,
+    request: &ReviewDraftRequest,
+    base_commit_id: Option<String>,
+) -> Result<(), ServerError> {
+    if base_commit_id.as_deref() == current_ref.as_deref() {
+        if request.candidate_id.is_some() || request.resolved_state.is_some() {
+            return Err(ServerError::InvalidRequest(
+                "a current draft must not submit reconciliation data".to_owned(),
+            ));
+        }
+        return Ok(());
+    }
+
+    let candidate_id = request.candidate_id.clone().ok_or_else(|| {
+        ServerError::InvalidRequest("a behind draft must submit reconciliation data".to_owned())
+    })?;
+    apply_draft_rebase_in_tx(
+        tx,
+        &request.draft_id,
+        author_user_id,
+        expected_ref,
+        CreateDraftRebaseRequest {
+            candidate_id,
+            expected_draft_version: request.expected_draft_version,
+            resolved_state: request.resolved_state.clone(),
+        },
+    )
+    .await?;
+    Ok(())
+}
+
 pub(super) async fn create_review(
     tx: &mut Transaction<'_, Postgres>,
     author_user_id: &str,
     expected_ref: Option<&str>,
     request: CreateReviewRequest,
-    requested_drafts: Vec<(String, i64)>,
 ) -> Result<CommitOutcome<ReviewDetail>, ServerError> {
-    let (primary_draft_id, primary_expected_version) = requested_drafts
+    let primary_request = request
+        .drafts
         .first()
-        .cloned()
         .expect("service validates non-empty review drafts");
-    let mut row = sqlx::query(
+    let primary_draft_id = &primary_request.draft_id;
+    let primary_expected_version = primary_request.expected_draft_version;
+    let row = sqlx::query(
         "SELECT draft_id, project_id, author_user_id, title, description, status, version,
                     base_commit_id, resource_scope
              FROM drafts
              WHERE draft_id = $1
              FOR UPDATE",
     )
-    .bind(&primary_draft_id)
+    .bind(primary_draft_id)
     .fetch_optional(&mut **tx)
     .await?
-    .ok_or_else(|| ServerError::not_found("draft", &primary_draft_id))?;
+    .ok_or_else(|| ServerError::not_found("draft", primary_draft_id))?;
 
     if row.try_get::<String, _>("author_user_id")? != author_user_id {
         return Err(ServerError::Forbidden(
             "only the draft author can create its review".to_owned(),
         ));
     }
-    let mut status: String = row.try_get("status")?;
+    let status: String = row.try_get("status")?;
     let version: i64 = row.try_get("version")?;
     if status != "open" {
         return Err(ServerError::invalid_transition(
@@ -3109,57 +3177,22 @@ pub(super) async fn create_review(
             current_ref.as_deref(),
         ));
     }
+    if let Some(error) =
+        missing_review_reconciliation_candidate(tx, &current_ref, &request.drafts).await?
+    {
+        return Ok(CommitOutcome::Failure(error));
+    }
     let base_commit_id: Option<String> = row.try_get("base_commit_id")?;
-    if base_commit_id != current_ref {
-        let Some(candidate_id) = request.candidate_id.clone() else {
-            let candidate = create_reconciliation_candidate_in_tx(
-                tx,
-                &primary_draft_id,
-                primary_expected_version,
-            )
-            .await?;
-            return Ok(CommitOutcome::Failure(
-                ServerError::ReconciliationRequired {
-                    draft_id: primary_draft_id,
-                    candidate_id: candidate.candidate_id,
-                    current_commit_id: candidate.current_commit_id,
-                },
-            ));
-        };
-        apply_draft_rebase_in_tx(
-            tx,
-            &primary_draft_id,
-            author_user_id,
-            expected_ref,
-            CreateDraftRebaseRequest {
-                candidate_id,
-                expected_draft_version: primary_expected_version,
-                resolved_state: request.resolved_state.clone(),
-            },
-        )
-        .await?;
-        row = sqlx::query(
-            "SELECT draft_id, project_id, author_user_id, title, description, status, version,
-                        base_commit_id, resource_scope
-                 FROM drafts WHERE draft_id = $1 FOR UPDATE",
-        )
-        .bind(&primary_draft_id)
-        .fetch_one(&mut **tx)
-        .await?;
-        status = row.try_get("status")?;
-    } else if request.candidate_id.is_some() || request.resolved_state.is_some() {
-        return Err(ServerError::InvalidRequest(
-            "a current draft must not submit reconciliation data".to_owned(),
-        ));
-    }
-    if status != "open" {
-        return Err(ServerError::invalid_transition(
-            "draft",
-            &status,
-            "submitted",
-        ));
-    }
-    let operations = load_draft_operations(tx, &primary_draft_id).await?;
+    reconcile_review_draft(
+        tx,
+        author_user_id,
+        expected_ref,
+        &current_ref,
+        primary_request,
+        base_commit_id,
+    )
+    .await?;
+    let operations = load_draft_operations(tx, primary_draft_id).await?;
     if operations.is_empty() {
         return Err(ServerError::InvalidRequest(
             "a review draft must contain at least one operation".to_owned(),
@@ -3177,15 +3210,15 @@ pub(super) async fn create_review(
         .await?;
     }
 
-    for (additional_draft_id, expected_version) in requested_drafts.iter().skip(1) {
+    for requested in request.drafts.iter().skip(1) {
         let additional = sqlx::query(
             "SELECT project_id, author_user_id, status, version, base_commit_id, resource_scope
                  FROM drafts WHERE draft_id = $1 FOR UPDATE",
         )
-        .bind(additional_draft_id)
+        .bind(&requested.draft_id)
         .fetch_optional(&mut **tx)
         .await?
-        .ok_or_else(|| ServerError::not_found("draft", additional_draft_id))?;
+        .ok_or_else(|| ServerError::not_found("draft", &requested.draft_id))?;
         if additional.try_get::<String, _>("author_user_id")? != author_user_id {
             return Err(ServerError::Forbidden(
                 "only the draft author can create its review".to_owned(),
@@ -3200,10 +3233,10 @@ pub(super) async fn create_review(
             ));
         }
         let actual_version: i64 = additional.try_get("version")?;
-        if actual_version != *expected_version {
+        if actual_version != requested.expected_draft_version {
             return Err(ServerError::version_conflict(
                 "draft",
-                *expected_version,
+                requested.expected_draft_version,
                 actual_version,
             ));
         }
@@ -3220,12 +3253,17 @@ pub(super) async fn create_review(
                 "all drafts in a review must use the same scope".to_owned(),
             ));
         }
-        if additional.try_get::<Option<String>, _>("base_commit_id")? != current_ref {
-            return Err(ServerError::InvalidRequest(format!(
-                "draft {additional_draft_id} must be reconciled before requesting this review"
-            )));
-        }
-        let additional_operations = load_draft_operations(tx, additional_draft_id).await?;
+        let base_commit_id: Option<String> = additional.try_get("base_commit_id")?;
+        reconcile_review_draft(
+            tx,
+            author_user_id,
+            expected_ref,
+            &current_ref,
+            requested,
+            base_commit_id,
+        )
+        .await?;
+        let additional_operations = load_draft_operations(tx, &requested.draft_id).await?;
         if additional_operations.is_empty() {
             return Err(ServerError::InvalidRequest(
                 "a review draft must contain at least one operation".to_owned(),
@@ -3256,13 +3294,13 @@ pub(super) async fn create_review(
              WHERE draft_id = $1
              RETURNING project_id, version",
     )
-    .bind(&primary_draft_id)
+    .bind(primary_draft_id)
     .fetch_one(&mut **tx)
     .await?;
-    invalidate_draft_candidates(tx, &primary_draft_id).await?;
+    invalidate_draft_candidates(tx, primary_draft_id).await?;
     insert_draft_event(
         tx,
-        &primary_draft_id,
+        primary_draft_id,
         &draft_event_row.try_get::<String, _>("project_id")?,
         DraftEventType::Submitted,
         draft_event_row.try_get("version")?,
@@ -3270,20 +3308,20 @@ pub(super) async fn create_review(
     )
     .await?;
 
-    for (additional_draft_id, _) in requested_drafts.iter().skip(1) {
+    for requested in request.drafts.iter().skip(1) {
         let additional_event_row = sqlx::query(
             "UPDATE drafts
                  SET status = 'submitted', version = version + 1, updated_at = now()
                  WHERE draft_id = $1
                  RETURNING project_id, version",
         )
-        .bind(additional_draft_id)
+        .bind(&requested.draft_id)
         .fetch_one(&mut **tx)
         .await?;
-        invalidate_draft_candidates(tx, additional_draft_id).await?;
+        invalidate_draft_candidates(tx, &requested.draft_id).await?;
         insert_draft_event(
             tx,
-            additional_draft_id,
+            &requested.draft_id,
             &additional_event_row.try_get::<String, _>("project_id")?,
             DraftEventType::Submitted,
             additional_event_row.try_get("version")?,
@@ -3300,7 +3338,7 @@ pub(super) async fn create_review(
              VALUES ($1, $2, $3, $4, $5, $6, 'open', 1)",
     )
     .bind(&review_id)
-    .bind(&primary_draft_id)
+    .bind(primary_draft_id)
     .bind(&project_id)
     .bind(author_user_id)
     .bind(&title)
@@ -3308,13 +3346,13 @@ pub(super) async fn create_review(
     .execute(&mut **tx)
     .await?;
 
-    for (ordinal, (draft_id, _)) in requested_drafts.iter().enumerate() {
+    for (ordinal, requested) in request.drafts.iter().enumerate() {
         sqlx::query(
             "INSERT INTO review_drafts (review_id, draft_id, ordinal)
                  VALUES ($1, $2, $3)",
         )
         .bind(&review_id)
-        .bind(draft_id)
+        .bind(&requested.draft_id)
         .bind(ordinal as i32)
         .execute(&mut **tx)
         .await?;
@@ -3416,44 +3454,21 @@ pub(super) async fn create_review_submission(
             current_ref.as_deref(),
         ));
     }
-    let base_commit_id: Option<String> = row.try_get("base_commit_id")?;
-    if base_commit_id != current_ref {
-        let Some(candidate_id) = request.candidate_id.clone() else {
-            let candidate =
-                create_reconciliation_candidate_in_tx(tx, &draft_id, primary_expected_version)
-                    .await?;
-            return Ok(CommitOutcome::Failure(
-                ServerError::ReconciliationRequired {
-                    draft_id,
-                    candidate_id: candidate.candidate_id,
-                    current_commit_id: candidate.current_commit_id,
-                },
-            ));
-        };
-        apply_draft_rebase_in_tx(
-            tx,
-            &draft_id,
-            author_user_id,
-            expected_ref,
-            CreateDraftRebaseRequest {
-                candidate_id,
-                expected_draft_version: primary_expected_version,
-                resolved_state: request.resolved_state.clone(),
-            },
-        )
-        .await?;
-    } else if request.candidate_id.is_some() || request.resolved_state.is_some() {
-        return Err(ServerError::InvalidRequest(
-            "a current draft must not submit reconciliation data".to_owned(),
-        ));
-    }
-    if request.drafts.len() > 1
-        && (request.candidate_id.is_some() || request.resolved_state.is_some())
+    if let Some(error) =
+        missing_review_reconciliation_candidate(tx, &current_ref, &request.drafts).await?
     {
-        return Err(ServerError::InvalidRequest(
-            "reconcile every draft before resubmitting a multi-file review".to_owned(),
-        ));
+        return Ok(CommitOutcome::Failure(error));
     }
+    let base_commit_id: Option<String> = row.try_get("base_commit_id")?;
+    reconcile_review_draft(
+        tx,
+        author_user_id,
+        expected_ref,
+        &current_ref,
+        primary_request,
+        base_commit_id,
+    )
+    .await?;
     let operations = load_draft_operations(tx, &draft_id).await?;
     if operations.is_empty() {
         return Err(ServerError::InvalidRequest(
@@ -3521,12 +3536,16 @@ pub(super) async fn create_review_submission(
                 "all drafts in a review must share one project and scope".to_owned(),
             ));
         }
-        if additional.try_get::<Option<String>, _>("base_commit_id")? != current_ref {
-            return Err(ServerError::InvalidRequest(format!(
-                "draft {} must be reconciled before resubmitting this review",
-                requested.draft_id
-            )));
-        }
+        let base_commit_id: Option<String> = additional.try_get("base_commit_id")?;
+        reconcile_review_draft(
+            tx,
+            author_user_id,
+            expected_ref,
+            &current_ref,
+            requested,
+            base_commit_id,
+        )
+        .await?;
         let operations = load_draft_operations(tx, &requested.draft_id).await?;
         if operations.is_empty() {
             return Err(ServerError::InvalidRequest(

--- a/crates/server/src/changes/service.rs
+++ b/crates/server/src/changes/service.rs
@@ -198,30 +198,20 @@ impl ServerRepository {
         expected_ref: Option<&str>,
         request: CreateReviewRequest,
     ) -> Result<ReviewDetail, ServerError> {
-        let requested_drafts = request
+        let draft_ids = request
             .drafts
             .iter()
-            .map(|draft| (draft.draft_id.clone(), draft.expected_draft_version))
+            .map(|draft| draft.draft_id.clone())
             .collect::<Vec<_>>();
-        let Some((primary_draft_id, _)) = requested_drafts.first() else {
+        let Some(primary_draft_id) = draft_ids.first() else {
             return Err(ServerError::InvalidRequest(
                 "a review must contain at least one draft".to_owned(),
             ));
         };
-        let distinct_draft_ids = requested_drafts
-            .iter()
-            .map(|(draft_id, _)| draft_id)
-            .collect::<BTreeSet<_>>();
-        if distinct_draft_ids.len() != requested_drafts.len() {
+        let distinct_draft_ids = draft_ids.iter().collect::<BTreeSet<_>>();
+        if distinct_draft_ids.len() != draft_ids.len() {
             return Err(ServerError::InvalidRequest(
                 "a review must not contain duplicate drafts".to_owned(),
-            ));
-        }
-        if requested_drafts.len() > 1
-            && (request.candidate_id.is_some() || request.resolved_state.is_some())
-        {
-            return Err(ServerError::InvalidRequest(
-                "reconcile every draft before requesting a multi-file review".to_owned(),
             ));
         }
         if let Some((review_id, version)) =
@@ -237,27 +227,15 @@ impl ServerRepository {
                         drafts: request.drafts,
                         title: request.title,
                         description: request.description,
-                        candidate_id: request.candidate_id,
-                        resolved_state: request.resolved_state,
                     },
                 )
                 .await;
         }
 
-        let draft_ids = requested_drafts
-            .iter()
-            .map(|(draft_id, _)| draft_id.clone())
-            .collect::<Vec<_>>();
         let mut tx = self.pool().begin().await?;
         postgres::ensure_drafts_authored_by(&mut tx, author_user_id, &draft_ids).await?;
-        let outcome = postgres::create_review(
-            &mut tx,
-            author_user_id,
-            expected_ref,
-            request,
-            requested_drafts,
-        )
-        .await?;
+        let outcome =
+            postgres::create_review(&mut tx, author_user_id, expected_ref, request).await?;
         tx.commit().await?;
         outcome.into_result()
     }
@@ -361,17 +339,19 @@ impl ServerRepository {
                 "a review must contain at least one draft".to_owned(),
             ));
         };
-        let distinct_draft_ids = request
+        let draft_ids = request
             .drafts
             .iter()
-            .map(|draft| &draft.draft_id)
-            .collect::<BTreeSet<_>>();
-        if distinct_draft_ids.len() != request.drafts.len() {
+            .map(|draft| draft.draft_id.clone())
+            .collect::<Vec<_>>();
+        let distinct_draft_ids = draft_ids.iter().collect::<BTreeSet<_>>();
+        if distinct_draft_ids.len() != draft_ids.len() {
             return Err(ServerError::InvalidRequest(
                 "a review must not contain duplicate drafts".to_owned(),
             ));
         }
         let mut tx = self.pool().begin().await?;
+        postgres::ensure_drafts_authored_by(&mut tx, author_user_id, &draft_ids).await?;
         let outcome = postgres::create_review_submission(
             &mut tx,
             review_id,

--- a/crates/server/tests/draft_operation_ordering.rs
+++ b/crates/server/tests/draft_operation_ordering.rs
@@ -3,12 +3,13 @@ mod common;
 use std::time::Duration;
 
 use server::api::{
-    CreateDraftRequest, CreateReviewDecisionRequest, CreateReviewMergeRequest, CreateReviewRequest,
-    DraftOperationAction, DraftOperationBatchItem, DraftOperationBatchRequest, DraftOperationInput,
-    DraftResourceContent, DraftResourceRef, ResourceScope, ReviewDecision, ReviewDraftRequest,
+    CreateDraftReconciliationCandidateRequest, CreateDraftRequest, CreateReviewDecisionRequest,
+    CreateReviewMergeRequest, CreateReviewRequest, DraftOperationAction, DraftOperationBatchItem,
+    DraftOperationBatchRequest, DraftOperationInput, DraftResourceContent, DraftResourceRef,
+    ResourceScope, ReviewDecision, ReviewDraftRequest,
 };
 use server::auth::AuthPrincipal;
-use server::repository::ServerRepository;
+use server::repository::{ServerError, ServerRepository};
 
 fn memory_content(content: &str) -> Option<DraftResourceContent> {
     Some(DraftResourceContent {
@@ -84,11 +85,11 @@ async fn multi_draft_review_merges_every_file_in_one_commit() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: drafts[0].draft.draft_id.clone(),
                     expected_draft_version: drafts[0].draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: Some("Create coding skill".to_owned()),
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -114,16 +115,18 @@ async fn multi_draft_review_merges_every_file_in_one_commit() {
                     ReviewDraftRequest {
                         draft_id: rejected.drafts[0].draft.draft_id.clone(),
                         expected_draft_version: rejected.drafts[0].draft.version,
+                        candidate_id: None,
+                        resolved_state: None,
                     },
                     ReviewDraftRequest {
                         draft_id: drafts[1].draft.draft_id.clone(),
                         expected_draft_version: drafts[1].draft.version,
+                        candidate_id: None,
+                        resolved_state: None,
                     },
                 ],
                 title: Some("Create coding skill".to_owned()),
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -209,6 +212,179 @@ async fn multi_draft_review_merges_every_file_in_one_commit() {
     assert!(paths.contains(&"skills/coding/references/workflow.md"));
 }
 
+#[tokio::test]
+async fn multi_draft_review_reconciles_atomically() {
+    let postgres = common::migrated_postgres().await;
+    let repo = ServerRepository::new(postgres.pool.clone());
+    let bootstrap = common::initialize_installation(
+        postgres.pool.clone(),
+        "Atomic Directory Review",
+        "owner@example.com",
+        "Owner",
+        "oidc-subject-owner",
+        "Atomic Directory Review",
+    )
+    .await;
+    let initial_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+
+    let mut drafts = Vec::new();
+    for (index, path) in [
+        "context/first.md",
+        "context/second.md",
+        "context/advance-head.md",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        drafts.push(
+            repo.create_draft(
+                &bootstrap.user_id,
+                CreateDraftRequest {
+                    daemon_installation_id: format!("daemon_atomic_review_{index}"),
+                    project_id: bootstrap.project_id.clone(),
+                    base_commit_id: initial_head.clone(),
+                    title: format!("Create {path}"),
+                    description: None,
+                    resource: DraftResourceRef {
+                        scope: ResourceScope::Org,
+                        id: None,
+                        path: Some(path.to_owned()),
+                    },
+                    operations: vec![DraftOperationInput {
+                        action: DraftOperationAction::Create,
+                        resource: DraftResourceRef {
+                            scope: ResourceScope::Org,
+                            id: None,
+                            path: Some(path.to_owned()),
+                        },
+                        content: memory_content(&format!("# File {index}")),
+                        new_path: None,
+                    }],
+                },
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    approve_and_merge(
+        &repo,
+        &bootstrap.user_id,
+        initial_head.as_deref(),
+        &drafts[2].draft.draft_id,
+        drafts[2].draft.version,
+    )
+    .await;
+    let current_head = repo
+        .get_org_commit_state(&bootstrap.org_id, None)
+        .await
+        .unwrap()
+        .reference
+        .commit_id;
+    let first_candidate = repo
+        .create_draft_reconciliation_candidate(
+            &drafts[0].draft.draft_id,
+            CreateDraftReconciliationCandidateRequest {
+                expected_draft_version: drafts[0].draft.version,
+            },
+        )
+        .await
+        .unwrap();
+    let second_candidate = repo
+        .create_draft_reconciliation_candidate(
+            &drafts[1].draft.draft_id,
+            CreateDraftReconciliationCandidateRequest {
+                expected_draft_version: drafts[1].draft.version,
+            },
+        )
+        .await
+        .unwrap();
+
+    let before = repo.get_draft(&drafts[0].draft.draft_id).await.unwrap();
+    let error = repo
+        .create_review(
+            &bootstrap.user_id,
+            current_head.as_deref(),
+            CreateReviewRequest {
+                drafts: vec![
+                    ReviewDraftRequest {
+                        draft_id: drafts[0].draft.draft_id.clone(),
+                        expected_draft_version: drafts[0].draft.version,
+                        candidate_id: Some(first_candidate.candidate_id.clone()),
+                        resolved_state: None,
+                    },
+                    ReviewDraftRequest {
+                        draft_id: drafts[1].draft.draft_id.clone(),
+                        expected_draft_version: drafts[1].draft.version,
+                        candidate_id: None,
+                        resolved_state: None,
+                    },
+                ],
+                title: Some("Update two files".to_owned()),
+                description: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        ServerError::ReconciliationRequired { draft_id, .. }
+            if draft_id == drafts[1].draft.draft_id
+    ));
+    let after_failure = repo.get_draft(&drafts[0].draft.draft_id).await.unwrap();
+    assert_eq!(after_failure.draft.version, before.draft.version);
+    assert_eq!(
+        after_failure.draft.base_commit_id,
+        before.draft.base_commit_id
+    );
+
+    let review = repo
+        .create_review(
+            &bootstrap.user_id,
+            current_head.as_deref(),
+            CreateReviewRequest {
+                drafts: vec![
+                    ReviewDraftRequest {
+                        draft_id: drafts[0].draft.draft_id.clone(),
+                        expected_draft_version: drafts[0].draft.version,
+                        candidate_id: Some(first_candidate.candidate_id),
+                        resolved_state: None,
+                    },
+                    ReviewDraftRequest {
+                        draft_id: drafts[1].draft.draft_id.clone(),
+                        expected_draft_version: drafts[1].draft.version,
+                        candidate_id: Some(second_candidate.candidate_id),
+                        resolved_state: None,
+                    },
+                ],
+                title: Some("Update two files".to_owned()),
+                description: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(review.drafts.len(), 2);
+    assert!(review.drafts.iter().all(|draft| {
+        draft.draft.base_commit_id == current_head
+            && draft.draft.status == server::api::DraftStatus::Submitted
+    }));
+    let revision_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM draft_revisions WHERE draft_id = ANY($1)")
+            .bind(vec![
+                drafts[0].draft.draft_id.clone(),
+                drafts[1].draft.draft_id.clone(),
+            ])
+            .fetch_one(&postgres.pool)
+            .await
+            .unwrap();
+    assert_eq!(revision_count, 2);
+}
+
 async fn approve_and_merge(
     repo: &ServerRepository,
     user_id: &str,
@@ -224,11 +400,11 @@ async fn approve_and_merge(
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft_id.to_owned(),
                     expected_draft_version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await

--- a/crates/server/tests/external_memory_lifecycle.rs
+++ b/crates/server/tests/external_memory_lifecycle.rs
@@ -200,11 +200,11 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: "drf_legacy_open".to_owned(),
                     expected_draft_version: 1,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -249,11 +249,11 @@ async fn legacy_project_drafts_cannot_enter_or_complete_publication() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: "drf_legacy_open".to_owned(),
                     expected_draft_version: 1,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -1479,11 +1479,11 @@ async fn invalid_org_projection_rolls_back_authority_and_every_ref() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: org_draft.draft.draft_id,
                     expected_draft_version: org_draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -1762,11 +1762,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: edited.draft.draft_id.clone(),
                 expected_draft_version: edited.draft.version,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: None,
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await;
@@ -1781,11 +1781,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: edited.draft.draft_id.clone(),
                 expected_draft_version: edited.draft.version - 1,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: None,
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await;
@@ -1800,11 +1800,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: edited.draft.draft_id.clone(),
                 expected_draft_version: edited.draft.version,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: None,
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await;
@@ -1828,11 +1828,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: edited.draft.draft_id.clone(),
                 expected_draft_version: edited.draft.version,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: Some("Revised review lifecycle context".to_owned()),
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await;
@@ -1879,11 +1879,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: edited.draft.draft_id.clone(),
                 expected_draft_version: edited.draft.version,
+                candidate_id: Some(candidate_id),
+                resolved_state: None,
             }],
             title: Some("Revised review lifecycle context".to_owned()),
             description: None,
-            candidate_id: Some(candidate_id),
-            resolved_state: None,
         },
     )
     .await;
@@ -1921,11 +1921,11 @@ async fn rejected_review_reopens_its_draft_and_reuses_the_same_review() {
             drafts: vec![ReviewDraftRequest {
                 draft_id: resubmitted.draft.draft_id.clone(),
                 expected_draft_version: resubmitted.draft.version,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: None,
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await;
@@ -2376,11 +2376,11 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
                 drafts: vec![ReviewDraftRequest {
                     draft_id: seed.draft.draft_id,
                     expected_draft_version: seed.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -2455,11 +2455,11 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
                 drafts: vec![ReviewDraftRequest {
                     draft_id: local_update.draft.draft_id.clone(),
                     expected_draft_version: local_update.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -2528,11 +2528,11 @@ async fn reconciliation_handles_overlapping_updates_and_editable_behind_drafts()
                 drafts: vec![ReviewDraftRequest {
                     draft_id: remote.draft.draft_id,
                     expected_draft_version: remote.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -3238,11 +3238,11 @@ async fn project_org_selection_resolves_legacy_path_only_draft_after_authority_r
                 drafts: vec![ReviewDraftRequest {
                     draft_id: rename_draft.draft.draft_id,
                     expected_draft_version: rename_draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -3623,11 +3623,11 @@ async fn created_org_draft_materializes_local_identity_updates_and_renames() {
                 drafts: vec![ReviewDraftRequest {
                     draft_id: draft.draft.draft_id,
                     expected_draft_version: draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -3765,11 +3765,11 @@ async fn org_delete_merge_advances_authority_past_other_projects_active_drafts()
                 drafts: vec![ReviewDraftRequest {
                     draft_id: deletion_draft.draft.draft_id,
                     expected_draft_version: deletion_draft.draft.version,
+                    candidate_id: None,
+                    resolved_state: None,
                 }],
                 title: None,
                 description: None,
-                candidate_id: None,
-                resolved_state: None,
             },
         )
         .await
@@ -4184,11 +4184,11 @@ async fn create_review_for_draft(app: axum::Router, draft: &DraftDetail) -> Revi
             drafts: vec![ReviewDraftRequest {
                 draft_id: draft.draft.draft_id.clone(),
                 expected_draft_version: draft.draft.version,
+                candidate_id: None,
+                resolved_state: None,
             }],
             title: None,
             description: None,
-            candidate_id: None,
-            resolved_state: None,
         },
     )
     .await

--- a/docs/server.md
+++ b/docs/server.md
@@ -62,8 +62,8 @@ comment; only an Organization owner or administrator may approve or reject an
 Org publication Review. Approval records the decision and advances the target
 Ref in one transaction, moving an Open Review directly to Merged. The merge
 endpoint still accepts historical Approved Reviews. Review creation/submission
-can apply a confirmed candidate in the same Ref-locked transaction. Publication
-never performs the first stale check as a normal workflow; it retains
+can apply each Draft's confirmed candidate in the same Ref-locked transaction.
+Publication never performs the first stale check as a normal workflow; it retains
 `If-Match`/CAS as the final concurrency guard.
 
 The detailed state model and failure semantics are maintained in the Obsidian


### PR DESCRIPTION
## Context and summary

Project-level Review could still return `reconciliation_required` after
#236 made the menu action available. The request carried only one top-level
candidate and resolved state, so it could not reconcile multiple behind
Drafts atomically.

This change attaches reconciliation data to each Draft, preflights every
candidate before applying rebases in the Review transaction, and lets the
macOS app gather and resolve all required candidates before submitting one
Review.

## Affected areas

- [ ] Rust daemon/runtime
- [x] Server/API
- [x] macOS app
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [x] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Before this change, a Review containing several behind Drafts could not
express a distinct reconciliation candidate for each Draft. The app asked
the user to sync files separately, and server processing could not guarantee
all-or-nothing reconciliation across the complete Review request.

After this change, each Draft carries its own candidate and optional resolved
state. The server validates all required candidates before rebasing any
Draft, then applies every rebase and creates or resubmits the Review in the
same transaction. The macOS sheet gathers every behind candidate, resolves
only conflicting Drafts, and submits the full set once.

Regression coverage verifies that a missing candidate leaves earlier Drafts
untouched and that valid candidates reconcile the entire Review.

## Verification

- [x] `cargo check -p server --tests`
- [x] `cargo clippy -p server --tests -- -D warnings`
- [x] `cargo test --workspace`
- [x] `sh apps/macos/Scripts/test.sh`
- [x] `bun run build`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [ ] Exercise clean and conflicting multi-Draft flows manually in the macOS
      app against the AgentOS project; not run in this environment.

## Compatibility and migration

The Review request wire shape changes by moving `candidate_id` and
`resolved_state` from the request root into each `drafts[]` entry. Client and
server should be upgraded together for behind-Draft reconciliation. Review
requests whose Drafts are already current are unaffected. No storage or data
migration is required.

## Risk, security, and privacy

The primary reliability risk is transaction ordering across several Draft
rebases; the preflight regression test covers the partial-update failure
mode. Conflict resolution remains sequential in the macOS sheet and reuses
existing server validation. There are no permission, secret, or private
Memory payload changes.

## Rollout and rollback

- Rollout: deploy matching server and macOS builds.
- Observability: monitor existing `reconciliation_required` responses and
  Review creation failures.
- Rollback: revert `0f969d0ed6f7c29da64b1aaf7319c4d1f7045b0e` and deploy matching client and server builds.

## Reviewer focus

Please focus on the preflight-before-rebase transaction ordering and the
per-candidate SwiftUI state isolation while stepping through multiple
conflicting Drafts.