### PR TITLE
macos: expose project creation from project filters

### DIFF
--- a/apps/macos/Sources/Components/ToolbarFilterMenu.swift
+++ b/apps/macos/Sources/Components/ToolbarFilterMenu.swift
@@ -45,6 +45,7 @@ struct ProjectFilterMenu: View {
     let unscopedSystemImage: String?
     let isLoading: Bool
     let help: String
+    let onCreate: (() -> Void)?
     let onSelect: (String?) -> Void
 
     private var selectionTitle: String {
@@ -92,6 +93,14 @@ struct ProjectFilterMenu: View {
                     }
                     .disabled(isLoading)
                 }
+            }
+
+            if let onCreate {
+                Divider()
+                Button("New Project…", systemImage: "plus") {
+                    onCreate()
+                }
+                .disabled(isLoading)
             }
         }
         .help(help)

--- a/apps/macos/Sources/Features/WorkspaceView.swift
+++ b/apps/macos/Sources/Features/WorkspaceView.swift
@@ -210,6 +210,9 @@ struct WorkspaceView: View {
                 }
             }
         }
+        .sheet(isPresented: $store.showsProjectCreation) {
+            ProjectCreationSheet(store: store)
+        }
         .onChange(of: store.selectedSection) { _, _ in
             DispatchQueue.main.async {
                 store.searchQuery = ""
@@ -524,9 +527,6 @@ struct WorkspaceView: View {
                 showsSyncIssuePopover = false
             }
         }
-        .sheet(isPresented: $store.showsProjectCreation) {
-            ProjectCreationSheet(store: store)
-        }
         .sheet(isPresented: $showsProjectReviewRequest) {
             ReviewRequestSheet(
                 initialTitle: "Update \(store.activeProject?.name ?? "project") memory",
@@ -703,9 +703,6 @@ struct WorkspaceView: View {
             if presentation == nil || presentation?.isSyncing == true {
                 showsSyncIssuePopover = false
             }
-        }
-        .sheet(isPresented: $store.showsProjectCreation) {
-            ProjectCreationSheet(store: store)
         }
     }
 
@@ -1152,9 +1149,6 @@ struct WorkspaceView: View {
         .task(id: store.activeProjectId) {
             await store.refreshProjectMembers()
         }
-        .sheet(isPresented: $store.showsProjectCreation) {
-            ProjectCreationSheet(store: store)
-        }
     }
 
     private var showsUnlinkedActivityButton: Bool {
@@ -1364,7 +1358,8 @@ private struct IssueProjectFilter: View {
             unscopedTitle: nil,
             unscopedSystemImage: nil,
             isLoading: store.loadingProjectId != nil,
-            help: "Filter Kanban by Project"
+            help: "Filter Kanban by Project",
+            onCreate: store.canManageProjects ? { store.presentProjectCreation() } : nil
         ) { projectId in
             if let projectId {
                 Task { await store.selectProject(projectId) }
@@ -1383,7 +1378,8 @@ private struct MemoryProjectFilter: View {
             unscopedTitle: "Org",
             unscopedSystemImage: "building.2",
             isLoading: store.isSwitchingMemoryContext,
-            help: "Filter Memory by Project"
+            help: "Filter Memory by Project",
+            onCreate: store.canManageProjects ? { store.presentProjectCreation() } : nil
         ) { projectId in
             if let projectId {
                 Task { await store.selectProject(projectId) }
@@ -1405,7 +1401,8 @@ private struct ActivityProjectFilter: View {
             unscopedTitle: "All Projects",
             unscopedSystemImage: nil,
             isLoading: model.isLoading,
-            help: "Filter Activity by Project"
+            help: "Filter Activity by Project",
+            onCreate: store.canManageProjects ? { store.presentProjectCreation() } : nil
         ) { projectId in
             Task { await model.selectProject(projectId) }
         }

--- a/apps/macos/Tests/ProjectManagementTests.swift
+++ b/apps/macos/Tests/ProjectManagementTests.swift
@@ -81,6 +81,30 @@ final class ProjectManagementTests: XCTestCase {
         )
     }
 
+    func testProjectCreationIsAvailableFromEveryProjectFilter() throws {
+        let macOSRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let filter = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Components/ToolbarFilterMenu.swift"),
+            encoding: .utf8
+        )
+        let workspace = try String(
+            contentsOf: macOSRoot.appending(path: "Sources/Features/WorkspaceView.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(filter.contains("Button(\"New Project…\", systemImage: \"plus\")"))
+        XCTAssertEqual(
+            workspace.components(separatedBy: "onCreate: store.canManageProjects").count - 1,
+            3
+        )
+        XCTAssertEqual(
+            workspace.components(separatedBy: "ProjectCreationSheet(store: store)").count - 1,
+            1
+        )
+    }
+
     func testAdministrationProjectCreationHasNoRepositoryRequirement() throws {
         let request = WorkspaceStore.adminProjectCreationRequest(
             name: "Server-only Project",


### PR DESCRIPTION
## Context and summary

Project creation already exists, but the common Project filters only allow
switching projects. Add a permission-gated `New Project…` action to the
Memory, Kanban, and Activity filters, reuse the existing creation flow, and
host its sheet at the workspace root so the File menu works from every
section.

## Affected areas

- [ ] Rust daemon/runtime
- [ ] Server/API
- [x] macOS app
- [ ] MCP, CLI, or agent protocol
- [ ] Storage, configuration, or schema
- [ ] Documentation
- [ ] CI, deployment, or release

## Behavior and evidence

Users with Project management permission can start the existing creation
flow from all three Project filters. Other users do not see the action. A
single root-level sheet now presents creation requests from every workspace
section.

## Verification

- [x] `just test-macos`
- [x] `git diff --check`
- [ ] Verify the three Project filters with an administrator account.
- [ ] Verify File > New Project… across workspace sections.
- [ ] Verify the action is hidden or disabled for a regular member.

Manual UI verification is deferred to the merged Debug build at the
requester's direction.

## Compatibility and migration

None. This reuses the existing Server API and project creation flow.

## Risk, security, and privacy

Creation remains gated by the existing `canManageProjects` permission. The
remaining risk is limited to SwiftUI presentation behavior that has not been
manually exercised.

## Rollout and rollback

- Rollout: Normal macOS Debug and release builds.
- Observability: Existing UI and Server error reporting.
- Rollback: Revert this Pull Request.

## Reviewer focus

Check the root-level sheet placement and the three permission-gated filter
callbacks.
